### PR TITLE
[Workers] Document @cloudflare/workers-types v5

### DIFF
--- a/src/content/changelog/workers/2026-07-03-workers-types-v5.mdx
+++ b/src/content/changelog/workers/2026-07-03-workers-types-v5.mdx
@@ -8,7 +8,7 @@ date: 2026-07-03
 
 import { PackageManagers } from "~/components";
 
-We've released version 5 of [`@cloudflare/workers-types`](https://www.npmjs.com/package/@cloudflare/workers-types). This release simplifies the package to expose only the latest runtime types.
+We have released version 5 of [`@cloudflare/workers-types`](https://www.npmjs.com/package/@cloudflare/workers-types). This release simplifies the package to expose only the latest runtime types.
 
 We still recommend that you generate types for your Worker using [`wrangler types`](/workers/wrangler/commands/general/#types), but if you want to use the package directly, you can install it with your package manager of choice:
 
@@ -21,3 +21,4 @@ The package now exposes two entrypoints:
 
 The dated entrypoints, such as `@cloudflare/workers-types/2022-11-30` and `@cloudflare/workers-types/2023-03-01`, are removed. With runtime type generation in [Wrangler v4](/workers/wrangler/), you can generate these with the `wrangler types` command to create types locked to your Worker's compatibility date.
 
+For more information, refer to [TypeScript language support](/workers/languages/typescript/).

--- a/src/content/changelog/workers/2026-07-03-workers-types-v5.mdx
+++ b/src/content/changelog/workers/2026-07-03-workers-types-v5.mdx
@@ -1,0 +1,23 @@
+---
+title: Simpler runtime types with @cloudflare/workers-types v5
+description: Ships only the latest runtime types and drops the dated entrypoints.
+products:
+  - workers
+date: 2026-07-03
+---
+
+import { PackageManagers } from "~/components";
+
+We've released version 5 of [`@cloudflare/workers-types`](https://www.npmjs.com/package/@cloudflare/workers-types). This release simplifies the package to expose only the latest runtime types.
+
+We still recommend that you generate types for your Worker using [`wrangler types`](/workers/wrangler/commands/general/#types), but if you want to use the package directly, you can install it with your package manager of choice:
+
+<PackageManagers type="add" pkg="@cloudflare/workers-types@latest" dev />
+
+The package now exposes two entrypoints:
+
+- `@cloudflare/workers-types` reflects the latest compatibility date, using the latest stable compatibility flags.
+- `@cloudflare/workers-types/experimental` reflects APIs behind experimental compatibility flags.
+
+The dated entrypoints, such as `@cloudflare/workers-types/2022-11-30` and `@cloudflare/workers-types/2023-03-01`, are removed. With runtime type generation in [Wrangler v4](/workers/wrangler/), you can generate these with the `wrangler types` command to create types locked to your Worker's compatibility date.
+

--- a/src/content/docs/workers/languages/typescript/index.mdx
+++ b/src/content/docs/workers/languages/typescript/index.mdx
@@ -17,6 +17,12 @@ TypeScript is a first-class language on Cloudflare Workers. All APIs provided in
 
 We recommend you generate types for your Worker by running [`wrangler types`](/workers/wrangler/commands/general/#types). Cloudflare also publishes type definitions to [GitHub](https://github.com/cloudflare/workers-types) and [npm](https://www.npmjs.com/package/@cloudflare/workers-types) (`npm install -D @cloudflare/workers-types`).
 
+:::note[Version 5 and later]
+
+`@cloudflare/workers-types` version 5 exposes only the latest runtime types. The dated entrypoints, such as `@cloudflare/workers-types/2022-11-30`, are removed. Import from `@cloudflare/workers-types` for the latest stable types, or from `@cloudflare/workers-types/experimental` for APIs behind experimental compatibility flags. To match types to a specific compatibility date and flags, run [`wrangler types`](/workers/wrangler/commands/general/#types).
+
+:::
+
 <h3 id="generate-types">
 	Generate types that match your Worker's configuration
 </h3>

--- a/src/content/docs/workers/vite-plugin/tutorial.mdx
+++ b/src/content/docs/workers/vite-plugin/tutorial.mdx
@@ -121,7 +121,7 @@ This tutorial, however, will show you how to go a step further and add an API Wo
 	"extends": "./tsconfig.node.json",
 	"compilerOptions": {
 		"tsBuildInfoFile": "./node_modules/.tmp/tsconfig.worker.tsbuildinfo",
-		"types": ["@cloudflare/workers-types/2023-07-01", "vite/client"],
+		"types": ["@cloudflare/workers-types", "vite/client"],
 	},
 	"include": ["worker"],
 }


### PR DESCRIPTION
### Summary

Documents the `@cloudflare/workers-types` v5 release. Version 5 reduces the package to two entrypoints — `@cloudflare/workers-types` for the latest stable runtime types and `@cloudflare/workers-types/experimental` for APIs behind experimental compatibility flags — and removes the dated entrypoints such as `/2023-07-01`.

- Adds a Workers changelog entry announcing v5 and pointing users to `wrangler types` for types locked to a specific compatibility date.
- Adds a note on the TypeScript language page explaining the v5 entrypoint changes.
- Updates the Vite plugin tutorial `tsconfig`, which referenced the now-removed `@cloudflare/workers-types/2023-07-01` entrypoint — the only dated entrypoint used anywhere in the docs.

Runtime change: https://github.com/cloudflare/workerd/pull/6853

### Documentation checklist

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
