### PR TITLE
[Network Interconnect] Remove beta tag from CNI Connection Maintenance Alert

### DIFF
--- a/src/content/docs/network-interconnect/monitoring-and-alerts.mdx
+++ b/src/content/docs/network-interconnect/monitoring-and-alerts.mdx
@@ -27,7 +27,7 @@ The Status column displays three statuses:
 
 You can configure notifications for upcoming CNI maintenance events using the Notifications feature in the Cloudflare dashboard. It is recommended to subscribe to two types of notifications to stay fully informed.
 
-**CNI Connection Maintenance Alert (beta):** This alert informs you about maintenance events (scheduled, updated, or canceled) that directly impact your CNI circuits used with the Cloudflare Virtual Network only.
+**CNI Connection Maintenance Alert:** This alert informs you about maintenance events (scheduled, updated, or canceled) that directly impact your CNI circuits used with the Cloudflare Virtual Network only.
 - You will receive warnings up to two weeks in advance for maintenance impacting your Magic Transit/WAN CNI connections.
 - You will be notified if the details of a scheduled maintenance change or if it is canceled.
 - For recently added maintenance, notifications are sent after a six-hour delay to prevent alerting fatigue from minor adjustments.
@@ -39,7 +39,7 @@ You can configure notifications for upcoming CNI maintenance events using the No
 
 ## How to configure alerts
 
-### Enable CNI Connection Maintenance Alert (beta)
+### Enable CNI Connection Maintenance Alert
 
 1. In the Cloudflare dashboard, go to the **Notifications** page.
 


### PR DESCRIPTION
### Summary

Removes the "(beta)" tag from the CNI Connection Maintenance Alert now that the feature is GA. Updates the section description and heading in `network-interconnect/monitoring-and-alerts`.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
