### PR TITLE
docs(ai-gateway): add Claude Desktop integration

### DIFF
--- a/src/content/docs/ai-gateway/integrations/coding-agents/claude-desktop.mdx
+++ b/src/content/docs/ai-gateway/integrations/coding-agents/claude-desktop.mdx
@@ -3,7 +3,7 @@ title: Claude Desktop
 description: Route Claude Desktop through AI Gateway using third-party inference settings and your Cloudflare gateway token.
 pcx_content_type: configuration
 sidebar:
-  order: 1.5
+  order: 2
 products:
   - ai-gateway
 ---

--- a/src/content/docs/ai-gateway/integrations/coding-agents/claude-desktop.mdx
+++ b/src/content/docs/ai-gateway/integrations/coding-agents/claude-desktop.mdx
@@ -1,0 +1,70 @@
+---
+title: Claude Desktop
+description: Route Claude Desktop through AI Gateway using third-party inference settings and your Cloudflare gateway token.
+pcx_content_type: configuration
+sidebar:
+  order: 1.5
+products:
+  - ai-gateway
+---
+
+import { Steps } from "~/components";
+
+[Claude Desktop](https://claude.ai/download) can send third-party inference requests to a custom gateway. This configuration sends those requests to AI Gateway's [Anthropic endpoint](/ai-gateway/usage/providers/anthropic/), authenticated with your Cloudflare gateway token. AI Gateway can supply the Anthropic credentials for you through [Unified Billing](/ai-gateway/features/unified-billing/) or a [stored provider key (BYOK)](/ai-gateway/configuration/bring-your-own-keys/).
+
+## Prerequisites
+
+Before you start, you need:
+
+- An [authenticated gateway](/ai-gateway/configuration/authentication/) and its [gateway token](/ai-gateway/configuration/authentication/#setting-up-authenticated-gateway-using-the-dashboard). The gateway token must have `Run` permissions.
+- Your Cloudflare account ID. To find it, refer to [Find your account and zone IDs](/fundamentals/account/find-account-and-zone-ids/).
+- Credentials for Anthropic requests. Use either [Unified Billing](/ai-gateway/features/unified-billing/) credits or an Anthropic API key stored in AI Gateway as a [provider key (BYOK)](/ai-gateway/configuration/bring-your-own-keys/).
+- Claude Desktop installed and updated to the latest version.
+
+:::note
+For the simplest setup, set Claude Desktop's gateway API key to your Cloudflare gateway token. If you set the gateway API key to your own Anthropic API key instead, add `cf-aig-authorization: Bearer <CF_AIG_TOKEN>` as a custom inference header so AI Gateway can authenticate the request.
+:::
+
+<Steps>
+
+1. In Claude Desktop, select **Help** > **Troubleshooting** > **Enable Developer Mode**.
+
+2. Select **Developer** > **Configure Third-Party Inference**.
+
+3. In **Connection**, set the connection type to _Gateway_.
+
+4. In **Gateway credentials**, set **Credential kind** to _Static API key_.
+
+5. Set **Gateway API key** to your Cloudflare gateway token.
+
+   Replace `<CF_AIG_TOKEN>` with your gateway token.
+
+   ```txt
+   <CF_AIG_TOKEN>
+   ```
+
+6. Set **Gateway auth scheme** to _Bearer_.
+
+7. Set the gateway base URL to your gateway's Anthropic endpoint.
+
+   Replace `<ACCOUNT_ID>` and `<GATEWAY_ID>` with your values.
+
+   ```txt
+   https://gateway.ai.cloudflare.com/v1/<ACCOUNT_ID>/<GATEWAY_ID>/anthropic
+   ```
+
+8. In **Models**, add the Claude model you want to use.
+
+   | Field        | Value                 |
+   | ------------ | --------------------- |
+   | Model ID     | `claude-sonnet-4-5`   |
+   | Display name | `Claude Sonnet 4.5`   |
+   | Tier alias   | `sonnet`              |
+
+9. In **Gateway credentials**, select **Test connection**.
+
+10. Start a Claude Desktop conversation. Requests now route through AI Gateway.
+
+</Steps>
+
+To confirm traffic reaches AI Gateway, refer to [Verify it works](/ai-gateway/integrations/coding-agents/#verify-it-works).

--- a/src/content/docs/ai-gateway/integrations/coding-agents/github-copilot-cli.mdx
+++ b/src/content/docs/ai-gateway/integrations/coding-agents/github-copilot-cli.mdx
@@ -3,7 +3,7 @@ title: GitHub Copilot CLI
 description: Route GitHub Copilot CLI through AI Gateway using the REST API and Unified Billing.
 pcx_content_type: configuration
 sidebar:
-  order: 2
+  order: 3
 products:
   - ai-gateway
 ---

--- a/src/content/docs/ai-gateway/integrations/coding-agents/index.mdx
+++ b/src/content/docs/ai-gateway/integrations/coding-agents/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Coding agents
-description: Route coding agents such as Claude Code, GitHub Copilot CLI, OpenAI Codex, and Pi through AI Gateway for observability, caching, rate limiting, and cost tracking.
+description: Route Claude Code, Claude Desktop, GitHub Copilot CLI, OpenAI Codex, and Pi through AI Gateway for observability and control.
 pcx_content_type: navigation
 sidebar:
   order: 5
@@ -27,6 +27,7 @@ Routing a coding agent through AI Gateway gives you:
 Follow the setup guide for your coding agent:
 
 - [Claude Code](/ai-gateway/integrations/coding-agents/claude-code/)
+- [Claude Desktop](/ai-gateway/integrations/coding-agents/claude-desktop/)
 - [GitHub Copilot CLI](/ai-gateway/integrations/coding-agents/github-copilot-cli/)
 - [OpenAI Codex](/ai-gateway/integrations/coding-agents/openai-codex/)
 - [Pi](/ai-gateway/integrations/coding-agents/pi/)

--- a/src/content/docs/ai-gateway/integrations/coding-agents/index.mdx
+++ b/src/content/docs/ai-gateway/integrations/coding-agents/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Coding agents
-description: Route Claude Code, Claude Desktop, GitHub Copilot CLI, OpenAI Codex, and Pi through AI Gateway for observability and control.
+description: Route Claude Code, Claude Desktop, GitHub Copilot CLI, OpenAI Codex, and Pi through AI Gateway for observability, caching, rate limiting, and cost tracking.
 pcx_content_type: navigation
 sidebar:
   order: 5

--- a/src/content/docs/ai-gateway/integrations/coding-agents/openai-codex.mdx
+++ b/src/content/docs/ai-gateway/integrations/coding-agents/openai-codex.mdx
@@ -3,7 +3,7 @@ title: OpenAI Codex
 description: Route OpenAI Codex through AI Gateway using a custom model provider that points at the OpenAI endpoint.
 pcx_content_type: configuration
 sidebar:
-  order: 3
+  order: 4
 products:
   - ai-gateway
 ---

--- a/src/content/docs/ai-gateway/integrations/coding-agents/pi.mdx
+++ b/src/content/docs/ai-gateway/integrations/coding-agents/pi.mdx
@@ -3,7 +3,7 @@ title: Pi
 description: Route the Pi coding agent through AI Gateway using its built-in Cloudflare AI Gateway provider.
 pcx_content_type: configuration
 sidebar:
-  order: 4
+  order: 5
 products:
   - ai-gateway
 ---


### PR DESCRIPTION
### Summary

Adds a Claude Desktop setup guide to AI Gateway's coding agents integrations. The guide documents the working Claude Desktop third-party inference flow: static API key credentials, bearer gateway auth, the AI Gateway Anthropic endpoint, and manual Claude model configuration.

| File | Change |
| --- | --- |
| `integrations/coding-agents/claude-desktop.mdx` | Add Claude Desktop configuration guide |
| `integrations/coding-agents/index.mdx` | Add Claude Desktop to the coding agents list |

### What changed

- **Claude Desktop** _(new)_ — routes Claude Desktop through AI Gateway's Anthropic endpoint using the Cloudflare gateway token as the static API key and `Bearer` as the gateway auth scheme.
- **Model configuration** — documents adding `claude-sonnet-4-5` manually because the gateway does not expose a native model list endpoint for Claude Desktop to consume.
- **Coding agents overview** — adds Claude Desktop to the setup guide list and shortens the page description.

#### Notes

- No custom inference headers are required for the gateway-token setup path.
- If users set the gateway API key to their own Anthropic API key instead, the guide notes that they should add `cf-aig-authorization` as a custom inference header.
- No files were renamed or moved, so no redirects are required.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
