### PR TITLE
[Client-Side Security] Split allowlisted-domain violation troubleshooting into two causes

### DIFF
--- a/src/content/docs/client-side-security/troubleshooting.mdx
+++ b/src/content/docs/client-side-security/troubleshooting.mdx
@@ -51,6 +51,8 @@ You can safely ignore these warnings, since they are related to the reports that
 
 ## I get rule violation reports for a domain I allowlisted
 
+### Redirects to other domains
+
 Rule violations reported via CSP's [report-only directive](/client-side-security/reference/csp-header/) do not take into consideration any redirects or redirect HTTP status codes. This is [by design](https://www.w3.org/TR/CSP3/#create-violation-for-request) for security reasons.
 
 Some third-party services you may want to cover in your allow rules perform redirects. An example of such a service is Google Ads, which [does not work well with CSP policies](https://support.google.com/adsense/thread/102839782?hl=en&msgid=103611259).
@@ -58,6 +60,14 @@ Some third-party services you may want to cover in your allow rules perform redi
 For example, if you add the `adservice.google.com` domain to an allow rule, you could get rule violation reports for this domain due to redirects to a different domain (not present in your allow rule). In this case, the violation report would still mention the original domain, and not the domain of the redirected destination, which can cause some confusion.
 
 To try to solve this issue, add the domain of the redirected destination to your allow rule. You may need to add several domains to your rule due to redirects.
+
+### Ad-blocking browser extensions
+
+If the violation reports reference domains that belong to user consent management or behavioral tracking services, an ad-blocking browser extension installed on the visitor's browser is a likely cause.
+
+These extensions commonly block requests to such domains, often by redirecting them to a local resource instead of letting them reach the destination. Since the violation report mentions the original domain requested by the page, not this blocked or redirected destination, you may see violation reports for a domain you already allowlisted.
+
+Because only visitors with these extensions installed trigger this behavior, the violation reports are sparse compared to your site's overall traffic volume.
 
 ## I get scoped alerts for hostnames I do not manage on a SaaS root zone
 


### PR DESCRIPTION
### Summary

Splits the "I get rule violation reports for a domain I allowlisted" troubleshooting section into two sub-sections covering the two distinct causes:

- **Redirects to other domains**: the existing content, unchanged, describing redirects to domains not covered by the allow rule.
- **Ad-blocking browser extensions**: new content explaining that reports referencing user consent or behavioral tracking domains are often caused by ad-blocking extensions redirecting those requests rather than blocking them outright.
