### PR TITLE
[Logs] Update Logpush dataset field definitions (2026-06-30)

### DIFF
--- a/src/content/changelog/logs/2026-06-30-log-fields-updated.mdx
+++ b/src/content/changelog/logs/2026-06-30-log-fields-updated.mdx
@@ -1,0 +1,15 @@
+---
+title: Updated fields across multiple Logpush datasets in Cloudflare Logs
+description: Fields have been updated across multiple Logpush datasets in Cloudflare Logs.
+date: 2026-06-30
+---
+
+Cloudflare has updated [Logpush datasets](/logs/logpush/logpush-job/datasets/):
+
+### Updated fields in existing datasets
+
+- **Gateway DNS** (added): `AppliedMaxTTL` and `UpstreamRecordTTLs`.
+- **Gateway HTTP** (added): `Warnings`.
+- **HTTP requests** (added): `CacheLockWaitedMs`.
+
+For the complete field definitions for each dataset, refer to [Logpush datasets](/logs/logpush/logpush-job/datasets/).

--- a/src/content/docs/logs/logpush/logpush-job/datasets/account/email_security_alerts.md
+++ b/src/content/docs/logs/logpush/logpush-job/datasets/account/email_security_alerts.md
@@ -49,7 +49,7 @@ Email address portions of the CC header provided by the sender (for example, 'Fi
 
 Type: `string`
 
-Summary of the DKIM authentication result for the message. <br />Possible values are <em>pass</em> \| <em>neutral</em> \| <em>fail</em> \| <em>error</em> \| <em>permerror</em> \| <em>temperror</em> \| <em>none</em>.
+Summary DKIM authentication result for the message. <br />Possible values are <em>pass</em> \| <em>neutral</em> \| <em>fail</em> \| <em>error</em> \| <em>permerror</em> \| <em>temperror</em> \| <em>none</em>.
 
 ## DMARCPolicy
 
@@ -169,7 +169,7 @@ Hostname provided by the SMTP HELO server.
 
 Type: `string`
 
-Summary of the SPF authentication result for the message. <br />Possible values are <em>pass</em> \| <em>neutral</em> \| <em>fail</em> \| <em>softfail</em> \| <em>permerror</em> \| <em>temperror</em> \| <em>none</em>.
+Summary SPF authentication result for the message. <br />Possible values are <em>pass</em> \| <em>neutral</em> \| <em>fail</em> \| <em>softfail</em> \| <em>permerror</em> \| <em>temperror</em> \| <em>none</em>.
 
 ## Subject
 

--- a/src/content/docs/logs/logpush/logpush-job/datasets/account/firewall_events.md
+++ b/src/content/docs/logs/logpush/logpush-job/datasets/account/firewall_events.md
@@ -43,25 +43,25 @@ The code of the first-class action the Cloudflare Firewall took on this request.
 
 Type: `int`
 
-The ASN of the visitor.
+The ASN number of the visitor.
 
 ## ClientASNDescription
 
 Type: `string`
 
-The ASN of the visitor as a string.
+The ASN of the visitor as string.
 
 ## ClientCountry
 
 Type: `string`
 
-Country from which the request originated.
+Country from which request originated.
 
 ## ClientIP
 
 Type: `string`
 
-The IP address of the visitor (IPv4 or IPv6).
+The visitor's IP address (IPv4 or IPv6).
 
 ## ClientIPClass
 
@@ -79,13 +79,13 @@ The referer host.
 
 Type: `string`
 
-The referer path requested by the visitor.
+The referer path requested by visitor.
 
 ## ClientRefererQuery
 
 Type: `string`
 
-The referer query string requested by the visitor.
+The referer query-string was requested by the visitor.
 
 ## ClientRefererScheme
 
@@ -109,7 +109,7 @@ The HTTP method used by the visitor.
 
 Type: `string`
 
-The path requested by the visitor.
+The path requested by visitor.
 
 ## ClientRequestProtocol
 
@@ -121,7 +121,7 @@ The version of HTTP protocol requested by the visitor.
 
 Type: `string`
 
-The query string requested by the visitor.
+The query-string was requested by the visitor.
 
 ## ClientRequestScheme
 
@@ -133,7 +133,7 @@ The URL scheme requested by the visitor.
 
 Type: `string`
 
-The user-agent string of the visitor.
+Visitor's user-agent string.
 
 ## ContentScanObjResults
 
@@ -157,7 +157,7 @@ List of content types.
 
 Type: `int or string`
 
-The date and time the event occurred at the edge. To specify the timestamp format, refer to [Output types](/logs/logpush/logpush-job/log-output-options/#output-types).
+The date and time the event occurred at the edge.
 
 ## Description
 
@@ -175,7 +175,7 @@ The airport code of the Cloudflare data center that served this request.
 
 Type: `int`
 
-HTTP response status code returned to the browser.
+HTTP response status code returned to browser.
 
 ## FirewallForAIInjectionScore (deprecated)
 
@@ -235,7 +235,7 @@ Additional product-specific information. Metadata is organized in key:value pair
 
 Type: `int`
 
-HTTP origin response status code returned to the browser.
+HTTP origin response status code returned to browser.
 
 ## OriginatorRayID
 

--- a/src/content/docs/logs/logpush/logpush-job/datasets/account/gateway_dns.md
+++ b/src/content/docs/logs/logpush/logpush-job/datasets/account/gateway_dns.md
@@ -27,6 +27,12 @@ Type: `string`
 
 Name of the application the domain belongs to (for example, 'Cloudflare Dashboard').
 
+## AppliedMaxTTL
+
+Type: `int`
+
+Maximum TTL cap applied to the response records, in seconds. Set to 0 when no cap was applied.
+
 ## AuthoritativeNameServerIPs
 
 Type: `array[string]`
@@ -482,6 +488,12 @@ Time zone used to calculate the current time, if a matched rule was scheduled wi
 Type: `string`
 
 Method used to pick the time zone for the schedule (from rule/ from user ip/ from local time).
+
+## UpstreamRecordTTLs
+
+Type: `array[int]`
+
+TTL of each record in the upstream response, in seconds. Maps one-to-one with the resource records (for example, [3600, 300]).
 
 ## UserID
 

--- a/src/content/docs/logs/logpush/logpush-job/datasets/account/gateway_http.md
+++ b/src/content/docs/logs/logpush/logpush-job/datasets/account/gateway_http.md
@@ -362,3 +362,9 @@ The identifier of the virtual network the device was connected to, if any.
 Type: `string`
 
 The name of the virtual network the device was connected to, if any.
+
+## Warnings
+
+Type: `array[string]`
+
+Warnings generated during request processing.

--- a/src/content/docs/logs/logpush/logpush-job/datasets/account/websocket_analytics.md
+++ b/src/content/docs/logs/logpush/logpush-job/datasets/account/websocket_analytics.md
@@ -73,13 +73,13 @@ IATA airport code of the data center that handled the connection.
 
 Type: `string`
 
-The reason the WebSocket connection ended. <br />Possible values are <em>none</em> \| <em>unspecifiedError</em> \| <em>timedOut</em> \| <em>peerReset</em> \| <em>upstreamReset</em> \| <em>protocolViolation</em> \| <em>peerNoError</em>.
+The reason the WebSocket connection ended. Possible values are <em>none</em> \| <em>unspecifiedError</em> \| <em>timedOut</em> \| <em>peerReset</em> \| <em>upstreamReset</em> \| <em>protocolViolation</em> \| <em>peerNoError</em>.
 
 ## ConnectionCloseSource
 
 Type: `string`
 
-Which side initiated the connection close. <br />Possible values are <em>upstream</em> \| <em>downstream</em> \| <em>me</em> \| <em>both</em>, or the raw internal value if unrecognized.
+Which side initiated the connection close; <em>upstream</em> \| <em>downstream</em> \| <em>me</em> \| <em>both</em>, or the raw internal value if unrecognized.
 
 ## ConnectionID
 
@@ -97,13 +97,13 @@ The first transport-level close code observed. For TLS connections this is the T
 
 Type: `int or string`
 
-Timestamp at which the WebSocket connection closed. To specify the timestamp format, refer to [Output types](/logs/logpush/logpush-job/log-output-options/#output-types).
+Timestamp at which the WebSocket connection closed.
 
 ## EdgeStartTimestamp
 
 Type: `int or string`
 
-Timestamp at which the WebSocket connection was established. To specify the timestamp format, refer to [Output types](/logs/logpush/logpush-job/log-output-options/#output-types).
+Timestamp at which the WebSocket connection was established.
 
 ## RayID
 

--- a/src/content/docs/logs/logpush/logpush-job/datasets/account/workers_trace_events.md
+++ b/src/content/docs/logs/logpush/logpush-job/datasets/account/workers_trace_events.md
@@ -43,7 +43,7 @@ The timestamp of when the event was received, in milliseconds.
 
 Type: `string`
 
-The event type that triggered the invocation. <br />Possible values are <em>fetch</em>.
+The event type that triggered the invocation. <br />Possible values are <em>fetch</em> \| <em>scheduled</em> \| <em>alarm</em> \| <em>queue</em> \| <em>email</em> \| <em>worker_rpc</em> \| <em>hibernatable_web_socket</em>.
 
 ## Exceptions
 
@@ -61,7 +61,7 @@ List of console messages emitted during the invocation.
 
 Type: `string`
 
-The outcome of the Worker script invocation. <br />Possible values are <em>ok</em> \| <em>exception</em>.
+The outcome of the Worker script invocation. <br />Possible values are <em>ok</em> \| <em>canceled</em> \| <em>exception</em> \| <em>unknown</em>.
 
 ## ScriptName
 

--- a/src/content/docs/logs/logpush/logpush-job/datasets/zone/firewall_events.md
+++ b/src/content/docs/logs/logpush/logpush-job/datasets/zone/firewall_events.md
@@ -43,25 +43,25 @@ The code of the first-class action the Cloudflare Firewall took on this request.
 
 Type: `int`
 
-The ASN of the visitor.
+The ASN number of the visitor.
 
 ## ClientASNDescription
 
 Type: `string`
 
-The ASN of the visitor as a string.
+The ASN of the visitor as string.
 
 ## ClientCountry
 
 Type: `string`
 
-Country from which the request originated.
+Country from which request originated.
 
 ## ClientIP
 
 Type: `string`
 
-The IP address of the visitor (IPv4 or IPv6).
+The visitor's IP address (IPv4 or IPv6).
 
 ## ClientIPClass
 
@@ -79,13 +79,13 @@ The referer host.
 
 Type: `string`
 
-The referer path requested by the visitor.
+The referer path requested by visitor.
 
 ## ClientRefererQuery
 
 Type: `string`
 
-The referer query string requested by the visitor.
+The referer query-string was requested by the visitor.
 
 ## ClientRefererScheme
 
@@ -109,7 +109,7 @@ The HTTP method used by the visitor.
 
 Type: `string`
 
-The path requested by the visitor.
+The path requested by visitor.
 
 ## ClientRequestProtocol
 
@@ -121,7 +121,7 @@ The version of HTTP protocol requested by the visitor.
 
 Type: `string`
 
-The query string requested by the visitor.
+The query-string was requested by the visitor.
 
 ## ClientRequestScheme
 
@@ -133,7 +133,7 @@ The URL scheme requested by the visitor.
 
 Type: `string`
 
-The user-agent string of the visitor.
+Visitor's user-agent string.
 
 ## ContentScanObjResults
 
@@ -157,7 +157,7 @@ List of content types.
 
 Type: `int or string`
 
-The date and time the event occurred at the edge. To specify the timestamp format, refer to [Output types](/logs/logpush/logpush-job/log-output-options/#output-types).
+The date and time the event occurred at the edge.
 
 ## Description
 
@@ -175,7 +175,7 @@ The airport code of the Cloudflare data center that served this request.
 
 Type: `int`
 
-HTTP response status code returned to the browser.
+HTTP response status code returned to browser.
 
 ## FirewallForAIInjectionScore (deprecated)
 
@@ -235,7 +235,7 @@ Additional product-specific information. Metadata is organized in key:value pair
 
 Type: `int`
 
-HTTP origin response status code returned to the browser.
+HTTP origin response status code returned to browser.
 
 ## OriginatorRayID
 

--- a/src/content/docs/logs/logpush/logpush-job/datasets/zone/http_requests.md
+++ b/src/content/docs/logs/logpush/logpush-job/datasets/zone/http_requests.md
@@ -69,6 +69,12 @@ Type: `string`
 
 Cache status. <br />Possible values are <em>unknown</em> \| <em>miss</em> \| <em>expired</em> \| <em>updating</em> \| <em>stale</em> \| <em>hit</em> \| <em>ignored</em> \| <em>bypass</em> \| <em>revalidated</em> \| <em>dynamic</em> \| <em>stream_hit</em> \| <em>deferred</em> <br />"dynamic" means that a request is not eligible for cache. This can mean, for example that it was blocked by the firewall. Refer to [Cloudflare cache responses](/cache/concepts/cache-responses/) for more details.
 
+## CacheLockWaitedMs
+
+Type: `int`
+
+Maximum time spent waiting on a cache lock across all cache tiers, in milliseconds.
+
 ## CacheReserveUsed
 
 Type: `bool`

--- a/src/content/docs/logs/logpush/logpush-job/datasets/zone/websocket_analytics.md
+++ b/src/content/docs/logs/logpush/logpush-job/datasets/zone/websocket_analytics.md
@@ -73,13 +73,13 @@ IATA airport code of the data center that handled the connection.
 
 Type: `string`
 
-The reason the WebSocket connection ended. <br />Possible values are <em>none</em> \| <em>unspecifiedError</em> \| <em>timedOut</em> \| <em>peerReset</em> \| <em>upstreamReset</em> \| <em>protocolViolation</em> \| <em>peerNoError</em>.
+The reason the WebSocket connection ended. Possible values are <em>none</em> \| <em>unspecifiedError</em> \| <em>timedOut</em> \| <em>peerReset</em> \| <em>upstreamReset</em> \| <em>protocolViolation</em> \| <em>peerNoError</em>.
 
 ## ConnectionCloseSource
 
 Type: `string`
 
-Which side initiated the connection close. <br />Possible values are <em>upstream</em> \| <em>downstream</em> \| <em>me</em> \| <em>both</em>, or the raw internal value if unrecognized.
+Which side initiated the connection close; <em>upstream</em> \| <em>downstream</em> \| <em>me</em> \| <em>both</em>, or the raw internal value if unrecognized.
 
 ## ConnectionID
 
@@ -97,13 +97,13 @@ The first transport-level close code observed. For TLS connections this is the T
 
 Type: `int or string`
 
-Timestamp at which the WebSocket connection closed. To specify the timestamp format, refer to [Output types](/logs/logpush/logpush-job/log-output-options/#output-types).
+Timestamp at which the WebSocket connection closed.
 
 ## EdgeStartTimestamp
 
 Type: `int or string`
 
-Timestamp at which the WebSocket connection was established. To specify the timestamp format, refer to [Output types](/logs/logpush/logpush-job/log-output-options/#output-types).
+Timestamp at which the WebSocket connection was established.
 
 ## RayID
 


### PR DESCRIPTION
## Summary

Automated sync of Logpush dataset field definitions from [data/entities](https://gitlab.cfdata.org/cloudflare/data/entities).

### Updated fields in existing datasets

- **Gateway DNS** (added): `AppliedMaxTTL` and `UpstreamRecordTTLs`.
- **Gateway HTTP** (added): `Warnings`.
- **HTTP requests** (added): `CacheLockWaitedMs`.

### Files changed
- `src/content/docs/logs/logpush/logpush-job/datasets/account/` — dataset pages
- `src/content/docs/logs/logpush/logpush-job/datasets/zone/` — dataset pages
- `src/content/changelog/logs/2026-06-30-log-fields-updated.mdx` — changelog

### Documentation checklist
- [x] Changelog entry added
- [x] Content generated by code generator (DO NOT EDIT manually)
