### PR TITLE
[Email Service] Document Email Sending event subscriptions

### DIFF
--- a/src/content/changelog/email-service/2026-07-02-event-subscriptions.mdx
+++ b/src/content/changelog/email-service/2026-07-02-event-subscriptions.mdx
@@ -3,6 +3,7 @@ title: Subscribe to Email Sending events with Queues
 description: Receive outbound transactional email lifecycle events on a queue by subscribing per sending domain.
 products:
   - email-service
+  - queues
 date: 2026-07-02
 ---
 

--- a/src/content/changelog/email-service/2026-07-02-event-subscriptions.mdx
+++ b/src/content/changelog/email-service/2026-07-02-event-subscriptions.mdx
@@ -1,0 +1,35 @@
+---
+title: Subscribe to Email Sending events with Queues
+description: Receive outbound transactional email lifecycle events on a queue by subscribing per sending domain.
+products:
+  - email-service
+date: 2026-07-02
+---
+
+You can now subscribe to **[Email Sending](/email-service/api/send-emails/) events** through [Queues event subscriptions](/queues/event-subscriptions/) and receive outbound transactional email lifecycle events on a queue. Each subscription is scoped to one sending domain — either the zone apex, such as `example.com`, or a verified sending subdomain, such as `send.example.com`.
+
+Six event types are published: `message.delivered`, `message.deferred`, `message.bounced`, `message.failed`, `message.rejected`, and `message.complained`. Use them to track deliverability, react to bounces and complaints, and drive suppression or retry logic. Email Routing events are not published on this source.
+
+Each event includes the message details, delivery status, and SMTP response:
+
+```json
+{
+	"type": "cf.email.sending.message.delivered",
+	"source": {
+		"type": "email.sending",
+		"zoneId": "023e105f4ecef8ad9ca31a8372d0c353",
+		"domain": "example.com"
+	},
+	"payload": {
+		"messageId": "0101018f7d0c4d9a-msg-deadbeef",
+		"recipient": "user@example.net",
+		"terminal": true,
+		"delivery": {
+			"status": "delivered",
+			"smtpStatusCode": "250"
+		}
+	}
+}
+```
+
+Refer to [Event subscriptions](/email-service/platform/event-subscriptions/) to see all event types and example payloads.

--- a/src/content/changelog/email-service/2026-07-15-event-subscriptions.mdx
+++ b/src/content/changelog/email-service/2026-07-15-event-subscriptions.mdx
@@ -4,7 +4,7 @@ description: Receive outbound transactional email lifecycle events on a queue by
 products:
   - email-service
   - queues
-date: 2026-07-02
+date: 2026-07-15
 ---
 
 You can now subscribe to **[Email Sending](/email-service/api/send-emails/) events** through [Queues event subscriptions](/queues/event-subscriptions/) and receive outbound transactional email lifecycle events on a queue. Each subscription is scoped to one sending domain — either the zone apex, such as `example.com`, or a verified sending subdomain, such as `send.example.com`.

--- a/src/content/docs/email-service/examples/email-sending/sync-recipient-records.mdx
+++ b/src/content/docs/email-service/examples/email-sending/sync-recipient-records.mdx
@@ -1,0 +1,181 @@
+---
+summary: Synchronize application recipient records with Email Sending lifecycle events.
+pcx_content_type: example
+title: Sync recipient records
+description: Remove recipients after hard bounces and spam complaints.
+sidebar:
+  order: 10
+products:
+  - email-service
+---
+
+import {
+	DashButton,
+	PackageManagers,
+	Steps,
+	TypeScriptExample,
+	WranglerConfig,
+} from "~/components";
+
+Use [Email Sending event subscriptions](/email-service/platform/event-subscriptions/) to update application records after delivery problems. This example uses [Cloudflare Queues](/queues/) and [Workers KV](/kv/) to remove recipients from transactional notifications.
+
+:::note[Suppression lists]
+Email Sending automatically [suppresses](/email-service/concepts/suppressions/) hard bounces and spam complaints. This example also prevents your application from selecting those recipients.
+
+Workers KV is eventually consistent. Deletions can take 60 seconds or longer to appear in other locations.
+:::
+
+## Prepare the resources
+
+Before you begin:
+
+- Enable an [Email Sending domain](/email-service/configuration/domains/).
+- Create a [Worker project](/workers/get-started/guide/).
+- Create a [Workers KV namespace](/kv/get-started/#2-create-a-kv-namespace).
+
+Store each eligible recipient address as a key in KV. The value can contain notification preferences or related metadata.
+
+## Review the event flow
+
+1. Email Sending publishes bounce and complaint events.
+2. A queue delivers those events to a Worker.
+3. The Worker removes ineligible recipient records from KV.
+
+## Choose removal events
+
+Remove records for every `message.complained` event. These events indicate that a recipient reported the message as spam.
+
+Remove bounced records only when `payload.bounce.type` is `"hard"`. Temporary failures produce `message.deferred` events while retries remain. Exhausted temporary retries can produce `message.bounced` events with a `"soft"` bounce type.
+
+For payload details, refer to [Available Email Sending events](/email-service/platform/event-subscriptions/#available-email-sending-events).
+
+## Create the queue and subscription
+
+Create a queue and subscribe it to your sending domain:
+
+<Steps>
+1. In the Cloudflare dashboard, go to the **Queues** page. Create a queue named `email-events`.
+
+	 <DashButton url="/?to=/:account/workers/queues" />
+
+2. Select `email-events`, then select **Subscriptions** > **Subscribe to events**.
+3. Enter a subscription name and select **Email Sending** as the source.
+4. Select your sending domain and the `message.bounced` and `message.complained` events.
+5. Select **Subscribe**.
+</Steps>
+
+## Configure the Worker
+
+Bind the KV namespace and register the Worker as the queue consumer:
+
+<WranglerConfig>
+
+```toml
+name = "recipient-record-sync"
+main = "src/index.ts"
+compatibility_date = "$today"
+
+[[kv_namespaces]]
+binding = "RECIPIENTS"
+id = "<RECIPIENTS_KV_NAMESPACE_ID>"
+
+[[queues.consumers]]
+queue = "email-events"
+max_batch_size = 10
+max_retries = 3
+dead_letter_queue = "email-events-dlq"
+```
+
+</WranglerConfig>
+
+The configuration creates `email-events-dlq` during deployment. Queues moves events there after three retries.
+
+## Add the queue consumer
+
+The [`queue()` handler](/queues/configuration/javascript-apis/#consumer) processes each event independently. It deletes applicable recipient records and retries failed KV operations.
+
+<TypeScriptExample filename="src/index.ts">
+
+```ts
+interface Env {
+	RECIPIENTS: KVNamespace;
+}
+
+interface EmailSendingEvent {
+	type:
+		| "cf.email.sending.message.bounced"
+		| "cf.email.sending.message.complained";
+	payload: {
+		eventId: string;
+		recipient: string;
+		bounce?: {
+			type: "hard" | "soft";
+		};
+	};
+}
+
+export default {
+	async queue(batch, env): Promise<void> {
+		for (const message of batch.messages) {
+			try {
+				const event = message.body;
+
+				if (shouldRemove(event)) {
+					await removeRecipient(env, event);
+				}
+
+				message.ack();
+			} catch (error) {
+				console.error("Failed to process Email Sending event", {
+					eventId: message.body.payload.eventId,
+					error,
+				});
+				message.retry();
+			}
+		}
+	},
+} satisfies ExportedHandler<Env, EmailSendingEvent>;
+
+function shouldRemove(event: EmailSendingEvent): boolean {
+	if (event.type === "cf.email.sending.message.complained") {
+		return true;
+	}
+
+	return (
+		event.type === "cf.email.sending.message.bounced" &&
+		event.payload.bounce?.type === "hard"
+	);
+}
+
+async function removeRecipient(
+	env: Env,
+	event: EmailSendingEvent,
+): Promise<void> {
+	await env.RECIPIENTS.delete(event.payload.recipient);
+	console.log("Removed recipient record", {
+		eventId: event.payload.eventId,
+		reason: event.type,
+	});
+}
+```
+
+</TypeScriptExample>
+
+Deleting a missing KV key succeeds. This makes repeated event delivery safe.
+
+The handler acknowledges each successful message. Failed operations move to the [dead letter queue](/queues/configuration/dead-letter-queues/) after three retries.
+
+## Deploy the Worker
+
+Deploy the Worker and its queue consumer configuration:
+
+<PackageManagers type="exec" pkg="wrangler" args="deploy" />
+
+Monitor the dead letter queue for failed events. Reprocess them after fixing the underlying error.
+
+## Explore related resources
+
+- [Event subscriptions](/email-service/platform/event-subscriptions/) — review event schemas.
+- [Suppression lists](/email-service/concepts/suppressions/) — understand automatic suppressions.
+- [Queues retries](/queues/configuration/batching-retries/) — control message retries.
+- [Workers KV consistency](/kv/concepts/how-kv-works/#consistency) — account for propagation delays.

--- a/src/content/docs/email-service/platform/event-subscriptions.mdx
+++ b/src/content/docs/email-service/platform/event-subscriptions.mdx
@@ -1,0 +1,20 @@
+---
+title: Event subscriptions
+description: Subscribe to Email Sending lifecycle events with Queues.
+pcx_content_type: reference
+sidebar:
+  order: 10
+head:
+  - tag: title
+    content: Event subscriptions
+products:
+  - email-service
+---
+
+import { Render } from "~/components";
+
+<Render file="event-subscriptions/intro" product="queues" />
+
+## Available Email Sending events
+
+<Render file="event-subscriptions/email-sending-events" product="queues" />

--- a/src/content/docs/queues/event-subscriptions/events-schemas.mdx
+++ b/src/content/docs/queues/event-subscriptions/events-schemas.mdx
@@ -25,6 +25,10 @@ This page provides a comprehensive reference of available event sources and thei
 
 <Render file="event-subscriptions/artifacts-events" product="queues" />
 
+### Email Sending
+
+<Render file="event-subscriptions/email-sending-events" product="queues" />
+
 ### R2
 
 <Render file="event-subscriptions/r2-events" product="queues" />

--- a/src/content/partials/queues/event-subscriptions/email-sending-events.mdx
+++ b/src/content/partials/queues/event-subscriptions/email-sending-events.mdx
@@ -1,0 +1,242 @@
+Email Sending event subscriptions publish outbound transactional email lifecycle events for messages sent from an enabled sending domain. Each subscription is scoped to one sending domain: either the zone apex, such as `example.com`, or a verified sending subdomain, such as `send.example.com`.
+
+Email Routing events, including inbound forwards, replies, Worker-emitted routing events, and deliveries to verified routing recipients, are not published as Email Sending events.
+
+#### `message.delivered`
+
+Triggered when the recipient mail server accepts the message.
+
+**Example:**
+
+```json
+{
+	"type": "cf.email.sending.message.delivered",
+	"source": {
+		"type": "email.sending",
+		"zoneId": "023e105f4ecef8ad9ca31a8372d0c353",
+		"domain": "example.com"
+	},
+	"payload": {
+		"eventId": "0190d0c4-7e9a-7b3c-9f12-1a2b3c4d5e6f",
+		"messageId": "0101018f7d0c4d9a-msg-deadbeef",
+		"sender": "noreply@example.com",
+		"recipient": "user@example.net",
+		"subject": "Welcome",
+		"terminal": true,
+		"delivery": {
+			"status": "delivered",
+			"provider": "gmail",
+			"deliveryTimeMs": 1234,
+			"smtpStatusCode": "250",
+			"smtpEnhancedStatusCode": "2.0.0",
+			"smtpResponse": "250 2.0.0 OK 1714820445 a1b2c3 - gsmtp"
+		}
+	},
+	"metadata": {
+		"accountId": "f9f79265f388666de8122cfb508d7776",
+		"eventSubscriptionId": "1830c4bb612e43c3af7f4cada31fbf3f",
+		"eventSchemaVersion": 1,
+		"eventTimestamp": "2026-06-01T02:48:57.132Z"
+	}
+}
+```
+
+#### `message.deferred`
+
+Triggered when a temporary delivery failure occurs and delivery retries are still pending.
+
+**Example:**
+
+```json
+{
+	"type": "cf.email.sending.message.deferred",
+	"source": {
+		"type": "email.sending",
+		"zoneId": "023e105f4ecef8ad9ca31a8372d0c353",
+		"domain": "send.example.com"
+	},
+	"payload": {
+		"eventId": "0190d0c4-7e9b-7714-9004-11f0b6d9a341",
+		"messageId": "0101018f7d0c4d9a-msg-deferred",
+		"sender": "receipts@send.example.com",
+		"recipient": "user@example.net",
+		"subject": "Your receipt",
+		"terminal": false,
+		"delivery": {
+			"status": "deferred",
+			"provider": "external_smtp",
+			"deliveryTimeMs": 2143,
+			"smtpStatusCode": "451",
+			"smtpEnhancedStatusCode": "4.2.0",
+			"smtpResponse": "451 4.2.0 Temporary mailbox error"
+		},
+		"bounce": {
+			"type": "soft",
+			"classification": "temporary_failure",
+			"reason": "451 4.2.0 Temporary mailbox error"
+		}
+	},
+	"metadata": {
+		"accountId": "f9f79265f388666de8122cfb508d7776",
+		"eventSubscriptionId": "1830c4bb612e43c3af7f4cada31fbf3f",
+		"eventSchemaVersion": 1,
+		"eventTimestamp": "2026-06-01T02:48:57.132Z"
+	}
+}
+```
+
+#### `message.bounced`
+
+Triggered when a permanent bounce occurs, or when temporary delivery retries are exhausted.
+
+**Example:**
+
+```json
+{
+	"type": "cf.email.sending.message.bounced",
+	"source": {
+		"type": "email.sending",
+		"zoneId": "023e105f4ecef8ad9ca31a8372d0c353",
+		"domain": "send.example.com"
+	},
+	"payload": {
+		"eventId": "0190d0c4-7ea1-7af2-8b88-c1d2e3f4a5b6",
+		"messageId": "0101018f7d0c4d9a-msg-bounced",
+		"sender": "receipts@send.example.com",
+		"recipient": "user@example.net",
+		"subject": "Your receipt",
+		"terminal": true,
+		"delivery": {
+			"status": "bounced",
+			"provider": "external_smtp",
+			"deliveryTimeMs": 2143,
+			"smtpStatusCode": "550",
+			"smtpEnhancedStatusCode": "5.1.1",
+			"smtpResponse": "550 5.1.1 User unknown"
+		},
+		"bounce": {
+			"type": "hard",
+			"classification": "permanent_failure",
+			"reason": "550 5.1.1 User unknown"
+		}
+	},
+	"metadata": {
+		"accountId": "f9f79265f388666de8122cfb508d7776",
+		"eventSubscriptionId": "1830c4bb612e43c3af7f4cada31fbf3f",
+		"eventSchemaVersion": 1,
+		"eventTimestamp": "2026-06-01T02:48:57.132Z"
+	}
+}
+```
+
+#### `message.failed`
+
+Triggered when an internal or non-SMTP delivery error occurs.
+
+**Example:**
+
+```json
+{
+	"type": "cf.email.sending.message.failed",
+	"source": {
+		"type": "email.sending",
+		"zoneId": "023e105f4ecef8ad9ca31a8372d0c353",
+		"domain": "example.com"
+	},
+	"payload": {
+		"eventId": "0190d0c4-81c1-7bc6-9344-829cd9001a12",
+		"messageId": "0101018f7d0c4d9a-msg-failed",
+		"sender": "noreply@example.com",
+		"recipient": "user@example.net",
+		"subject": "Welcome",
+		"terminal": true,
+		"delivery": {
+			"status": "failed"
+		},
+		"failure": {
+			"reason": "delivery_failed"
+		}
+	},
+	"metadata": {
+		"accountId": "f9f79265f388666de8122cfb508d7776",
+		"eventSubscriptionId": "1830c4bb612e43c3af7f4cada31fbf3f",
+		"eventSchemaVersion": 1,
+		"eventTimestamp": "2026-06-01T02:48:57.132Z"
+	}
+}
+```
+
+#### `message.rejected`
+
+Triggered when the message is rejected before delivery by policy, including suppression, validation rejection, or spam rejection.
+
+**Example:**
+
+```json
+{
+	"type": "cf.email.sending.message.rejected",
+	"source": {
+		"type": "email.sending",
+		"zoneId": "023e105f4ecef8ad9ca31a8372d0c353",
+		"domain": "example.com"
+	},
+	"payload": {
+		"eventId": "0190d0c4-830a-77e5-8fa0-8d10f4e8dc8b",
+		"messageId": "0101018f7d0c4d9a-msg-rejected",
+		"sender": "noreply@example.com",
+		"recipient": "user@example.net",
+		"subject": "Welcome",
+		"terminal": true,
+		"delivery": {
+			"status": "rejected"
+		},
+		"rejection": {
+			"reason": "suppressed",
+			"party": "recipient",
+			"detail": "Recipient is suppressed"
+		}
+	},
+	"metadata": {
+		"accountId": "f9f79265f388666de8122cfb508d7776",
+		"eventSubscriptionId": "1830c4bb612e43c3af7f4cada31fbf3f",
+		"eventSchemaVersion": 1,
+		"eventTimestamp": "2026-06-01T02:48:57.132Z"
+	}
+}
+```
+
+#### `message.complained`
+
+Triggered when a delivered message is marked as spam by the recipient through a feedback loop.
+
+**Example:**
+
+```json
+{
+	"type": "cf.email.sending.message.complained",
+	"source": {
+		"type": "email.sending",
+		"zoneId": "023e105f4ecef8ad9ca31a8372d0c353",
+		"domain": "send.example.com"
+	},
+	"payload": {
+		"eventId": "0190d0c4-9f01-7c44-b2a1-aabbccddeeff",
+		"messageId": "0101018f7d0c4d9a-msg-complained",
+		"sender": "news@send.example.com",
+		"recipient": "user@example.net",
+		"terminal": true,
+		"delivery": {
+			"status": "complained"
+		},
+		"complaint": {
+			"type": "abuse"
+		}
+	},
+	"metadata": {
+		"accountId": "f9f79265f388666de8122cfb508d7776",
+		"eventSubscriptionId": "1830c4bb612e43c3af7f4cada31fbf3f",
+		"eventSchemaVersion": 1,
+		"eventTimestamp": "2026-06-01T02:48:57.132Z"
+	}
+}
+```


### PR DESCRIPTION
### Summary

Documents Email Sending event subscriptions, a new source for Queues event subscriptions. Customers can subscribe per sending domain — the zone apex or a verified sending subdomain — to receive outbound transactional email lifecycle events on a queue.

- Add an Event subscriptions page under Email Service > Platform, following the same pattern as the other product event-subscription pages (Workers AI, KV, R2), which render shared partials from Queues.
- Add an email-sending-events partial documenting the six event types (message.delivered, message.deferred, message.bounced, message.failed, message.rejected, message.complained) with example payloads, and noting that Email Routing events are not published on this source.
- Register the Email Sending source in the Queues Events & schemas reference so it appears alongside the other sources.


### Documentation checklist

<!-- Remove items that do not apply -->

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
