### PR TITLE
[Logs] Update Logpush dataset field definitions (2026-07-02)

### DIFF
--- a/src/content/changelog/logs/2026-07-02-log-fields-updated.mdx
+++ b/src/content/changelog/logs/2026-07-02-log-fields-updated.mdx
@@ -1,0 +1,15 @@
+---
+title: Updated fields across multiple Logpush datasets in Cloudflare Logs
+description: Fields have been updated across multiple Logpush datasets in Cloudflare Logs.
+date: 2026-07-02
+---
+
+Cloudflare has updated [Logpush datasets](/logs/logpush/logpush-job/datasets/):
+
+### Updated fields in existing datasets
+
+- **Gateway DNS** (added): `AppliedMaxTTL` and `UpstreamRecordTTLs`.
+- **Gateway HTTP** (added): `Warnings`.
+- **HTTP requests** (added): `CacheLockWaitedMs`.
+
+For the complete field definitions for each dataset, refer to [Logpush datasets](/logs/logpush/logpush-job/datasets/).

--- a/src/content/docs/logs/logpush/logpush-job/datasets/account/gateway_dns.md
+++ b/src/content/docs/logs/logpush/logpush-job/datasets/account/gateway_dns.md
@@ -27,6 +27,12 @@ Type: `string`
 
 Name of the application the domain belongs to (for example, 'Cloudflare Dashboard').
 
+## AppliedMaxTTL
+
+Type: `int`
+
+Maximum TTL cap applied to the response records, in seconds. Set to 0 when no cap was applied.
+
 ## AuthoritativeNameServerIPs
 
 Type: `array[string]`
@@ -482,6 +488,12 @@ Time zone used to calculate the current time, if a matched rule was scheduled wi
 Type: `string`
 
 Method used to pick the time zone for the schedule (from rule/ from user ip/ from local time).
+
+## UpstreamRecordTTLs
+
+Type: `array[int]`
+
+TTL of each record in the upstream response, in seconds. Maps one-to-one with the resource records (for example, [3600, 300]).
 
 ## UserID
 

--- a/src/content/docs/logs/logpush/logpush-job/datasets/account/gateway_http.md
+++ b/src/content/docs/logs/logpush/logpush-job/datasets/account/gateway_http.md
@@ -362,3 +362,9 @@ The identifier of the virtual network the device was connected to, if any.
 Type: `string`
 
 The name of the virtual network the device was connected to, if any.
+
+## Warnings
+
+Type: `array[string]`
+
+Warnings generated during request processing.

--- a/src/content/docs/logs/logpush/logpush-job/datasets/account/workers_trace_events.md
+++ b/src/content/docs/logs/logpush/logpush-job/datasets/account/workers_trace_events.md
@@ -43,7 +43,7 @@ The timestamp of when the event was received, in milliseconds.
 
 Type: `string`
 
-The event type that triggered the invocation. <br />Possible values are <em>fetch</em>.
+The event type that triggered the invocation. <br />Possible values are <em>fetch</em> \| <em>scheduled</em> \| <em>alarm</em> \| <em>queue</em> \| <em>email</em> \| <em>worker_rpc</em> \| <em>hibernatable_web_socket</em>.
 
 ## Exceptions
 
@@ -61,7 +61,7 @@ List of console messages emitted during the invocation.
 
 Type: `string`
 
-The outcome of the Worker script invocation. <br />Possible values are <em>ok</em> \| <em>exception</em>.
+The outcome of the Worker script invocation. <br />Possible values are <em>ok</em> \| <em>canceled</em> \| <em>exception</em> \| <em>unknown</em>.
 
 ## ScriptName
 

--- a/src/content/docs/logs/logpush/logpush-job/datasets/zone/http_requests.md
+++ b/src/content/docs/logs/logpush/logpush-job/datasets/zone/http_requests.md
@@ -69,6 +69,12 @@ Type: `string`
 
 Cache status. <br />Possible values are <em>unknown</em> \| <em>miss</em> \| <em>expired</em> \| <em>updating</em> \| <em>stale</em> \| <em>hit</em> \| <em>ignored</em> \| <em>bypass</em> \| <em>revalidated</em> \| <em>dynamic</em> \| <em>stream_hit</em> \| <em>deferred</em> <br />"dynamic" means that a request is not eligible for cache. This can mean, for example that it was blocked by the firewall. Refer to [Cloudflare cache responses](/cache/concepts/cache-responses/) for more details.
 
+## CacheLockWaitedMs
+
+Type: `int`
+
+Maximum time spent waiting on a cache lock across all cache tiers, in milliseconds.
+
 ## CacheReserveUsed
 
 Type: `bool`


### PR DESCRIPTION
## Summary

Automated sync of Logpush dataset field definitions from [data/entities](https://gitlab.cfdata.org/cloudflare/data/entities).

### Updated fields in existing datasets

- **Gateway DNS** (added): `AppliedMaxTTL` and `UpstreamRecordTTLs`.
- **Gateway HTTP** (added): `Warnings`.
- **HTTP requests** (added): `CacheLockWaitedMs`.

### Files changed
- `src/content/docs/logs/logpush/logpush-job/datasets/account/` — dataset pages
- `src/content/docs/logs/logpush/logpush-job/datasets/zone/` — dataset pages
- `src/content/changelog/logs/2026-07-02-log-fields-updated.mdx` — changelog

### Documentation checklist
- [x] Changelog entry added
- [x] Content generated by code generator (DO NOT EDIT manually)
