### PR TITLE
docs(d1): add rules of D1 best practices guide

### DIFF
--- a/src/content/docs/d1/best-practices/index.mdx
+++ b/src/content/docs/d1/best-practices/index.mdx
@@ -3,7 +3,7 @@ title: Best practices
 description: Recommended patterns and techniques for building with D1 databases.
 pcx_content_type: navigation
 sidebar:
-  order: 3
+  order: 4
   group:
     hideIndex: true
 products:

--- a/src/content/docs/d1/best-practices/rules-of-d1.mdx
+++ b/src/content/docs/d1/best-practices/rules-of-d1.mdx
@@ -31,7 +31,7 @@ A single D1 database has fixed resources. You do not choose instance sizes, CPU,
 
 The first limits to design around are:
 
-| Limit                              | Workers Paid | Workers Free |
+| Limit                              | Workers paid | Workers free |
 | ---------------------------------- | ------------ | ------------ |
 | Databases per account              | 50,000       | 10           |
 | Maximum database size              | 10 GB        | 500 MB       |
@@ -264,7 +264,7 @@ Do this for every dynamic clause: `ORDER BY`, sort direction, optional filters, 
 
 ### Implement application level retry with exponential backoff and jitter for write queries
 
-D1 automatically retries `SELECT`, `EXPLAIN`, and `WITH` queries up to two times on transient errors. Write queries are never automatically retried. Your application must implement its own retry for idempotent write operations.
+D1 automatically retries read only queries up to two times on transient errors. Only queries containing solely `SELECT`, `EXPLAIN`, or read only `WITH` statements are retried. Any query that can write is never automatically retried. Your application must implement its own retry for idempotent write operations.
 
 Make writes idempotent before you retry them. For order creation, require a client generated idempotency key and enforce it with a `UNIQUE` constraint. If a transient error occurs after D1 commits the write but before the Worker receives the response, the retry returns the existing order instead of creating a duplicate. If a retry hits the unique constraint, treat that as a signal to fetch and return the existing record rather than issuing a second logical write.
 
@@ -391,7 +391,7 @@ An ORM such as Drizzle or Prisma works well when:
 - You want autocompletion in your editor when writing queries.
 - You are iterating rapidly on schema design and want to see what SQL each change produces before applying it.
 
-If you use an ORM, be aware that ORM migration generators cannot apply migrations to D1 directly. Generate the SQL with your ORM, then apply it with `wrangler`. Review all generated SQL before applying it, especially as described in [Review generated migrations before applying them](#review-generated-migrations-before-applying-them), because ORMs may generate destructive statements for tables they do not manage, including Wrangler's `d1_migrations` table.
+If you use an ORM, be aware that ORM migration generators cannot apply migrations to D1 directly. Generate the SQL with your ORM, then apply it with `wrangler`. Review all generated SQL before applying it, especially as described in [Review generated migrations before applying them](#review-generated-migrations-before-applying-them), because ORMs may generate destructive statements for tables they do not manage, including `wrangler`'s `d1_migrations` table.
 
 ### Apply migrations outside your Worker startup path
 
@@ -428,11 +428,11 @@ CREATE TABLE IF NOT EXISTS orders (
 );
 ```
 
-This pattern lets Wrangler record the migration without trying to recreate tables that already exist. After the baseline is applied, future migrations should contain only the incremental schema changes.
+This pattern lets `wrangler` record the migration without trying to recreate tables that already exist. After the baseline is applied, future migrations should contain only the incremental schema changes.
 
 ### Review generated migrations before applying them
 
-Never apply ORM generated SQL blindly. A migration generator only knows the schema model it was given. If Wrangler's `d1_migrations` table, manually created indexes, or existing production tables are missing from that model, generated SQL can include destructive statements you did not intend.
+Never apply ORM generated SQL blindly. A migration generator only knows the schema model it was given. If `wrangler`'s `d1_migrations` table, manually created indexes, or existing production tables are missing from that model, generated SQL can include destructive statements you did not intend.
 
 Bad migration review looks like this:
 
@@ -442,7 +442,7 @@ DROP TABLE d1_migrations;
 DROP TABLE order_events;
 ```
 
-Good migration review keeps Wrangler metadata intact and limits the migration to the intended schema change:
+`wrangler` metadata remains intact and limits the migration to the intended schema change:
 
 ```sql
 -- Good: only the intended application change remains.
@@ -451,7 +451,7 @@ CREATE INDEX IF NOT EXISTS idx_orders_archived_at ON orders(archived_at);
 PRAGMA optimize;
 ```
 
-If your ORM writes migrations in nested directories, configure `migrations_pattern` so Wrangler finds the files. For more detail, refer to [Migrations](/d1/reference/migrations/#nested-migration-layouts).
+If your ORM writes migrations in nested directories, configure `migrations_pattern` so `wrangler` finds the files. For more detail, refer to [Migrations](/d1/reference/migrations/#nested-migration-layouts).
 
 ### Defer foreign keys during migrations
 

--- a/src/content/docs/d1/best-practices/rules-of-d1.mdx
+++ b/src/content/docs/d1/best-practices/rules-of-d1.mdx
@@ -1,0 +1,329 @@
+---
+title: Rules of D1
+description: Best practices for building fast, reliable applications on D1, covering indexing, batching, retries, migrations, and scale.
+pcx_content_type: concept
+sidebar:
+  order: 2
+products:
+  - d1
+---
+
+import { TypeScriptExample } from "~/components";
+
+[D1](/d1/) is a serverless SQL database built on [SQLite](https://www.sqlite.org/). A single database runs against one primary instance and processes queries against it, so the cost of each query and the shape of your schema directly determine how your application performs and scales.
+
+This is a guidebook of rules for building fast, reliable applications on D1. Each rule explains the behavior behind it and shows the pattern to follow.
+
+## Query performance
+
+### Index every queried column
+
+A query that scans a whole table reads every row, which is slow and counts every scanned row toward your bill. An index turns a scan into a lookup. Create an index for any column you filter on in a `WHERE` clause, join on, or sort by in an `ORDER BY` clause.
+
+```sql
+-- Index a column used in predicates and joins
+CREATE INDEX IF NOT EXISTS idx_orders_customer_id ON orders(customer_id);
+```
+
+After you create or drop an index, run `PRAGMA optimize`. This runs `ANALYZE` on each table and updates the statistics the query planner uses to choose an index.
+
+```sql
+PRAGMA optimize;
+```
+
+Verify that a query uses the index you expect with `EXPLAIN QUERY PLAN`. Output containing `USING INDEX` confirms the index is used; a `SCAN` over the table means it is not.
+
+```sql
+EXPLAIN QUERY PLAN SELECT * FROM users WHERE email_address = ?;
+```
+
+For a multi-column index, a query uses the index only if it filters on all of the indexed columns, or on a left-prefix of them. An index on `(customer_id, transaction_date)` serves a query that filters on `customer_id`, or on both columns, but not one that filters on `transaction_date` alone.
+
+Tables with the default `INTEGER PRIMARY KEY` do not need a separate index for that column. Every other indexed column adds a write to the index on each `INSERT`, `UPDATE`, or `DELETE` that touches it. For read-heavy workloads, the reduction in rows read almost always outweighs this write amplification.
+
+Indexes are hard to add after the fact on a multi-gigabyte database, so define them up front where you can. For full detail on unique, partial, and multi-column indexes, refer to [Use indexes](/d1/best-practices/use-indexes/).
+
+### Batch related queries to reduce round-trips
+
+Each call to `run()` is a separate round-trip to your database. Calling `run()` in a loop multiplies network latency by the number of statements. [`batch()`](/d1/worker-api/d1-database/#batch) sends a set of statements in one round-trip, and runs them as a single transaction: if any statement fails, the entire sequence rolls back.
+
+<TypeScriptExample filename="index.ts">
+
+```ts
+const users = [{ name: "Alice" }, { name: "Bob" }, { name: "Carol" }];
+const stmt = env.DB.prepare("INSERT INTO users (name) VALUES (?)");
+
+// Bad: one round-trip per statement
+for (const user of users) {
+	await stmt.bind(user.name).run();
+}
+
+// Good: one round-trip, one transaction
+await env.DB.batch(users.map((user) => stmt.bind(user.name)));
+```
+
+</TypeScriptExample>
+
+The per-query limits apply to each statement inside a batch. For example, the 100 KB maximum statement length applies to every statement in the batch, not the batch as a whole.
+
+### Always use parameterized queries
+
+Never interpolate user input or runtime values into a SQL string. Bind them as parameters with [`bind()`](/d1/worker-api/prepared-statements/) instead. D1 follows SQLite's convention and supports ordered (`?NNN`) and anonymous (`?`) parameters.
+
+<TypeScriptExample filename="index.ts">
+
+```ts
+// Bad: string interpolation is open to SQL injection
+const bad = env.DB.prepare(`SELECT * FROM users WHERE email = '${email}'`);
+
+// Good: bind the value as a parameter
+const good = env.DB.prepare("SELECT * FROM users WHERE email = ?").bind(email);
+```
+
+</TypeScriptExample>
+
+Beyond preventing SQL injection, parameterized queries make your query metrics useful. D1 captures query strings for [query insights](/d1/observability/metrics-analytics/) but strips bound parameters, so every execution of the same query template aggregates together instead of appearing as thousands of distinct queries.
+
+## Reliability and error handling
+
+### Retry write queries from your application
+
+D1 automatically retries read-only queries up to two times on a retryable error. Only queries containing solely `SELECT`, `EXPLAIN`, or `WITH` are retried; any query that can write is never auto-retried. Your application must retry its own writes.
+
+Retry only idempotent writes, and only on errors that are safe to retry. Use exponential backoff with jitter so concurrent clients do not retry in lockstep.
+
+<TypeScriptExample filename="retry.ts">
+
+```ts
+// Retryable errors from the D1 error list
+function isRetryable(err: unknown): boolean {
+	const message = String(err);
+	return (
+		message.includes("Network connection lost") ||
+		message.includes("storage caused object to be reset") ||
+		message.includes("reset because its code was updated")
+	);
+}
+
+async function writeWithRetry(
+	stmt: D1PreparedStatement,
+	maxAttempts = 3,
+): Promise<D1Result> {
+	for (let attempt = 1; ; attempt++) {
+		try {
+			return await stmt.run();
+		} catch (err) {
+			if (attempt >= maxAttempts || !isRetryable(err)) throw err;
+			// Exponential backoff capped at 2s, with full jitter
+			const backoff = Math.min(50 * 2 ** attempt, 2000);
+			await new Promise((resolve) =>
+				setTimeout(resolve, Math.random() * backoff),
+			);
+		}
+	}
+}
+```
+
+</TypeScriptExample>
+
+For the complete set of error messages and which are safe to retry, refer to the [error list](/d1/observability/debug-d1/#error-list). Refer to [Retry queries](/d1/best-practices/retry-queries/) for more.
+
+### Chunk bulk mutations
+
+A single `UPDATE` or `DELETE` over hundreds of thousands of rows can exceed the database's CPU or memory limit and reset the instance, which surfaces as an internal error and loses the in-flight operation. Process large mutations in chunks of roughly 10,000 rows.
+
+<TypeScriptExample filename="cleanup.ts">
+
+```ts
+const CHUNK_SIZE = 10_000;
+let deleted = CHUNK_SIZE;
+
+// Delete in bounded chunks until none remain
+while (deleted >= CHUNK_SIZE) {
+	const result = await env.DB.prepare(
+		`DELETE FROM logs WHERE id IN (
+			SELECT id FROM logs WHERE created_at < ? LIMIT ?
+		)`,
+	)
+		.bind(cutoff, CHUNK_SIZE)
+		.run();
+
+	deleted = result.meta.changes ?? 0;
+}
+```
+
+</TypeScriptExample>
+
+The same applies to bulk imports. Partition import data into files of tens of megabytes rather than one large file. Refer to [Import and export data](/d1/best-practices/import-export-data/).
+
+## Schema and migrations
+
+### Use migrations for team and multi-environment workflows
+
+Migrations are not required for every schema change. If you are a solo developer with one database, running `ALTER TABLE` directly with `wrangler d1 execute` is valid and permanent.
+
+Migrations become valuable when you work on a team or have multiple environments (local dev, staging, production) that need identical schemas. A migration is a `.sql` file checked into git that records a schema change. Wrangler tracks which migrations have been applied in a `d1_migrations` table so they are never double-applied.
+
+Typical team workflow:
+
+1. Developer pulls latest code from git (which includes new `.sql` migration files from teammates).
+2. Developer runs `wrangler d1 migrations apply <DATABASE> --local` to update their local database.
+3. Developer creates a new migration with `wrangler d1 migrations create`, writes SQL, tests locally.
+4. Developer commits the migration file and pushes to git.
+5. CI/CD applies the migration to production with `wrangler d1 migrations apply <DATABASE> --remote`, then deploys the Worker.
+
+Migration files live in git, not in the database. The `d1_migrations` table is a checklist of which files have been applied in each environment. Refer to [Migrations](/d1/reference/migrations/) for the full guide.
+
+### Choose the right migration tooling
+
+You can write migration SQL by hand or use an ORM to generate it. Each approach has trade-offs.
+
+**Raw SQL with Wrangler** works well when:
+
+- You have 1-5 tables
+- Your queries are straightforward CRUD
+- You are the only developer
+- You are comfortable writing SQL
+
+**An ORM like Drizzle or Prisma** starts paying off when:
+
+- You have 10+ tables with foreign key relationships between them
+- You build complex queries with joins across 3+ tables, where type safety prevents you from accidentally joining on the wrong column or misspelling a field name
+- Multiple developers touch the schema, and the TypeScript definition becomes the single source of truth with compile errors catching mismatches immediately
+- You want autocompletion in your editor when writing queries
+- You are iterating rapidly on schema design and want to see what SQL each change produces without writing it yourself
+
+If you use an ORM, be aware that ORM migration generators cannot apply migrations to D1 directly. You generate the SQL with your ORM, then apply it with Wrangler. Review all generated SQL before applying — ORMs may generate destructive statements for tables they do not manage. Refer to the [Drizzle integration notes](/d1/reference/community-projects/#drizzle-orm) for specific gotchas.
+
+### Defer foreign keys during migrations, do not disable them
+
+D1 enforces foreign key constraints by default, equivalent to `PRAGMA foreign_keys = on` for every transaction. This is unlike plain SQLite, where enforcement is off by default. If you migrate a schema that was designed with enforcement off, existing violations surface immediately.
+
+Because D1 runs every query inside an implicit transaction, you cannot turn enforcement off with `PRAGMA foreign_keys = off`; D1 ignores it. A migration script copied from a SQLite dump that sets `foreign_keys = off` has no effect and can fail with constraint errors.
+
+To violate constraints temporarily within a migration, use `PRAGMA defer_foreign_keys = on`. This defers enforcement to the end of the current transaction instead of disabling it.
+
+```sql
+PRAGMA defer_foreign_keys = on;
+
+-- Run ALTER TABLE, data backfills, and other migration statements here.
+-- Resolve every constraint violation before the transaction ends.
+```
+
+Any violation left unresolved when the transaction commits fails with a `FOREIGN KEY constraint failed` error. For relationship definitions and the available actions (`CASCADE`, `RESTRICT`, `SET DEFAULT`, `SET NULL`, `NO ACTION`), refer to [Define foreign keys](/d1/sql-api/foreign-keys/).
+
+### Capture a Time Travel bookmark before a destructive migration
+
+[Time Travel](/d1/reference/time-travel/) is always on and free, and lets you restore a database to any minute within the last 30 days (7 days on the Workers Free plan). Before any migration that drops columns, drops tables, or runs a bulk `UPDATE` or `DELETE`, capture the current bookmark and store it.
+
+```sh
+npx wrangler d1 time-travel info my-database
+```
+
+If the migration goes wrong, restore to that bookmark.
+
+```sh
+npx wrangler d1 time-travel restore my-database --bookmark=<YOUR_BOOKMARK>
+```
+
+Restoring is a destructive, in-place overwrite that cancels in-flight queries, so treat it as you would any production rollback. Bookmarks older than the retention window cannot be used as a restore point, so capture one as part of every destructive deploy rather than relying on recovering after the window closes.
+
+## Data location and replication
+
+### Set a location hint that matches your workload
+
+A D1 database is pinned to one primary region. Without a location hint, D1 places the primary close to the request that created the database, which is often your control plane or CI pipeline rather than your users. Every cross-region query then pays a round-trip penalty.
+
+Set a [location hint](/d1/configuration/data-location/) at creation time, matching the region closest to the workload that queries the database most.
+
+```sh
+npx wrangler d1 create my-database --location=weur
+```
+
+A location hint is a preference, not a guarantee, and write latency is always dominated by the primary's location even when read replicas exist. Refer to [Data location](/d1/configuration/data-location/) for the full list of hints and for jurisdiction constraints.
+
+### Use the Sessions API so you can add replicas later
+
+[Read replication](/d1/best-practices/read-replication/) helps read-heavy applications with users around the world. To use replicas, you must use the [Sessions API](/d1/worker-api/d1-database/#withsession); otherwise every query goes to the primary. The Sessions API also works on databases without replication enabled, so writing code with `withSession()` from the start lets you turn on replication later with a single API call, without changing Worker code.
+
+`withSession()` returns an object with the same interface as the top-level database, so your query code is unchanged. To preserve [sequential consistency](/d1/best-practices/read-replication/#sequential-consistency) across requests, pass the bookmark from one request to the next.
+
+<TypeScriptExample filename="index.ts">
+
+```ts
+export default {
+	async fetch(request: Request, env: Env): Promise<Response> {
+		// Resume from the bookmark the client last saw, or start unconstrained
+		const bookmark =
+			request.headers.get("x-d1-bookmark") ?? "first-unconstrained";
+		const session = env.DB.withSession(bookmark);
+
+		const { results } = await session
+			.prepare("SELECT * FROM orders WHERE customer_id = ?")
+			.bind(customerId)
+			.all();
+
+		const response = Response.json(results);
+		// Return the new bookmark so the next request stays consistent
+		response.headers.set("x-d1-bookmark", session.getBookmark() ?? "");
+		return response;
+	},
+} satisfies ExportedHandler<Env>;
+```
+
+</TypeScriptExample>
+
+Start a session with `first-primary` when the first read must see the latest data, or `first-unconstrained` (the default) when minimum latency matters more. Refer to [Global read replication](/d1/best-practices/read-replication/) for the full guide.
+
+## Scaling
+
+### Respect the limits of a single database
+
+A single D1 database has fixed resources. The size and shape of your queries, not a configurable instance size, determine how much it can do. The limits to design around first:
+
+| Limit                               | Workers Paid | Workers Free |
+| ----------------------------------- | ------------ | ------------ |
+| Maximum database size               | 10 GB        | 500 MB       |
+| Queries per Worker invocation       | 1,000        | 50           |
+| Maximum SQL query duration          | 30 seconds   | 30 seconds   |
+| Maximum bound parameters per query  | 100          | 100          |
+| Maximum string, `BLOB`, or row size | 2 MB         | 2 MB         |
+
+A frequent issue on databases of 5 GB and larger is an aggregation query that tries to scan the entire table into memory and fails on the CPU or memory limit. Keep hot-path queries indexed and bounded, and avoid `SELECT *` over a large table without a `LIMIT`. Refer to [Limits](/d1/platform/limits/) for the complete table.
+
+### Scale out across many databases
+
+D1 is designed for horizontal scale-out across many smaller databases, not vertical scale-up of one large one. When a single database approaches its size or throughput limit, shard your data across multiple databases instead of growing one.
+
+A natural sharding boundary is one database per tenant: each user, organization, or project gets its own isolated database. This gives complete data isolation, per-tenant schema evolution, and a migration blast radius limited to a single tenant. You can create databases programmatically with the [REST API](/d1/d1-api/), setting a location hint per tenant. Workers Paid accounts support 50,000 databases, raisable to millions by request.
+
+Attribute usage per database with the `rows_read` and `rows_written` fields that every query returns in its `meta` object, and apply per-query and per-tenant limits so one tenant cannot inflate your bill.
+
+<TypeScriptExample filename="index.ts">
+
+```ts
+const result = await env.DB.prepare("SELECT * FROM orders WHERE status = ?")
+	.bind(status)
+	.all();
+
+console.log({
+	rowsRead: result.meta.rows_read,
+	rowsWritten: result.meta.rows_written,
+});
+```
+
+</TypeScriptExample>
+
+To dynamically bind a separate database per tenant for a SaaS platform, refer to [Workers for Platforms](/cloudflare-for-platforms/workers-for-platforms/).
+
+## Related resources
+
+- [Use indexes](/d1/best-practices/use-indexes/) — unique, partial, and multi-column indexes.
+- [Retry queries](/d1/best-practices/retry-queries/) — auto-retry behavior and application retries.
+- [Debug D1](/d1/observability/debug-d1/) — the full error list and which errors are retryable.
+- [Global read replication](/d1/best-practices/read-replication/) — replicas and the Sessions API.
+- [Define foreign keys](/d1/sql-api/foreign-keys/) — relationships and migration handling.
+- [Time Travel](/d1/reference/time-travel/) — backups and point-in-time recovery.
+- [Migrations](/d1/reference/migrations/) — versioning your schema with migration files.
+- [Community projects](/d1/reference/community-projects/) — ORMs, query builders, and tools.
+- [Limits](/d1/platform/limits/) — the full list of D1 limits.

--- a/src/content/docs/d1/best-practices/rules-of-d1.mdx
+++ b/src/content/docs/d1/best-practices/rules-of-d1.mdx
@@ -378,7 +378,7 @@ You can write migration SQL by hand or use an object relational mapping (ORM) to
 
 Raw SQL with `wrangler` works well when:
 
-- You have one to five tables.
+- You have a small schema that you can review comfortably in SQL.
 - Your queries are basic create, read, update, and delete (CRUD) operations.
 - You are the only developer working on the schema.
 - You are comfortable writing SQL.

--- a/src/content/docs/d1/best-practices/rules-of-d1.mdx
+++ b/src/content/docs/d1/best-practices/rules-of-d1.mdx
@@ -88,7 +88,7 @@ Beyond preventing SQL injection, parameterized queries make your query metrics u
 
 ### Retry write queries from your application
 
-D1 automatically retries read-only queries up to two times on a retryable error. Only queries containing solely `SELECT`, `EXPLAIN`, or `WITH` are retried; any query that can write is never auto-retried. Your application must retry its own writes.
+D1 automatically retries read-only queries up to two times on a retryable error. Only read-only queries — those containing solely `SELECT`, `EXPLAIN`, or read-only `WITH` statements — are retried; any query that can write is never auto-retried. Your application must retry its own writes.
 
 Retry only idempotent writes, and only on errors that are safe to retry. Use exponential backoff with jitter so concurrent clients do not retry in lockstep.
 
@@ -162,7 +162,7 @@ The same applies to bulk imports. Partition import data into files of tens of me
 
 Migrations are not required for every schema change. If you are a solo developer with one database, running `ALTER TABLE` directly with `wrangler d1 execute` is valid and permanent.
 
-Migrations become valuable when you work on a team or have multiple environments (local dev, staging, production) that need identical schemas. A migration is a `.sql` file checked into git that records a schema change. Wrangler tracks which migrations have been applied in a `d1_migrations` table so they are never double-applied.
+Migrations become valuable when you work on a team or have multiple environments (local dev, staging, production) that need identical schemas. A migration is a `.sql` file checked into git that records a schema change. `wrangler` tracks which migrations have been applied in a `d1_migrations` table so they are never double-applied.
 
 Typical team workflow:
 
@@ -176,24 +176,24 @@ Migration files live in git, not in the database. The `d1_migrations` table is a
 
 ### Choose the right migration tooling
 
-You can write migration SQL by hand or use an ORM to generate it. Each approach has trade-offs.
+You can write migration SQL by hand or use an object-relational mapping (ORM) tool to generate it. Each approach has trade-offs.
 
-**Raw SQL with Wrangler** works well when:
+**Raw SQL** with `wrangler` works well when:
 
-- You have 1-5 tables
-- Your queries are straightforward CRUD
+- You have one to five tables
+- Your queries are basic create, read, update, and delete (CRUD) operations
 - You are the only developer
 - You are comfortable writing SQL
 
 **An ORM like Drizzle or Prisma** starts paying off when:
 
 - You have 10+ tables with foreign key relationships between them
-- You build complex queries with joins across 3+ tables, where type safety prevents you from accidentally joining on the wrong column or misspelling a field name
+- You build complex queries with joins across three or more tables, where type safety prevents you from accidentally joining on the wrong column or misspelling a field name
 - Multiple developers touch the schema, and the TypeScript definition becomes the single source of truth with compile errors catching mismatches immediately
 - You want autocompletion in your editor when writing queries
 - You are iterating rapidly on schema design and want to see what SQL each change produces without writing it yourself
 
-If you use an ORM, be aware that ORM migration generators cannot apply migrations to D1 directly. You generate the SQL with your ORM, then apply it with Wrangler. Review all generated SQL before applying — ORMs may generate destructive statements for tables they do not manage. Refer to the [Drizzle integration notes](/d1/reference/community-projects/#drizzle-orm) for specific gotchas.
+If you use an ORM, be aware that ORM migration generators cannot apply migrations to D1 directly. You generate the SQL with your ORM, then apply it with `wrangler`. Review all generated SQL before applying — ORMs may generate destructive statements for tables they do not manage. Refer to the [Drizzle integration notes](/d1/reference/community-projects/#drizzle-orm) for specific gotchas.
 
 ### Defer foreign keys during migrations, do not disable them
 
@@ -281,7 +281,7 @@ Start a session with `first-primary` when the first read must see the latest dat
 
 A single D1 database has fixed resources. The size and shape of your queries, not a configurable instance size, determine how much it can do. The limits to design around first:
 
-| Limit                               | Workers Paid | Workers Free |
+| Limit                               | Workers paid | Workers free |
 | ----------------------------------- | ------------ | ------------ |
 | Maximum database size               | 10 GB        | 500 MB       |
 | Queries per Worker invocation       | 1,000        | 50           |

--- a/src/content/docs/d1/best-practices/rules-of-d1.mdx
+++ b/src/content/docs/d1/best-practices/rules-of-d1.mdx
@@ -12,28 +12,91 @@ import { TypeScriptExample } from "~/components";
 
 [D1](/d1/) is Cloudflare's serverless SQL database. It is built on [SQLite](https://www.sqlite.org/), integrates directly with Workers, and gives applications a relational database without connection strings, connection pools, or database servers to manage. This is a guidebook on how to build more resilient, scalable, and correct D1 applications.
 
+## Overview
+
+D1 is the relational database in Cloudflare's developer platform. Workers are stateless compute, [Workers KV](/kv/) is a globally distributed key-value store, [Durable Objects](/durable-objects/) provide in-memory single-point coordination, and [R2](/r2/) stores unstructured objects. D1 gives Workers applications standard relational SQL, ACID transactions, structured querying, migrations, read replication, and automatic Time Travel backups without managing a database server.
+
 ## When to use D1
 
-### Use D1 for relational application data, not arbitrary global state
-
-D1 is a SQL database. Use it when your application needs tables, indexes, joins, constraints, transactions, and familiar SQLite syntax from a Worker.
+Use D1 for structured, relational data and complex SQL querying. Do not use D1 as a high-throughput key-value cache, blob store, or real-time coordination primitive.
 
 Use D1 when you need:
 
-- **Relational data** — Users, orders, products, comments, permissions, settings, or other records that benefit from SQL queries and constraints.
-- **Worker-native access** — A database binding available as `env.DB`, without exposing a public database endpoint or managing connections.
-- **Global reads with SQL** — Read-heavy applications where users are distributed globally and read replicas can reduce read latency.
-- **Per-tenant or per-entity databases** — Many smaller databases, such as one database per user, organization, project, or tenant.
-- **Moderate writes with correctness** — Writes that benefit from transactions, constraints, idempotency keys, and application-level retry.
+- **Relational data modeling** — Data that relies on tables, schemas, foreign keys, and `JOIN` operations, such as user profiles, ecommerce product catalogs, content management systems, and order records.
+- **Complex SQL queries** — Searching, filtering, sorting, paginating, and aggregating across multiple tables or rows.
+- **Structured transactions** — Atomic operations that require ACID guarantees across multiple rows or tables, such as order processing, balance adjustments, and multi-step signups.
+- **Centralized application state** — A single source of truth that is accessible globally from Worker instances and can use read replication for lower-latency reads.
+- **Zero-config edge SQL** — A fully managed relational database with no connection pooling, built-in migration tooling, and automatic Time Travel backups.
 
-Use another storage product, or partition your data across multiple D1 databases, when you need:
+Use alternative storage when you need:
 
-- **Massive write ingestion** — Event streams, logs, metrics, or analytics workloads that continuously append high-volume data.
-- **Unbounded database growth** — A single database larger than the D1 database size limit.
-- **Long table scans on hot paths** — Warehouse-style aggregations that scan large tables for every request.
-- **Strict global serialization across every reader** — Applications where every globally distributed read must immediately observe every write in one total order.
+- **Workers KV for high-volume key-value reads** — Simple key-to-value lookups optimized for low-latency reads and flexible write propagation, such as session tokens, feature flags, and cached API responses.
+- **Durable Objects for real-time coordination** — In-memory state, long-lived WebSockets, or single-point serialization without SQL overhead, such as chat rooms, multiplayer lobbies, and live document editing.
+- **R2 for unstructured blob storage** — Large files, media assets, backups, and logs, such as images, PDFs, and video files.
+- **Hyperdrive for external databases** — Existing self-hosted or cloud-hosted PostgreSQL and MySQL databases that need connection pooling and query caching from Workers.
 
 D1 can serve high-traffic applications when the data model and access pattern fit. For example, a globally cached blog may rarely query D1 on the request path, so database placement matters less. If requests frequently query D1, choose a location hint close to the primary workload and use read replication for global reads.
+
+## Limits
+
+A single D1 database has fixed resources. You do not choose instance sizes, CPU, or memory. The way you scale one database is by keeping queries short, indexed, bounded, and observable.
+
+The first limits to design around are:
+
+| Limit                              | Workers Paid | Workers Free |
+| ---------------------------------- | ------------ | ------------ |
+| Databases per account              | 50,000       | 10           |
+| Maximum database size              | 10 GB        | 500 MB       |
+| Queries per Worker invocation      | 1,000        | 50           |
+| Maximum SQL query duration         | 30 seconds   | 30 seconds   |
+| SQL statements per query           | 100          | 100          |
+| Maximum bound parameters per query | 100          | 100          |
+
+A common failure mode for large D1 databases is an aggregation query that tries to scan an entire multi-gigabyte table into memory. Keep hot-path aggregations precomputed or bounded by indexed predicates. For the complete list, refer to [Limits](/d1/platform/limits/).
+
+## Scale out across many databases
+
+D1 is designed for horizontal scale-out across many smaller databases, not vertical scale-up of one large database. When a single database approaches its size or throughput limits, shard your data across multiple databases instead of growing one.
+
+A natural sharding boundary is one database per tenant: each user, organization, or project gets its own isolated database. This gives complete data isolation, per-tenant schema evolution, and a migration blast radius limited to a single tenant. You can create databases programmatically with the [REST API](/api/resources/d1/subresources/database/methods/create/) and set a location hint per tenant.
+
+Workers Paid accounts support 50,000 databases. This limit can be increased by request on Workers Paid and Enterprise plans, with support for millions to tens of millions of databases per account.
+
+Attribute usage per database with the `rows_read` and `rows_written` fields that every query returns in its `meta` object. Apply per-query and per-tenant limits so one tenant cannot consume all of your account-level limits or inflate your bill.
+
+<TypeScriptExample filename="index.ts">
+
+```ts
+export default {
+	async fetch(request: Request, env: Env): Promise<Response> {
+		const userId = new URL(request.url).searchParams.get("userId") ?? "";
+
+		// Bad: every user shares one hot database.
+		const overloaded = await env.DB.prepare(
+			"SELECT * FROM orders WHERE user_id = ? LIMIT 50",
+		)
+			.bind(userId)
+			.all();
+
+		// Good: route the request to the user's own D1 database.
+		const userDb = await getUserDatabase(env, userId);
+		const { results, meta } = await userDb
+			.prepare("SELECT * FROM orders ORDER BY created_at DESC LIMIT 50")
+			.all();
+
+		return Response.json({
+			overloaded,
+			results,
+			rowsRead: meta.rows_read,
+			rowsWritten: meta.rows_written,
+		});
+	},
+} satisfies ExportedHandler<Env>;
+```
+
+</TypeScriptExample>
+
+For SaaS platforms that dynamically bind databases per tenant, refer to [Workers for Platforms](/cloudflare-for-platforms/workers-for-platforms/).
 
 ## Example schema
 
@@ -107,16 +170,12 @@ export default {
 		const email = new URL(request.url).searchParams.get("email") ?? "";
 
 		// Bad: this becomes a table scan if users.email is not indexed.
-		const slowUser = await env.DB.prepare(
-			"SELECT * FROM users WHERE email = ?",
-		)
+		const slowUser = await env.DB.prepare("SELECT * FROM users WHERE email = ?")
 			.bind(email)
 			.first();
 
 		// Good: create idx_users_email before this query is on the hot path.
-		const user = await env.DB.prepare(
-			"SELECT * FROM users WHERE email = ?",
-		)
+		const user = await env.DB.prepare("SELECT * FROM users WHERE email = ?")
 			.bind(email)
 			.first();
 
@@ -195,9 +254,7 @@ export default {
 		).first();
 
 		// Good: the SQL string stays stable and the value is bound.
-		const good = await env.DB.prepare(
-			"SELECT * FROM users WHERE email = ?",
-		)
+		const good = await env.DB.prepare("SELECT * FROM users WHERE email = ?")
 			.bind(email)
 			.first();
 
@@ -230,7 +287,8 @@ export default {
 		const unsafeSql = `SELECT * FROM orders ORDER BY ${sort}`;
 
 		// Good: the user selects one known SQL fragment.
-		const orderBy = ORDER_SORTS[sort as keyof typeof ORDER_SORTS] ?? ORDER_SORTS.newest;
+		const orderBy =
+			ORDER_SORTS[sort as keyof typeof ORDER_SORTS] ?? ORDER_SORTS.newest;
 		const safeSql = `SELECT * FROM orders ORDER BY ${orderBy} LIMIT ?`;
 
 		const { results } = await env.DB.prepare(safeSql).bind(50).all();
@@ -489,7 +547,10 @@ Use this for read-after-write flows, such as creating an order and then immediat
 <TypeScriptExample filename="index.ts">
 
 ```ts
-async function badCreateThenRead(env: Env, input: OrderInput): Promise<Order | null> {
+async function badCreateThenRead(
+	env: Env,
+	input: OrderInput,
+): Promise<Order | null> {
 	// Bad: after enabling replicas, an unconstrained read can reach a stale replica.
 	await env.DB.prepare(
 		"INSERT INTO orders (id, user_id, idempotency_key, status) VALUES (?, ?, ?, ?)",
@@ -502,7 +563,10 @@ async function badCreateThenRead(env: Env, input: OrderInput): Promise<Order | n
 		.first<Order>();
 }
 
-async function goodCreateThenRead(env: Env, input: OrderInput): Promise<Response> {
+async function goodCreateThenRead(
+	env: Env,
+	input: OrderInput,
+): Promise<Response> {
 	// Good: use a session bookmark for sequential consistency.
 	const session = env.DB.withSession("first-primary");
 	await session
@@ -524,87 +588,6 @@ async function goodCreateThenRead(env: Env, input: OrderInput): Promise<Response
 </TypeScriptExample>
 
 `withSession()` returns an object with the same query interface as the top-level database binding, so downstream query code stays familiar. If you may enable read replication later, designing new code around sessions can make that change a configuration update instead of an application rewrite. For more detail, refer to [Global read replication](/d1/best-practices/read-replication/).
-
-## Scaling
-
-### Design for the fixed resources of one database
-
-A single D1 database has fixed resources. You do not choose instance sizes, CPU, or memory. The way you scale one database is by keeping queries short, indexed, bounded, and observable.
-
-The first limits to design around are:
-
-| Limit                              | Workers Paid | Workers Free |
-| ---------------------------------- | ------------ | ------------ |
-| Maximum database size              | 10 GB        | 500 MB       |
-| Queries per Worker invocation      | 1,000        | 50           |
-| Maximum SQL query duration         | 30 seconds   | 30 seconds   |
-| SQL statements per query           | 100          | 100          |
-| Maximum bound parameters per query | 100          | 100          |
-
-A common failure mode for large D1 databases is an aggregation query that tries to scan an entire multi-gigabyte table into memory. Keep hot-path aggregations precomputed or bounded by indexed predicates.
-
-<TypeScriptExample filename="index.ts">
-
-```ts
-export default {
-	async fetch(request: Request, env: Env): Promise<Response> {
-		const userId = new URL(request.url).searchParams.get("userId") ?? "";
-
-		// Bad: scans the whole table as order volume grows.
-		const globalTotal = await env.DB.prepare(
-			"SELECT COUNT(*) AS count FROM orders",
-		).first();
-
-		// Good: bounded by an indexed predicate.
-		const userTotal = await env.DB.prepare(
-			"SELECT COUNT(*) AS count FROM orders WHERE user_id = ?",
-		)
-			.bind(userId)
-			.first();
-
-		return Response.json({ globalTotal, userTotal });
-	},
-} satisfies ExportedHandler<Env>;
-```
-
-</TypeScriptExample>
-
-For the complete list, refer to [Limits](/d1/platform/limits/).
-
-### Scale out with more databases, not one bigger database
-
-D1 is designed for horizontal scale-out across multiple smaller databases, such as per-user, per-tenant, or per-entity databases. When one database approaches its size or throughput limits, split the workload instead of treating one database as a vertically scalable server.
-
-A natural boundary is one database per user, tenant, organization, project, or high-cardinality entity. This gives each entity isolated storage, isolated migration risk, and its own throughput envelope.
-
-<TypeScriptExample filename="index.ts">
-
-```ts
-export default {
-	async fetch(request: Request, env: Env): Promise<Response> {
-		const userId = new URL(request.url).searchParams.get("userId") ?? "";
-
-		// Bad: every user shares one hot database.
-		const overloaded = await env.DB.prepare(
-			"SELECT * FROM orders WHERE user_id = ? LIMIT 50",
-		)
-			.bind(userId)
-			.all();
-
-		// Good: route the request to the user's own D1 database.
-		const userDb = await getUserDatabase(env, userId);
-		const { results } = await userDb
-			.prepare("SELECT * FROM orders ORDER BY created_at DESC LIMIT 50")
-			.all();
-
-		return Response.json({ overloaded, results });
-	},
-} satisfies ExportedHandler<Env>;
-```
-
-</TypeScriptExample>
-
-Use the `rows_read` and `rows_written` metadata returned by D1 queries to understand which databases and queries consume the most work. For SaaS platforms that dynamically bind databases per tenant, refer to [Workers for Platforms](/cloudflare-for-platforms/workers-for-platforms/).
 
 ## Related resources
 

--- a/src/content/docs/d1/best-practices/rules-of-d1.mdx
+++ b/src/content/docs/d1/best-practices/rules-of-d1.mdx
@@ -14,7 +14,7 @@ import { TypeScriptExample } from "~/components";
 
 ## Overview
 
-D1 is the relational database in Cloudflare's developer platform. Workers are stateless compute, [Workers KV](/kv/) is a globally distributed key-value store, [Durable Objects](/durable-objects/) provide in-memory single-point coordination, and [R2](/r2/) stores unstructured objects. D1 gives Workers applications standard relational SQL, ACID transactions, structured querying, migrations, read replication, and automatic Time Travel backups without managing a database server.
+D1 is the relational database in Cloudflare's developer platform. It gives Workers applications standard relational SQL, ACID transactions, structured querying, migrations, read replication, and automatic Time Travel backups without managing a database server.
 
 ## When to use D1
 
@@ -54,6 +54,8 @@ The first limits to design around are:
 
 A common failure mode for large D1 databases is an aggregation query that tries to scan an entire multi-gigabyte table into memory. Keep hot-path aggregations precomputed or bounded by indexed predicates. For the complete list, refer to [Limits](/d1/platform/limits/).
 
+Workers Paid accounts support 50,000 D1 databases by default. To request an adjustment to a limit, complete the [Limit Increase Request Form](https://forms.gle/eX6pXvit1wBv77Yw5). If the limit can be increased, Cloudflare will contact you with next steps.
+
 ## Scale out across many databases
 
 D1 is designed for horizontal scale-out across many smaller databases, not vertical scale-up of one large database. When a single database approaches its size or throughput limits, shard your data across multiple databases instead of growing one.
@@ -61,8 +63,6 @@ D1 is designed for horizontal scale-out across many smaller databases, not verti
 A natural sharding boundary is one database per tenant: each user, organization, or project gets its own isolated database. This gives complete data isolation, per-tenant schema evolution, and a migration blast radius limited to a single tenant. You can create databases programmatically with the [REST API](/api/resources/d1/subresources/database/methods/create/) and set a location hint per tenant.
 
 Sharding has trade-offs. You cannot run SQL `JOIN` operations across D1 databases, and ACID transactions do not span database boundaries. Keep data that must be joined or updated atomically in the same database, or design explicit application-level workflows for cross-database operations.
-
-Workers Paid accounts support 50,000 databases. This limit can be increased by request on Workers Paid and Enterprise plans, with support for millions to tens of millions of databases per account.
 
 Attribute usage per database with the `rows_read` and `rows_written` fields that every query returns in its `meta` object. Apply per-query and per-tenant limits so one tenant cannot consume all of your account-level limits or inflate your bill.
 
@@ -98,7 +98,7 @@ export default {
 
 </TypeScriptExample>
 
-For SaaS platforms that dynamically bind databases per tenant, refer to [Workers for Platforms](/cloudflare-for-platforms/workers-for-platforms/).
+For platforms that deploy user Workers with per-customer D1 bindings, refer to [Workers for Platforms bindings](/cloudflare-for-platforms/workers-for-platforms/configuration/bindings/).
 
 ## Example schema
 
@@ -437,6 +437,12 @@ An ORM such as Drizzle or Prisma works well when:
 - You are iterating rapidly on schema design and want to see what SQL each change produces before applying it.
 
 If you use an ORM, be aware that ORM migration generators cannot apply migrations to D1 directly. Generate the SQL with your ORM, then apply it with `wrangler`. Review all generated SQL before applying it because ORMs may generate destructive statements for tables they do not manage, including Wrangler's `d1_migrations` table.
+
+### Apply migrations outside your Worker startup path
+
+Do not create tables, create indexes, or run schema migrations from Worker startup code or request handlers. Schema changes are usually more expensive than normal application queries, and D1 may need to scan existing data, update query planner statistics, or rewrite table data. Running that work during startup or on the first request can add latency, duplicate work across deployments, and fail under normal request limits.
+
+Treat D1 schema changes as deployment operations. Generate or write migration SQL, review it, apply it with `wrangler d1 migrations apply`, and then deploy Worker code that depends on the new schema. Create indexes in migration files, not in Worker code that runs on every isolate startup.
 
 ### Test migrations locally before remote
 

--- a/src/content/docs/d1/best-practices/rules-of-d1.mdx
+++ b/src/content/docs/d1/best-practices/rules-of-d1.mdx
@@ -60,6 +60,8 @@ D1 is designed for horizontal scale-out across many smaller databases, not verti
 
 A natural sharding boundary is one database per tenant: each user, organization, or project gets its own isolated database. This gives complete data isolation, per-tenant schema evolution, and a migration blast radius limited to a single tenant. You can create databases programmatically with the [REST API](/api/resources/d1/subresources/database/methods/create/) and set a location hint per tenant.
 
+Sharding has trade-offs. You cannot run SQL `JOIN` operations across D1 databases, and ACID transactions do not span database boundaries. Keep data that must be joined or updated atomically in the same database, or design explicit application-level workflows for cross-database operations.
+
 Workers Paid accounts support 50,000 databases. This limit can be increased by request on Workers Paid and Enterprise plans, with support for millions to tens of millions of databases per account.
 
 Attribute usage per database with the `rows_read` and `rows_written` fields that every query returns in its `meta` object. Apply per-query and per-tenant limits so one tenant cannot consume all of your account-level limits or inflate your bill.
@@ -265,7 +267,7 @@ export default {
 
 </TypeScriptExample>
 
-### Whitelist dynamic SQL identifiers
+### Allowlist dynamic SQL identifiers
 
 Bound parameters are for values, not SQL identifiers. You cannot bind a column name, table name, or sort direction. If a query must choose a dynamic identifier, map user input to a fixed allowlist and reject everything else.
 
@@ -307,7 +309,9 @@ Do this for every dynamic clause: `ORDER BY`, sort direction, optional filters, 
 
 D1 automatically retries read-only queries up to two more times when it encounters a retryable error. Write queries are not automatically retried. Your application must retry write operations that are safe to repeat.
 
-Make writes idempotent before you retry them. For order creation, require a client-generated idempotency key and enforce it with a `UNIQUE` constraint. If a transient error occurs after D1 commits the write but before the Worker receives the response, the retry returns the existing order instead of creating a duplicate.
+Automatic retries handle retryable network-level or service-level failures for read-only queries. They do not decide whether a write is safe to repeat, and they do not resolve application-level outcomes such as unique constraint collisions. Your application owns the logical retry behavior for writes.
+
+Make writes idempotent before you retry them. For order creation, require a client-generated idempotency key and enforce it with a `UNIQUE` constraint. If a transient error occurs after D1 commits the write but before the Worker receives the response, the retry returns the existing order instead of creating a duplicate. If a retry hits the unique constraint, treat that as a signal to fetch and return the existing record rather than issuing a second logical write.
 
 Use exponential backoff with full jitter so clients do not retry in lockstep. Start around `50 ms`, cap around `2 s`, and keep the maximum attempt count small. Retry only errors marked retryable in the [D1 error list](/d1/observability/debug-d1/#error-list).
 
@@ -413,26 +417,26 @@ The same rule applies to imports. Partition import data into files of tens of me
 
 ## Schema and migrations
 
-### Use raw SQL until an ORM pays for itself
+### Choose the right migration tooling
 
-Do not add an ORM by default. D1 speaks SQL directly, and hand-written SQL is often the simplest option for small applications.
+You can write migration SQL by hand or use an object-relational mapping (ORM) tool to generate it. Each approach has trade-offs.
 
-Raw SQL is usually enough when:
+Raw SQL with `wrangler` works well when:
 
 - You have one to five tables.
-- Your queries are straightforward create, read, update, and delete operations.
+- Your queries are basic create, read, update, and delete (CRUD) operations.
 - You are the only developer working on the schema.
 - You are comfortable writing SQL.
 
-An ORM such as Drizzle starts paying off when:
+An ORM such as Drizzle or Prisma works well when:
 
-- You have 10 or more tables with foreign key relationships.
-- You write joins across three or more tables and want type safety for columns and relationships.
-- Multiple developers change the schema and need TypeScript definitions as a shared source of truth.
-- You want editor autocomplete for table and column names.
-- You are iterating quickly on schema design and want generated SQL to review.
+- You have 10 or more tables with foreign key relationships between them.
+- You build complex queries with joins across three or more tables, where type safety helps prevent joining on the wrong column or misspelling a field name.
+- Multiple developers touch the schema, and the TypeScript definition becomes the single source of truth with compile errors catching mismatches immediately.
+- You want autocompletion in your editor when writing queries.
+- You are iterating rapidly on schema design and want to see what SQL each change produces before applying it.
 
-The cost is migration complexity. ORM migration generators produce SQL, but Wrangler applies migrations to D1 and tracks them in the `d1_migrations` table. Review generated migrations before applying them, especially statements that drop tables or alter migration metadata.
+If you use an ORM, be aware that ORM migration generators cannot apply migrations to D1 directly. Generate the SQL with your ORM, then apply it with `wrangler`. Review all generated SQL before applying it because ORMs may generate destructive statements for tables they do not manage, including Wrangler's `d1_migrations` table.
 
 ### Test migrations locally before remote
 

--- a/src/content/docs/d1/best-practices/rules-of-d1.mdx
+++ b/src/content/docs/d1/best-practices/rules-of-d1.mdx
@@ -14,28 +14,16 @@ import { TypeScriptExample } from "~/components";
 
 ## Overview
 
-D1 is the relational database in Cloudflare's developer platform. It gives Workers applications standard relational SQL, ACID transactions, structured querying, migrations, read replication, and automatic Time Travel backups without managing a database server.
+D1 is a relational database. It gives Workers applications standard relational SQL, ACID transactions, structured querying, migrations, read replication, and automatic Time Travel backups without managing a database server.
 
-## When to use D1
-
-Use D1 for structured, relational data and complex SQL querying. Do not use D1 as a high-throughput key-value cache, blob store, or real-time coordination primitive.
-
-Use D1 when you need:
-
-- **Relational data modeling** — Data that relies on tables, schemas, foreign keys, and `JOIN` operations, such as user profiles, ecommerce product catalogs, content management systems, and order records.
-- **Complex SQL queries** — Searching, filtering, sorting, paginating, and aggregating across multiple tables or rows.
-- **Structured transactions** — Atomic operations that require ACID guarantees across multiple rows or tables, such as order processing, balance adjustments, and multi-step signups.
-- **Centralized application state** — A single source of truth that is accessible globally from Worker instances and can use read replication for lower-latency reads.
-- **Zero-config edge SQL** — A fully managed relational database with no connection pooling, built-in migration tooling, and automatic Time Travel backups.
+Use D1 for structured relational data, complex SQL queries, and transactional workflows. D1 can serve high traffic applications when the data model and access pattern fit. For example, a globally cached blog may rarely query D1 on the request path, so database placement matters less. If requests frequently query D1, choose a [location hint](/d1/configuration/data-location/#provide-a-location-hint) close to the primary workload and use read replication for global reads.
 
 Use alternative storage when you need:
 
-- **Workers KV for high-volume key-value reads** — Simple key-to-value lookups optimized for low-latency reads and flexible write propagation, such as session tokens, feature flags, and cached API responses.
-- **Durable Objects for real-time coordination** — In-memory state, long-lived WebSockets, or single-point serialization without SQL overhead, such as chat rooms, multiplayer lobbies, and live document editing.
+- **Workers KV for high volume key-value reads** — Simple key to value lookups optimized for low latency reads and flexible write propagation, such as session tokens, feature flags, and cached API responses.
+- **Durable Objects for real time coordination** — In memory state, long lived WebSockets, or single point serialization without SQL overhead, such as chat rooms, multiplayer lobbies, and live document editing.
 - **R2 for unstructured blob storage** — Large files, media assets, backups, and logs, such as images, PDFs, and video files.
-- **Hyperdrive for external databases** — Existing self-hosted or cloud-hosted PostgreSQL and MySQL databases that need connection pooling and query caching from Workers.
-
-D1 can serve high-traffic applications when the data model and access pattern fit. For example, a globally cached blog may rarely query D1 on the request path, so database placement matters less. If requests frequently query D1, choose a location hint close to the primary workload and use read replication for global reads.
+- **Hyperdrive for external databases** — Existing self hosted or cloud hosted PostgreSQL and MySQL databases that need connection pooling and query caching from Workers.
 
 ## Limits
 
@@ -52,53 +40,21 @@ The first limits to design around are:
 | SQL statements per query           | 100          | 100          |
 | Maximum bound parameters per query | 100          | 100          |
 
-A common failure mode for large D1 databases is an aggregation query that tries to scan an entire multi-gigabyte table into memory. Keep hot-path aggregations precomputed or bounded by indexed predicates. For the complete list, refer to [Limits](/d1/platform/limits/).
+A common failure mode for large D1 databases is an aggregation query that tries to scan an entire large table into memory. Precompute hot path aggregations or [use indexes](/d1/best-practices/use-indexes/) to avoid table scans. For the complete list, refer to [Limits](/d1/platform/limits/).
 
 Workers Paid accounts support 50,000 D1 databases by default. To request an adjustment to a limit, complete the [Limit Increase Request Form](https://forms.gle/eX6pXvit1wBv77Yw5). If the limit can be increased, Cloudflare will contact you with next steps.
 
 ## Scale out across many databases
 
-D1 is designed for horizontal scale-out across many smaller databases, not vertical scale-up of one large database. When a single database approaches its size or throughput limits, shard your data across multiple databases instead of growing one.
+D1 is designed for horizontal scale out across many smaller databases, not vertical scale up of one large database. Do not shard by default: sharding adds routing, migration, and operational complexity that D1 does not hide for you.
 
-A natural sharding boundary is one database per tenant: each user, organization, or project gets its own isolated database. This gives complete data isolation, per-tenant schema evolution, and a migration blast radius limited to a single tenant. You can create databases programmatically with the [REST API](/api/resources/d1/subresources/database/methods/create/) and set a location hint per tenant.
+Only shard when you have a stable shard key and can choose a fixed number of shards up front. For example, you can bind a fixed set of databases such as `env.USERS_DB_0` through `env.USERS_DB_N_MINUS_1`, then route each request with `hash(userId) % N`. D1 does not provide automatic resharding tools. Changing the number of shards later requires an application level data migration and a careful cutover plan.
 
-Sharding has trade-offs. You cannot run SQL `JOIN` operations across D1 databases, and ACID transactions do not span database boundaries. Keep data that must be joined or updated atomically in the same database, or design explicit application-level workflows for cross-database operations.
+Sharding has tradeoffs. You cannot run SQL `JOIN` operations across D1 databases, and ACID transactions do not span database boundaries. Keep data that must be joined or updated atomically in the same database, or design explicit application level workflows for cross database operations.
 
-Attribute usage per database with the `rows_read` and `rows_written` fields that every query returns in its `meta` object. Apply per-query and per-tenant limits so one tenant cannot consume all of your account-level limits or inflate your bill.
+Track costs for each database with the `rows_read` and `rows_written` fields that every query returns in its `meta` object. Apply per query and per tenant limits so one tenant cannot consume all of your account level limits or inflate your bill.
 
-<TypeScriptExample filename="index.ts">
-
-```ts
-export default {
-	async fetch(request: Request, env: Env): Promise<Response> {
-		const userId = new URL(request.url).searchParams.get("userId") ?? "";
-
-		// Bad: every user shares one hot database.
-		const overloaded = await env.DB.prepare(
-			"SELECT * FROM orders WHERE user_id = ? LIMIT 50",
-		)
-			.bind(userId)
-			.all();
-
-		// Good: route the request to the user's own D1 database.
-		const userDb = await getUserDatabase(env, userId);
-		const { results, meta } = await userDb
-			.prepare("SELECT * FROM orders ORDER BY created_at DESC LIMIT 50")
-			.all();
-
-		return Response.json({
-			overloaded,
-			results,
-			rowsRead: meta.rows_read,
-			rowsWritten: meta.rows_written,
-		});
-	},
-} satisfies ExportedHandler<Env>;
-```
-
-</TypeScriptExample>
-
-For platforms that deploy user Workers with per-customer D1 bindings, refer to [Workers for Platforms bindings](/cloudflare-for-platforms/workers-for-platforms/configuration/bindings/).
+If you are building a platform where user Workers need isolated D1 bindings, refer to [Workers for Platforms bindings](/cloudflare-for-platforms/workers-for-platforms/configuration/bindings/).
 
 ## Example schema
 
@@ -141,28 +97,34 @@ CREATE TABLE order_events (
 
 D1 processes queries one at a time for each individual database. Your maximum throughput is directly related to query duration: if the average query takes `1 ms`, the database can process about `1,000` queries per second; if it takes `100 ms`, it can process about `10` queries per second.
 
-A table scan makes every matching request slower and reads rows you did not need. Create indexes for columns used in predicates, joins, and sort keys. For the schema above, `users.email`, `orders.user_id`, `order_items.order_id`, and `order_events.order_id` are hot-path columns.
+A table scan makes every matching request slower and reads rows you did not need. Create indexes for columns used in predicates, joins, and sort keys. For the schema above, `users.email`, `orders.user_id`, `order_items.order_id`, and `order_events.order_id` are good candidates because the examples filter or join on those columns.
 
-```sql
-CREATE INDEX IF NOT EXISTS idx_users_email ON users(email);
-CREATE INDEX IF NOT EXISTS idx_orders_user_id ON orders(user_id);
-CREATE INDEX IF NOT EXISTS idx_order_items_order_id ON order_items(order_id);
-CREATE INDEX IF NOT EXISTS idx_order_events_order_id ON order_events(order_id);
-```
-
-After creating or dropping an index, run `PRAGMA optimize` so SQLite updates the statistics used by the query planner.
-
-```sql
-PRAGMA optimize;
-```
-
-Use `EXPLAIN QUERY PLAN` to verify that D1 uses the expected index. A plan that contains `USING INDEX` is what you want. A plan that contains `SCAN users` on a large table is a warning sign.
+Use `EXPLAIN QUERY PLAN` to verify that D1 uses the expected index. A plan that contains `SCAN users` on a large table is a warning sign.
 
 ```sql
 EXPLAIN QUERY PLAN SELECT * FROM users WHERE email = ?;
+
+-- Bad: the query planner must scan the table.
+-- SCAN users
 ```
 
-Use [D1 Insights](/d1/observability/metrics-analytics/#query-insights), the GraphQL API, or the D1 dashboard to find slow production queries and then validate their indexes with `EXPLAIN QUERY PLAN`.
+Create the index, then run `PRAGMA optimize` so SQLite updates the statistics used by the query planner.
+
+```sql
+CREATE INDEX IF NOT EXISTS idx_users_email ON users(email);
+PRAGMA optimize;
+```
+
+Run `EXPLAIN QUERY PLAN` again. A plan that contains `USING INDEX` is what you want.
+
+```sql
+EXPLAIN QUERY PLAN SELECT * FROM users WHERE email = ?;
+
+-- Good: the query planner can use the index.
+-- SEARCH users USING INDEX idx_users_email (email=?)
+```
+
+Use [D1 query insights](/d1/observability/metrics-analytics/#query-insights), the GraphQL API, or the D1 dashboard to find slow production queries and then validate their indexes with `EXPLAIN QUERY PLAN`.
 
 <TypeScriptExample filename="index.ts">
 
@@ -171,24 +133,19 @@ export default {
 	async fetch(request: Request, env: Env): Promise<Response> {
 		const email = new URL(request.url).searchParams.get("email") ?? "";
 
-		// Bad: this becomes a table scan if users.email is not indexed.
-		const slowUser = await env.DB.prepare("SELECT * FROM users WHERE email = ?")
-			.bind(email)
-			.first();
-
-		// Good: create idx_users_email before this query is on the hot path.
+		// Good: users.email is indexed before this query is on the hot path.
 		const user = await env.DB.prepare("SELECT * FROM users WHERE email = ?")
 			.bind(email)
 			.first();
 
-		return Response.json({ user: user ?? slowUser });
+		return Response.json({ user });
 	},
 } satisfies ExportedHandler<Env>;
 ```
 
 </TypeScriptExample>
 
-Every indexed column adds at least one extra row write on `INSERT`, `UPDATE`, or `DELETE` because SQLite must update the index too. That tradeoff is usually worth it for read-heavy workloads because indexed point lookups avoid long scans. Add important indexes early; adding indexes after a database grows to multiple gigabytes is harder and slower.
+Every indexed column adds at least one extra row write on `INSERT`, `UPDATE`, or `DELETE` because SQLite must update the index too. That tradeoff is usually worth it for read heavy workloads because indexed point lookups avoid long scans. Add important indexes early: creating an index on a large table requires D1 to scan the existing table and can stall work on that single threaded database while the index is built.
 
 For more index patterns, refer to [Use indexes](/d1/best-practices/use-indexes/).
 
@@ -196,7 +153,7 @@ For more index patterns, refer to [Use indexes](/d1/best-practices/use-indexes/)
 
 Do not call `run()` in a loop for related statements. Each separate call pays a round trip to D1. [`batch()`](/d1/worker-api/d1-database/#batch) sends related prepared statements in one round trip and runs them as a single transaction.
 
-Use `batch()` for multi-statement writes that should succeed or fail together, such as creating an order and its items.
+You should also use `batch()` for multiple statement writes that should succeed or fail together, such as creating an order and its items.
 
 <TypeScriptExample filename="index.ts">
 
@@ -235,13 +192,13 @@ async function goodCreateOrder(env: Env, order: OrderInput): Promise<void> {
 
 </TypeScriptExample>
 
-The per-query limits still apply to each statement in the batch. A batch reduces round trips; it does not make an unbounded write safe.
+The per query limits still apply individually to each statement in the batch. A batch reduces round trips; it does not make an unbounded write safe.
 
 ### Bind every runtime value
 
 Never interpolate user input or runtime values directly into SQL strings. Use [`bind()`](/d1/worker-api/prepared-statements/) for values.
 
-This protects your application from SQL injection and makes query observability useful. D1 strips bound parameter values from query metrics, so all executions of the same query template aggregate together in [D1 Insights](/d1/observability/metrics-analytics/#query-insights). If you bake values into the SQL text, the metrics can fragment across many unique query strings.
+This protects your application from SQL injection and makes query observability useful. D1 strips bound parameter values from query metrics, so all executions of the same query template aggregate together in [D1 query insights](/d1/observability/metrics-analytics/#query-insights). If you bake values into the SQL text, the metrics can fragment across many unique query strings.
 
 <TypeScriptExample filename="index.ts">
 
@@ -305,15 +262,13 @@ Do this for every dynamic clause: `ORDER BY`, sort direction, optional filters, 
 
 ## Writes and reliability
 
-### Retry idempotent writes from your application
+### Implement application level retry with exponential backoff and jitter for write queries
 
-D1 automatically retries read-only queries up to two more times when it encounters a retryable error. Write queries are not automatically retried. Your application must retry write operations that are safe to repeat.
+D1 automatically retries `SELECT`, `EXPLAIN`, and `WITH` queries up to two times on transient errors. Write queries are never automatically retried. Your application must implement its own retry for idempotent write operations.
 
-Automatic retries handle retryable network-level or service-level failures for read-only queries. They do not decide whether a write is safe to repeat, and they do not resolve application-level outcomes such as unique constraint collisions. Your application owns the logical retry behavior for writes.
+Make writes idempotent before you retry them. For order creation, require a client generated idempotency key and enforce it with a `UNIQUE` constraint. If a transient error occurs after D1 commits the write but before the Worker receives the response, the retry returns the existing order instead of creating a duplicate. If a retry hits the unique constraint, treat that as a signal to fetch and return the existing record rather than issuing a second logical write.
 
-Make writes idempotent before you retry them. For order creation, require a client-generated idempotency key and enforce it with a `UNIQUE` constraint. If a transient error occurs after D1 commits the write but before the Worker receives the response, the retry returns the existing order instead of creating a duplicate. If a retry hits the unique constraint, treat that as a signal to fetch and return the existing record rather than issuing a second logical write.
-
-Use exponential backoff with full jitter so clients do not retry in lockstep. Start around `50 ms`, cap around `2 s`, and keep the maximum attempt count small. Retry only errors marked retryable in the [D1 error list](/d1/observability/debug-d1/#error-list).
+Mirror the internal retry pattern: start around `50 ms`, cap around `2 s`, use full jitter, and keep the maximum attempt count to three attempts. Retry only `D1_ERROR` codes marked as retryable in the [D1 error list](/d1/observability/debug-d1/#error-list).
 
 <TypeScriptExample filename="index.ts">
 
@@ -328,7 +283,7 @@ function shouldRetryD1(error: unknown): boolean {
 	);
 }
 
-async function writeWithRetry<T>(operation: () => Promise<T>): Promise<T> {
+async function retryWriteOperation<T>(operation: () => Promise<T>): Promise<T> {
 	for (let attempt = 1; ; attempt++) {
 		try {
 			return await operation();
@@ -344,7 +299,7 @@ async function writeWithRetry<T>(operation: () => Promise<T>): Promise<T> {
 }
 
 async function createOrder(env: Env, input: OrderInput): Promise<Order> {
-	return await writeWithRetry(async () => {
+	return await retryWriteOperation(async () => {
 		// Bad: retrying an INSERT without a unique idempotency key can duplicate data.
 		// Good: idempotency_key is UNIQUE, so retries return the same logical order.
 		await env.DB.prepare(
@@ -374,9 +329,9 @@ For more detail, refer to [Retry queries](/d1/best-practices/retry-queries/).
 
 ### Chunk bulk mutations
 
-Never modify hundreds of thousands of rows in one query. A single `UPDATE` or `DELETE` over a large table can exceed CPU or memory limits, reset the underlying database object, and lose the in-flight operation.
+Never modify hundreds of thousands of rows in one query. A single `UPDATE` or `DELETE` over a large table can exceed CPU or memory limits, reset the underlying database object, and lose the in flight operations.
 
-Process bulk changes in bounded chunks of about `10,000` rows. Use a stable key, commit each chunk, and continue until no rows remain.
+Process bulk changes in bounded chunks of about `10,000` rows. Use a stable key, commit each chunk, and continue until no rows remain. Create an index for the column that selects each chunk, such as `order_events.created_at` in the example below, so each chunk does not scan the full table.
 
 <TypeScriptExample filename="cleanup.ts">
 
@@ -419,7 +374,7 @@ The same rule applies to imports. Partition import data into files of tens of me
 
 ### Choose the right migration tooling
 
-You can write migration SQL by hand or use an object-relational mapping (ORM) tool to generate it. Each approach has trade-offs.
+You can write migration SQL by hand or use an object relational mapping (ORM) tool to generate it. Each approach has tradeoffs.
 
 Raw SQL with `wrangler` works well when:
 
@@ -430,13 +385,13 @@ Raw SQL with `wrangler` works well when:
 
 An ORM such as Drizzle or Prisma works well when:
 
-- You have 10 or more tables with foreign key relationships between them.
+- Your schema has enough foreign key relationships that type checking and generated SQL make changes easier to review.
 - You build complex queries with joins across three or more tables, where type safety helps prevent joining on the wrong column or misspelling a field name.
 - Multiple developers touch the schema, and the TypeScript definition becomes the single source of truth with compile errors catching mismatches immediately.
 - You want autocompletion in your editor when writing queries.
 - You are iterating rapidly on schema design and want to see what SQL each change produces before applying it.
 
-If you use an ORM, be aware that ORM migration generators cannot apply migrations to D1 directly. Generate the SQL with your ORM, then apply it with `wrangler`. Review all generated SQL before applying it because ORMs may generate destructive statements for tables they do not manage, including Wrangler's `d1_migrations` table.
+If you use an ORM, be aware that ORM migration generators cannot apply migrations to D1 directly. Generate the SQL with your ORM, then apply it with `wrangler`. Review all generated SQL before applying it, especially as described in [Review generated migrations before applying them](#review-generated-migrations-before-applying-them), because ORMs may generate destructive statements for tables they do not manage, including Wrangler's `d1_migrations` table.
 
 ### Apply migrations outside your Worker startup path
 
@@ -446,14 +401,14 @@ Treat D1 schema changes as deployment operations. Generate or write migration SQ
 
 ### Test migrations locally before remote
 
-Do not discover migration mistakes in production. Apply every migration locally before you apply it remotely.
+Do not discover migration mistakes in production. Apply every migration locally before you apply it remotely. If a migration fails, D1 rolls back the changes from that migration.
 
 ```sh
 npx wrangler d1 migrations apply DB --local
 npx wrangler d1 migrations apply DB --remote
 ```
 
-Use a baseline migration when you adopt migrations for an existing database. The baseline should describe the existing schema in a way that is safe to run once against an already-created database.
+Use a baseline migration when you adopt migrations for an existing database. The baseline should describe the existing schema in a way that is safe to run once against an already created database.
 
 ```sql
 -- 0001_baseline.sql
@@ -477,7 +432,7 @@ This pattern lets Wrangler record the migration without trying to recreate table
 
 ### Review generated migrations before applying them
 
-Never apply ORM-generated SQL blindly. A migration generator only knows the schema model it was given. If Wrangler's `d1_migrations` table, manually created indexes, or existing production tables are missing from that model, generated SQL can include destructive statements you did not intend.
+Never apply ORM generated SQL blindly. A migration generator only knows the schema model it was given. If Wrangler's `d1_migrations` table, manually created indexes, or existing production tables are missing from that model, generated SQL can include destructive statements you did not intend.
 
 Bad migration review looks like this:
 
@@ -530,7 +485,7 @@ If the migration goes wrong, restore to the captured bookmark.
 npx wrangler d1 time-travel restore DB --bookmark=<BOOKMARK>
 ```
 
-Restoring is a destructive, in-place overwrite that cancels in-flight queries and transactions. Bookmarks older than the retention window cannot be used as restore points, so capture the bookmark before the migration rather than assuming you can recover later. For more detail, refer to [Time Travel and backups](/d1/reference/time-travel/).
+Restoring is a destructive, in place overwrite that cancels in flight queries and transactions. Bookmarks older than the retention window cannot be used as restore points, so capture the bookmark before the migration rather than assuming you can recover later. For more detail, refer to [Time Travel and backups](/d1/reference/time-travel/).
 
 ## Location and replication
 
@@ -538,21 +493,21 @@ Restoring is a destructive, in-place overwrite that cancels in-flight queries an
 
 Set a location hint when you create the database if the workload that queries D1 is not near the place where you run the create command. Without a location hint, D1 creates the primary database instance close to the request that created the database, which may be your laptop, CI system, or control plane rather than your users.
 
-Choose the location closest to the primary write or query region. Cross-region requests add round-trip latency to every query that goes to the primary.
+Choose the location closest to the primary write or query region. Cross region requests add round trip latency to every query that goes to the primary.
 
 ```sh
 npx wrangler d1 create commerce-db --location=weur
 ```
 
-A location hint is a preference, not a guarantee. D1 runs the database in the nearest available location to that preference. Read replicas can improve global read latency, but write latency is still dominated by the primary database location because writes go to the primary. For the full list of hints, refer to [Data location](/d1/configuration/data-location/#available-location-hints).
+A location hint is a preference, not a guarantee. D1 runs the database in the nearest available location to that preference. If your application has data residency requirements, use a [jurisdiction](/d1/configuration/data-location/#jurisdictions) instead. Read replicas can improve global read latency, but write latency is still dominated by the primary database location because writes go to the primary. For the full list of hints, refer to [Data location](/d1/configuration/data-location/#available-location-hints).
 
 ### Use sessions when read replication is enabled
 
-Read replicas can lower read latency and increase read throughput for globally distributed users. To use read replicas, you must query through the [Sessions API](/d1/worker-api/d1-database/#withsession). Without sessions, D1 continues to execute all queries on the primary database.
+Read replicas can lower read latency and increase read throughput for globally distributed users. To use read replicas, you must query through the [Sessions API](/d1/worker-api/d1-database/#withsession). Without sessions, D1 continues to execute all queries on the primary database, so you do not get the latency benefit of replicas.
 
-Sessions also protect correctness. D1 replicates from the primary to read replicas asynchronously, so a replica may lag behind the latest write. A session carries a bookmark so later reads can require a database version at least as up-to-date as the previous query.
+Sessions also protect correctness. D1 replicates from the primary to read replicas asynchronously, so a replica may lag behind the latest write. A session carries a bookmark so later reads can require a database version at least as up to date as the previous query.
 
-Use this for read-after-write flows, such as creating an order and then immediately fetching it.
+Use this for read after write flows, such as creating an order and then immediately fetching it.
 
 <TypeScriptExample filename="index.ts">
 
@@ -561,7 +516,7 @@ async function badCreateThenRead(
 	env: Env,
 	input: OrderInput,
 ): Promise<Order | null> {
-	// Bad: after enabling replicas, an unconstrained read can reach a stale replica.
+	// Bad: without a session, all queries go to the primary and bypass read replicas.
 	await env.DB.prepare(
 		"INSERT INTO orders (id, user_id, idempotency_key, status) VALUES (?, ?, ?, ?)",
 	)
@@ -597,16 +552,17 @@ async function goodCreateThenRead(
 
 </TypeScriptExample>
 
-`withSession()` returns an object with the same query interface as the top-level database binding, so downstream query code stays familiar. If you may enable read replication later, designing new code around sessions can make that change a configuration update instead of an application rewrite. For more detail, refer to [Global read replication](/d1/best-practices/read-replication/).
+`withSession()` returns an object with the same query interface as the top level database binding, so downstream query code stays familiar. If you may enable read replication later, designing new code around sessions can make that change a configuration update instead of an application rewrite. For more detail, refer to [Global read replication](/d1/best-practices/read-replication/).
 
 ## Related resources
 
-- [Use indexes](/d1/best-practices/use-indexes/) — Unique, partial, and multi-column indexes.
-- [Retry queries](/d1/best-practices/retry-queries/) — Auto-retry behavior and application retries.
+- [Use indexes](/d1/best-practices/use-indexes/) — Unique, partial, and multi column indexes.
+- [Retry queries](/d1/best-practices/retry-queries/) — Auto retry behavior and application retries.
 - [Debug D1](/d1/observability/debug-d1/) — The full error list and which errors are retryable.
 - [Global read replication](/d1/best-practices/read-replication/) — Replicas and the Sessions API.
 - [Define foreign keys](/d1/sql-api/foreign-keys/) — Relationships and migration handling.
-- [Time Travel](/d1/reference/time-travel/) — Backups and point-in-time recovery.
+- [Time Travel](/d1/reference/time-travel/) — Backups and point in time recovery.
 - [Migrations](/d1/reference/migrations/) — Versioning your schema with migration files.
 - [Community projects](/d1/reference/community-projects/) — ORMs, query builders, and tools.
 - [Limits](/d1/platform/limits/) — The full list of D1 limits.
+- [Data location](/d1/configuration/data-location/) — Location hints and jurisdictions.

--- a/src/content/docs/d1/best-practices/rules-of-d1.mdx
+++ b/src/content/docs/d1/best-practices/rules-of-d1.mdx
@@ -1,6 +1,6 @@
 ---
 title: Rules of D1
-description: Best practices for building fast, reliable applications on D1, covering indexing, batching, retries, migrations, and scale.
+description: Best practices for building resilient, scalable, and correct applications on D1.
 pcx_content_type: concept
 sidebar:
   order: 2
@@ -10,115 +10,340 @@ products:
 
 import { TypeScriptExample } from "~/components";
 
-[D1](/d1/) is a serverless SQL database built on [SQLite](https://www.sqlite.org/). A single database runs against one primary instance and processes queries against it, so the cost of each query and the shape of your schema directly determine how your application performs and scales.
+[D1](/d1/) is Cloudflare's serverless SQL database. It is built on [SQLite](https://www.sqlite.org/), integrates directly with Workers, and gives applications a relational database without connection strings, connection pools, or database servers to manage. This is a guidebook on how to build more resilient, scalable, and correct D1 applications.
 
-This is a guidebook of rules for building fast, reliable applications on D1. Each rule explains the behavior behind it and shows the pattern to follow.
+## When to use D1
 
-## Query performance
+### Use D1 for relational application data, not arbitrary global state
 
-### Index every queried column
+D1 is a SQL database. Use it when your application needs tables, indexes, joins, constraints, transactions, and familiar SQLite syntax from a Worker.
 
-A query that scans a whole table reads every row, which is slow and counts every scanned row toward your bill. An index turns a scan into a lookup. Create an index for any column you filter on in a `WHERE` clause, join on, or sort by in an `ORDER BY` clause.
+Use D1 when you need:
+
+- **Relational data** — Users, orders, products, comments, permissions, settings, or other records that benefit from SQL queries and constraints.
+- **Worker-native access** — A database binding available as `env.DB`, without exposing a public database endpoint or managing connections.
+- **Global reads with SQL** — Read-heavy applications where users are distributed globally and read replicas can reduce read latency.
+- **Per-tenant or per-entity databases** — Many smaller databases, such as one database per user, organization, project, or tenant.
+- **Moderate writes with correctness** — Writes that benefit from transactions, constraints, idempotency keys, and application-level retry.
+
+Use another storage product, or partition your data across multiple D1 databases, when you need:
+
+- **Massive write ingestion** — Event streams, logs, metrics, or analytics workloads that continuously append high-volume data.
+- **Unbounded database growth** — A single database larger than the D1 database size limit.
+- **Long table scans on hot paths** — Warehouse-style aggregations that scan large tables for every request.
+- **Strict global serialization across every reader** — Applications where every globally distributed read must immediately observe every write in one total order.
+
+D1 can serve high-traffic applications when the data model and access pattern fit. For example, a globally cached blog may rarely query D1 on the request path, so database placement matters less. If requests frequently query D1, choose a location hint close to the primary workload and use read replication for global reads.
+
+## Example schema
+
+The following rules use one schema throughout the page. The examples model a small commerce application with users, orders, order items, and order events.
 
 ```sql
--- Index a column used in predicates and joins
-CREATE INDEX IF NOT EXISTS idx_orders_customer_id ON orders(customer_id);
+CREATE TABLE users (
+	id TEXT PRIMARY KEY,
+	email TEXT NOT NULL UNIQUE,
+	name TEXT NOT NULL,
+	created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE orders (
+	id TEXT PRIMARY KEY,
+	user_id TEXT NOT NULL REFERENCES users(id),
+	idempotency_key TEXT NOT NULL UNIQUE,
+	status TEXT NOT NULL,
+	created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE order_items (
+	id TEXT PRIMARY KEY,
+	order_id TEXT NOT NULL REFERENCES orders(id) ON DELETE CASCADE,
+	sku TEXT NOT NULL,
+	quantity INTEGER NOT NULL CHECK (quantity > 0)
+);
+
+CREATE TABLE order_events (
+	id INTEGER PRIMARY KEY AUTOINCREMENT,
+	order_id TEXT NOT NULL REFERENCES orders(id) ON DELETE CASCADE,
+	type TEXT NOT NULL,
+	created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
 ```
 
-After you create or drop an index, run `PRAGMA optimize`. This runs `ANALYZE` on each table and updates the statistics the query planner uses to choose an index.
+## Querying
+
+### Index every column you filter, join, or sort on
+
+D1 processes queries one at a time for each individual database. Your maximum throughput is directly related to query duration: if the average query takes `1 ms`, the database can process about `1,000` queries per second; if it takes `100 ms`, it can process about `10` queries per second.
+
+A table scan makes every matching request slower and reads rows you did not need. Create indexes for columns used in predicates, joins, and sort keys. For the schema above, `users.email`, `orders.user_id`, `order_items.order_id`, and `order_events.order_id` are hot-path columns.
+
+```sql
+CREATE INDEX IF NOT EXISTS idx_users_email ON users(email);
+CREATE INDEX IF NOT EXISTS idx_orders_user_id ON orders(user_id);
+CREATE INDEX IF NOT EXISTS idx_order_items_order_id ON order_items(order_id);
+CREATE INDEX IF NOT EXISTS idx_order_events_order_id ON order_events(order_id);
+```
+
+After creating or dropping an index, run `PRAGMA optimize` so SQLite updates the statistics used by the query planner.
 
 ```sql
 PRAGMA optimize;
 ```
 
-Verify that a query uses the index you expect with `EXPLAIN QUERY PLAN`. Output containing `USING INDEX` confirms the index is used; a `SCAN` over the table means it is not.
+Use `EXPLAIN QUERY PLAN` to verify that D1 uses the expected index. A plan that contains `USING INDEX` is what you want. A plan that contains `SCAN users` on a large table is a warning sign.
 
 ```sql
-EXPLAIN QUERY PLAN SELECT * FROM users WHERE email_address = ?;
+EXPLAIN QUERY PLAN SELECT * FROM users WHERE email = ?;
 ```
 
-For a multi-column index, a query uses the index only if it filters on all of the indexed columns, or on a left-prefix of them. An index on `(customer_id, transaction_date)` serves a query that filters on `customer_id`, or on both columns, but not one that filters on `transaction_date` alone.
-
-Tables with the default `INTEGER PRIMARY KEY` do not need a separate index for that column. Every other indexed column adds a write to the index on each `INSERT`, `UPDATE`, or `DELETE` that touches it. For read-heavy workloads, the reduction in rows read almost always outweighs this write amplification.
-
-Indexes are hard to add after the fact on a multi-gigabyte database, so define them up front where you can. For full detail on unique, partial, and multi-column indexes, refer to [Use indexes](/d1/best-practices/use-indexes/).
-
-### Batch related queries to reduce round-trips
-
-Each call to `run()` is a separate round-trip to your database. Calling `run()` in a loop multiplies network latency by the number of statements. [`batch()`](/d1/worker-api/d1-database/#batch) sends a set of statements in one round-trip, and runs them as a single transaction: if any statement fails, the entire sequence rolls back.
+Use [D1 Insights](/d1/observability/metrics-analytics/#query-insights), the GraphQL API, or the D1 dashboard to find slow production queries and then validate their indexes with `EXPLAIN QUERY PLAN`.
 
 <TypeScriptExample filename="index.ts">
 
 ```ts
-const users = [{ name: "Alice" }, { name: "Bob" }, { name: "Carol" }];
-const stmt = env.DB.prepare("INSERT INTO users (name) VALUES (?)");
+export default {
+	async fetch(request: Request, env: Env): Promise<Response> {
+		const email = new URL(request.url).searchParams.get("email") ?? "";
 
-// Bad: one round-trip per statement
-for (const user of users) {
-	await stmt.bind(user.name).run();
+		// Bad: this becomes a table scan if users.email is not indexed.
+		const slowUser = await env.DB.prepare(
+			"SELECT * FROM users WHERE email = ?",
+		)
+			.bind(email)
+			.first();
+
+		// Good: create idx_users_email before this query is on the hot path.
+		const user = await env.DB.prepare(
+			"SELECT * FROM users WHERE email = ?",
+		)
+			.bind(email)
+			.first();
+
+		return Response.json({ user: user ?? slowUser });
+	},
+} satisfies ExportedHandler<Env>;
+```
+
+</TypeScriptExample>
+
+Every indexed column adds at least one extra row write on `INSERT`, `UPDATE`, or `DELETE` because SQLite must update the index too. That tradeoff is usually worth it for read-heavy workloads because indexed point lookups avoid long scans. Add important indexes early; adding indexes after a database grows to multiple gigabytes is harder and slower.
+
+For more index patterns, refer to [Use indexes](/d1/best-practices/use-indexes/).
+
+### Batch related queries
+
+Do not call `run()` in a loop for related statements. Each separate call pays a round trip to D1. [`batch()`](/d1/worker-api/d1-database/#batch) sends related prepared statements in one round trip and runs them as a single transaction.
+
+Use `batch()` for multi-statement writes that should succeed or fail together, such as creating an order and its items.
+
+<TypeScriptExample filename="index.ts">
+
+```ts
+async function badCreateOrder(env: Env, order: OrderInput): Promise<void> {
+	// Bad: every statement is its own round trip.
+	await env.DB.prepare(
+		"INSERT INTO orders (id, user_id, idempotency_key, status) VALUES (?, ?, ?, ?)",
+	)
+		.bind(order.id, order.userId, order.idempotencyKey, "pending")
+		.run();
+
+	for (const item of order.items) {
+		await env.DB.prepare(
+			"INSERT INTO order_items (id, order_id, sku, quantity) VALUES (?, ?, ?, ?)",
+		)
+			.bind(item.id, order.id, item.sku, item.quantity)
+			.run();
+	}
 }
 
-// Good: one round-trip, one transaction
-await env.DB.batch(users.map((user) => stmt.bind(user.name)));
+async function goodCreateOrder(env: Env, order: OrderInput): Promise<void> {
+	// Good: one round trip and one transaction.
+	await env.DB.batch([
+		env.DB.prepare(
+			"INSERT INTO orders (id, user_id, idempotency_key, status) VALUES (?, ?, ?, ?)",
+		).bind(order.id, order.userId, order.idempotencyKey, "pending"),
+		...order.items.map((item) =>
+			env.DB.prepare(
+				"INSERT INTO order_items (id, order_id, sku, quantity) VALUES (?, ?, ?, ?)",
+			).bind(item.id, order.id, item.sku, item.quantity),
+		),
+	]);
+}
 ```
 
 </TypeScriptExample>
 
-The per-query limits apply to each statement inside a batch. For example, the 100 KB maximum statement length applies to every statement in the batch, not the batch as a whole.
+The per-query limits still apply to each statement in the batch. A batch reduces round trips; it does not make an unbounded write safe.
 
-### Always use parameterized queries
+### Bind every runtime value
 
-Never interpolate user input or runtime values into a SQL string. Bind them as parameters with [`bind()`](/d1/worker-api/prepared-statements/) instead. D1 follows SQLite's convention and supports ordered (`?NNN`) and anonymous (`?`) parameters.
+Never interpolate user input or runtime values directly into SQL strings. Use [`bind()`](/d1/worker-api/prepared-statements/) for values.
+
+This protects your application from SQL injection and makes query observability useful. D1 strips bound parameter values from query metrics, so all executions of the same query template aggregate together in [D1 Insights](/d1/observability/metrics-analytics/#query-insights). If you bake values into the SQL text, the metrics can fragment across many unique query strings.
 
 <TypeScriptExample filename="index.ts">
 
 ```ts
-// Bad: string interpolation is open to SQL injection
-const bad = env.DB.prepare(`SELECT * FROM users WHERE email = '${email}'`);
+export default {
+	async fetch(request: Request, env: Env): Promise<Response> {
+		const email = new URL(request.url).searchParams.get("email") ?? "";
 
-// Good: bind the value as a parameter
-const good = env.DB.prepare("SELECT * FROM users WHERE email = ?").bind(email);
+		// Bad: user input changes the SQL string itself.
+		const bad = await env.DB.prepare(
+			`SELECT * FROM users WHERE email = '${email}'`,
+		).first();
+
+		// Good: the SQL string stays stable and the value is bound.
+		const good = await env.DB.prepare(
+			"SELECT * FROM users WHERE email = ?",
+		)
+			.bind(email)
+			.first();
+
+		return Response.json({ bad, good });
+	},
+} satisfies ExportedHandler<Env>;
 ```
 
 </TypeScriptExample>
 
-Beyond preventing SQL injection, parameterized queries make your query metrics useful. D1 captures query strings for [query insights](/d1/observability/metrics-analytics/) but strips bound parameters, so every execution of the same query template aggregates together instead of appearing as thousands of distinct queries.
+### Whitelist dynamic SQL identifiers
 
-## Reliability and error handling
+Bound parameters are for values, not SQL identifiers. You cannot bind a column name, table name, or sort direction. If a query must choose a dynamic identifier, map user input to a fixed allowlist and reject everything else.
 
-### Retry write queries from your application
-
-D1 automatically retries read-only queries up to two times on a retryable error. Only read-only queries — those containing solely `SELECT`, `EXPLAIN`, or read-only `WITH` statements — are retried; any query that can write is never auto-retried. Your application must retry its own writes.
-
-Retry only idempotent writes, and only on errors that are safe to retry. Use exponential backoff with jitter so concurrent clients do not retry in lockstep.
-
-<TypeScriptExample filename="retry.ts">
+<TypeScriptExample filename="index.ts">
 
 ```ts
-// Retryable errors from the D1 error list
-function isRetryable(err: unknown): boolean {
-	const message = String(err);
+const ORDER_SORTS = {
+	newest: "created_at DESC",
+	oldest: "created_at ASC",
+	status: "status ASC, created_at DESC",
+} as const;
+
+export default {
+	async fetch(request: Request, env: Env): Promise<Response> {
+		const url = new URL(request.url);
+		const sort = url.searchParams.get("sort") ?? "newest";
+
+		// Bad: the user controls a SQL fragment.
+		const unsafeSql = `SELECT * FROM orders ORDER BY ${sort}`;
+
+		// Good: the user selects one known SQL fragment.
+		const orderBy = ORDER_SORTS[sort as keyof typeof ORDER_SORTS] ?? ORDER_SORTS.newest;
+		const safeSql = `SELECT * FROM orders ORDER BY ${orderBy} LIMIT ?`;
+
+		const { results } = await env.DB.prepare(safeSql).bind(50).all();
+		return Response.json({ results, unsafeSql });
+	},
+} satisfies ExportedHandler<Env>;
+```
+
+</TypeScriptExample>
+
+Do this for every dynamic clause: `ORDER BY`, sort direction, optional filters, and table names in internal jobs. If a value can be bound, bind it. If an identifier cannot be bound, allowlist it.
+
+## Writes and reliability
+
+### Retry idempotent writes from your application
+
+D1 automatically retries read-only queries up to two more times when it encounters a retryable error. Write queries are not automatically retried. Your application must retry write operations that are safe to repeat.
+
+Make writes idempotent before you retry them. For order creation, require a client-generated idempotency key and enforce it with a `UNIQUE` constraint. If a transient error occurs after D1 commits the write but before the Worker receives the response, the retry returns the existing order instead of creating a duplicate.
+
+Use exponential backoff with full jitter so clients do not retry in lockstep. Start around `50 ms`, cap around `2 s`, and keep the maximum attempt count small. Retry only errors marked retryable in the [D1 error list](/d1/observability/debug-d1/#error-list).
+
+<TypeScriptExample filename="index.ts">
+
+```ts
+function shouldRetryD1(error: unknown): boolean {
+	const message = String(error);
 	return (
 		message.includes("Network connection lost") ||
 		message.includes("storage caused object to be reset") ||
-		message.includes("reset because its code was updated")
+		message.includes("reset because its code was updated") ||
+		message.includes("Cannot resolve D1 DB due to transient issue")
 	);
 }
 
-async function writeWithRetry(
-	stmt: D1PreparedStatement,
-	maxAttempts = 3,
-): Promise<D1Result> {
+async function writeWithRetry<T>(operation: () => Promise<T>): Promise<T> {
 	for (let attempt = 1; ; attempt++) {
 		try {
-			return await stmt.run();
-		} catch (err) {
-			if (attempt >= maxAttempts || !isRetryable(err)) throw err;
-			// Exponential backoff capped at 2s, with full jitter
-			const backoff = Math.min(50 * 2 ** attempt, 2000);
-			await new Promise((resolve) =>
-				setTimeout(resolve, Math.random() * backoff),
-			);
+			return await operation();
+		} catch (error) {
+			if (attempt >= 3 || !shouldRetryD1(error)) {
+				throw error;
+			}
+
+			const cap = Math.min(50 * 2 ** attempt, 2000);
+			await new Promise((resolve) => setTimeout(resolve, Math.random() * cap));
+		}
+	}
+}
+
+async function createOrder(env: Env, input: OrderInput): Promise<Order> {
+	return await writeWithRetry(async () => {
+		// Bad: retrying an INSERT without a unique idempotency key can duplicate data.
+		// Good: idempotency_key is UNIQUE, so retries return the same logical order.
+		await env.DB.prepare(
+			"INSERT OR IGNORE INTO orders (id, user_id, idempotency_key, status) VALUES (?, ?, ?, ?)",
+		)
+			.bind(input.id, input.userId, input.idempotencyKey, "pending")
+			.run();
+
+		const order = await env.DB.prepare(
+			"SELECT * FROM orders WHERE idempotency_key = ?",
+		)
+			.bind(input.idempotencyKey)
+			.first<Order>();
+
+		if (!order) {
+			throw new Error("Order was not created");
+		}
+
+		return order;
+	});
+}
+```
+
+</TypeScriptExample>
+
+For more detail, refer to [Retry queries](/d1/best-practices/retry-queries/).
+
+### Chunk bulk mutations
+
+Never modify hundreds of thousands of rows in one query. A single `UPDATE` or `DELETE` over a large table can exceed CPU or memory limits, reset the underlying database object, and lose the in-flight operation.
+
+Process bulk changes in bounded chunks of about `10,000` rows. Use a stable key, commit each chunk, and continue until no rows remain.
+
+<TypeScriptExample filename="cleanup.ts">
+
+```ts
+const CHUNK_SIZE = 10_000;
+
+async function deleteOldEvents(env: Env, cutoff: string): Promise<number> {
+	let totalDeleted = 0;
+
+	while (true) {
+		// Bad: one unbounded DELETE can scan and mutate too much at once.
+		// await env.DB.prepare("DELETE FROM order_events WHERE created_at < ?")
+		// 	.bind(cutoff)
+		// 	.run();
+
+		// Good: delete a bounded set of primary keys, then repeat.
+		const result = await env.DB.prepare(
+			`DELETE FROM order_events WHERE id IN (
+				SELECT id FROM order_events WHERE created_at < ? ORDER BY id LIMIT ?
+			)`,
+		)
+			.bind(cutoff, CHUNK_SIZE)
+			.run();
+
+		const deleted = result.meta.changes ?? 0;
+		totalDeleted += deleted;
+
+		if (deleted < CHUNK_SIZE) {
+			return totalDeleted;
 		}
 	}
 }
@@ -126,204 +351,269 @@ async function writeWithRetry(
 
 </TypeScriptExample>
 
-For the complete set of error messages and which are safe to retry, refer to the [error list](/d1/observability/debug-d1/#error-list). Refer to [Retry queries](/d1/best-practices/retry-queries/) for more.
+The same rule applies to imports. Partition import data into files of tens of megabytes instead of one very large file. For more detail, refer to [Import and export data](/d1/best-practices/import-export-data/).
 
-### Chunk bulk mutations
+## Schema and migrations
 
-A single `UPDATE` or `DELETE` over hundreds of thousands of rows can exceed the database's CPU or memory limit and reset the instance, which surfaces as an internal error and loses the in-flight operation. Process large mutations in chunks of roughly 10,000 rows.
+### Use raw SQL until an ORM pays for itself
 
-<TypeScriptExample filename="cleanup.ts">
+Do not add an ORM by default. D1 speaks SQL directly, and hand-written SQL is often the simplest option for small applications.
+
+Raw SQL is usually enough when:
+
+- You have one to five tables.
+- Your queries are straightforward create, read, update, and delete operations.
+- You are the only developer working on the schema.
+- You are comfortable writing SQL.
+
+An ORM such as Drizzle starts paying off when:
+
+- You have 10 or more tables with foreign key relationships.
+- You write joins across three or more tables and want type safety for columns and relationships.
+- Multiple developers change the schema and need TypeScript definitions as a shared source of truth.
+- You want editor autocomplete for table and column names.
+- You are iterating quickly on schema design and want generated SQL to review.
+
+The cost is migration complexity. ORM migration generators produce SQL, but Wrangler applies migrations to D1 and tracks them in the `d1_migrations` table. Review generated migrations before applying them, especially statements that drop tables or alter migration metadata.
+
+### Test migrations locally before remote
+
+Do not discover migration mistakes in production. Apply every migration locally before you apply it remotely.
+
+```sh
+npx wrangler d1 migrations apply DB --local
+npx wrangler d1 migrations apply DB --remote
+```
+
+Use a baseline migration when you adopt migrations for an existing database. The baseline should describe the existing schema in a way that is safe to run once against an already-created database.
+
+```sql
+-- 0001_baseline.sql
+CREATE TABLE IF NOT EXISTS users (
+	id TEXT PRIMARY KEY,
+	email TEXT NOT NULL UNIQUE,
+	name TEXT NOT NULL,
+	created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS orders (
+	id TEXT PRIMARY KEY,
+	user_id TEXT NOT NULL REFERENCES users(id),
+	idempotency_key TEXT NOT NULL UNIQUE,
+	status TEXT NOT NULL,
+	created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+```
+
+This pattern lets Wrangler record the migration without trying to recreate tables that already exist. After the baseline is applied, future migrations should contain only the incremental schema changes.
+
+### Review generated migrations before applying them
+
+Never apply ORM-generated SQL blindly. A migration generator only knows the schema model it was given. If Wrangler's `d1_migrations` table, manually created indexes, or existing production tables are missing from that model, generated SQL can include destructive statements you did not intend.
+
+Bad migration review looks like this:
+
+```sql
+-- Bad: generated SQL was applied without review.
+DROP TABLE d1_migrations;
+DROP TABLE order_events;
+```
+
+Good migration review keeps Wrangler metadata intact and limits the migration to the intended schema change:
+
+```sql
+-- Good: only the intended application change remains.
+ALTER TABLE orders ADD COLUMN archived_at TEXT;
+CREATE INDEX IF NOT EXISTS idx_orders_archived_at ON orders(archived_at);
+PRAGMA optimize;
+```
+
+If your ORM writes migrations in nested directories, configure `migrations_pattern` so Wrangler finds the files. For more detail, refer to [Migrations](/d1/reference/migrations/#nested-migration-layouts).
+
+### Defer foreign keys during migrations
+
+Foreign keys are on by default in D1. This is different from plain SQLite, where foreign key enforcement is often off unless enabled. If you import or migrate a SQLite database that already contains foreign key violations, D1 surfaces them.
+
+Do not use `PRAGMA foreign_keys = off` in D1 migrations. D1 runs each query inside an implicit transaction, so that statement is ignored and the migration can still fail with constraint errors. Use `PRAGMA defer_foreign_keys = on` when a migration or import temporarily violates constraints and fixes them before commit.
+
+```sql
+-- Bad: ignored by D1 inside a transaction.
+PRAGMA foreign_keys = off;
+
+-- Good: defer checks until the transaction commits.
+PRAGMA defer_foreign_keys = on;
+
+-- Make schema changes, backfill data, and resolve violations here.
+```
+
+Any violation left unresolved at commit fails with `FOREIGN KEY constraint failed`. For more detail, refer to [Define foreign keys](/d1/sql-api/foreign-keys/).
+
+### Capture a Time Travel bookmark before destructive migrations
+
+Time Travel is always on and has no additional cost. Before any migration that drops columns, drops tables, or performs a bulk `UPDATE` or `DELETE`, capture the current bookmark and store it with your deployment record.
+
+```sh
+npx wrangler d1 time-travel info DB
+```
+
+If the migration goes wrong, restore to the captured bookmark.
+
+```sh
+npx wrangler d1 time-travel restore DB --bookmark=<BOOKMARK>
+```
+
+Restoring is a destructive, in-place overwrite that cancels in-flight queries and transactions. Bookmarks older than the retention window cannot be used as restore points, so capture the bookmark before the migration rather than assuming you can recover later. For more detail, refer to [Time Travel and backups](/d1/reference/time-travel/).
+
+## Location and replication
+
+### Put the primary near the workload
+
+Set a location hint when you create the database if the workload that queries D1 is not near the place where you run the create command. Without a location hint, D1 creates the primary database instance close to the request that created the database, which may be your laptop, CI system, or control plane rather than your users.
+
+Choose the location closest to the primary write or query region. Cross-region requests add round-trip latency to every query that goes to the primary.
+
+```sh
+npx wrangler d1 create commerce-db --location=weur
+```
+
+A location hint is a preference, not a guarantee. D1 runs the database in the nearest available location to that preference. Read replicas can improve global read latency, but write latency is still dominated by the primary database location because writes go to the primary. For the full list of hints, refer to [Data location](/d1/configuration/data-location/#available-location-hints).
+
+### Use sessions when read replication is enabled
+
+Read replicas can lower read latency and increase read throughput for globally distributed users. To use read replicas, you must query through the [Sessions API](/d1/worker-api/d1-database/#withsession). Without sessions, D1 continues to execute all queries on the primary database.
+
+Sessions also protect correctness. D1 replicates from the primary to read replicas asynchronously, so a replica may lag behind the latest write. A session carries a bookmark so later reads can require a database version at least as up-to-date as the previous query.
+
+Use this for read-after-write flows, such as creating an order and then immediately fetching it.
+
+<TypeScriptExample filename="index.ts">
 
 ```ts
-const CHUNK_SIZE = 10_000;
-let deleted = CHUNK_SIZE;
-
-// Delete in bounded chunks until none remain
-while (deleted >= CHUNK_SIZE) {
-	const result = await env.DB.prepare(
-		`DELETE FROM logs WHERE id IN (
-			SELECT id FROM logs WHERE created_at < ? LIMIT ?
-		)`,
+async function badCreateThenRead(env: Env, input: OrderInput): Promise<Order | null> {
+	// Bad: after enabling replicas, an unconstrained read can reach a stale replica.
+	await env.DB.prepare(
+		"INSERT INTO orders (id, user_id, idempotency_key, status) VALUES (?, ?, ?, ?)",
 	)
-		.bind(cutoff, CHUNK_SIZE)
+		.bind(input.id, input.userId, input.idempotencyKey, "pending")
 		.run();
 
-	deleted = result.meta.changes ?? 0;
+	return await env.DB.prepare("SELECT * FROM orders WHERE id = ?")
+		.bind(input.id)
+		.first<Order>();
+}
+
+async function goodCreateThenRead(env: Env, input: OrderInput): Promise<Response> {
+	// Good: use a session bookmark for sequential consistency.
+	const session = env.DB.withSession("first-primary");
+	await session
+		.prepare(
+			"INSERT INTO orders (id, user_id, idempotency_key, status) VALUES (?, ?, ?, ?)",
+		)
+		.bind(input.id, input.userId, input.idempotencyKey, "pending")
+		.run();
+
+	const order = await session
+		.prepare("SELECT * FROM orders WHERE id = ?")
+		.bind(input.id)
+		.first<Order>();
+
+	return Response.json({ order, bookmark: session.getBookmark() });
 }
 ```
 
 </TypeScriptExample>
 
-The same applies to bulk imports. Partition import data into files of tens of megabytes rather than one large file. Refer to [Import and export data](/d1/best-practices/import-export-data/).
+`withSession()` returns an object with the same query interface as the top-level database binding, so downstream query code stays familiar. If you may enable read replication later, designing new code around sessions can make that change a configuration update instead of an application rewrite. For more detail, refer to [Global read replication](/d1/best-practices/read-replication/).
 
-## Schema and migrations
+## Scaling
 
-### Use migrations for team and multi-environment workflows
+### Design for the fixed resources of one database
 
-Migrations are not required for every schema change. If you are a solo developer with one database, running `ALTER TABLE` directly with `wrangler d1 execute` is valid and permanent.
+A single D1 database has fixed resources. You do not choose instance sizes, CPU, or memory. The way you scale one database is by keeping queries short, indexed, bounded, and observable.
 
-Migrations become valuable when you work on a team or have multiple environments (local dev, staging, production) that need identical schemas. A migration is a `.sql` file checked into git that records a schema change. `wrangler` tracks which migrations have been applied in a `d1_migrations` table so they are never double-applied.
+The first limits to design around are:
 
-Typical team workflow:
+| Limit                              | Workers Paid | Workers Free |
+| ---------------------------------- | ------------ | ------------ |
+| Maximum database size              | 10 GB        | 500 MB       |
+| Queries per Worker invocation      | 1,000        | 50           |
+| Maximum SQL query duration         | 30 seconds   | 30 seconds   |
+| SQL statements per query           | 100          | 100          |
+| Maximum bound parameters per query | 100          | 100          |
 
-1. Developer pulls latest code from git (which includes new `.sql` migration files from teammates).
-2. Developer runs `wrangler d1 migrations apply <DATABASE> --local` to update their local database.
-3. Developer creates a new migration with `wrangler d1 migrations create`, writes SQL, tests locally.
-4. Developer commits the migration file and pushes to git.
-5. CI/CD applies the migration to production with `wrangler d1 migrations apply <DATABASE> --remote`, then deploys the Worker.
-
-Migration files live in git, not in the database. The `d1_migrations` table is a checklist of which files have been applied in each environment. Refer to [Migrations](/d1/reference/migrations/) for the full guide.
-
-### Choose the right migration tooling
-
-You can write migration SQL by hand or use an object-relational mapping (ORM) tool to generate it. Each approach has trade-offs.
-
-**Raw SQL** with `wrangler` works well when:
-
-- You have one to five tables
-- Your queries are basic create, read, update, and delete (CRUD) operations
-- You are the only developer
-- You are comfortable writing SQL
-
-**An ORM like Drizzle or Prisma** starts paying off when:
-
-- You have 10+ tables with foreign key relationships between them
-- You build complex queries with joins across three or more tables, where type safety prevents you from accidentally joining on the wrong column or misspelling a field name
-- Multiple developers touch the schema, and the TypeScript definition becomes the single source of truth with compile errors catching mismatches immediately
-- You want autocompletion in your editor when writing queries
-- You are iterating rapidly on schema design and want to see what SQL each change produces without writing it yourself
-
-If you use an ORM, be aware that ORM migration generators cannot apply migrations to D1 directly. You generate the SQL with your ORM, then apply it with `wrangler`. Review all generated SQL before applying — ORMs may generate destructive statements for tables they do not manage. Refer to the [Drizzle integration notes](/d1/reference/community-projects/#drizzle-orm) for specific gotchas.
-
-### Defer foreign keys during migrations, do not disable them
-
-D1 enforces foreign key constraints by default, equivalent to `PRAGMA foreign_keys = on` for every transaction. This is unlike plain SQLite, where enforcement is off by default. If you migrate a schema that was designed with enforcement off, existing violations surface immediately.
-
-Because D1 runs every query inside an implicit transaction, you cannot turn enforcement off with `PRAGMA foreign_keys = off`; D1 ignores it. A migration script copied from a SQLite dump that sets `foreign_keys = off` has no effect and can fail with constraint errors.
-
-To violate constraints temporarily within a migration, use `PRAGMA defer_foreign_keys = on`. This defers enforcement to the end of the current transaction instead of disabling it.
-
-```sql
-PRAGMA defer_foreign_keys = on;
-
--- Run ALTER TABLE, data backfills, and other migration statements here.
--- Resolve every constraint violation before the transaction ends.
-```
-
-Any violation left unresolved when the transaction commits fails with a `FOREIGN KEY constraint failed` error. For relationship definitions and the available actions (`CASCADE`, `RESTRICT`, `SET DEFAULT`, `SET NULL`, `NO ACTION`), refer to [Define foreign keys](/d1/sql-api/foreign-keys/).
-
-### Capture a Time Travel bookmark before a destructive migration
-
-[Time Travel](/d1/reference/time-travel/) is always on and free, and lets you restore a database to any minute within the last 30 days (7 days on the Workers Free plan). Before any migration that drops columns, drops tables, or runs a bulk `UPDATE` or `DELETE`, capture the current bookmark and store it.
-
-```sh
-npx wrangler d1 time-travel info my-database
-```
-
-If the migration goes wrong, restore to that bookmark.
-
-```sh
-npx wrangler d1 time-travel restore my-database --bookmark=<YOUR_BOOKMARK>
-```
-
-Restoring is a destructive, in-place overwrite that cancels in-flight queries, so treat it as you would any production rollback. Bookmarks older than the retention window cannot be used as a restore point, so capture one as part of every destructive deploy rather than relying on recovering after the window closes.
-
-## Data location and replication
-
-### Set a location hint that matches your workload
-
-A D1 database is pinned to one primary region. Without a location hint, D1 places the primary close to the request that created the database, which is often your control plane or CI pipeline rather than your users. Every cross-region query then pays a round-trip penalty.
-
-Set a [location hint](/d1/configuration/data-location/) at creation time, matching the region closest to the workload that queries the database most.
-
-```sh
-npx wrangler d1 create my-database --location=weur
-```
-
-A location hint is a preference, not a guarantee, and write latency is always dominated by the primary's location even when read replicas exist. Refer to [Data location](/d1/configuration/data-location/) for the full list of hints and for jurisdiction constraints.
-
-### Use the Sessions API so you can add replicas later
-
-[Read replication](/d1/best-practices/read-replication/) helps read-heavy applications with users around the world. To use replicas, you must use the [Sessions API](/d1/worker-api/d1-database/#withsession); otherwise every query goes to the primary. The Sessions API also works on databases without replication enabled, so writing code with `withSession()` from the start lets you turn on replication later with a single API call, without changing Worker code.
-
-`withSession()` returns an object with the same interface as the top-level database, so your query code is unchanged. To preserve [sequential consistency](/d1/best-practices/read-replication/#sequential-consistency) across requests, pass the bookmark from one request to the next.
+A common failure mode for large D1 databases is an aggregation query that tries to scan an entire multi-gigabyte table into memory. Keep hot-path aggregations precomputed or bounded by indexed predicates.
 
 <TypeScriptExample filename="index.ts">
 
 ```ts
 export default {
 	async fetch(request: Request, env: Env): Promise<Response> {
-		// Resume from the bookmark the client last saw, or start unconstrained
-		const bookmark =
-			request.headers.get("x-d1-bookmark") ?? "first-unconstrained";
-		const session = env.DB.withSession(bookmark);
+		const userId = new URL(request.url).searchParams.get("userId") ?? "";
 
-		const { results } = await session
-			.prepare("SELECT * FROM orders WHERE customer_id = ?")
-			.bind(customerId)
-			.all();
+		// Bad: scans the whole table as order volume grows.
+		const globalTotal = await env.DB.prepare(
+			"SELECT COUNT(*) AS count FROM orders",
+		).first();
 
-		const response = Response.json(results);
-		// Return the new bookmark so the next request stays consistent
-		response.headers.set("x-d1-bookmark", session.getBookmark() ?? "");
-		return response;
+		// Good: bounded by an indexed predicate.
+		const userTotal = await env.DB.prepare(
+			"SELECT COUNT(*) AS count FROM orders WHERE user_id = ?",
+		)
+			.bind(userId)
+			.first();
+
+		return Response.json({ globalTotal, userTotal });
 	},
 } satisfies ExportedHandler<Env>;
 ```
 
 </TypeScriptExample>
 
-Start a session with `first-primary` when the first read must see the latest data, or `first-unconstrained` (the default) when minimum latency matters more. Refer to [Global read replication](/d1/best-practices/read-replication/) for the full guide.
+For the complete list, refer to [Limits](/d1/platform/limits/).
 
-## Scaling
+### Scale out with more databases, not one bigger database
 
-### Respect the limits of a single database
+D1 is designed for horizontal scale-out across multiple smaller databases, such as per-user, per-tenant, or per-entity databases. When one database approaches its size or throughput limits, split the workload instead of treating one database as a vertically scalable server.
 
-A single D1 database has fixed resources. The size and shape of your queries, not a configurable instance size, determine how much it can do. The limits to design around first:
-
-| Limit                               | Workers paid | Workers free |
-| ----------------------------------- | ------------ | ------------ |
-| Maximum database size               | 10 GB        | 500 MB       |
-| Queries per Worker invocation       | 1,000        | 50           |
-| Maximum SQL query duration          | 30 seconds   | 30 seconds   |
-| Maximum bound parameters per query  | 100          | 100          |
-| Maximum string, `BLOB`, or row size | 2 MB         | 2 MB         |
-
-A frequent issue on databases of 5 GB and larger is an aggregation query that tries to scan the entire table into memory and fails on the CPU or memory limit. Keep hot-path queries indexed and bounded, and avoid `SELECT *` over a large table without a `LIMIT`. Refer to [Limits](/d1/platform/limits/) for the complete table.
-
-### Scale out across many databases
-
-D1 is designed for horizontal scale-out across many smaller databases, not vertical scale-up of one large one. When a single database approaches its size or throughput limit, shard your data across multiple databases instead of growing one.
-
-A natural sharding boundary is one database per tenant: each user, organization, or project gets its own isolated database. This gives complete data isolation, per-tenant schema evolution, and a migration blast radius limited to a single tenant. You can create databases programmatically with the [REST API](/d1/d1-api/), setting a location hint per tenant. Workers Paid accounts support 50,000 databases, raisable to millions by request.
-
-Attribute usage per database with the `rows_read` and `rows_written` fields that every query returns in its `meta` object, and apply per-query and per-tenant limits so one tenant cannot inflate your bill.
+A natural boundary is one database per user, tenant, organization, project, or high-cardinality entity. This gives each entity isolated storage, isolated migration risk, and its own throughput envelope.
 
 <TypeScriptExample filename="index.ts">
 
 ```ts
-const result = await env.DB.prepare("SELECT * FROM orders WHERE status = ?")
-	.bind(status)
-	.all();
+export default {
+	async fetch(request: Request, env: Env): Promise<Response> {
+		const userId = new URL(request.url).searchParams.get("userId") ?? "";
 
-console.log({
-	rowsRead: result.meta.rows_read,
-	rowsWritten: result.meta.rows_written,
-});
+		// Bad: every user shares one hot database.
+		const overloaded = await env.DB.prepare(
+			"SELECT * FROM orders WHERE user_id = ? LIMIT 50",
+		)
+			.bind(userId)
+			.all();
+
+		// Good: route the request to the user's own D1 database.
+		const userDb = await getUserDatabase(env, userId);
+		const { results } = await userDb
+			.prepare("SELECT * FROM orders ORDER BY created_at DESC LIMIT 50")
+			.all();
+
+		return Response.json({ overloaded, results });
+	},
+} satisfies ExportedHandler<Env>;
 ```
 
 </TypeScriptExample>
 
-To dynamically bind a separate database per tenant for a SaaS platform, refer to [Workers for Platforms](/cloudflare-for-platforms/workers-for-platforms/).
+Use the `rows_read` and `rows_written` metadata returned by D1 queries to understand which databases and queries consume the most work. For SaaS platforms that dynamically bind databases per tenant, refer to [Workers for Platforms](/cloudflare-for-platforms/workers-for-platforms/).
 
 ## Related resources
 
-- [Use indexes](/d1/best-practices/use-indexes/) — unique, partial, and multi-column indexes.
-- [Retry queries](/d1/best-practices/retry-queries/) — auto-retry behavior and application retries.
-- [Debug D1](/d1/observability/debug-d1/) — the full error list and which errors are retryable.
-- [Global read replication](/d1/best-practices/read-replication/) — replicas and the Sessions API.
-- [Define foreign keys](/d1/sql-api/foreign-keys/) — relationships and migration handling.
-- [Time Travel](/d1/reference/time-travel/) — backups and point-in-time recovery.
-- [Migrations](/d1/reference/migrations/) — versioning your schema with migration files.
+- [Use indexes](/d1/best-practices/use-indexes/) — Unique, partial, and multi-column indexes.
+- [Retry queries](/d1/best-practices/retry-queries/) — Auto-retry behavior and application retries.
+- [Debug D1](/d1/observability/debug-d1/) — The full error list and which errors are retryable.
+- [Global read replication](/d1/best-practices/read-replication/) — Replicas and the Sessions API.
+- [Define foreign keys](/d1/sql-api/foreign-keys/) — Relationships and migration handling.
+- [Time Travel](/d1/reference/time-travel/) — Backups and point-in-time recovery.
+- [Migrations](/d1/reference/migrations/) — Versioning your schema with migration files.
 - [Community projects](/d1/reference/community-projects/) — ORMs, query builders, and tools.
-- [Limits](/d1/platform/limits/) — the full list of D1 limits.
+- [Limits](/d1/platform/limits/) — The full list of D1 limits.


### PR DESCRIPTION
## Summary

Rebased this PR onto the current `production` branch and revised the new **Rules of D1** best-practices guide under `src/content/docs/d1/best-practices/rules-of-d1.mdx`.

The guide now prioritizes D1 product guidance and addresses PR review feedback:

- Keeps the opening flow as **Overview → Limits → Scale out across many databases** and removes the separate **When to use D1** section while preserving alternative-storage guidance in the overview.
- Simplifies the overview language to **“D1 is a relational database.”**
- Reduces unnecessary hyphenation while keeping **key-value**.
- Tightens cautious sharding guidance: only shard with a stable shard key and fixed shard count, notes that D1 does not provide automatic resharding tools, and removes the misleading dynamic database example.
- Clarifies Workers for Platforms guidance around user Workers with isolated D1 bindings.
- Reworks indexing guidance with `EXPLAIN QUERY PLAN` examples before and after creating an index, and explains why adding indexes to large tables can stall a single threaded database.
- Switches `D1 Insights` wording to **D1 query insights**.
- Clarifies batch guidance and per query limits.
- Preserves the explicit engineering retry guidance: exponential backoff, full jitter, three-attempt maximum, and retry only retryable `D1_ERROR` codes from the documented error list.
- Adds chunked bulk mutation guidance, including indexing the column used to select chunks.
- Adds migration tooling guidance for hand written SQL versus ORM generated SQL, including generated migration review and `d1_migrations` risk.
- Removes the arbitrary table-count threshold from raw SQL migration tooling guidance.
- Adds guidance to run migrations and index creation outside Worker startup paths.
- Adds local before remote migration guidance with rollback behavior.
- Adds location hint, jurisdiction, and Sessions API/read replication guidance.
- Adds Data location to related resources.
- Addresses remaining style feedback: sentence case table headers, monospace `wrangler`, acronym expansion for object relational mapping (ORM) and create/read/update/delete (CRUD), spelled out small numbers, and read only `WITH` retry wording.

## Validation

- Rebased onto the latest `origin/production` during PR monitoring.
- Ran `git diff --check` successfully after the latest rebase.
- Ran `pnpm exec prettier --check src/content/docs/d1/best-practices/rules-of-d1.mdx` under Node 24 successfully.
- Ran `pnpm exec astro check` under Node 24; result: 0 errors, 0 warnings, existing repository hints only.

## Notes

A follow-up PR can add a dedicated Drizzle-specific D1 page as discussed.