### PR TITLE
Clarify Keyless key server auto-generates its certificate

### DIFF
--- a/src/content/partials/ssl/keyless-key-server-setup.mdx
+++ b/src/content/partials/ssl/keyless-key-server-setup.mdx
@@ -163,4 +163,10 @@ To activate, restart your keyless instance:
 - systemd: `sudo service gokeyless restart`
 - upstart/sysvinit: `sudo /etc/init.d/gokeyless restart`
 
+:::note
+
+The first time the key server starts with the hostname, Zone ID, and Origin CA API key set, it automatically generates its own private key and certificate signing request (CSR), submits the CSR to Cloudflare, and saves the signed authentication certificate it presents for mutual TLS. You do not need to create this certificate manually. If those three values are not set, the key server will not start and asks you to set them — or to run it with `--config-only` or `--manual-activation` to generate the key and CSR interactively.
+
+:::
+
 If this command fails, try troubleshooting by [checking the logs](/ssl/keyless-ssl/troubleshooting/).

--- a/src/content/partials/ssl/keyless-key-server-setup.mdx
+++ b/src/content/partials/ssl/keyless-key-server-setup.mdx
@@ -165,7 +165,7 @@ To activate, restart your keyless instance:
 
 :::note
 
-The first time the key server starts with the hostname, Zone ID, and Origin CA API key set, it automatically generates its own private key and certificate signing request (CSR), submits the CSR to Cloudflare, and saves the signed authentication certificate it presents for mutual TLS. You do not need to create this certificate manually. If those three values are not set, the key server will not start and asks you to set them — or to run it with `--config-only` or `--manual-activation` to generate the key and CSR interactively.
+The first time the key server starts with the hostname, Zone ID, and Origin CA API key set, it automatically generates its own private key and certificate signing request (CSR), submits the CSR to Cloudflare, and saves the signed authentication certificate it presents for mutual TLS. You do not need to create this certificate manually. If those three values are not set, the key server will not start and will ask you to set them — or to run it with `--config-only` or `--manual-activation` to generate the key and CSR interactively.
 
 :::
 


### PR DESCRIPTION
Adds a note to the Activate step: on first start (with hostname, Zone ID, and Origin CA API key set), gokeyless generates its key + CSR and gets the certificate signed automatically — no manual cert creation needed. Addresses T257 / customer feedback.

### Summary

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
