### PR TITLE
docs(d1): add baseline migration pattern for existing databases

### DIFF
--- a/src/content/docs/d1/reference/migrations.mdx
+++ b/src/content/docs/d1/reference/migrations.mdx
@@ -92,15 +92,15 @@ If your D1 database already has tables and you want to start using the migration
 
 A baseline migration records your existing schema as the first entry in your migration history, so every future migration builds on a known starting point. This lets anyone recreate the database from scratch — for example, when a new developer sets up a local database, when CI/CD spins up fresh test databases, or when you want a complete schema history in your git repository.
 
-The baseline is a suggestion, not a requirement. Migrations are useful even if you work solo, so that you can roll your schema forward and back over time. You only need a baseline if you want to reproduce the database from your migration files. If you never recreate the database and only ever apply new migrations to it, you can skip this step and start with your next migration.
+The baseline is a suggestion, not a requirement. Migrations are useful even if you work solo because they track schema changes over time. You only need a baseline if you want to reproduce the database from your migration files. If you never recreate the database and only ever apply new migrations to it, you can skip this step and start with your next migration.
 
 <Steps>
 
-1. Get your current schema, including tables, indexes, and views:
+1. Get your current schema, including tables, indexes, views, and triggers:
 
 	```sh
 	npx wrangler d1 execute <DATABASE_NAME> --remote \
-		--command="SELECT sql FROM sqlite_master WHERE sql IS NOT NULL AND name NOT LIKE '_cf%' AND name != 'sqlite_sequence' AND name != 'd1_migrations'"
+		--command="SELECT sql FROM sqlite_master WHERE sql IS NOT NULL AND name NOT GLOB '_cf*' AND name != 'sqlite_sequence' AND name != 'd1_migrations'"
 	```
 
 2. Create a baseline migration:
@@ -109,7 +109,7 @@ The baseline is a suggestion, not a requirement. Migrations are useful even if y
 	npx wrangler d1 migrations create <DATABASE_NAME> baseline
 	```
 
-3. Copy the output from step 1 into the migration file. Add `IF NOT EXISTS` to each `CREATE TABLE` statement so the migration is safe to run against the live database:
+3. Copy the output from step 1 into the migration file. Add `IF NOT EXISTS` to each `CREATE` statement so the migration is safe to run against the live database:
 
 	```sql
 	-- migrations/0001_baseline.sql
@@ -129,7 +129,7 @@ The baseline is a suggestion, not a requirement. Migrations are useful even if y
 
 </Steps>
 
-The `IF NOT EXISTS` clause prevents the existing tables from being recreated. The migration is recorded in the `d1_migrations` table, establishing a starting point for all future migrations.
+The `IF NOT EXISTS` clause prevents existing schema objects from being recreated. The migration is recorded in the `d1_migrations` table, establishing a starting point for all future migrations.
 
 ## Foreign key constraints
 

--- a/src/content/docs/d1/reference/migrations.mdx
+++ b/src/content/docs/d1/reference/migrations.mdx
@@ -8,7 +8,7 @@ products:
   - d1
 ---
 
-import { WranglerConfig } from "~/components";
+import { WranglerConfig, Steps } from "~/components";
 
 Database migrations are a way of versioning your database. Each migration is stored as an `.sql` file in your `migrations` folder. The `migrations` folder is created in your project directory when you create your first migration. This enables you to store and track changes throughout database development.
 
@@ -92,11 +92,13 @@ If your D1 database already has tables and you want to start using the migration
 
 This is useful when you work on a team and a new developer needs to set up a local database from scratch, when you use CI/CD that creates fresh test databases, or when you want a complete schema history in your git repository. If you are a solo developer with one database and do not plan to recreate it, you can skip this step.
 
-1. Get your current schema:
+<Steps>
+
+1. Get your current schema, including tables, indexes, and views:
 
 	```sh
 	npx wrangler d1 execute <DATABASE_NAME> --remote \
-		--command="SELECT sql FROM sqlite_master WHERE type='table' AND name NOT LIKE '_cf%' AND name != 'sqlite_sequence'"
+		--command="SELECT sql FROM sqlite_master WHERE sql IS NOT NULL AND name NOT LIKE '_cf%' AND name != 'sqlite_sequence' AND name != 'd1_migrations'"
 	```
 
 2. Create a baseline migration:
@@ -105,7 +107,7 @@ This is useful when you work on a team and a new developer needs to set up a loc
 	npx wrangler d1 migrations create <DATABASE_NAME> baseline
 	```
 
-3. Paste your existing `CREATE TABLE` statements into the file, adding `IF NOT EXISTS` so the migration is safe to run against the live database that already has these tables:
+3. Copy the output from step 1 into the migration file. Add `IF NOT EXISTS` to each `CREATE TABLE` statement so the migration is safe to run against the live database:
 
 	```sql
 	-- migrations/0001_baseline.sql
@@ -122,6 +124,8 @@ This is useful when you work on a team and a new developer needs to set up a loc
 	npx wrangler d1 migrations apply <DATABASE_NAME> --local
 	npx wrangler d1 migrations apply <DATABASE_NAME> --remote
 	```
+
+</Steps>
 
 The `IF NOT EXISTS` clause prevents the existing tables from being recreated. The migration is recorded in the `d1_migrations` table, establishing a starting point for all future migrations.
 

--- a/src/content/docs/d1/reference/migrations.mdx
+++ b/src/content/docs/d1/reference/migrations.mdx
@@ -86,11 +86,13 @@ The pattern is a standard glob — `*` matches one path segment, `**` matches an
 
 `wrangler d1 migrations create` only writes top-level files inside `migrations_dir`, so if your `migrations_pattern` only matches nested files (as with the Drizzle layout), generate new migrations using your ORM's command (for example, `drizzle-kit generate`) instead.
 
-## Adopt migrations on an existing database
+## Add migrations to an existing database
 
-If your D1 database already has tables and you want to start using the migration system, create a baseline migration that captures your current schema.
+If your D1 database already has tables and you want to start using the migration system, we suggest creating a baseline migration that captures your current schema.
 
-This is useful when you work on a team and a new developer needs to set up a local database from scratch, when you use CI/CD that creates fresh test databases, or when you want a complete schema history in your git repository. If you are a solo developer with one database and do not plan to recreate it, you can skip this step.
+A baseline migration records your existing schema as the first entry in your migration history, so every future migration builds on a known starting point. This lets anyone recreate the database from scratch — for example, when a new developer sets up a local database, when CI/CD spins up fresh test databases, or when you want a complete schema history in your git repository.
+
+The baseline is a suggestion, not a requirement. Migrations are useful even if you work solo, so that you can roll your schema forward and back over time. You only need a baseline if you want to reproduce the database from your migration files. If you never recreate the database and only ever apply new migrations to it, you can skip this step and start with your next migration.
 
 <Steps>
 

--- a/src/content/docs/d1/reference/migrations.mdx
+++ b/src/content/docs/d1/reference/migrations.mdx
@@ -86,6 +86,45 @@ The pattern is a standard glob — `*` matches one path segment, `**` matches an
 
 `wrangler d1 migrations create` only writes top-level files inside `migrations_dir`, so if your `migrations_pattern` only matches nested files (as with the Drizzle layout), generate new migrations using your ORM's command (for example, `drizzle-kit generate`) instead.
 
+## Adopt migrations on an existing database
+
+If your D1 database already has tables and you want to start using the migration system, create a baseline migration that captures your current schema.
+
+This is useful when you work on a team and a new developer needs to set up a local database from scratch, when you use CI/CD that creates fresh test databases, or when you want a complete schema history in your git repository. If you are a solo developer with one database and do not plan to recreate it, you can skip this step.
+
+1. Get your current schema:
+
+	```sh
+	npx wrangler d1 execute <DATABASE_NAME> --remote \
+		--command="SELECT sql FROM sqlite_master WHERE type='table' AND name NOT LIKE '_cf%' AND name != 'sqlite_sequence'"
+	```
+
+2. Create a baseline migration:
+
+	```sh
+	npx wrangler d1 migrations create <DATABASE_NAME> baseline
+	```
+
+3. Paste your existing `CREATE TABLE` statements into the file, adding `IF NOT EXISTS` so the migration is safe to run against the live database that already has these tables:
+
+	```sql
+	-- migrations/0001_baseline.sql
+	CREATE TABLE IF NOT EXISTS users (
+		user_id INTEGER PRIMARY KEY,
+		email TEXT NOT NULL,
+		name TEXT
+	);
+	```
+
+4. Apply locally and remotely:
+
+	```sh
+	npx wrangler d1 migrations apply <DATABASE_NAME> --local
+	npx wrangler d1 migrations apply <DATABASE_NAME> --remote
+	```
+
+The `IF NOT EXISTS` clause prevents the existing tables from being recreated. The migration is recorded in the `d1_migrations` table, establishing a starting point for all future migrations.
+
 ## Foreign key constraints
 
 When applying a migration, you may need to temporarily disable [foreign key constraints](/d1/sql-api/foreign-keys/). To do so, call `PRAGMA defer_foreign_keys = true` before making changes that would violate foreign keys.


### PR DESCRIPTION
## Summary

Adds a new section to the D1 migrations page documenting how to adopt the migration system on an existing database that already has tables.

### Problem

The current migrations documentation assumes you are starting from scratch. Developers who have an existing D1 database with tables and want to start using `wrangler d1 migrations` have no guidance on how to create a baseline migration that captures the current schema without breaking anything.

### Changes

Adds an "Adopt migrations on an existing database" section to `src/content/docs/d1/reference/migrations.mdx` that covers:

- When a baseline migration is useful (teams, CI/CD, schema history) and when you can skip it (solo developer, single database)
- How to export the current schema with `sqlite_master`
- How to create a baseline migration using `CREATE TABLE IF NOT EXISTS` so it is safe to apply against the live database
- How to apply locally and remotely

### Context

Discovered during hands-on testing of D1 schema management workflows. The `CREATE TABLE IF NOT EXISTS` pattern ensures the migration records itself in `d1_migrations` without attempting to recreate tables that already exist.