### PR TITLE
[Flagship] add wrangler flagship documentation

### DIFF
--- a/package.json
+++ b/package.json
@@ -179,7 +179,7 @@
 		"vite": "7.3.5",
 		"vite-tsconfig-paths": "6.1.1",
 		"vitest": "4.1.9",
-		"wrangler": "4.106.0",
+		"wrangler": "4.107.0",
 		"zod": "4.4.3"
 	},
 	"lint-staged": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -429,8 +429,8 @@ importers:
         specifier: 4.1.9
         version: 4.1.9(@types/node@25.9.3)(happy-dom@20.10.3)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0))
       wrangler:
-        specifier: 4.106.0
-        version: 4.106.0(@cloudflare/workers-types@4.20260615.1)
+        specifier: 4.107.0
+        version: 4.107.0(@cloudflare/workers-types@4.20260615.1)
       zod:
         specifier: 4.4.3
         version: 4.4.3
@@ -836,11 +836,11 @@ packages:
     engines: {node: '>= 20.12.0'}
 
   '@cloudflare/kv-asset-handler@0.5.0':
-    resolution: {integrity: sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==}
+    resolution: {integrity: sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==, tarball: https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.5.0.tgz}
     engines: {node: '>=22.0.0'}
 
   '@cloudflare/unenv-preset@2.16.1':
-    resolution: {integrity: sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==}
+    resolution: {integrity: sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==, tarball: https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.1.tgz}
     peerDependencies:
       unenv: 2.0.0-rc.24
       workerd: '>1.20260305.0 <2.0.0-0'
@@ -861,8 +861,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@cloudflare/workerd-darwin-64@1.20260630.1':
-    resolution: {integrity: sha512-oEVsD2NZtPAMaEvFeH2Y6N63yiFuOnPDKeAM+l8AkRbLAbFk462uWOq6/ZLn8ouY4P4coMkgsOPqcT1mkuzvzg==, tarball: https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260630.1.tgz}
+  '@cloudflare/workerd-darwin-64@1.20260701.1':
+    resolution: {integrity: sha512-Zd9Y1bah6DwwBN2RW8vJohffQrIUazb8UXnqSNecOxM+jJLhUuvv5IOG8dbHcV83TyZAubea6gsQXo2yH1lDdw==, tarball: https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260701.1.tgz}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [darwin]
@@ -873,8 +873,8 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@cloudflare/workerd-darwin-arm64@1.20260630.1':
-    resolution: {integrity: sha512-tar1vcQSzM+27Agrlv28BhtN1tIFKw2YHrzldEMyQJOJB/885TU8Z3oO1c/a9YOmsKABhD6I4dGFhsmXyrbK1g==, tarball: https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260630.1.tgz}
+  '@cloudflare/workerd-darwin-arm64@1.20260701.1':
+    resolution: {integrity: sha512-yBLsjS1qCWqFyCY37qRUrYfzHHvMGvjh8zRKJ6MvUivYDhkZTzqduppK38FoqYvayLJ5KbcxH7zo5rkxGqbsaA==, tarball: https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260701.1.tgz}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
@@ -885,8 +885,8 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@cloudflare/workerd-linux-64@1.20260630.1':
-    resolution: {integrity: sha512-mhjIg91+ikWw5v9tY4BYO7N9vLOZBhn7EnVFvxCdxcpuUUFBKATxUYHUy1kkgYxnmiI6s93PRNbzBz1NpYQ3IQ==, tarball: https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260630.1.tgz}
+  '@cloudflare/workerd-linux-64@1.20260701.1':
+    resolution: {integrity: sha512-vMfqSIMfoo4xmZXEuUVqLpSFS921YKjiR9q7kDXPi6Vld1PK74UHg9LZuBavT2KSyemHUCTpj9y/4JSYOEyQbQ==, tarball: https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260701.1.tgz}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [linux]
@@ -897,8 +897,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@cloudflare/workerd-linux-arm64@1.20260630.1':
-    resolution: {integrity: sha512-7g0iGvMCwGct+vE3FOKXtFWMAIGHzK2Ei9oALp44gXuL4lBcs3PPJISeTp5itquW2JwS1fw4Hnq7zrT7N/dgPw==, tarball: https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260630.1.tgz}
+  '@cloudflare/workerd-linux-arm64@1.20260701.1':
+    resolution: {integrity: sha512-HRfwbKU2pK44V2NhoM0+iH0JJSj7nQ9Wv13ifIiGYCmTtDL8/zKtEhX7kQ3D4Vy/Cpjhttl0FkfqXj1aqLDPPg==, tarball: https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260701.1.tgz}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [linux]
@@ -909,8 +909,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@cloudflare/workerd-windows-64@1.20260630.1':
-    resolution: {integrity: sha512-J5KF9VF8yRpRBib/cPSuEp6iR9q3/cKgeDVhg1ZtuwpkzwnmCb+rxMF5WFLxAN8bI2x2FMG1v6o4vVFOGZ0fOQ==, tarball: https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260630.1.tgz}
+  '@cloudflare/workerd-windows-64@1.20260701.1':
+    resolution: {integrity: sha512-ngxCiIN9s/fM2o1IBMD0o1/mcXrv2NJVdyznh51UH8sQuvrTrXvV2nM0Uj/qU2wMwF6prgNBcdcd7AZeZGiBQA==, tarball: https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260701.1.tgz}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
@@ -5032,8 +5032,8 @@ packages:
     engines: {node: '>=22.0.0'}
     hasBin: true
 
-  miniflare@4.20260630.0:
-    resolution: {integrity: sha512-lyRplDrSJJWVpzSSQPBSQtNmUuxScCZyOOkXFs37uSbdTfWRDDmw6DyFKVS2s1eYtA/i4u2xR/0FyPIsTl/HJw==}
+  miniflare@4.20260701.0:
+    resolution: {integrity: sha512-L6eAAi6IKtyb/7J6L+YsH2vb1yBrJWKRXI293JYDiMl70+6nncdAgigex58w6WBd+CwvdMsqOyNyGs95Op5gWQ==}
     engines: {node: '>=22.0.0'}
     hasBin: true
 
@@ -6750,8 +6750,8 @@ packages:
     engines: {node: '>=16'}
     hasBin: true
 
-  workerd@1.20260630.1:
-    resolution: {integrity: sha512-7M0AA4l14hmPGtzQ5YPHyXosIKI/uz3TdcPHeiFDbgb7/0c8ECVMzIaodSV5bZIVhDHL0OlzqITAdPiwAr+dTg==}
+  workerd@1.20260701.1:
+    resolution: {integrity: sha512-uF813NG09JwNRRUfJ0zBomyTslSPM810dMj9LVvkQ7RAkLrQLzAlPU8Xh/3dIqZDo2bfd7tChbf2PtqLRARRJQ==}
     engines: {node: '>=16'}
     hasBin: true
 
@@ -6765,12 +6765,12 @@ packages:
       '@cloudflare/workers-types':
         optional: true
 
-  wrangler@4.106.0:
-    resolution: {integrity: sha512-b6EVbsvbmAUY4bUQXT3+f8oFP8x+J5rEa5z3Akeh+6vyKiN4x8+PyZ53DPpnqdxhIihhq/a00Yq5chGJ19QXBQ==}
+  wrangler@4.107.0:
+    resolution: {integrity: sha512-fw69ThymNitZ0oIEBU2yNeq3kK59UKz/jyA3udwRrQIAIsxX57q5qLOpPTN7qc5t8n9pnUeofe0uxtMuhQZW8w==}
     engines: {node: '>=22.0.0'}
     hasBin: true
     peerDependencies:
-      '@cloudflare/workers-types': ^4.20260630.1
+      '@cloudflare/workers-types': ^4.20260701.1
     peerDependenciesMeta:
       '@cloudflare/workers-types':
         optional: true
@@ -7506,11 +7506,11 @@ snapshots:
     optionalDependencies:
       workerd: 1.20260611.1
 
-  '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260630.1)':
+  '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260701.1)':
     dependencies:
       unenv: 2.0.0-rc.24
     optionalDependencies:
-      workerd: 1.20260630.1
+      workerd: 1.20260701.1
 
   '@cloudflare/vitest-pool-workers@0.16.15(@cloudflare/workers-types@4.20260615.1)(@vitest/runner@4.1.9)(@vitest/snapshot@4.1.9)(vitest@4.1.9(@types/node@25.9.3)(happy-dom@20.10.3)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0)))':
     dependencies:
@@ -7530,31 +7530,31 @@ snapshots:
   '@cloudflare/workerd-darwin-64@1.20260611.1':
     optional: true
 
-  '@cloudflare/workerd-darwin-64@1.20260630.1':
+  '@cloudflare/workerd-darwin-64@1.20260701.1':
     optional: true
 
   '@cloudflare/workerd-darwin-arm64@1.20260611.1':
     optional: true
 
-  '@cloudflare/workerd-darwin-arm64@1.20260630.1':
+  '@cloudflare/workerd-darwin-arm64@1.20260701.1':
     optional: true
 
   '@cloudflare/workerd-linux-64@1.20260611.1':
     optional: true
 
-  '@cloudflare/workerd-linux-64@1.20260630.1':
+  '@cloudflare/workerd-linux-64@1.20260701.1':
     optional: true
 
   '@cloudflare/workerd-linux-arm64@1.20260611.1':
     optional: true
 
-  '@cloudflare/workerd-linux-arm64@1.20260630.1':
+  '@cloudflare/workerd-linux-arm64@1.20260701.1':
     optional: true
 
   '@cloudflare/workerd-windows-64@1.20260611.1':
     optional: true
 
-  '@cloudflare/workerd-windows-64@1.20260630.1':
+  '@cloudflare/workerd-windows-64@1.20260701.1':
     optional: true
 
   '@cloudflare/workers-types@4.20260615.1': {}
@@ -12242,12 +12242,12 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  miniflare@4.20260630.0:
+  miniflare@4.20260701.0:
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       sharp: 0.34.5
       undici: 7.28.0
-      workerd: 1.20260630.1
+      workerd: 1.20260701.1
       ws: 8.21.0
       youch: 4.1.0-beta.10
     transitivePeerDependencies:
@@ -14267,13 +14267,13 @@ snapshots:
       '@cloudflare/workerd-linux-arm64': 1.20260611.1
       '@cloudflare/workerd-windows-64': 1.20260611.1
 
-  workerd@1.20260630.1:
+  workerd@1.20260701.1:
     optionalDependencies:
-      '@cloudflare/workerd-darwin-64': 1.20260630.1
-      '@cloudflare/workerd-darwin-arm64': 1.20260630.1
-      '@cloudflare/workerd-linux-64': 1.20260630.1
-      '@cloudflare/workerd-linux-arm64': 1.20260630.1
-      '@cloudflare/workerd-windows-64': 1.20260630.1
+      '@cloudflare/workerd-darwin-64': 1.20260701.1
+      '@cloudflare/workerd-darwin-arm64': 1.20260701.1
+      '@cloudflare/workerd-linux-64': 1.20260701.1
+      '@cloudflare/workerd-linux-arm64': 1.20260701.1
+      '@cloudflare/workerd-windows-64': 1.20260701.1
 
   wrangler@4.100.0(@cloudflare/workers-types@4.20260615.1):
     dependencies:
@@ -14292,16 +14292,16 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  wrangler@4.106.0(@cloudflare/workers-types@4.20260615.1):
+  wrangler@4.107.0(@cloudflare/workers-types@4.20260615.1):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.5.0
-      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260630.1)
+      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260701.1)
       blake3-wasm: 2.1.5
       esbuild: 0.28.1
-      miniflare: 4.20260630.0
+      miniflare: 4.20260701.0
       path-to-regexp: 6.3.0
       unenv: 2.0.0-rc.24
-      workerd: 1.20260630.1
+      workerd: 1.20260701.1
     optionalDependencies:
       '@cloudflare/workers-types': 4.20260615.1
       fsevents: 2.3.3

--- a/src/content/changelog/flagship/2026-07-16-wrangler-commands.mdx
+++ b/src/content/changelog/flagship/2026-07-16-wrangler-commands.mdx
@@ -1,0 +1,59 @@
+---
+title: Manage Flagship from the command line with Wrangler
+description: Create Flagship apps, bind them to Workers, switch feature flags, and run rollouts with wrangler flagship.
+products:
+  - flagship
+date: 2026-07-16
+---
+
+**[Wrangler](/workers/wrangler/)** now includes `wrangler flagship`, a command suite for managing [Flagship](/flagship/) apps and feature flags from your terminal.
+
+Create an app and, if you use it from a Worker, add it to your `wrangler.json` or `wrangler.jsonc` file as a binding:
+
+```bash
+wrangler flagship apps create "My Worker App" \
+  --binding FLAGS \
+  --update-config
+```
+
+Then create flags for the behavior you want to control. Flags can be booleans, strings, numbers, or JSON values:
+
+```bash
+wrangler flagship flags create <APP_ID> new-checkout
+
+wrangler flagship flags create <APP_ID> checkout-flow \
+  --variation control=old-checkout \
+  --variation treatment=new-checkout \
+  --default control \
+  --type string
+```
+
+After a flag exists, change its default variation or use enable and disable commands as kill switches. Existing targeting rules continue to apply unless you change or clear them explicitly:
+
+```bash
+wrangler flagship flags update <APP_ID> checkout-flow --default treatment
+wrangler flagship flags disable <APP_ID> checkout-flow
+wrangler flagship flags enable <APP_ID> checkout-flow
+```
+
+For release workflows, use `rollout`, `split`, and `rules` to change exposure without redeploying your Worker:
+
+```bash
+wrangler flagship flags rollout <APP_ID> new-checkout \
+  --to on \
+  --percentage 25 \
+  --by user_id
+
+wrangler flagship flags split <APP_ID> checkout-flow \
+  --weight control=80 \
+  --weight treatment=20 \
+  --by user_id
+
+wrangler flagship flags rules update <APP_ID> checkout-flow \
+  --priority 1 \
+  --when "country equals US"
+```
+
+These commands can also be used from CI/CD pipelines, scripts, and AI agents to inspect Flagship state, update flag behavior, or roll back changes through Wrangler.
+
+Refer to the [`wrangler flagship` command reference](/flagship/reference/wrangler-commands/) for the full command guide.

--- a/src/content/docs/flagship/get-started.mdx
+++ b/src/content/docs/flagship/get-started.mdx
@@ -179,6 +179,7 @@ Refer to the [SDK documentation](/flagship/sdk/) for detailed setup instructions
 
 ## Next steps
 
+- Manage flags from the command line with the [`wrangler flagship` commands](/flagship/reference/wrangler-commands/).
 - Learn about [targeting rules](/flagship/targeting/) to serve different values based on user attributes.
 - Explore the full [binding API reference](/flagship/binding/) for all evaluation methods.
 - Read about [percentage rollouts](/flagship/targeting/percentage-rollouts/) for gradual feature releases.

--- a/src/content/docs/flagship/reference/wrangler-commands.mdx
+++ b/src/content/docs/flagship/reference/wrangler-commands.mdx
@@ -447,6 +447,14 @@ wrangler flagship flags rules update <APP_ID> premium-banner \
 	--clear-conditions
 ```
 
+<Aside type="caution">
+
+A rule with no conditions matches every evaluation context. Flagship requires unconditional rules to come after all rules that have conditions. If the rule you are clearing is not the last rule in the set, the API will reject the update with `Rules with empty conditions must come after rules with conditions`.
+
+Use `rules reorder` first to move the rule to the last position, then clear its conditions. If you want to serve a single variation to everyone and discard all other rules, use `--clear-rules` on `flags set` instead.
+
+</Aside>
+
 Remove a rollout from a rule:
 
 ```sh
@@ -466,6 +474,12 @@ wrangler flagship flags rules delete <APP_ID> premium-banner --priority 2
 After deleting a rule, Wrangler renumbers the remaining rules so priorities stay contiguous.
 
 ## Run releases and kill switches
+
+<Aside type="note">
+
+After you change a flag, it can take up to 30 seconds for the updated value to reflect globally. During this propagation window, some evaluations may still return the previous flag value.
+
+</Aside>
 
 ### Enable and disable
 

--- a/src/content/docs/flagship/reference/wrangler-commands.mdx
+++ b/src/content/docs/flagship/reference/wrangler-commands.mdx
@@ -1,0 +1,649 @@
+---
+pcx_content_type: reference
+title: Wrangler commands
+description: Use wrangler flagship to create apps, manage feature flags, configure targeting rules, run rollouts, evaluate flags, and inspect changelog history.
+sidebar:
+  order: 4
+products:
+  - flagship
+---
+
+import { Aside, WranglerConfig, WranglerNamespace } from "~/components";
+
+Use `wrangler flagship` to manage Flagship apps and feature flags from the command line. Every `wrangler flagship flags` command takes the app ID as the first argument. Most subcommands then take a flag key, for example `wrangler flagship flags get <APP_ID> <KEY>`. List-style commands, such as `wrangler flagship flags list <APP_ID>`, take only the app ID.
+
+## Before you begin
+
+### Authenticate Wrangler
+
+`wrangler flagship` calls the Cloudflare API. Authenticate Wrangler before running commands:
+
+```sh
+wrangler login
+```
+
+For automation, set [`CLOUDFLARE_API_TOKEN`](/workers/wrangler/system-environment-variables/) to an [API token](/fundamentals/api/get-started/create-token/) with the appropriate Flagship permissions.
+
+| Permission       | Use it for                                                                                                                                          |
+| ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `flagship:read`  | Listing apps, getting apps, listing flags, inspecting flags, evaluating flags, and reading changelogs.                                               |
+| `flagship:write` | Creating apps, updating apps, deleting apps, creating flags, updating flags, changing defaults, rollouts, splits, enable/disable, and deleting flags. |
+
+Most commands that modify an existing flag first read the current flag and then write back the updated definition. For those workflows, grant both `flagship:read` and `flagship:write`.
+
+### Bind Flagship to your Worker
+
+Add a Flagship binding to your Worker project so your Worker code can evaluate flags with low latency at runtime:
+
+<WranglerConfig>
+
+```toml
+[[flagship]]
+binding = "FLAGS"
+app_id = "<APP_ID>"
+```
+
+</WranglerConfig>
+
+<Aside type="note">
+
+This binding is only used by your Worker's runtime code (`env.FLAGS`). `wrangler flagship` commands always take the app ID as an explicit argument and do not read it from this binding.
+
+</Aside>
+
+## Quick start
+
+Create a boolean flag, evaluate it for a user, and disable it as a kill switch:
+
+```sh
+# With no variations, Wrangler creates on=true, off=false,
+# and serves off by default.
+wrangler flagship flags create <APP_ID> new-checkout
+
+# Evaluate the flag for a user.
+wrangler flagship flags evaluate <APP_ID> new-checkout --targeting-key user-42
+
+# Disable the flag instantly. Disabled flags always serve their default variation.
+wrangler flagship flags disable <APP_ID> new-checkout
+```
+
+## Manage apps
+
+Apps group related flags. A common pattern is one app per service, Worker, or product surface.
+
+| Task       | Command                                                |
+| ---------- | ------------------------------------------------------ |
+| Create app | `wrangler flagship apps create <NAME>`                 |
+| List apps  | `wrangler flagship apps list`                          |
+| Get app    | `wrangler flagship apps get <APP_ID>`                  |
+| Rename app | `wrangler flagship apps update <APP_ID> --name <NAME>` |
+| Delete app | `wrangler flagship apps delete <APP_ID>`               |
+
+`wrangler flagship apps ls` is an alias for `apps list`. `wrangler flagship apps rm` is an alias for `apps delete`.
+
+`wrangler flagship apps list` follows pagination automatically and displays all apps in the account.
+
+Creating an app returns the app ID and shows the binding snippet to add to your Wrangler configuration:
+
+```sh
+wrangler flagship apps create checkout-service
+```
+
+To add the new app to your `wrangler.json` or `wrangler.jsonc` file as a Worker binding, pass `--binding`:
+
+```sh
+wrangler flagship apps create checkout-service --binding FLAGS
+```
+
+Wrangler also supports `--update-config` to update your JSON or JSONC configuration after prompting for a binding name.
+
+For non-JSON configuration files, Wrangler prints the binding snippet but does not edit the file automatically.
+
+When `--json` is used, `apps create` prints the created app as JSON and does not prompt for or update configuration.
+
+For scripts, capture the app ID from JSON output:
+
+```sh
+APP_ID=$(wrangler flagship apps create checkout-service --json | jq -r '.id')
+```
+
+Deleting an app deletes all of its flags and changelog history. The API rejects app deletion if a Worker still references the app through a Flagship binding.
+
+Use `--force` or `-y` to skip the delete confirmation prompt. If you also use `--json`, you must pass `--force` so the confirmation prompt cannot appear in JSON output.
+
+```sh
+wrangler flagship apps delete <APP_ID> --force
+```
+
+Delete multiple apps by passing multiple app IDs:
+
+```sh
+wrangler flagship apps delete <APP_ID_1> <APP_ID_2> <APP_ID_3> --force
+```
+
+## Create flags
+
+Flag keys are unique within an app. Use stable keys that describe the behavior being controlled, such as `new-checkout`, `pricing-page-layout`, or `upload-limit`.
+
+### Boolean flags
+
+If you omit variations, Wrangler creates a boolean flag with `on=true`, `off=false`, and `off` as the default variation.
+
+```sh
+wrangler flagship flags create <APP_ID> new-checkout
+```
+
+### Explicit variations
+
+Use `--variation` (`-V`) to add each variation as `name=value`. Use `--default` to choose the fallback variation.
+
+```sh
+# String flag.
+wrangler flagship flags create <APP_ID> checkout-flow \
+	-V v1=old-checkout \
+	-V v2=new-checkout \
+	--default v1 \
+	--type string
+
+# Number flag.
+wrangler flagship flags create <APP_ID> upload-limit \
+	-V free=10 \
+	-V pro=100 \
+	-V enterprise=1000 \
+	--default free \
+	--type number
+
+# JSON flag.
+wrangler flagship flags create <APP_ID> theme-config \
+	-V 'light={"bg":"#ffffff","fg":"#111111"}' \
+	-V 'dark={"bg":"#111111","fg":"#ffffff"}' \
+	--default light \
+	--type json
+```
+
+Supported value types are `boolean`, `string`, `number`, and `json`. If `--type` is omitted, Wrangler infers each value's scalar type independently.
+
+All variations on a flag must use the same value type. Wrangler rejects a flag whose variations resolve to mixed types, for example one boolean and one number, before sending the request. Pass `--type` explicitly to coerce every variation to the same type.
+
+Use `--description` (`-d`) to document the purpose of a flag:
+
+```sh
+wrangler flagship flags create <APP_ID> checkout-flow \
+	-V v1=old-checkout \
+	-V v2=new-checkout \
+	--default v1 \
+	--type string \
+	--description "Controls which checkout experience is served"
+```
+
+Flag keys and variation names can contain letters, numbers, hyphens, and underscores. Keep keys stable, because application code evaluates flags by key.
+
+### Disabled flags
+
+Use `--disabled` to create a flag that serves its default variation until you enable it.
+
+```sh
+wrangler flagship flags create <APP_ID> coming-soon \
+	-V on=true \
+	-V off=false \
+	--default off \
+	--disabled
+```
+
+## Target users with rules
+
+Targeting rules decide which variation to serve for a given evaluation context. Pass rules with `--rule` or `--rule-json`.
+
+### Rule syntax
+
+The compact `--rule` syntax uses semicolon-separated segments:
+
+```txt
+serve=<VARIATION>; when=<CONDITIONS>; rollout=<PERCENT>%@<ATTRIBUTE>; priority=<NUMBER>
+```
+
+| Segment    | Required | Description                                                                                     |
+| ---------- | -------- | ----------------------------------------------------------------------------------------------- |
+| `serve`    | Yes      | Variation served when the rule matches. Must reference an existing variation.                    |
+| `when`     | No       | Conditions matched against evaluation context. If omitted, the rule matches every context.       |
+| `rollout`  | No       | Percentage of matching traffic to receive the variation. The attribute controls sticky bucketing. |
+| `priority` | No       | Evaluation order. Lower numbers run first. If omitted, Wrangler assigns priorities by order.     |
+
+```sh
+wrangler flagship flags create <APP_ID> premium-banner \
+	-V on=true \
+	-V off=false \
+	--default off \
+	--rule "serve=on; when=plan equals enterprise AND country in [US,CA]; rollout=25%@user_id"
+```
+
+### Conditions
+
+Conditions compare attributes from the evaluation context with rule values. The compact syntax supports all [Flagship operators](/flagship/targeting/operators/):
+
+```sh
+--rule "serve=on; when=plan equals pro"
+--rule "serve=on; when=country in [US,CA,UK]"
+--rule "serve=off; when=email ends_with @example.com"
+--rule "serve=strict; when=score less_than 20"
+```
+
+Use `AND` and `OR` to combine conditions. `AND` has higher precedence than `OR`.
+
+```sh
+# Both conditions must match.
+--rule "serve=on; when=plan equals pro AND country equals US"
+
+# Either condition can match.
+--rule "serve=on; when=plan equals enterprise OR plan equals team"
+
+# Equivalent to: (plan=pro AND country=US) OR plan=enterprise.
+--rule "serve=on; when=plan equals pro AND country equals US OR plan equals enterprise"
+```
+
+`AND` and `OR` are reserved as logical operators when they appear outside quoted values or lists. Wrap values in single or double quotes when they contain reserved words or separators such as `AND`, `OR`, `;`, or `,`:
+
+```sh
+--rule 'serve=on; when=title equals "WAR AND PEACE" OR title equals "tom; jerry"'
+--rule 'serve=on; when=country in ["US","CA"]'
+```
+
+For `in` and `not_in`, pass a bracketed list. Wrangler rejects malformed lists, empty list items, unterminated quotes, and unbalanced brackets before sending the request.
+
+Use `--rule-json` for deeply nested logical groups or if you prefer to pass the API rule shape directly. Wrangler validates `--rule-json` against the Flagship rule schema and rejects unknown or conflicting fields.
+
+```sh
+wrangler flagship flags create <APP_ID> beta-features \
+	-V on=true \
+	-V off=false \
+	--default off \
+	--rule-json '{"serve_variation":"on","conditions":[{"logical_operator":"OR","clauses":[{"attribute":"beta","operator":"equals","value":true},{"attribute":"plan","operator":"equals","value":"enterprise"}]}]}'
+```
+
+### Multiple rules
+
+Repeat `--rule` or `--rule-json` to declare multiple rules. Rules are evaluated in priority order. The first matching rule wins.
+
+```sh
+wrangler flagship flags create <APP_ID> rate-limit-tier \
+	-V strict=50 \
+	-V normal=200 \
+	-V relaxed=1000 \
+	--default normal \
+	--type number \
+	--rule "serve=strict; when=score less_than 20" \
+	--rule "serve=relaxed; when=score greater_than_or_equals 90"
+```
+
+Wrangler validates duplicate rule priorities, duplicate variation names, malformed lists, non-finite numeric values such as `Infinity`, and unknown variation names before sending the request.
+
+## Inspect flags
+
+List flags in an app:
+
+```sh
+wrangler flagship flags list <APP_ID>
+```
+
+The list command is paginated. Use `--limit` and `--cursor` for manual pagination, or `--all` to fetch every page.
+
+```sh
+wrangler flagship flags list <APP_ID> --limit 50
+wrangler flagship flags list <APP_ID> --cursor <CURSOR>
+wrangler flagship flags list <APP_ID> --all
+```
+
+Inspect a full flag definition:
+
+```sh
+wrangler flagship flags get <APP_ID> new-checkout
+```
+
+`wrangler flagship flags ls` is an alias for `flags list`. `wrangler flagship flags inspect` is an alias for `flags get`.
+
+## Update flags
+
+`wrangler flagship flags update` reads the current flag, applies your changes, and writes the full flag definition back to the API.
+
+### Update metadata and variations
+
+```sh
+wrangler flagship flags update <APP_ID> new-checkout \
+	--description "Redesigned checkout experience"
+
+wrangler flagship flags update <APP_ID> upload-limit \
+	--set-variation team=500
+
+wrangler flagship flags update <APP_ID> upload-limit \
+	--remove-variation team
+```
+
+To add a variant to an existing flag, set a new variation name and value:
+
+```sh
+wrangler flagship flags update <APP_ID> checkout-flow \
+	--set-variation experiment=new-checkout-v2
+```
+
+Pass an empty description to clear it:
+
+```sh
+wrangler flagship flags update <APP_ID> new-checkout --description ""
+```
+
+When you add or replace variations on an existing flag, use `--type` if Wrangler should coerce the new values to a specific type:
+
+```sh
+wrangler flagship flags update <APP_ID> upload-limit \
+	--type number \
+	--set-variation team=500
+```
+
+Wrangler validates that the resulting variation set still has a single value type and that the default variation and targeting rules still reference known variations.
+
+You can also enable or disable a flag through `flags update`, although `flags enable` and `flags disable` are shorter for kill-switch workflows:
+
+```sh
+wrangler flagship flags update <APP_ID> new-checkout --disable
+wrangler flagship flags update <APP_ID> new-checkout --enable
+```
+
+### Change the default variation
+
+```sh
+wrangler flagship flags set <APP_ID> checkout-flow --variation v2
+```
+
+Use `--clear-rules` if the new default should be served to everyone.
+
+```sh
+wrangler flagship flags set <APP_ID> checkout-flow --variation v2 --clear-rules
+```
+
+### Replace, append, or clear all rules
+
+Use `--rule` or `--rule-json` to replace the full rule set:
+
+```sh
+wrangler flagship flags update <APP_ID> premium-banner \
+	--rule "serve=on; when=plan equals pro AND country not_in [CN,RU]"
+```
+
+Use `--add-rule` or `--add-rule-json` to append rules without changing existing rules:
+
+```sh
+wrangler flagship flags update <APP_ID> premium-banner \
+	--add-rule "serve=off; when=account_age less_than 7"
+
+wrangler flagship flags update <APP_ID> premium-banner \
+	--add-rule-json '{"serve_variation":"off","conditions":[{"attribute":"country","operator":"in","value":["CN","RU"]}]}'
+```
+
+Clear all rules:
+
+```sh
+wrangler flagship flags update <APP_ID> premium-banner --clear-rules
+```
+
+<Aside type="note">
+
+Do not combine replacement flags (`--rule`, `--rule-json`) with append flags (`--add-rule`, `--add-rule-json`), or with `--clear-rules`, in the same command.
+
+</Aside>
+
+### List rules
+
+Use `rules list` to see the priorities you can target with rule-specific commands:
+
+```sh
+wrangler flagship flags rules list <APP_ID> premium-banner
+```
+
+### Reorder rules
+
+Flagship evaluates rules by ascending `priority`; the first matching rule wins. Use `rules reorder` to reorder existing rules without rewriting every condition.
+
+Pass the existing priorities in the new order. Wrangler renumbers them to `1..n` in that order:
+
+```sh
+wrangler flagship flags rules reorder <APP_ID> rate-limit-tier --order 2,1
+```
+
+If the existing priorities were `1=strict` and `2=relaxed`, this makes `relaxed` priority `1` and `strict` priority `2`.
+
+### Change one rule
+
+Use `rules update` to edit one rule by priority while preserving the rest of the rule set.
+
+Change only a rollout percentage:
+
+```sh
+wrangler flagship flags rules update <APP_ID> premium-banner \
+	--priority 1 \
+	--rollout 50%@user_id
+```
+
+Change the variation served by a rule:
+
+```sh
+wrangler flagship flags rules update <APP_ID> premium-banner \
+	--priority 1 \
+	--serve off
+```
+
+Change the conditions on a rule:
+
+```sh
+wrangler flagship flags rules update <APP_ID> premium-banner \
+	--priority 1 \
+	--when "plan equals enterprise OR plan equals team"
+```
+
+Remove conditions from a rule so it matches every evaluation context:
+
+```sh
+wrangler flagship flags rules update <APP_ID> premium-banner \
+	--priority 1 \
+	--clear-conditions
+```
+
+Remove a rollout from a rule:
+
+```sh
+wrangler flagship flags rules update <APP_ID> premium-banner \
+	--priority 1 \
+	--clear-rollout
+```
+
+### Delete one rule
+
+Use `rules delete` to remove one rule by priority:
+
+```sh
+wrangler flagship flags rules delete <APP_ID> premium-banner --priority 2
+```
+
+After deleting a rule, Wrangler renumbers the remaining rules so priorities stay contiguous.
+
+## Run releases and kill switches
+
+### Enable and disable
+
+Disabling a flag is an immediate kill switch. A disabled flag ignores targeting rules and serves its default variation.
+
+```sh
+wrangler flagship flags disable <APP_ID> new-checkout
+wrangler flagship flags enable <APP_ID> new-checkout
+```
+
+Enable or disable multiple flags in an app by passing the app ID followed by multiple keys:
+
+```sh
+wrangler flagship flags disable <APP_ID> new-checkout dark-mode premium-banner
+wrangler flagship flags enable <APP_ID> new-checkout dark-mode premium-banner
+```
+
+### Roll out one variation
+
+Use `rollout` to serve one variation to a percentage of traffic.
+
+```sh
+wrangler flagship flags rollout <APP_ID> new-checkout \
+	--to on \
+	--percentage 25 \
+	--by user_id
+```
+
+Use `--from-variation` (alias `--from`) to choose the fallback variation for the remaining traffic. A rollout percentage of `0` removes the rollout rule and keeps the flag's current default variation unchanged.
+
+`rollout` sends the percentage you provide directly to Flagship. For example, `--percentage 25 --to on` serves the `on` variation to 25% of bucketed traffic. The remaining traffic falls through to the flag's default variation.
+
+### Split traffic across variations
+
+Use `split` for A/B tests or multi-way traffic allocation. Wrangler converts weights into cumulative rollout thresholds.
+
+```sh
+wrangler flagship flags split <APP_ID> checkout-flow \
+	--weight v1=80 \
+	--weight v2=20 \
+	--by user_id
+```
+
+`-w` is an alias for `--weight`. Each variation can only be weighted once, and weights must be finite, non-negative numbers.
+
+Weights are relative. Wrangler totals the weights, converts each one into a percentage of the total, and sends cumulative thresholds to Flagship. For example, `--weight v1=80 --weight v2=20` sends two generated rules: one for `v1` with a rollout percentage of `80`, and one for `v2` with a rollout percentage of `100`. This creates bucket ranges of `0-80` for `v1` and `80-100` for `v2`.
+
+With three weights, `--weight a=50 --weight b=30 --weight c=20` becomes cumulative thresholds of `50`, `80`, and `100`. Zero-weight variations are skipped.
+
+Use `--default` with `split` to choose the fallback variation when bucketing cannot run:
+
+```sh
+wrangler flagship flags split <APP_ID> checkout-flow \
+	--weight v1=80 \
+	--weight v2=20 \
+	--default v1 \
+	--by user_id
+```
+
+<Aside type="caution">
+
+`rollout` and `split` replace the flag's entire rule set with the rollout or split rules they generate. If the flag has other targeting rules built with `--rule`, `--rule-json`, `--add-rule`, or `rules update` (rules with real conditions, not just a previous rollout or split), Wrangler asks for confirmation before overwriting them. Pass `--force` (`-y`) to skip the prompt, or use `--json` with `--force` in scripts. Rules with no conditions, such as ones created by an earlier `rollout` or `split` call, are replaced without a prompt.
+
+</Aside>
+
+```sh
+wrangler flagship flags rollout <APP_ID> new-checkout --to on --percentage 100 --force
+```
+
+## Evaluate flags
+
+Evaluate a flag from the CLI to verify what a specific context receives.
+
+```sh
+wrangler flagship flags evaluate <APP_ID> new-checkout
+
+wrangler flagship flags evaluate <APP_ID> new-checkout \
+	--targeting-key user-42
+
+wrangler flagship flags evaluate <APP_ID> premium-banner \
+	--context plan=enterprise \
+	--context country=US \
+	--targeting-key user-99
+```
+
+Use `--targeting-key` for stable percentage rollout bucketing. Pass each context attribute with `--context name=value`. `wrangler flagship flags eval` is an alias for `flags evaluate`.
+
+`--context` can be repeated. `--ctx` and `-C` are aliases:
+
+```sh
+wrangler flagship flags evaluate <APP_ID> premium-banner \
+	-C plan=enterprise \
+	-C country=US \
+	--targeting-key user-99
+```
+
+Context values are sent to the evaluation endpoint as strings. Use the same attribute names that your targeting rules expect.
+
+Evaluation output includes:
+
+| Field     | Description                                                                      |
+| --------- | -------------------------------------------------------------------------------- |
+| `value`   | The flag value returned for the context.                                          |
+| `variant` | The variation selected for the context.                                           |
+| `reason`  | Why the value was returned: `TARGETING_MATCH`, `DEFAULT`, `DISABLED`, or `SPLIT`. |
+
+## Audit changes
+
+Flagship records create, update, and delete events for each flag. View changelog history newest first:
+
+```sh
+wrangler flagship flags changelog <APP_ID> new-checkout
+```
+
+Use pagination controls for long histories:
+
+```sh
+wrangler flagship flags changelog <APP_ID> new-checkout --limit 10
+wrangler flagship flags changelog <APP_ID> new-checkout --cursor <CURSOR>
+wrangler flagship flags changelog <APP_ID> new-checkout --all
+```
+
+`wrangler flagship flags history` is an alias for `flags changelog`.
+
+## Delete flags
+
+```sh
+wrangler flagship flags delete <APP_ID> coming-soon
+```
+
+Use `--force` or `-y` to skip the confirmation prompt. If you also use `--json`, you must pass `--force` so the confirmation prompt cannot appear in JSON output.
+
+```sh
+wrangler flagship flags delete <APP_ID> coming-soon --force
+```
+
+`wrangler flagship flags rm` is an alias for `flags delete`.
+
+Delete multiple flags by passing the app ID followed by multiple keys:
+
+```sh
+wrangler flagship flags delete <APP_ID> coming-soon old-checkout temporary-banner --force
+```
+
+## Automate with JSON output
+
+Every `wrangler flagship` command accepts `--json`. JSON output suppresses the Wrangler banner and is intended for scripts.
+
+Delete commands require `--force` with `--json` to keep stdout valid JSON. `rollout` and `split` also require `--force` with `--json` if they would replace existing targeting rules that have conditions.
+
+Bulk commands, such as `flags delete`, `flags enable`, and `flags disable`, continue processing remaining flags if one flag fails. In JSON mode, partial failures return a JSON error object containing successful `results` and per-flag `failures`.
+
+Commands that can update `wrangler.json` or `wrangler.jsonc`, such as `apps create --binding`, do not prompt for or update configuration when `--json` is used.
+
+Create an app, capture its ID, then create a flag:
+
+```sh
+APP_ID=$(wrangler flagship apps create checkout-service --json | jq -r '.id')
+
+wrangler flagship flags create "$APP_ID" new-checkout --json
+```
+
+Delete several apps in a loop:
+
+```sh
+for app_id in <APP_ID_1> <APP_ID_2> <APP_ID_3>; do
+	wrangler flagship apps delete "$app_id" --force
+done
+```
+
+Or pass the app IDs directly:
+
+```sh
+wrangler flagship apps delete <APP_ID_1> <APP_ID_2> <APP_ID_3> --force
+```
+
+## Command reference
+
+The following reference is generated from Wrangler's `flagship` command definitions.
+
+<WranglerNamespace namespace="flagship" />

--- a/src/content/docs/workers/wrangler/commands/flagship.mdx
+++ b/src/content/docs/workers/wrangler/commands/flagship.mdx
@@ -1,0 +1,110 @@
+---
+pcx_content_type: reference
+title: Flagship
+description: Wrangler commands for managing Flagship apps, feature flags, targeting rules, rollouts, evaluations, and changelog history.
+products:
+  - workers
+---
+
+import { WranglerNamespace } from "~/components";
+
+Use `wrangler flagship` to manage [Flagship](/flagship/) apps and feature flags from the command line.
+
+`wrangler flagship` is available in Wrangler v4.107.0 and later.
+
+## Authentication
+
+Run `wrangler login`, or set [`CLOUDFLARE_API_TOKEN`](/workers/wrangler/system-environment-variables/) to an API token with Flagship permissions.
+
+| Permission       | Required for                                                                                |
+| ---------------- | ------------------------------------------------------------------------------------------- |
+| `flagship:read`  | Listing apps, inspecting flags, evaluating flags, and reading changelogs.                    |
+| `flagship:write` | Creating, updating, deleting, enabling, disabling, rolling out, and splitting apps or flags. |
+
+Most write workflows also read the current flag before writing the updated definition, so grant both permissions for operational use.
+
+## App IDs
+
+`wrangler flagship flags` commands always take the app ID as the first argument. Most subcommands then take a flag key; list-style commands, such as `flags list`, take only the app ID:
+
+```sh
+wrangler flagship flags get <APP_ID> new-checkout
+wrangler flagship flags disable <APP_ID> new-checkout
+wrangler flagship flags list <APP_ID>
+```
+
+Create an app first if you do not already have one:
+
+```sh
+wrangler flagship apps create checkout-service
+```
+
+Pass `--binding <NAME>` when creating an app to add it to your `wrangler.json` or `wrangler.jsonc` file as a Worker binding.
+
+## Common workflows
+
+Create a boolean flag. With no variations, Wrangler creates `on=true`, `off=false`, and serves `off` by default:
+
+```sh
+wrangler flagship flags create <APP_ID> new-checkout
+```
+
+Add targeting rules with the compact rule syntax:
+
+```sh
+wrangler flagship flags create <APP_ID> premium-banner \
+	-V on=true \
+	-V off=false \
+	--default off \
+	--rule "serve=on; when=plan equals enterprise AND country in [US,CA]; rollout=25%@user_id"
+```
+
+Use uppercase `AND` and `OR` outside quoted values to combine conditions. Quote values that contain reserved words or separators:
+
+```sh
+wrangler flagship flags create <APP_ID> banner-copy \
+	-V shown=true \
+	-V hidden=false \
+	--default hidden \
+	--rule 'serve=shown; when=title equals "WAR AND PEACE" OR country in ["US","CA"]'
+```
+
+For deeply nested condition groups, use `--rule-json`. Wrangler validates both compact rules and JSON rules before sending requests.
+
+Change one existing rule without rewriting the full rule set:
+
+```sh
+wrangler flagship flags rules update <APP_ID> premium-banner \
+	--priority 1 \
+	--rollout 50%@user_id
+```
+
+Evaluate a flag for a user:
+
+```sh
+wrangler flagship flags evaluate <APP_ID> premium-banner \
+	--context plan=enterprise \
+	--context country=US \
+	--targeting-key user-42
+```
+
+Use `disable` as an immediate kill switch:
+
+```sh
+wrangler flagship flags disable <APP_ID> premium-banner
+```
+
+Enable, disable, or delete multiple flags by passing the app ID followed by multiple keys:
+
+```sh
+wrangler flagship flags disable <APP_ID> new-checkout dark-mode premium-banner
+wrangler flagship flags delete <APP_ID> coming-soon old-banner --force
+```
+
+Delete commands require `--force` when used with `--json` so prompts cannot corrupt JSON output. `rollout` and `split` require the same when they would replace existing targeting rules that have conditions.
+
+Refer to the [Flagship Wrangler commands reference](/flagship/reference/wrangler-commands/) for a complete workflow guide covering targeting rules, rollouts, traffic splits, changelogs, and scripting with `--json`.
+
+## Commands
+
+<WranglerNamespace namespace="flagship" />


### PR DESCRIPTION
### Summary

Adds documentation for the new `wrangler flagship` CLI command group, which manages Flagship apps and feature flags from the command line.

This change adds:

- A new reference page, [`flagship/reference/wrangler-commands`](https://developers.cloudflare.com/flagship/reference/wrangler-commands/), covering authentication, binding a Flagship app to a Worker, creating and inspecting apps and flags, targeting rules (including the compact rule syntax and `--rule-json`), rollouts and traffic splits, enabling and disabling flags, evaluating flags, changelog history, and scripting with `--json` output.
- A new Wrangler command reference page at [`workers/wrangler/commands/flagship`](https://developers.cloudflare.com/workers/wrangler/commands/flagship/), consistent with how other Wrangler command groups are documented, that links to the fuller Flagship reference guide for complete workflows.
- A link to the new reference page from the existing Flagship "Get started" guide.

### Documentation checklist

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).