### PR TITLE
Add Keyless SSL "Run with Docker" page + container debug logging note

### DIFF
--- a/src/content/docs/ssl/keyless-ssl/configuration/run-with-docker.mdx
+++ b/src/content/docs/ssl/keyless-ssl/configuration/run-with-docker.mdx
@@ -1,0 +1,72 @@
+---
+title: Run with Docker
+pcx_content_type: how-to
+description: Run a Keyless SSL key server as a container using environment variables.
+products:
+  - ssl
+sidebar:
+  order: 4
+head:
+  - tag: title
+    content: Run Keyless SSL with Docker
+---
+
+The `gokeyless` key server is published as a container image, and most settings can be configured with environment variables instead of a `gokeyless.yaml` file.
+
+## Pull the image
+
+```sh
+docker pull ghcr.io/cloudflare/gokeyless:latest
+```
+
+:::note
+The image is published on the GitHub Container Registry (`ghcr.io`), not Docker Hub.
+:::
+
+A complete example is available in [`docker-compose.example.yaml`](https://github.com/cloudflare/gokeyless/blob/master/docker-compose.example.yaml) in the gokeyless repository.
+
+## Environment variables
+
+Each environment variable maps to the equivalent setting in `gokeyless.yaml`. When both are present, the environment variable takes precedence (the order is command-line flag, then environment variable, then configuration file).
+
+| Environment variable | Purpose |
+| --- | --- |
+| `KEYLESS_HOSTNAME` | Hostname of this key server (must match the value configured in Cloudflare). |
+| `KEYLESS_ZONE_ID` | Cloudflare Zone ID. |
+| `KEYLESS_ORIGIN_CA_API_KEY` | Origin CA API key used to enroll the key server and obtain its authentication certificate. |
+| `KEYLESS_AUTH_CERT` | Path to the key server authentication certificate (default `server.pem`). |
+| `KEYLESS_AUTH_KEY` | Path to the authentication certificate private key (default `server-key.pem`). |
+| `KEYLESS_AUTH_CSR` | Path to write the CSR generated during initialization (default `server.csr`). |
+| `KEYLESS_CLOUDFLARE_CA_CERT` | Path to the Cloudflare CA certificate used to authenticate connecting key clients (default `keyless_cacert.pem`). |
+| `KEYLESS_PORT` | Port the key server listens on (default `2407`). |
+| `KEYLESS_METRICS_PORT` | Port for the `/metrics` endpoint (default `2406`). |
+| `KEYLESS_LOGLEVEL` | Log verbosity, `0` (most verbose) to `5`. |
+
+## Configure private keys
+
+Private key locations **cannot** be set with an environment variable. Configure them with either:
+
+- a `private_key_stores` block in `gokeyless.yaml` (each entry sets exactly one of `dir`, `file`, or `uri`), or
+- the `--private-key-dirs` / `--private-key-files` flags (comma-separated), passed as arguments after the image name.
+
+## Run the container
+
+```sh
+docker run -d \
+  -e KEYLESS_HOSTNAME=<KEY_SERVER_HOSTNAME> \
+  -e KEYLESS_ZONE_ID=<ZONE_ID> \
+  -e KEYLESS_AUTH_CERT=/config/server.pem \
+  -e KEYLESS_AUTH_KEY=/config/server-key.pem \
+  -e KEYLESS_CLOUDFLARE_CA_CERT=/config/keyless_cacert.pem \
+  -v /local/config:/config:ro \
+  -v /local/keys:/keys:ro \
+  -p 2407:2407 \
+  ghcr.io/cloudflare/gokeyless:latest \
+  --private-key-dirs /keys
+```
+
+The image entrypoint is `gokeyless`, so any command-line flags (such as `--private-key-dirs`) are appended after the image name.
+
+## Serving multiple private keys
+
+A single key server can hold private keys for multiple certificates. List several directories or files with `--private-key-dirs` / `--private-key-files` (comma-separated), or define multiple `private_key_stores` entries in `gokeyless.yaml`.

--- a/src/content/docs/ssl/keyless-ssl/configuration/run-with-docker.mdx
+++ b/src/content/docs/ssl/keyless-ssl/configuration/run-with-docker.mdx
@@ -67,6 +67,6 @@ docker run -d \
 
 The image entrypoint is `gokeyless`, so any command-line flags (such as `--private-key-dirs`) are appended after the image name.
 
-## Serving multiple private keys
+## Serve multiple private keys
 
 A single key server can hold private keys for multiple certificates. List several directories or files with `--private-key-dirs` / `--private-key-files` (comma-separated), or define multiple `private_key_stores` entries in `gokeyless.yaml`.

--- a/src/content/docs/ssl/keyless-ssl/configuration/run-with-docker.mdx
+++ b/src/content/docs/ssl/keyless-ssl/configuration/run-with-docker.mdx
@@ -44,10 +44,7 @@ Each environment variable maps to the equivalent setting in `gokeyless.yaml`. Wh
 
 ## Configure private keys
 
-Private key locations **cannot** be set with an environment variable. Configure them with either:
-
-- a `private_key_stores` block in `gokeyless.yaml` (each entry sets exactly one of `dir`, `file`, or `uri`), or
-- the `--private-key-dirs` / `--private-key-files` flags (comma-separated), passed as arguments after the image name.
+Private key locations **cannot** be set with an environment variable. Configure them with a `private_key_stores` block in `gokeyless.yaml` (each entry sets exactly one of `dir`, `file`, or `uri`), or with the `--private-key-dirs` / `--private-key-files` flags (comma-separated), passed as arguments after the image name.
 
 ## Run the container
 

--- a/src/content/docs/ssl/keyless-ssl/troubleshooting.mdx
+++ b/src/content/docs/ssl/keyless-ssl/troubleshooting.mdx
@@ -29,6 +29,16 @@ cd /etc/keyless
 sudo -u keyless gokeyless --loglevel 0
 ```
 
+When running in a container, `gokeyless` is the container's main process (PID 1), so the command above does not apply. Instead, set the log level when you start the container and read logs from the container runtime:
+
+```sh
+# Set verbosity via environment variable
+docker run ... -e KEYLESS_LOGLEVEL=0 ghcr.io/cloudflare/gokeyless:latest
+
+# Read logs
+docker logs -f <container>   # or: kubectl logs -f <pod>
+```
+
 ## Browsers are seeing a TLS connection failure after trying to connect
 
 1. Make sure your key server is accessible from outside your network (tcp/2407).

--- a/src/content/docs/ssl/keyless-ssl/troubleshooting.mdx
+++ b/src/content/docs/ssl/keyless-ssl/troubleshooting.mdx
@@ -29,7 +29,7 @@ cd /etc/keyless
 sudo -u keyless gokeyless --loglevel 0
 ```
 
-When running in a container, `gokeyless` is the container's main process (PID 1), so the command above does not apply. Instead, set the log level when you start the container and read logs from the container runtime:
+When running in a container, `gokeyless` is the container's main process (PID 1), so the host/systemd command above does not apply. Instead, set the log level when you start the container and read logs from the container runtime:
 
 ```sh
 # Set verbosity via environment variable

--- a/src/content/docs/ssl/keyless-ssl/troubleshooting.mdx
+++ b/src/content/docs/ssl/keyless-ssl/troubleshooting.mdx
@@ -36,7 +36,7 @@ When running in a container, `gokeyless` is the container's main process (PID 1)
 docker run ... -e KEYLESS_LOGLEVEL=0 ghcr.io/cloudflare/gokeyless:latest
 
 # Read logs
-docker logs -f <container>   # or: kubectl logs -f <pod>
+docker logs -f <CONTAINER>   # or: kubectl logs -f <POD>
 ```
 
 ## Browsers are seeing a TLS connection failure after trying to connect


### PR DESCRIPTION
## What this changes

Adds container/Docker documentation for the Keyless SSL key server (`gokeyless`), addressing gaps reported by an enterprise customer (T257).

- **New page — Run with Docker** (`configuration/run-with-docker.mdx`): pulling the `ghcr.io/cloudflare/gokeyless` image, a full `KEYLESS_*` environment-variable reference, how to configure private keys (config block / `--private-key-dirs` — not an env var), a runnable `docker run` example, and serving multiple private keys.
- **Troubleshooting — Enable debug logging**: adds a container variant. The existing `sudo -u keyless gokeyless --loglevel 0` command assumes a host/systemd install and does not apply in a container (gokeyless is PID 1); documents setting `KEYLESS_LOGLEVEL` at startup and reading logs via `docker logs` / `kubectl logs`.

All environment-variable names, defaults, ports (2407/2406), precedence (flag > env > config), and the private-key mechanism were verified against `gokeyless` master source (`cmd/gokeyless/gokeyless.go`).

## Documentation checklist
- [x] The change adheres to the documentation style guide.
- [ ] Changelog entry (n/a — clarifying existing product docs)
- [ ] Redirects (n/a — new page, no moves)