### PR TITLE
[Browser Run][/json endpoint] Fix failing curl examples

### DIFF
--- a/src/content/docs/browser-run/quick-actions/json-endpoint.mdx
+++ b/src/content/docs/browser-run/quick-actions/json-endpoint.mdx
@@ -242,7 +242,7 @@ curl -X POST 'https://api.cloudflare.com/client/v4/accounts/<accountId>/browser-
 	"response_format": {
 		"type": "json_schema",
 		"json_schema": {
-			"type": object",
+			"type": "object",
 			"properties": {
 			"products": {
 				"type": "array",
@@ -353,7 +353,7 @@ Browser Run can use a custom model for which you supply credentials. List the mo
 This example uses the `custom_ai` parameter to instruct Browser Run to use a Anthropic's Claude Sonnet 4 model. The prompt asks the model to extract the main `<h1>` and `<h2>` headings from the target URL and return them in a structured JSON object.
 
 ```bash
-curl -X POST https://api.cloudflare.com/client/v4/accounts/<accountId>/browser-rendering/json \
+curl -X POST 'https://api.cloudflare.com/client/v4/accounts/<accountId>/browser-rendering/json' \
   -H 'authorization: Bearer <apiToken>' \
   -H 'content-type: application/json' \
   -d '{

--- a/src/content/docs/browser-run/quick-actions/json-endpoint.mdx
+++ b/src/content/docs/browser-run/quick-actions/json-endpoint.mdx
@@ -55,15 +55,15 @@ And at least one of:
 This example captures webpage data by providing both a prompt and a JSON schema. The prompt guides the extraction process, while the JSON schema defines the expected structure of the output.
 
 ```bash
-curl --request POST 'https://api.cloudflare.com/client/v4/accounts/CF_ACCOUNT_ID/browser-rendering/json' \
-  --header 'authorization: Bearer CF_API_TOKEN' \
-  --header 'content-type: application/json' \
-  --data '{
+curl -X POST 'https://api.cloudflare.com/client/v4/accounts/<accountId>/browser-rendering/json' \
+  -H 'authorization: Bearer <apiToken>' \
+  -H 'content-type: application/json' \
+  -d '{
   "url": "https://developers.cloudflare.com/",
   "prompt": "Get me the list of AI products",
   "response_format": {
     "type": "json_schema",
-    "schema": {
+    "json_schema": {
         "type": "object",
         "properties": {
           "products": {
@@ -136,7 +136,7 @@ const json = await client.browserRendering.json.create({
 	prompt: "Get me the list of AI products",
 	response_format: {
 		type: "json_schema",
-		schema: {
+		json_schema: {
 			type: "object",
 			properties: {
 				products: {
@@ -175,7 +175,7 @@ export default {
 			prompt: "Get me the list of AI products",
 			response_format: {
 				type: "json_schema",
-				schema: {
+				json_schema: {
 					type: "object",
 					properties: {
 						products: {
@@ -205,17 +205,17 @@ In this example, only a prompt is provided. The endpoint will use the prompt to 
 This is useful for simple extractions where you do not need a specific format.
 
 ```bash
-curl --request POST 'https://api.cloudflare.com/client/v4/accounts/CF_ACCOUNT_ID/browser-rendering/json' \
-  --header 'authorization: Bearer CF_API_TOKEN' \
-  --header 'content-type: application/json' \
-  --data '{
+curl -X POST 'https://api.cloudflare.com/client/v4/accounts/<accountId>/browser-rendering/json' \
+  -H 'authorization: Bearer <apiToken>' \
+  -H 'content-type: application/json' \
+  -d '{
     "url": "https://developers.cloudflare.com/",
     "prompt": "get me the list of AI products"
   }'
 ```
 
 ```json output
-
+{
 	"success": true,
 	"result": {
 		"AI Products": [
@@ -234,33 +234,36 @@ curl --request POST 'https://api.cloudflare.com/client/v4/accounts/CF_ACCOUNT_ID
 In this case, you supply a JSON schema via the `response_format` parameter. The schema defines the structure of the extracted data.
 
 ```bash
-curl --request POST 'https://api.cloudflare.com/client/v4/accounts/CF_ACCOUNT_ID/browser-rendering/json' \
-  --header 'authorization: Bearer CF_API_TOKEN' \
-  --header 'content-type: application/json' \
-  --data '"response_format": {
-    "type": "json_schema",
-    "schema": {
-        "type": "object",
-        "properties": {
-          "products": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "name": {
-                  "type": "string"
-                },
-                "link": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "name"
-              ]
-            }
-          }
-        }
-      }
+curl -X POST 'https://api.cloudflare.com/client/v4/accounts/<accountId>/browser-rendering/json' \
+  -H 'authorization: Bearer <apiToken>' \
+  -H 'content-type: application/json' \
+  -d '{
+	"url": "https://developers.cloudflare.com/",
+	"response_format": {
+		"type": "json_schema",
+		"json_schema": {
+			"type": object",
+			"properties": {
+			"products": {
+				"type": "array",
+				"items": {
+				"type": "object",
+				"properties": {
+					"name": {
+					"type": "string"
+					},
+					"link": {
+					"type": "string"
+					}
+				},
+				"required": [
+					"name"
+				]
+				}
+			}
+			}
+		}
+    }
   }'
 ```
 
@@ -350,16 +353,15 @@ Browser Run can use a custom model for which you supply credentials. List the mo
 This example uses the `custom_ai` parameter to instruct Browser Run to use a Anthropic's Claude Sonnet 4 model. The prompt asks the model to extract the main `<h1>` and `<h2>` headings from the target URL and return them in a structured JSON object.
 
 ```bash
-curl --request POST \
-  --url https://api.cloudflare.com/client/v4/accounts/CF_ACCOUNT_ID/browser-rendering/json \
-  --header 'authorization: Bearer CF_API_TOKEN' \
-  --header 'content-type: application/json' \
-  --data '{
+curl -X POST https://api.cloudflare.com/client/v4/accounts/<accountId>/browser-rendering/json \
+  -H 'authorization: Bearer <apiToken>' \
+  -H 'content-type: application/json' \
+  -d '{
   "url": "http://demoto.xyz/headings",
   "prompt": "Get the heading from the page in the form of an object like h1, h2. If there are many headings of the same kind then grab the first one.",
   "response_format": {
     "type": "json_schema",
-    "schema": {
+    "json_schema": {
       "type": "object",
       "properties": {
         "h1": {
@@ -380,7 +382,7 @@ curl --request POST \
       "authorization": "Bearer <ANTHROPIC_API_KEY>"
     }
   ]
-}
+}'
 ```
 
 ```json output


### PR DESCRIPTION
### Summary

Fixes broken curl examples on the /json endpoint page and aligns the request payload shape with what the API actually accepts, so users can copy-paste the snippets and have them run successfully.
Changes:
- Fixed invalid response_format field name. 
- Fixed the "With only a JSON schema" curl example. The -d payload was not valid JSON — it opened with a bare "response_format": key and no wrapping {}, and was missing the required url field. Rewrote it as a complete, runnable request body.
- Fixed the missing closing quote in the "Using a custom model (BYO API Key)" curl example (} → }'), which previously caused the shell to hang waiting for input.
- Fixed the "With only a prompt" sample response. The json output block was missing its opening {.
- Standardized curl syntax across all examples to match other quick-action pages: short flags (-X, -H, -d) instead of long flags (--request, --header, --data), and <accountId> / <apiToken> placeholders instead of CF_ACCOUNT_ID / CF_API_TOKEN.

### Screenshots (optional)
N/A — text-only changes to code samples.

### Documentation checklist

- [X] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).