### PR TITLE
[AI Gateway] Document Access user metadata

### DIFF
--- a/src/content/changelog/ai-gateway/2026-07-01-access-user-id-metadata.mdx
+++ b/src/content/changelog/ai-gateway/2026-07-01-access-user-id-metadata.mdx
@@ -8,6 +8,6 @@ date: 2026-07-01
 
 AI Gateway now supports identity-aware controls through a new Cloudflare Access integration. When traffic reaches AI Gateway through an Access-protected custom domain, AI Gateway can use the authenticated user's Access identity in logs, analytics, routing, and spend controls.
 
-This means you can set per-user or per-team spend limits, control which models different users can access, filter logs by user, and build policies without passing user IDs from the client application. AI Gateway adds the verified Access user ID to request metadata as `cf.user_id`.
+This means you can set spend limits by authenticated user, control which models different users can access, filter logs by user, and build policies without passing user IDs from the client application. AI Gateway adds the verified Access user ID to request metadata as `cf.user_id`.
 
 For setup instructions, refer to [Custom domains](/ai-gateway/configuration/custom-domains/).

--- a/src/content/changelog/ai-gateway/2026-07-01-access-user-id-metadata.mdx
+++ b/src/content/changelog/ai-gateway/2026-07-01-access-user-id-metadata.mdx
@@ -1,0 +1,13 @@
+---
+title: Track Access users in AI Gateway metadata
+description: AI Gateway now adds the authenticated Access user ID to request metadata for Access-protected custom domain traffic.
+products:
+  - ai-gateway
+date: 2026-07-01
+---
+
+AI Gateway now records the authenticated Cloudflare Access user ID in request metadata for traffic sent through an Access-protected custom domain.
+
+When AI Gateway receives a valid Access JWT with a user subject, it adds the user's Access `sub` claim as `cf.user_id`. You can use this metadata field to filter logs, review usage, and build per-user or per-team spend controls without passing user IDs from the client application.
+
+For setup instructions, refer to [Custom domains](/ai-gateway/configuration/custom-domains/).

--- a/src/content/changelog/ai-gateway/2026-07-01-access-user-id-metadata.mdx
+++ b/src/content/changelog/ai-gateway/2026-07-01-access-user-id-metadata.mdx
@@ -1,13 +1,13 @@
 ---
-title: Track Access users in AI Gateway metadata
-description: AI Gateway now adds the authenticated Access user ID to request metadata for Access-protected custom domain traffic.
+title: Identity-aware controls are now available in AI Gateway
+description: Use Cloudflare Access identity in AI Gateway to set spend limits, control model access, filter logs, and more.
 products:
   - ai-gateway
 date: 2026-07-01
 ---
 
-AI Gateway now records the authenticated Cloudflare Access user ID in request metadata for traffic sent through an Access-protected custom domain.
+AI Gateway now supports identity-aware controls through a new Cloudflare Access integration. When traffic reaches AI Gateway through an Access-protected custom domain, AI Gateway can use the authenticated user's Access identity in logs, analytics, routing, and spend controls.
 
-When AI Gateway receives a valid Access JWT with a user subject, it adds the user's Access `sub` claim as `cf.user_id`. You can use this metadata field to filter logs, review usage, and build per-user or per-team spend controls without passing user IDs from the client application.
+This means you can set per-user or per-team spend limits, control which models different users can access, filter logs by user, and build policies without passing user IDs from the client application. AI Gateway adds the verified Access user ID to request metadata as `cf.user_id`.
 
 For setup instructions, refer to [Custom domains](/ai-gateway/configuration/custom-domains/).

--- a/src/content/changelog/ai-gateway/2026-08-05-access-user-id-metadata.mdx
+++ b/src/content/changelog/ai-gateway/2026-08-05-access-user-id-metadata.mdx
@@ -7,8 +7,11 @@ products:
 date: 2026-08-05
 ---
 
-AI Gateway now supports identity-aware controls through a new Cloudflare Access integration. When traffic reaches AI Gateway through an Access-protected custom domain, AI Gateway can use the authenticated user's Access identity in logs, analytics, routing, and spend controls.
+AI Gateway now integrates with Cloudflare Access, giving you two new capabilities:
 
-This means you can set spend limits by authenticated user, control which gateways different users can access, filter logs by user, and build policies without passing user IDs from the client application. AI Gateway adds the verified Access user ID to request metadata as `cf.user_id`.
+- **Protect your gateway endpoint.** Put your AI Gateway behind Access so you can set policies that control who is allowed to call a specific gateway's endpoint.
+- **Identity-aware controls.** When traffic reaches AI Gateway through an Access-protected custom domain, AI Gateway can use the authenticated user's Access identity in logs, analytics, routing, and spend controls.
+
+With identity-aware controls, you can set spend limits by authenticated user, control which gateways different users can access, filter logs by user, and build policies without passing user IDs from the client application. AI Gateway adds the verified Access user ID to request metadata as `cf.user_id`.
 
 For setup instructions, refer to [Cloudflare Access](/ai-gateway/configuration/cloudflare-access/).

--- a/src/content/changelog/ai-gateway/2026-08-05-access-user-id-metadata.mdx
+++ b/src/content/changelog/ai-gateway/2026-08-05-access-user-id-metadata.mdx
@@ -3,11 +3,11 @@ title: Identity-aware controls are now available in AI Gateway
 description: Use Cloudflare Access identity in AI Gateway to set spend limits, control model access, filter logs, and more.
 products:
   - ai-gateway
-date: 2026-07-01
+date: 2026-08-05
 ---
 
 AI Gateway now supports identity-aware controls through a new Cloudflare Access integration. When traffic reaches AI Gateway through an Access-protected custom domain, AI Gateway can use the authenticated user's Access identity in logs, analytics, routing, and spend controls.
 
 This means you can set spend limits by authenticated user, control which models different users can access, filter logs by user, and build policies without passing user IDs from the client application. AI Gateway adds the verified Access user ID to request metadata as `cf.user_id`.
 
-For setup instructions, refer to [Custom domains](/ai-gateway/configuration/custom-domains/).
+For setup instructions, refer to [Cloudflare Access](/ai-gateway/configuration/cloudflare-access/).

--- a/src/content/changelog/ai-gateway/2026-08-05-access-user-id-metadata.mdx
+++ b/src/content/changelog/ai-gateway/2026-08-05-access-user-id-metadata.mdx
@@ -3,11 +3,12 @@ title: Identity-aware controls are now available in AI Gateway
 description: Use Cloudflare Access identity in AI Gateway to set spend limits, control model access, filter logs, and more.
 products:
   - ai-gateway
+  - access
 date: 2026-08-05
 ---
 
 AI Gateway now supports identity-aware controls through a new Cloudflare Access integration. When traffic reaches AI Gateway through an Access-protected custom domain, AI Gateway can use the authenticated user's Access identity in logs, analytics, routing, and spend controls.
 
-This means you can set spend limits by authenticated user, control which models different users can access, filter logs by user, and build policies without passing user IDs from the client application. AI Gateway adds the verified Access user ID to request metadata as `cf.user_id`.
+This means you can set spend limits by authenticated user, control which gateways different users can access, filter logs by user, and build policies without passing user IDs from the client application. AI Gateway adds the verified Access user ID to request metadata as `cf.user_id`.
 
 For setup instructions, refer to [Cloudflare Access](/ai-gateway/configuration/cloudflare-access/).

--- a/src/content/docs/ai-gateway/configuration/cloudflare-access.mdx
+++ b/src/content/docs/ai-gateway/configuration/cloudflare-access.mdx
@@ -10,7 +10,7 @@ products:
 
 Protect your gateway with [Cloudflare Access](/cloudflare-one/access-controls/applications/http-apps/) so users authenticate with your identity provider before they can send requests. Putting AI Gateway behind Access gives you identity-aware control over your AI traffic: you decide who can reach the gateway, tie each request to a verified user, and govern usage per user without building your own authentication layer or passing user IDs from the client application.
 
-To put AI Gateway behind Access, you must first [set a custom domain](/ai-gateway/configuration/custom-domains/) on your gateway and have Cloudflare Access activated on your account.
+To put AI Gateway behind Access, you must first [set a custom domain](/ai-gateway/configuration/custom-domains/) on your gateway and have [Cloudflare Access](/cloudflare-one/access-controls/applications/http-apps/) enabled on your account.
 
 ## How it works
 
@@ -19,6 +19,8 @@ When a request to a custom domain includes a valid Cloudflare Access JWT, AI Gat
 AI Gateway also adds the verified Access user ID to request metadata as [`cf.user_id`](/ai-gateway/observability/custom-metadata/#reserved-metadata). This value is the Access JWT `sub` claim, not the user's email address. You can then filter logs, analytics, and spend by the authenticated user.
 
 Before AI Gateway forwards the request to the upstream provider, it removes Cloudflare-only credentials such as the Access JWT and AI Gateway authorization headers.
+
+Once a custom domain is protected by Access, every request to that domain must pass an Access policy. Requests that only include an AI Gateway token, without a valid Access token, are blocked by Access before they reach the gateway. Update existing integrations to authenticate through Access, or keep sending gateway-token traffic to the default `gateway.ai.cloudflare.com` endpoint, which is not protected by Access.
 
 ## Set up Access on a gateway
 

--- a/src/content/docs/ai-gateway/configuration/cloudflare-access.mdx
+++ b/src/content/docs/ai-gateway/configuration/cloudflare-access.mdx
@@ -1,0 +1,67 @@
+---
+title: Cloudflare Access
+description: Add identity-aware controls to AI Gateway so users authenticate with your identity provider before they can call your gateway.
+pcx_content_type: how-to
+sidebar:
+  order: 9
+products:
+  - ai-gateway
+---
+
+Use [Cloudflare Access](/cloudflare-one/access-controls/applications/http-apps/) to add identity-aware controls to your gateway. Users authenticate with your identity provider before they can send requests, and AI Gateway records the authenticated user's identity on each request.
+
+With this integration, you can:
+
+- Set spend limits by authenticated user.
+- Control which models different users can access.
+- Filter logs and analytics by user.
+- Build policies without passing user IDs from the client application.
+
+## Prerequisites
+
+- [Cloudflare Access](/cloudflare-one/access-controls/applications/http-apps/) activated on your account.
+- A [custom domain](/ai-gateway/configuration/custom-domains/) configured for the gateway you want to protect. Access is applied to the custom domain, not to the default `gateway.ai.cloudflare.com` endpoint.
+
+## How it works
+
+When a request to a custom domain includes a valid Cloudflare Access JWT, AI Gateway accepts the Access JWT as the request credential. The client does not need to send an AI Gateway token for that request.
+
+AI Gateway also adds the verified Access user ID to request metadata as [`cf.user_id`](/ai-gateway/observability/custom-metadata/#reserved-metadata). This value is the Access JWT `sub` claim, not the user's email address. You can then filter logs, analytics, and spend by the authenticated user.
+
+Before AI Gateway forwards the request to the upstream provider, it removes Cloudflare-only credentials such as the Access JWT and AI Gateway authorization headers.
+
+## Set up Access on a gateway
+
+1. [Set up a custom domain](/ai-gateway/configuration/custom-domains/) for the gateway you want to protect.
+2. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **AI** > **AI Gateway**.
+3. Select the gateway you configured with a custom domain.
+4. Go to the **Access** tab and set up Cloudflare Access on the gateway.
+5. Add Access policies that define which users can call the gateway.
+
+After setup, users can make requests to the custom domain after authenticating through Access. Requests with a valid Access user subject include `cf.user_id` in AI Gateway metadata.
+
+## Make a request
+
+After the user authenticates to Access, send requests to the custom domain without the account ID or gateway ID in the path:
+
+```bash
+curl -X POST "https://ai.example.com/openai/v1/chat/completions" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "model": "gpt-4.1-mini",
+    "messages": [
+      {
+        "role": "user",
+        "content": "What is Cloudflare?"
+      }
+    ]
+  }'
+```
+
+If you call the custom domain from a non-browser client, include the Access token using the header or cookie format supported by Cloudflare Access. For example, [`cloudflared access curl`](/cloudflare-one/access-controls/authenticate-agents/#make-requests-with-cloudflared-access-curl) can send the Access token for command-line requests.
+
+## Limitations
+
+- `cf.user_id` is only added when AI Gateway receives a valid Access JWT with a non-empty user subject.
+- Service-token requests do not include `cf.user_id` because they do not represent an individual Access user.
+- You may not supply metadata keys that begin with `cf.`. These keys are reserved and are not saved.

--- a/src/content/docs/ai-gateway/configuration/cloudflare-access.mdx
+++ b/src/content/docs/ai-gateway/configuration/cloudflare-access.mdx
@@ -1,26 +1,16 @@
 ---
 title: Cloudflare Access
 description: Add identity-aware controls to AI Gateway so users authenticate with your identity provider before they can call your gateway.
-pcx_content_type: how-to
+pcx_content_type: configuration
 sidebar:
   order: 9
 products:
   - ai-gateway
 ---
 
-Use [Cloudflare Access](/cloudflare-one/access-controls/applications/http-apps/) to add identity-aware controls to your gateway. Users authenticate with your identity provider before they can send requests, and AI Gateway records the authenticated user's identity on each request.
+Protect your gateway with [Cloudflare Access](/cloudflare-one/access-controls/applications/http-apps/) so users authenticate with your identity provider before they can send requests. Putting AI Gateway behind Access gives you identity-aware control over your AI traffic: you decide who can reach the gateway, tie each request to a verified user, and govern usage per user without building your own authentication layer or passing user IDs from the client application.
 
-With this integration, you can:
-
-- Set spend limits by authenticated user.
-- Control which models different users can access.
-- Filter logs and analytics by user.
-- Build policies without passing user IDs from the client application.
-
-## Prerequisites
-
-- [Cloudflare Access](/cloudflare-one/access-controls/applications/http-apps/) activated on your account.
-- A [custom domain](/ai-gateway/configuration/custom-domains/) configured for the gateway you want to protect. Access is applied to the custom domain, not to the default `gateway.ai.cloudflare.com` endpoint.
+To put AI Gateway behind Access, you must first [set a custom domain](/ai-gateway/configuration/custom-domains/) on your gateway and have Cloudflare Access activated on your account.
 
 ## How it works
 
@@ -37,6 +27,8 @@ Before AI Gateway forwards the request to the upstream provider, it removes Clou
 3. Select the gateway you configured with a custom domain.
 4. Go to the **Access** tab and set up Cloudflare Access on the gateway.
 5. Add Access policies that define which users can call the gateway.
+
+Setting up Access from the **Access** tab configures the Access application for you, so coding agents and other non-browser clients can authenticate by sending the Access token as a bearer token.
 
 After setup, users can make requests to the custom domain after authenticating through Access. Requests with a valid Access user subject include `cf.user_id` in AI Gateway metadata.
 
@@ -59,6 +51,8 @@ curl -X POST "https://ai.example.com/openai/v1/chat/completions" \
 ```
 
 If you call the custom domain from a non-browser client, include the Access token using the header or cookie format supported by Cloudflare Access. For example, [`cloudflared access curl`](/cloudflare-one/access-controls/authenticate-agents/#make-requests-with-cloudflared-access-curl) can send the Access token for command-line requests.
+
+For coding agents, refer to the per-agent setup under [Coding agents](/ai-gateway/integrations/coding-agents/) — for example, [Claude Code](/ai-gateway/integrations/coding-agents/claude-code/#use-with-cloudflare-access) and [OpenAI Codex](/ai-gateway/integrations/coding-agents/openai-codex/#use-with-cloudflare-access).
 
 ## Limitations
 

--- a/src/content/docs/ai-gateway/configuration/custom-domains.mdx
+++ b/src/content/docs/ai-gateway/configuration/custom-domains.mdx
@@ -1,7 +1,7 @@
 ---
 pcx_content_type: configuration
 title: Custom domains
-description: Use a custom hostname for AI Gateway and protect it with Cloudflare Access.
+description: Send AI Gateway requests through a hostname that you own, such as ai.example.com.
 sidebar:
   order: 8
 products:
@@ -10,13 +10,17 @@ products:
 
 import { CURL } from "~/components";
 
-Custom domains let you send AI Gateway requests through a hostname that you own, such as `ai.example.com`. You can then protect that hostname with [Cloudflare Access](/cloudflare-one/access-controls/applications/http-apps/) so users authenticate with your identity provider before they can call your gateway.
+Custom domains let you send AI Gateway requests through a hostname that you own, such as `ai.example.com`, instead of the default `gateway.ai.cloudflare.com` endpoint.
 
-When a request to a custom domain includes a valid Cloudflare Access JWT, AI Gateway accepts the Access JWT as the request credential. The client does not need to send an AI Gateway token for that request. AI Gateway also adds the verified Access user ID to request metadata as [`cf.user_id`](/ai-gateway/observability/custom-metadata/#reserved-metadata), so you can filter logs, analytics, and spend by the authenticated user.
+The hostname identifies your account and gateway, so you can omit the account ID and gateway ID from request URLs. Requests go directly to AI Gateway provider-native routes and OpenAI-compatible `compat` routes.
+
+Custom domains are also the foundation for [identity-aware controls with Cloudflare Access](/ai-gateway/configuration/cloudflare-access/), which let users authenticate with your identity provider before they can call your gateway.
+
+:::note
+Custom domains work with the AI Gateway endpoint (`gateway.ai.cloudflare.com`). They do not work with the [Cloudflare REST API](/api/) (`api.cloudflare.com`).
+:::
 
 ## How it works
-
-Custom domains let you omit the account ID and gateway ID from request URLs. The hostname identifies the account and gateway, so requests can go directly to AI Gateway provider-native routes and OpenAI-compatible `compat` routes.
 
 For example, if your custom domain is `ai.example.com`, an OpenAI provider request uses:
 
@@ -30,7 +34,7 @@ Instead of:
 https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/openai/v1/chat/completions
 ```
 
-For example, `https://ai.example.com/compat/chat/completions` routes through the same gateway using the OpenAI-compatible endpoint. Before AI Gateway forwards the request to the upstream provider, it removes Cloudflare-only credentials such as the Access JWT and AI Gateway authorization headers.
+The same applies to the OpenAI-compatible endpoint. For example, `https://ai.example.com/compat/chat/completions` routes through the same gateway using the `compat` route.
 
 ## Set up a custom domain in the dashboard
 
@@ -40,13 +44,11 @@ To add a custom domain:
 
 1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **AI** > **AI Gateway**.
 2. Select the gateway you want to configure.
-3. Go to **Settings** > **Custom domains**.
-4. Add the hostname you want to use for this gateway.
-5. Create the DNS record shown in the dashboard. The custom domain remains in a pending state until domain control validation completes.
-6. After the custom domain is active, create a [Cloudflare Access self-hosted application](/cloudflare-one/access-controls/applications/http-apps/) for the same hostname.
-7. Add Access policies that define which users can call the gateway.
+3. Go to the **Domains** tab.
+4. Select **Add Domain** and enter the hostname you want to use. Optionally, choose a subdomain.
+5. AI Gateway automatically creates the DNS record in the dashboard.
 
-After setup, users can make requests to the custom domain after authenticating through Access. Requests with a valid Access user subject include `cf.user_id` in AI Gateway metadata.
+After the domain is set up, you can send requests to it. To require users to authenticate before they can call the gateway, [set up Cloudflare Access on the domain](/ai-gateway/configuration/cloudflare-access/).
 
 ## Set up a custom domain via API
 
@@ -126,7 +128,7 @@ The custom domain remains in `pending_dcv` until domain control validation compl
 
 ## Example request
 
-After the user authenticates to Access, send requests to the custom domain without the account ID or gateway ID in the path:
+Send requests to the custom domain without the account ID or gateway ID in the path:
 
 ```bash
 curl -X POST "https://ai.example.com/openai/v1/chat/completions" \
@@ -142,11 +144,8 @@ curl -X POST "https://ai.example.com/openai/v1/chat/completions" \
   }'
 ```
 
-If you call the custom domain from a non-browser client, include the Access token using the header or cookie format supported by Cloudflare Access. For example, [`cloudflared access curl`](/cloudflare-one/access-controls/authenticate-agents/#make-requests-with-cloudflared-access-curl) can send the Access token for command-line requests.
+If the domain is protected by Cloudflare Access, the request must also include a valid Access token. For details, refer to [Cloudflare Access](/ai-gateway/configuration/cloudflare-access/).
 
 ## Limitations
 
-- Newer AI Gateway REST API endpoints are not yet supported on custom domains.
-- `cf.user_id` is only added when AI Gateway receives a valid Access JWT with a non-empty user subject.
-- Service-token requests do not include `cf.user_id` because they do not represent an individual Access user.
-- Customer-supplied metadata keys that begin with `cf.` are reserved and are not saved.
+- Custom domains are not yet supported on the newer AI Gateway endpoints served through the [Cloudflare REST API](/api/) (`api.cloudflare.com`).

--- a/src/content/docs/ai-gateway/configuration/custom-domains.mdx
+++ b/src/content/docs/ai-gateway/configuration/custom-domains.mdx
@@ -8,15 +8,17 @@ products:
   - ai-gateway
 ---
 
+import { CURL } from "~/components";
+
 Custom domains let you send AI Gateway requests through a hostname that you own, such as `ai.example.com`. You can then protect that hostname with [Cloudflare Access](/cloudflare-one/access-controls/applications/http-apps/) so users authenticate with your identity provider before they can call your gateway.
 
 When a request to a custom domain includes a valid Cloudflare Access JWT, AI Gateway accepts the Access JWT as the request credential. The client does not need to send an AI Gateway token for that request. AI Gateway also adds the verified Access user ID to request metadata as [`cf.user_id`](/ai-gateway/observability/custom-metadata/#reserved-metadata), so you can filter logs, analytics, and spend by the authenticated user.
 
 ## How it works
 
-Custom domains use provider-relative paths. The hostname identifies the account and gateway, so the request path starts with the provider route rather than `/v1/{account_id}/{gateway_id}`.
+Custom domains let you omit the account ID and gateway ID from request URLs. The hostname identifies the account and gateway, so requests can go directly to AI Gateway provider-native routes and OpenAI-compatible `compat` routes.
 
-For example, if your custom domain is `ai.example.com`, an OpenAI-compatible request uses:
+For example, if your custom domain is `ai.example.com`, an OpenAI provider request uses:
 
 ```txt
 https://ai.example.com/openai/v1/chat/completions
@@ -28,9 +30,9 @@ Instead of:
 https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/openai/v1/chat/completions
 ```
 
-Before AI Gateway forwards the request to the upstream provider, it removes Cloudflare-only credentials such as the Access JWT and AI Gateway authorization headers.
+For example, `https://ai.example.com/compat/chat/completions` routes through the same gateway using the OpenAI-compatible endpoint. Before AI Gateway forwards the request to the upstream provider, it removes Cloudflare-only credentials such as the Access JWT and AI Gateway authorization headers.
 
-## Set up a custom domain
+## Set up a custom domain in the dashboard
 
 Custom domains for AI Gateway are being rolled out. If the option is not visible in your account, contact your Cloudflare account team.
 
@@ -46,9 +48,89 @@ To add a custom domain:
 
 After setup, users can make requests to the custom domain after authenticating through Access. Requests with a valid Access user subject include `cf.user_id` in AI Gateway metadata.
 
+## Set up a custom domain via API
+
+You can also create and manage custom domains through the Cloudflare API.
+
+:::note
+The custom domains API is not yet included in the public API reference while the contract is still being finalized.
+:::
+
+Unlike the dashboard, the API does not create the DNS record for you. After you create the custom domain, use the returned `cname_target` to create a proxied CNAME record for your hostname.
+
+### Create a custom domain
+
+<CURL
+	url="https://api.cloudflare.com/client/v4/accounts/{account_id}/ai-gateway/gateways/{gateway_id}/custom-domains"
+	method="POST"
+	headers={{ Authorization: "Bearer $CLOUDFLARE_API_TOKEN" }}
+	json={{
+		domain: "ai.example.com",
+		zone_id: "395566f4c8a5b9d2a5fc0d457b007c44",
+	}}
+/>
+
+The response includes the custom domain status and the CNAME target:
+
+```json
+{
+	"success": true,
+	"result": {
+		"hostname": "ai.example.com",
+		"gateway_id": "my-gateway",
+		"status": "pending_dcv",
+		"cname_target": "<cname-target>",
+		"created_at": 1782925200000,
+		"modified_at": 1782925200000
+	}
+}
+```
+
+### Create the DNS record
+
+Create a proxied CNAME record in the zone that owns your custom domain. Set `content` to the `cname_target` returned when you created the custom domain.
+
+<CURL
+	url="https://api.cloudflare.com/client/v4/zones/{zone_id}/dns_records"
+	method="POST"
+	headers={{ Authorization: "Bearer $CLOUDFLARE_API_TOKEN" }}
+	json={{
+		type: "CNAME",
+		name: "ai",
+		content: "<cname-target>",
+		proxied: true,
+	}}
+/>
+
+The custom domain remains in `pending_dcv` until domain control validation completes.
+
+### List custom domains
+
+<CURL
+	url="https://api.cloudflare.com/client/v4/accounts/{account_id}/ai-gateway/gateways/{gateway_id}/custom-domains"
+	method="GET"
+	headers={{ Authorization: "Bearer $CLOUDFLARE_API_TOKEN" }}
+/>
+
+### Get a custom domain
+
+<CURL
+	url="https://api.cloudflare.com/client/v4/accounts/{account_id}/ai-gateway/gateways/{gateway_id}/custom-domains/{hostname}"
+	method="GET"
+	headers={{ Authorization: "Bearer $CLOUDFLARE_API_TOKEN" }}
+/>
+
+### Delete a custom domain
+
+<CURL
+	url="https://api.cloudflare.com/client/v4/accounts/{account_id}/ai-gateway/gateways/{gateway_id}/custom-domains/{hostname}"
+	method="DELETE"
+	headers={{ Authorization: "Bearer $CLOUDFLARE_API_TOKEN" }}
+/>
+
 ## Example request
 
-After the user authenticates to Access, send requests to the custom domain with the provider-relative path:
+After the user authenticates to Access, send requests to the custom domain without the account ID or gateway ID in the path:
 
 ```bash
 curl -X POST "https://ai.example.com/openai/v1/chat/completions" \
@@ -68,7 +150,7 @@ If you call the custom domain from a non-browser client, include the Access toke
 
 ## Limitations
 
-- Custom-domain routes are provider-relative. Do not include `/v1/{account_id}/{gateway_id}` in the path when using the custom hostname.
+- Newer AI Gateway REST API endpoints are not yet supported on custom domains.
 - `cf.user_id` is only added when AI Gateway receives a valid Access JWT with a non-empty user subject.
 - Service-token requests do not include `cf.user_id` because they do not represent an individual Access user.
 - Customer-supplied metadata keys that begin with `cf.` are reserved and are not saved.

--- a/src/content/docs/ai-gateway/configuration/custom-domains.mdx
+++ b/src/content/docs/ai-gateway/configuration/custom-domains.mdx
@@ -146,4 +146,4 @@ If the domain is protected by Cloudflare Access, the request must also include a
 
 ## Limitations
 
-- Custom domains are not yet supported on the newer AI Gateway endpoints served through the [Cloudflare REST API](/api/) (`api.cloudflare.com`).
+Custom domains are not yet supported on the newer AI Gateway endpoints served through the [Cloudflare REST API](/api/) (`api.cloudflare.com`).

--- a/src/content/docs/ai-gateway/configuration/custom-domains.mdx
+++ b/src/content/docs/ai-gateway/configuration/custom-domains.mdx
@@ -52,10 +52,6 @@ After setup, users can make requests to the custom domain after authenticating t
 
 You can also create and manage custom domains through the Cloudflare API.
 
-:::note
-The custom domains API is not yet included in the public API reference while the contract is still being finalized.
-:::
-
 Unlike the dashboard, the API does not create the DNS record for you. After you create the custom domain, use the returned `cname_target` to create a proxied CNAME record for your hostname.
 
 ### Create a custom domain

--- a/src/content/docs/ai-gateway/configuration/custom-domains.mdx
+++ b/src/content/docs/ai-gateway/configuration/custom-domains.mdx
@@ -38,8 +38,6 @@ The same applies to the OpenAI-compatible endpoint. For example, `https://ai.exa
 
 ## Set up a custom domain in the dashboard
 
-Custom domains for AI Gateway are being rolled out. If the option is not visible in your account, contact your Cloudflare account team.
-
 To add a custom domain:
 
 1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **AI** > **AI Gateway**.

--- a/src/content/docs/ai-gateway/configuration/custom-domains.mdx
+++ b/src/content/docs/ai-gateway/configuration/custom-domains.mdx
@@ -1,0 +1,74 @@
+---
+pcx_content_type: configuration
+title: Custom domains
+description: Use a custom hostname for AI Gateway and protect it with Cloudflare Access.
+sidebar:
+  order: 8
+products:
+  - ai-gateway
+---
+
+Custom domains let you send AI Gateway requests through a hostname that you own, such as `ai.example.com`. You can then protect that hostname with [Cloudflare Access](/cloudflare-one/access-controls/applications/http-apps/) so users authenticate with your identity provider before they can call your gateway.
+
+When a request to a custom domain includes a valid Cloudflare Access JWT, AI Gateway accepts the Access JWT as the request credential. The client does not need to send an AI Gateway token for that request. AI Gateway also adds the verified Access user ID to request metadata as [`cf.user_id`](/ai-gateway/observability/custom-metadata/#reserved-metadata), so you can filter logs, analytics, and spend by the authenticated user.
+
+## How it works
+
+Custom domains use provider-relative paths. The hostname identifies the account and gateway, so the request path starts with the provider route rather than `/v1/{account_id}/{gateway_id}`.
+
+For example, if your custom domain is `ai.example.com`, an OpenAI-compatible request uses:
+
+```txt
+https://ai.example.com/openai/v1/chat/completions
+```
+
+Instead of:
+
+```txt
+https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/openai/v1/chat/completions
+```
+
+Before AI Gateway forwards the request to the upstream provider, it removes Cloudflare-only credentials such as the Access JWT and AI Gateway authorization headers.
+
+## Set up a custom domain
+
+Custom domains for AI Gateway are being rolled out. If the option is not visible in your account, contact your Cloudflare account team.
+
+To add a custom domain:
+
+1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **AI** > **AI Gateway**.
+2. Select the gateway you want to configure.
+3. Go to **Settings** > **Custom domains**.
+4. Add the hostname you want to use for this gateway.
+5. Create the DNS record shown in the dashboard. The custom domain remains in a pending state until domain control validation completes.
+6. After the custom domain is active, create a [Cloudflare Access self-hosted application](/cloudflare-one/access-controls/applications/http-apps/) for the same hostname.
+7. Add Access policies that define which users can call the gateway.
+
+After setup, users can make requests to the custom domain after authenticating through Access. Requests with a valid Access user subject include `cf.user_id` in AI Gateway metadata.
+
+## Example request
+
+After the user authenticates to Access, send requests to the custom domain with the provider-relative path:
+
+```bash
+curl -X POST "https://ai.example.com/openai/v1/chat/completions" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "model": "gpt-4.1-mini",
+    "messages": [
+      {
+        "role": "user",
+        "content": "What is Cloudflare?"
+      }
+    ]
+  }'
+```
+
+If you call the custom domain from a non-browser client, include the Access token using the header or cookie format supported by Cloudflare Access. For example, [`cloudflared access curl`](/cloudflare-one/access-controls/authenticate-agents/#make-requests-with-cloudflared-access-curl) can send the Access token for command-line requests.
+
+## Limitations
+
+- Custom-domain routes are provider-relative. Do not include `/v1/{account_id}/{gateway_id}` in the path when using the custom hostname.
+- `cf.user_id` is only added when AI Gateway receives a valid Access JWT with a non-empty user subject.
+- Service-token requests do not include `cf.user_id` because they do not represent an individual Access user.
+- Customer-supplied metadata keys that begin with `cf.` are reserved and are not saved.

--- a/src/content/docs/ai-gateway/integrations/coding-agents/claude-code.mdx
+++ b/src/content/docs/ai-gateway/integrations/coding-agents/claude-code.mdx
@@ -10,7 +10,7 @@ products:
 
 import { Tabs, TabItem, Steps } from "~/components";
 
-[Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview) reads its endpoint and credentials from environment variables. This configuration sends requests to AI Gateway's [Anthropic endpoint](/ai-gateway/usage/providers/anthropic/), authenticated with your Cloudflare gateway token. The Anthropic endpoint exposes the same `/v1/messages` API that Claude Code expects. When AI Gateway supplies the Anthropic credentials for you — using either an Anthropic API key you [store as a provider key (BYOK)](/ai-gateway/configuration/bring-your-own-keys/) or [Unified Billing](/ai-gateway/features/unified-billing/) credits — the `ANTHROPIC_API_KEY` that Claude Code requires can be any placeholder value.
+[Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview) reads its endpoint and credentials from environment variables. If your gateway is protected by Cloudflare Access, see [Use with Cloudflare Access](#use-with-cloudflare-access). This configuration sends requests to AI Gateway's [Anthropic endpoint](/ai-gateway/usage/providers/anthropic/), authenticated with your Cloudflare gateway token. The Anthropic endpoint exposes the same `/v1/messages` API that Claude Code expects. When AI Gateway supplies the Anthropic credentials for you — using either an Anthropic API key you [store as a provider key (BYOK)](/ai-gateway/configuration/bring-your-own-keys/) or [Unified Billing](/ai-gateway/features/unified-billing/) credits — the `ANTHROPIC_API_KEY` that Claude Code requires can be any placeholder value.
 
 ## Prerequisites
 
@@ -143,5 +143,22 @@ To run Claude models through [Google Vertex AI](/ai-gateway/usage/providers/vert
    ```
 
 </Steps>
+
+## Use with Cloudflare Access
+
+If your gateway is protected by [Cloudflare Access](/ai-gateway/configuration/cloudflare-access/), Claude Code can authenticate with a short-lived Access token instead of a gateway token. Point `ANTHROPIC_BASE_URL` at your [custom domain](/ai-gateway/configuration/custom-domains/) and use Claude Code's `apiKeyHelper` to fetch the token with [`cloudflared`](/cloudflare-one/access-controls/authenticate-agents/#make-requests-with-cloudflared-access-curl). Claude Code sends the token as the API key, and Access verifies it at the edge.
+
+Add the following to Claude Code's [`settings.json`](https://docs.anthropic.com/en/docs/claude-code/settings#settings-files), replacing `ai-gateway.example.com` with your custom domain:
+
+```json title="~/.claude/settings.json"
+{
+	"apiKeyHelper": "cloudflared access login --no-verbose -app=https://ai-gateway.example.com",
+	"env": {
+		"ANTHROPIC_BASE_URL": "https://ai-gateway.example.com/anthropic"
+	}
+}
+```
+
+The first request opens your identity provider's login flow. After you authenticate, requests route through AI Gateway with your Access identity attached as [`cf.user_id`](/ai-gateway/observability/custom-metadata/#reserved-metadata).
 
 To confirm traffic reaches AI Gateway, refer to [Verify it works](/ai-gateway/integrations/coding-agents/#verify-it-works).

--- a/src/content/docs/ai-gateway/integrations/coding-agents/claude-code.mdx
+++ b/src/content/docs/ai-gateway/integrations/coding-agents/claude-code.mdx
@@ -10,7 +10,7 @@ products:
 
 import { Tabs, TabItem, Steps } from "~/components";
 
-[Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview) reads its endpoint and credentials from environment variables. If your gateway is protected by Cloudflare Access, see [Use with Cloudflare Access](#use-with-cloudflare-access). This configuration sends requests to AI Gateway's [Anthropic endpoint](/ai-gateway/usage/providers/anthropic/), authenticated with your Cloudflare gateway token. The Anthropic endpoint exposes the same `/v1/messages` API that Claude Code expects. When AI Gateway supplies the Anthropic credentials for you — using either an Anthropic API key you [store as a provider key (BYOK)](/ai-gateway/configuration/bring-your-own-keys/) or [Unified Billing](/ai-gateway/features/unified-billing/) credits — the `ANTHROPIC_API_KEY` that Claude Code requires can be any placeholder value.
+[Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview) reads its endpoint and credentials from environment variables. If your gateway is protected by Cloudflare Access, refer to [Use with Cloudflare Access](#use-with-cloudflare-access). This configuration sends requests to AI Gateway's [Anthropic endpoint](/ai-gateway/usage/providers/anthropic/), authenticated with your Cloudflare gateway token. The Anthropic endpoint exposes the same `/v1/messages` API that Claude Code expects. When AI Gateway supplies the Anthropic credentials for you — using either an Anthropic API key you [store as a provider key (BYOK)](/ai-gateway/configuration/bring-your-own-keys/) or [Unified Billing](/ai-gateway/features/unified-billing/) credits — the `ANTHROPIC_API_KEY` that Claude Code requires can be any placeholder value.
 
 ## Prerequisites
 

--- a/src/content/docs/ai-gateway/integrations/coding-agents/claude-code.mdx
+++ b/src/content/docs/ai-gateway/integrations/coding-agents/claude-code.mdx
@@ -152,7 +152,7 @@ Add the following to Claude Code's [`settings.json`](https://docs.anthropic.com/
 
 ```json title="~/.claude/settings.json"
 {
-	"apiKeyHelper": "cloudflared access login --no-verbose -app=https://ai-gateway.example.com",
+	"apiKeyHelper": "cloudflared access login --no-verbose https://ai-gateway.example.com",
 	"env": {
 		"ANTHROPIC_BASE_URL": "https://ai-gateway.example.com/anthropic"
 	}

--- a/src/content/docs/ai-gateway/integrations/coding-agents/openai-codex.mdx
+++ b/src/content/docs/ai-gateway/integrations/coding-agents/openai-codex.mdx
@@ -73,7 +73,7 @@ Before you start, you need:
    </TabItem>
    </Tabs>
 
-3. Start Codex with the profile and send a prompt. Requests now route through AI Gateway.
+3. Start Codex with the profile and send a prompt. Requests now route through AI Gateway. The `cloudflare-aig` profile name matches the `cloudflare-aig.config.toml` file you created.
 
    ```bash
    codex --profile cloudflare-aig
@@ -85,7 +85,7 @@ Before you start, you need:
 
 If your gateway is protected by [Cloudflare Access](/ai-gateway/configuration/cloudflare-access/), Codex can authenticate with a short-lived Access token instead of a Cloudflare API token. Point the provider at your [custom domain](/ai-gateway/configuration/custom-domains/), and configure the provider's `auth` command to fetch the token with [`cloudflared`](/cloudflare-one/access-controls/authenticate-agents/#make-requests-with-cloudflared-access-curl) instead of passing a token through an environment variable.
 
-Update your profile so the provider points at your custom domain and uses `cloudflared` for authentication. Replace `ai-gateway.example.com` with your custom domain.
+Update the same `~/.codex/cloudflare-aig.config.toml` profile from the setup above so the provider points at your custom domain and uses `cloudflared` for authentication. The `cloudflare-aig` in `codex --profile cloudflare-aig` refers to this file's name. Replace `ai-gateway.example.com` with your custom domain.
 
 ```toml title="~/.codex/cloudflare-aig.config.toml"
 model_provider = "cloudflare-ai-gateway"

--- a/src/content/docs/ai-gateway/integrations/coding-agents/openai-codex.mdx
+++ b/src/content/docs/ai-gateway/integrations/coding-agents/openai-codex.mdx
@@ -10,7 +10,7 @@ products:
 
 import { Tabs, TabItem, Steps } from "~/components";
 
-[OpenAI Codex](https://developers.openai.com/codex/) is a coding agent you run in your terminal. It supports [custom model providers](https://developers.openai.com/codex/config-advanced#custom-model-providers) defined in `config.toml`. This configuration adds a provider that points at AI Gateway's [OpenAI endpoint](/ai-gateway/usage/providers/openai/), so Codex sends its requests through AI Gateway. AI Gateway authenticates the model provider for you through [Unified Billing](/ai-gateway/features/unified-billing/), so you pass a Cloudflare API token instead of an OpenAI API key.
+[OpenAI Codex](https://developers.openai.com/codex/) is a coding agent you run in your terminal. It supports [custom model providers](https://developers.openai.com/codex/config-advanced#custom-model-providers) defined in `config.toml`. This configuration adds a provider that points at AI Gateway's [OpenAI endpoint](/ai-gateway/usage/providers/openai/), so Codex sends its requests through AI Gateway. AI Gateway authenticates the model provider for you through [Unified Billing](/ai-gateway/features/unified-billing/), so you pass a Cloudflare API token instead of an OpenAI API key. If your gateway is protected by Cloudflare Access, see [Use with Cloudflare Access](#use-with-cloudflare-access).
 
 :::note
 Codex custom providers only support the OpenAI Responses API (`wire_api = "responses"`). This means you can only use OpenAI models that support the Responses API, such as `gpt-5.5`. Models from other providers (for example, Anthropic or Google) do not use the OpenAI Responses request format, so they do not work with Codex through this configuration.
@@ -80,5 +80,38 @@ Before you start, you need:
    ```
 
 </Steps>
+
+## Use with Cloudflare Access
+
+If your gateway is protected by [Cloudflare Access](/ai-gateway/configuration/cloudflare-access/), Codex can authenticate with a short-lived Access token instead of a Cloudflare API token. Point the provider at your [custom domain](/ai-gateway/configuration/custom-domains/), and configure the provider's `auth` command to fetch the token with [`cloudflared`](/cloudflare-one/access-controls/authenticate-agents/#make-requests-with-cloudflared-access-curl) instead of passing a token through an environment variable.
+
+Update your profile so the provider points at your custom domain and uses `cloudflared` for authentication. Replace `ai-gateway.example.com` with your custom domain.
+
+```toml title="~/.codex/cloudflare-aig.config.toml"
+model_provider = "cloudflare-ai-gateway"
+model = "gpt-5.5"
+model_reasoning_effort = "medium"
+
+[model_providers.cloudflare-ai-gateway]
+name = "Cloudflare AI Gateway"
+base_url = "https://ai-gateway.example.com/openai"
+wire_api = "responses"
+
+[model_providers.cloudflare-ai-gateway.auth]
+command = "cloudflared"
+args = ["access", "login", "--no-verbose", "-app=https://ai-gateway.example.com"]
+timeout_ms = 30000
+refresh_interval_ms = 0
+```
+
+Compared to the Unified Billing setup above, the custom domain replaces the account ID and gateway ID in `base_url`, and the `auth` block replaces `env_key`.
+
+Start Codex with the profile:
+
+```bash
+codex --profile cloudflare-aig
+```
+
+The first request opens your identity provider's login flow. After you authenticate, requests route through AI Gateway with your Access identity attached as [`cf.user_id`](/ai-gateway/observability/custom-metadata/#reserved-metadata).
 
 To confirm traffic reaches AI Gateway, refer to [Verify it works](/ai-gateway/integrations/coding-agents/#verify-it-works).

--- a/src/content/docs/ai-gateway/integrations/coding-agents/openai-codex.mdx
+++ b/src/content/docs/ai-gateway/integrations/coding-agents/openai-codex.mdx
@@ -10,7 +10,7 @@ products:
 
 import { Tabs, TabItem, Steps } from "~/components";
 
-[OpenAI Codex](https://developers.openai.com/codex/) is a coding agent you run in your terminal. It supports [custom model providers](https://developers.openai.com/codex/config-advanced#custom-model-providers) defined in `config.toml`. This configuration adds a provider that points at AI Gateway's [OpenAI endpoint](/ai-gateway/usage/providers/openai/), so Codex sends its requests through AI Gateway. AI Gateway authenticates the model provider for you through [Unified Billing](/ai-gateway/features/unified-billing/), so you pass a Cloudflare API token instead of an OpenAI API key. If your gateway is protected by Cloudflare Access, see [Use with Cloudflare Access](#use-with-cloudflare-access).
+[OpenAI Codex](https://developers.openai.com/codex/) is a coding agent you run in your terminal. It supports [custom model providers](https://developers.openai.com/codex/config-advanced#custom-model-providers) defined in `config.toml`. This configuration adds a provider that points at AI Gateway's [OpenAI endpoint](/ai-gateway/usage/providers/openai/), so Codex sends its requests through AI Gateway. AI Gateway authenticates the model provider for you through [Unified Billing](/ai-gateway/features/unified-billing/), so you pass a Cloudflare API token instead of an OpenAI API key. If your gateway is protected by Cloudflare Access, refer to [Use with Cloudflare Access](#use-with-cloudflare-access).
 
 :::note
 Codex custom providers only support the OpenAI Responses API (`wire_api = "responses"`). This means you can only use OpenAI models that support the Responses API, such as `gpt-5.5`. Models from other providers (for example, Anthropic or Google) do not use the OpenAI Responses request format, so they do not work with Codex through this configuration.
@@ -85,7 +85,7 @@ Before you start, you need:
 
 If your gateway is protected by [Cloudflare Access](/ai-gateway/configuration/cloudflare-access/), Codex can authenticate with a short-lived Access token instead of a Cloudflare API token. Point the provider at your [custom domain](/ai-gateway/configuration/custom-domains/), and configure the provider's `auth` command to fetch the token with [`cloudflared`](/cloudflare-one/access-controls/authenticate-agents/#make-requests-with-cloudflared-access-curl) instead of passing a token through an environment variable.
 
-Update the same `~/.codex/cloudflare-aig.config.toml` profile from the setup above so the provider points at your custom domain and uses `cloudflared` for authentication. The `cloudflare-aig` in `codex --profile cloudflare-aig` refers to this file's name. Replace `ai-gateway.example.com` with your custom domain.
+Update the same `~/.codex/cloudflare-aig.config.toml` profile from the Unified Billing setup so the provider points at your custom domain and uses `cloudflared` for authentication. The `cloudflare-aig` in `codex --profile cloudflare-aig` refers to this file's name. Replace `ai-gateway.example.com` with your custom domain.
 
 ```toml title="~/.codex/cloudflare-aig.config.toml"
 model_provider = "cloudflare-ai-gateway"
@@ -99,12 +99,12 @@ wire_api = "responses"
 
 [model_providers.cloudflare-ai-gateway.auth]
 command = "cloudflared"
-args = ["access", "login", "--no-verbose", "-app=https://ai-gateway.example.com"]
+args = ["access", "login", "--no-verbose", "https://ai-gateway.example.com"]
 timeout_ms = 30000
 refresh_interval_ms = 0
 ```
 
-Compared to the Unified Billing setup above, the custom domain replaces the account ID and gateway ID in `base_url`, and the `auth` block replaces `env_key`.
+Compared to the Unified Billing setup in the previous section, the custom domain replaces the account ID and gateway ID in `base_url`, and the `auth` block replaces `env_key`.
 
 Start Codex with the profile:
 

--- a/src/content/docs/ai-gateway/observability/custom-metadata.mdx
+++ b/src/content/docs/ai-gateway/observability/custom-metadata.mdx
@@ -40,7 +40,7 @@ Objects are not supported as metadata values.
 
 Metadata keys that begin with `cf.` are reserved for metadata added by Cloudflare. Do not send your own `cf.*` metadata keys. AI Gateway removes customer-supplied `cf.*` keys before saving request metadata.
 
-When a request reaches AI Gateway through a [custom domain protected by Cloudflare Access](/ai-gateway/configuration/custom-domains/), AI Gateway adds the authenticated Access user ID to request metadata as `cf.user_id`. This value is the verified Access JWT `sub` claim, not the user's email address.
+When a request reaches AI Gateway through a custom domain protected by [Cloudflare Access](/ai-gateway/configuration/cloudflare-access/), AI Gateway adds the authenticated Access user ID to request metadata as `cf.user_id`. This value is the verified Access JWT `sub` claim, not the user's email address.
 
 AI Gateway guarantees that `cf.user_id` is saved when a valid Access user ID is present. If the request already has five custom metadata entries, AI Gateway may remove the last custom entry so `cf.user_id` can be saved. Service-token requests and requests without a user subject do not receive `cf.user_id` metadata.
 

--- a/src/content/docs/ai-gateway/observability/custom-metadata.mdx
+++ b/src/content/docs/ai-gateway/observability/custom-metadata.mdx
@@ -36,6 +36,14 @@ Objects are not supported as metadata values.
 
 :::
 
+## Reserved metadata
+
+Metadata keys that begin with `cf.` are reserved for metadata added by Cloudflare. Do not send your own `cf.*` metadata keys. AI Gateway removes customer-supplied `cf.*` keys before saving request metadata.
+
+When a request reaches AI Gateway through a [custom domain protected by Cloudflare Access](/ai-gateway/configuration/custom-domains/), AI Gateway adds the authenticated Access user ID to request metadata as `cf.user_id`. This value is the verified Access JWT `sub` claim, not the user's email address.
+
+AI Gateway guarantees that `cf.user_id` is saved when a valid Access user ID is present. If the request already has five custom metadata entries, AI Gateway may remove the last custom entry so `cf.user_id` can be saved. Service-token requests and requests without a user subject do not receive `cf.user_id` metadata.
+
 ## Implementations
 
 ### Using cURL


### PR DESCRIPTION
## Summary

Documents AI Gateway's Cloudflare Access integration and the custom domains that enable it — authenticating users through your identity provider before they reach a gateway, and attaching the verified Access user ID to request metadata as `cf.user_id`.

## Changes

- **`configuration/custom-domains.mdx`** (new) — Route requests through a hostname you own (for example, `ai.example.com`), omitting account/gateway IDs. Covers dashboard and API setup, the required DNS CNAME step, and limitations.
- **`configuration/cloudflare-access.mdx`** (new) — Put a gateway behind Access, accept an Access JWT as the credential, and inject the verified user ID as `cf.user_id`.
- **`observability/custom-metadata.mdx`** — Add a Reserved metadata section covering the `cf.*` namespace and automatic `cf.user_id` injection.
- **`integrations/coding-agents/claude-code.mdx`** & **`openai-codex.mdx`** — Add "Use with Cloudflare Access" sections showing `cloudflared`-based auth against a custom domain.
- **`changelog/ai-gateway/2026-08-05-access-user-id-metadata.mdx`** (new) — Announce identity-aware controls.

## Source context

- aig-worker-config-api!641 — custom-domain config plane + SSL-for-SaaS
- ai-gateway-infra!486 — custom-domain data plane + Access JWT auth
- ai-gateway-infra!681 — inject Access JWT `sub` as `cf.user_id`
- ai-gateway-infra!716 — release bundle

## Validation

- `pnpm exec prettier --write <changed files>`
- `pnpm run check`