### PR TITLE
fix: retry trailing-slash redirect when URL has a query string

### DIFF
--- a/worker/index.ts
+++ b/worker/index.ts
@@ -165,16 +165,16 @@ export default class extends WorkerEntrypoint<Env> {
 				console.error("Could not evaluate redirects", error);
 			}
 
-			if (!pathname.endsWith("/")) {
+			// Markdown requests are handled by the first pass via the stripped
+			// base path, so no trailing-slash retry is needed here.
+			if (!pathname.endsWith("/") && !isMarkdownRequest) {
 				try {
 					const redirect = await redirectsEvaluator(
 						new Request(`${url.origin}${pathname}/${url.search}`, request),
 						this.env.ASSETS,
 					);
 					if (redirect) {
-						return isMarkdownRequest
-							? rewriteRedirectForMarkdown(redirect, url)
-							: redirect;
+						return redirect;
 					}
 				} catch (error) {
 					console.error(

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -165,25 +165,23 @@ export default class extends WorkerEntrypoint<Env> {
 				console.error("Could not evaluate redirects", error);
 			}
 
-			try {
-				const forceTrailingSlashURL = new URL(
-					request.url.replace(/([^/])$/, "$1/"),
-					request.url,
-				);
-				const redirect = await redirectsEvaluator(
-					new Request(forceTrailingSlashURL, request),
-					this.env.ASSETS,
-				);
-				if (redirect) {
-					return isMarkdownRequest
-						? rewriteRedirectForMarkdown(redirect, url)
-						: redirect;
+			if (!pathname.endsWith("/")) {
+				try {
+					const redirect = await redirectsEvaluator(
+						new Request(`${url.origin}${pathname}/${url.search}`, request),
+						this.env.ASSETS,
+					);
+					if (redirect) {
+						return isMarkdownRequest
+							? rewriteRedirectForMarkdown(redirect, url)
+							: redirect;
+					}
+				} catch (error) {
+					console.error(
+						"Could not evaluate redirects with a forced trailing slash",
+						error,
+					);
 				}
-			} catch (error) {
-				console.error(
-					"Could not evaluate redirects with a forced trailing slash",
-					error,
-				);
 			}
 		} catch (error) {
 			console.error("Unknown error", error);

--- a/worker/index.worker.test.ts
+++ b/worker/index.worker.test.ts
@@ -33,6 +33,24 @@ describe("Cloudflare Docs", () => {
 			expect(response.status).toBe(301);
 			expect(response.headers.get("Location")).toBe("/directory/");
 		});
+
+		it("preserves query strings on trailing-slash redirects", async () => {
+			const request = new Request("http://fakehost/docs/?test=whatever");
+			const response = await SELF.fetch(request, { redirect: "manual" });
+			expect(response.status).toBe(301);
+			expect(response.headers.get("Location")).toBe(
+				"/directory/?test=whatever",
+			);
+		});
+
+		it("preserves query strings when forcing a trailing slash", async () => {
+			const request = new Request("http://fakehost/docs?test=whatever");
+			const response = await SELF.fetch(request, { redirect: "manual" });
+			expect(response.status).toBe(301);
+			expect(response.headers.get("Location")).toBe(
+				"/directory/?test=whatever",
+			);
+		});
 	});
 
 	describe("json endpoints", () => {

--- a/worker/index.worker.test.ts
+++ b/worker/index.worker.test.ts
@@ -51,6 +51,13 @@ describe("Cloudflare Docs", () => {
 				"/directory/?test=whatever",
 			);
 		});
+
+		it("does not force a trailing slash on index.md requests", async () => {
+			const request = new Request("http://fakehost/docs/index.md");
+			const response = await SELF.fetch(request, { redirect: "manual" });
+			expect(response.status).toBe(301);
+			expect(response.headers.get("Location")).toBe("/directory/index.md");
+		});
 	});
 
 	describe("json endpoints", () => {


### PR DESCRIPTION


### Summary

The worker's trailing-slash retry ran `request.url.replace(/([^/])$/, "$1/")` against the full URL string. For requests with a query string, that regex appended the slash at the end of the query (e.g. `?test=whatever/`) rather than to the pathname, so a rule like `/foo/* /bar/:splat 301` was never matched and the request 404'd. 

**TLDR**: https://developers.cloudflare.com/cloudflare-one/policies/data-loss-prevention?x=y 404s but should redirect the same way as https://developers.cloudflare.com/cloudflare-one/policies/data-loss-prevention/?x=y

The retry now:

- Skips entirely when pathname already ends in `/` (avoids a redundant evaluator call on every non-redirected request).
- Appends `/` to the pathname only, so the retry actually forces a trailing slash on paths that carry a query string.
- Reuses the URL parsed at the top of `fetch` instead of allocating another one.

Adds two regression tests: one exercising a query string on a source path that already has a trailing slash (baseline for the library), and one on a source path that requires the trailing-slash retry to fire — the case the fix restores.


