### PR TITLE
[SSL] Remove FIPS caveat for PQ key agreement

### DIFF
--- a/src/content/docs/ssl/post-quantum-cryptography/index.mdx
+++ b/src/content/docs/ssl/post-quantum-cryptography/index.mdx
@@ -21,7 +21,7 @@ To protect you against the risk of [harvest-now, decrypt-later attacks](https://
 Refer to [Cloudflare Radar](https://radar.cloudflare.com/adoption-and-usage#post-quantum-encryption-adoption) for current statistics on the adoption of PQ encryption in requests to Cloudflare, and visit [Cloudflare Radar's browser support check](https://radar.cloudflare.com/post-quantum#browser-support) to check if your browser is secured using PQ key agreement.
 
 :::caution[TLS 1.3]
-Cloudflare post-quantum key agreements are only supported in protocols based on TLS 1.3 (including HTTP/3) and are disabled for websites in [FIPS mode](/cloudflare-one/traffic-policies/http-policies/tls-decryption/#fips-compliance).
+Cloudflare post-quantum key agreements are only supported in protocols based on TLS 1.3 (including HTTP/3).
 :::
 
 ## Three building blocks of TLS


### PR DESCRIPTION
### Summary

X25519MLKEM768 is now enabled for FIPS-mode zones, so the caveat stating PQ key agreements are disabled in FIPS mode is no longer accurate. Removed it.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
