### PR TITLE
[Sandbox] Add documentation for extensions

### DIFF
--- a/src/content/changelog/sandbox/2026-07-03-extensions-framework.mdx
+++ b/src/content/changelog/sandbox/2026-07-03-extensions-framework.mdx
@@ -1,0 +1,44 @@
+---
+title: Sandbox SDK extensions framework
+description: Attach opt-in capabilities to your Sandbox subclass with the new extension framework. The code interpreter and Git client are now shipped as extensions.
+products:
+  - sandbox
+date: 2026-07-03
+---
+
+The Sandbox SDK now has an **extension framework** that lets you attach opt-in capabilities to your `Sandbox` subclass instead of relying on features baked into the core SDK or container image. Extensions come in two flavors: SDK-only extensions that orchestrate existing container APIs from the Durable Object side, and sidecar extensions that ship a bundled runtime provisioned inside the container on first use.
+
+The framework also delivers on our previously announced [plan to move non-core features into helpers](/changelog/2026-06-09-deprecating-sandbox-sdk-features/). Two Cloudflare-authored extensions ship alongside the framework:
+
+- **`@cloudflare/sandbox/interpreter`** — the Python and JavaScript code interpreter, now provisioned as a sidecar the first time you use it.
+- **`@cloudflare/sandbox/git`** — the Git client, driving `exec()` from the Durable Object side.
+
+Attach them to your `Sandbox` subclass:
+
+```ts
+import { Sandbox as BaseSandbox } from "@cloudflare/sandbox";
+import { withInterpreter } from "@cloudflare/sandbox/interpreter";
+import { withGit } from "@cloudflare/sandbox/git";
+
+export class Sandbox extends BaseSandbox<Env> {
+	interpreter = withInterpreter(this);
+	git = withGit(this);
+}
+```
+
+And call them from a Worker as a nested namespace on the sandbox stub:
+
+```ts
+await sandbox.interpreter.runCode('print("hello")', { context });
+await sandbox.git.checkout("https://github.com/owner/repo.git", { depth: 1 });
+```
+
+The extension framework, `withInterpreter()`, and `withGit()` are currently available in the [`@cloudflare/sandbox@next`](https://www.npmjs.com/package/@cloudflare/sandbox/v/next) prerelease of the SDK. Install it explicitly to try it today:
+
+```sh
+npm install @cloudflare/sandbox@next
+```
+
+The `next` channel will become the default `latest` release in a future version. Note that on `next`, `sandbox.gitCheckout()` and the interpreter methods (`createCodeContext`, `runCode`, `runCodeStream`, `listCodeContexts`, `deleteCodeContext`) no longer exist on the base `Sandbox` class — attach the extension and, optionally, add a delegate method to preserve the previous flat API.
+
+For the full authoring guide, examples, and migration notes, refer to the new [Extensions concept page](/sandbox/concepts/extensions/).

--- a/src/content/changelog/sandbox/2026-07-03-extensions-framework.mdx
+++ b/src/content/changelog/sandbox/2026-07-03-extensions-framework.mdx
@@ -1,44 +1,57 @@
 ---
-title: Sandbox SDK extensions framework
-description: Attach opt-in capabilities to your Sandbox subclass with the new extension framework. The code interpreter and Git client are now shipped as extensions.
+title: Build reusable Sandbox capabilities with extensions
+description: Package Sandbox workflows and specialized runtimes into reusable, opt-in APIs with the new extensions framework.
 products:
   - sandbox
 date: 2026-07-03
 ---
 
-The Sandbox SDK now has an **extension framework** that lets you attach opt-in capabilities to your `Sandbox` subclass instead of relying on features baked into the core SDK or container image. Extensions come in two flavors: SDK-only extensions that orchestrate existing container APIs from the Durable Object side, and sidecar extensions that ship a bundled runtime provisioned inside the container on first use.
+import { PackageManagers, TypeScriptExample } from "~/components";
 
-The framework also delivers on our previously announced [plan to move non-core features into helpers](/changelog/2026-06-09-deprecating-sandbox-sdk-features/). Two Cloudflare-authored extensions ship alongside the framework:
+Sandbox extensions let you turn repeated workflows into reusable, typed APIs. Instead of coordinating commands, files, and processes throughout your Worker, you can group that logic into a named capability and attach it to your `Sandbox` class.
 
-- **`@cloudflare/sandbox/interpreter`** — the Python and JavaScript code interpreter, now provisioned as a sidecar the first time you use it.
-- **`@cloudflare/sandbox/git`** — the Git client, driving `exec()` from the Durable Object side.
+For example, you can build extensions that:
 
-Attach them to your `Sandbox` subclass:
+- Prepare a repository and run project-specific checks.
+- Install tools and configure a development environment.
+- Run a language server, code interpreter, or other long-running service inside the container.
 
-```ts
+Your Worker calls each extension through its own namespace, such as `sandbox.git.checkout()` or `sandbox.interpreter.runCode()`. This keeps application code focused on what the sandbox should do, rather than each command required to do it. You can also reuse the extension across Sandbox applications.
+
+The framework supports lightweight extensions that coordinate existing Sandbox APIs. It also supports sidecar extensions with a dedicated process inside the container. Sidecars start when first used and do not require an exposed port or separate service.
+
+The code interpreter and Git client are the first Cloudflare-provided extensions. Attach only the capabilities your application needs:
+
+<TypeScriptExample>
+```
 import { Sandbox as BaseSandbox } from "@cloudflare/sandbox";
 import { withInterpreter } from "@cloudflare/sandbox/interpreter";
 import { withGit } from "@cloudflare/sandbox/git";
 
 export class Sandbox extends BaseSandbox<Env> {
-	interpreter = withInterpreter(this);
-	git = withGit(this);
+  interpreter = withInterpreter(this);
+  git = withGit(this);
 }
 ```
+</TypeScriptExample>
 
-And call them from a Worker as a nested namespace on the sandbox stub:
+You can then call each capability from your Worker:
 
-```ts
+<TypeScriptExample>
+```
+const context = await sandbox.interpreter.createCodeContext({
+  language: "python",
+});
 await sandbox.interpreter.runCode('print("hello")', { context });
+
 await sandbox.git.checkout("https://github.com/owner/repo.git", { depth: 1 });
 ```
+</TypeScriptExample>
 
-The extension framework, `withInterpreter()`, and `withGit()` are currently available in the [`@cloudflare/sandbox@next`](https://www.npmjs.com/package/@cloudflare/sandbox/v/next) prerelease of the SDK. Install it explicitly to try it today:
+The extension framework, `withInterpreter()`, and `withGit()` are available in the [`@cloudflare/sandbox@next`](https://www.npmjs.com/package/@cloudflare/sandbox/v/next) prerelease. Install this version explicitly:
 
-```sh
-npm install @cloudflare/sandbox@next
-```
+<PackageManagers pkg="@cloudflare/sandbox@next" />
 
-The `next` channel will become the default `latest` release in a future version. Note that on `next`, `sandbox.gitCheckout()` and the interpreter methods (`createCodeContext`, `runCode`, `runCodeStream`, `listCodeContexts`, `deleteCodeContext`) no longer exist on the base `Sandbox` class — attach the extension and, optionally, add a delegate method to preserve the previous flat API.
+The `next` channel will become the default `latest` release in a future version. In `next`, the Git and interpreter methods no longer exist directly on the base `Sandbox` class. Attach their extensions to use these capabilities.
 
-For the full authoring guide, examples, and migration notes, refer to the new [Extensions concept page](/sandbox/concepts/extensions/).
+For extension types, authoring examples, and migration guidance, refer to [Extensions](/sandbox/concepts/extensions/).

--- a/src/content/docs/sandbox/concepts/extensions.mdx
+++ b/src/content/docs/sandbox/concepts/extensions.mdx
@@ -10,7 +10,7 @@ products:
 
 import { TypeScriptExample, PackageManagers } from "~/components";
 
-The extension framework lets you attach opt-in capabilities to your `Sandbox` subclass instead of relying on features baked into the core SDK or container image. Extensions are how larger, optional features (such as the code interpreter and Git client) now ship in the Sandbox SDK.
+Extensions let you package Sandbox workflows into reusable, typed APIs. Attach an extension to your `Sandbox` class, then call it from your Worker through a named namespace such as `sandbox.git` or `sandbox.interpreter`.
 
 :::caution[Available in the `next` release only]
 The extension framework, the `withInterpreter()` extension, and the `withGit()` extension are only available in the [`@cloudflare/sandbox@next`](https://www.npmjs.com/package/@cloudflare/sandbox/v/next) prerelease of the SDK. Install it explicitly:
@@ -20,20 +20,26 @@ The extension framework, the `withInterpreter()` extension, and the `withGit()` 
 The `next` channel will become the default `latest` release in a future version. Until then, code samples on this page will not work against the current stable release.
 :::
 
-## What extensions are for
+## Why use extensions
 
-The base `Sandbox` class exposes a small, general-purpose surface: commands, files, processes, ports, and sessions. Extensions layer higher-level capabilities on top of that surface without bloating it:
+The base `Sandbox` class provides commands, files, processes, ports, and sessions. These APIs are useful building blocks, but an application often repeats the same sequence of operations.
 
-- **Keep the core lean.** You only pay for what you opt into. Extensions that are not attached are not shipped, provisioned, or executed.
-- **Isolate feature runtimes.** An extension can ship its own long-running process inside the container (a sidecar) without polluting the base container image, and without exposing extra ports.
-- **Encapsulate cross-layer logic.** An extension can drive existing container APIs from the Durable Object side, own its own container-side runtime, or do both.
-- **Provide a stable authoring pattern.** Every extension follows the same `SandboxExtension` + `withX(this)` shape, so features written by Cloudflare and features you write yourself look identical to a caller.
+An extension turns that sequence into one reusable capability. For example, an extension can:
 
-The code interpreter and Git client are the first two Cloudflare-authored extensions. Both were previously methods on the base `Sandbox` class and are now opt-in extensions instead.
+- Prepare a repository, install dependencies, and run project checks.
+- Configure a development environment for an AI agent.
+- Add a code interpreter or language server to a sandbox.
+- Provide a typed API for an internal command-line tool.
 
-## How extensions work
+Your application calls a high-level method such as `sandbox.project.validate()` instead of coordinating every command and file operation itself. This makes the workflow easier to reuse, test, and maintain.
 
-Every extension is a subclass of `SandboxExtension` from `@cloudflare/sandbox/extensions`, attached to a `Sandbox` subclass via a `withX(this)` factory:
+Extensions also keep optional features separate from the base SDK. Attach only the capabilities your application uses. If a capability needs a long-running process inside the container, its extension can provide and manage that process without exposing another network service.
+
+The code interpreter and Git client are the first two Cloudflare-provided extensions. You can use them directly or follow the same pattern to build an extension for your own workflow.
+
+## Attach an extension
+
+Each extension provides a `withX(this)` factory. Add the factory to your `Sandbox` subclass as a class field:
 
 <TypeScriptExample>
 ```
@@ -65,20 +71,27 @@ await sandbox.git.checkout("https://github.com/owner/repo.git", { depth: 1 });
 ```
 </TypeScriptExample>
 
-Under the hood, the SDK routes `sandbox.<extension>.<method>(...)` calls across the Worker to Durable Object boundary and dispatches them to the matching `SandboxExtension` instance. You can still add flatter delegate methods on your `Sandbox` subclass if you want to keep an existing API shape (`sandbox.runCode(...)`), but they are optional.
+The field name becomes the namespace that your Worker uses. In this example, the fields expose `sandbox.interpreter` and `sandbox.git`.
 
-Extension methods called from a Worker must return serializable data. You cannot hand back class instances that only make sense inside the Durable Object.
+The SDK routes calls such as `sandbox.<extension>.<method>(...)` to the matching extension on the Sandbox Durable Object. Extension methods must return serializable data because their results cross the Worker to Durable Object boundary.
 
-### Two flavors: SDK-only and sidecar
+You can add delegate methods if you prefer a flatter API. For example, a `runCode()` method on your `Sandbox` subclass can delegate to `this.interpreter.runCode()`.
 
-Extensions come in two flavors, depending on whether they need their own container-side runtime:
+## Choose an extension type
 
-- **SDK-only extensions** orchestrate existing container APIs (`commands`, `files`, `processes`, and so on) from the Durable Object side. Nothing extra runs inside the container. The Git extension works this way, because `git` is just shell commands: the extension calls `exec()` with the right arguments and parses the output.
-- **Sidecar extensions** ship a bundled runtime that runs as a supervised process inside the container. The SDK talks to it over a private channel, with no extra network ports and no HTTP. The code interpreter works this way, because its Python and JavaScript executors need a long-running process pool inside the container.
+Choose an extension type based on where its work runs.
 
-Sidecars are provisioned lazily the first time you call the extension, cached across sandboxes, and restarted automatically if they crash. You never manage the lifecycle yourself.
+### SDK-only extensions
 
-As a rule of thumb: if existing container APIs are enough to implement your feature, use an SDK-only extension. Reach for a sidecar only when you need a long-running process inside the container.
+Use an SDK-only extension when existing Sandbox APIs can perform the work. The extension coordinates commands, files, processes, or other APIs from the Durable Object. It does not add another process to the container.
+
+The Git extension uses this model. It runs Git commands through the Sandbox command API and returns structured results.
+
+### Sidecar extensions
+
+Use a sidecar extension when the capability needs a dedicated process inside the container. The extension bundles that process and communicates with it through a private channel. You do not need to expose a port or deploy another service.
+
+The code interpreter uses this model because its Python and JavaScript executors need a long-running process pool. The container provisions the sidecar when you first call it. The Sandbox SDK manages its lifecycle and restarts it after a failure.
 
 ## Author an extension
 
@@ -197,11 +210,13 @@ class Interpreter extends SandboxExtension {
 ```
 </TypeScriptExample>
 
-## Practical examples
+## Use Cloudflare-provided extensions
 
-### Code interpreter (sidecar extension)
+Cloudflare provides extensions for code interpretation and Git workflows. Attach either extension when your application needs that capability.
 
-The Python/JavaScript interpreter ships as `@cloudflare/sandbox/interpreter`. Its container-side runtime (the process pool and language executors) runs as a sidecar that is provisioned the first time you use it, so you only pay for it when you opt in.
+### Run Python and JavaScript
+
+Use `@cloudflare/sandbox/interpreter` when your application needs to run generated code, analyze data, or preserve variables between executions. The extension provides Python and JavaScript execution contexts with structured results.
 
 <TypeScriptExample>
 ```
@@ -233,9 +248,9 @@ const result = await sandbox.interpreter.runCode('print("hello")', {
 
 Python execution still requires the `-python` container image variant. `runCode()` resolves to an `ExecutionResult` (a plain, serializable object) so it can safely cross the Worker to Durable Object boundary.
 
-### Git client (SDK-only extension)
+### Work with Git repositories
 
-Git ships as `@cloudflare/sandbox/git`. Because `git` is just shell commands, no sidecar is needed: the extension calls `exec()` with the right arguments and parses the results.
+Use `@cloudflare/sandbox/git` when your application needs to clone a repository, change branches, or inspect branch information. The extension runs Git commands and returns structured results.
 
 <TypeScriptExample>
 ```

--- a/src/content/docs/sandbox/concepts/extensions.mdx
+++ b/src/content/docs/sandbox/concepts/extensions.mdx
@@ -36,14 +36,14 @@ The code interpreter and Git client are the first two Cloudflare-authored extens
 Every extension is a subclass of `SandboxExtension` from `@cloudflare/sandbox/extensions`, attached to a `Sandbox` subclass via a `withX(this)` factory:
 
 <TypeScriptExample>
-```ts
+```
 import { Sandbox as BaseSandbox } from "@cloudflare/sandbox";
 import { withInterpreter } from "@cloudflare/sandbox/interpreter";
 import { withGit } from "@cloudflare/sandbox/git";
 
 export class Sandbox extends BaseSandbox<Env> {
-	interpreter = withInterpreter(this);
-	git = withGit(this);
+  interpreter = withInterpreter(this);
+  git = withGit(this);
 }
 ```
 </TypeScriptExample>
@@ -51,20 +51,21 @@ export class Sandbox extends BaseSandbox<Env> {
 From a Worker, you call extension methods as a nested namespace on the sandbox stub:
 
 <TypeScriptExample>
-```ts
+```
 import { getSandbox } from "@cloudflare/sandbox";
 
 const sandbox = getSandbox(env.Sandbox, "my-sandbox");
 
 const ctx = await sandbox.interpreter.createCodeContext({ language: "python" });
-const result = await sandbox.interpreter.runCode('print("hello")', { context: ctx });
+const result = await sandbox.interpreter.runCode('print("hello")', {
+  context: ctx,
+});
 
 await sandbox.git.checkout("https://github.com/owner/repo.git", { depth: 1 });
-
-````
+```
 </TypeScriptExample>
 
-Under the hood, the SDK routes `sandbox.<extension>.<method>(...)` calls across the Worker → Durable Object boundary and dispatches them to the matching `SandboxExtension` instance. You can still add flatter delegate methods on your `Sandbox` subclass if you want to keep an existing API shape (`sandbox.runCode(...)`), but they are optional.
+Under the hood, the SDK routes `sandbox.<extension>.<method>(...)` calls across the Worker to Durable Object boundary and dispatches them to the matching `SandboxExtension` instance. You can still add flatter delegate methods on your `Sandbox` subclass if you want to keep an existing API shape (`sandbox.runCode(...)`), but they are optional.
 
 Extension methods called from a Worker must return serializable data. You cannot hand back class instances that only make sense inside the Durable Object.
 
@@ -88,40 +89,37 @@ Every extension follows the same shape: a class extending `SandboxExtension`, an
 An SDK-only extension calls existing container APIs. Here is a minimal example that shells out via `commands.execute`:
 
 <TypeScriptExample>
-```ts
+```
 import {
-	SandboxExtension,
-	type SandboxLike,
+  SandboxExtension,
+  type SandboxLike,
 } from "@cloudflare/sandbox/extensions";
 
 class Greeter extends SandboxExtension {
-	constructor(sandbox: SandboxLike) {
-		super(sandbox);
-	}
-
-	async greet(name: string, sessionId: string) {
-		const { stdout } = await this.client.commands.execute(
-			`echo "hi ${name}"`,
-			sessionId,
-		);
-		return stdout.trim();
-	}
+  constructor(sandbox: SandboxLike) {
+    super(sandbox);
+  }
+  async greet(name: string, sessionId: string) {
+    const { stdout } = await this.client.commands.execute(
+      `echo "hi ${name}"`,
+      sessionId,
+    );
+    return stdout.trim();
+  }
 }
-
 export const withGreeter = (s: SandboxLike) => new Greeter(s);
-````
-
+```
 </TypeScriptExample>
 
 Wire it onto a `Sandbox` subclass:
 
 <TypeScriptExample>
-```ts
+```
 import { Sandbox as BaseSandbox } from "@cloudflare/sandbox";
 import { withGreeter } from "./greeter";
 
 export class Sandbox extends BaseSandbox<Env> {
-	greeter = withGreeter(this);
+  greeter = withGreeter(this);
 }
 ```
 </TypeScriptExample>
@@ -133,26 +131,23 @@ Callers use `sandbox.greeter.greet(name, sessionId)` from a Worker.
 A sidecar extension additionally passes a tarball to `super()` and reaches its container-side runtime through `this.sidecar<T>()`:
 
 <TypeScriptExample>
-```ts
+```
 import sidecarTarballBytes from "./sidecar-package.tgz";
 import {
-	SandboxExtension,
-	type SandboxLike,
+  SandboxExtension,
+  type SandboxLike,
 } from "@cloudflare/sandbox/extensions";
 import type { MySidecarAPI } from "./shared";
 
 class MyExtension extends SandboxExtension {
-constructor(sandbox: SandboxLike) {
-super(sandbox, { tarball: new Uint8Array(sidecarTarballBytes) });
+  constructor(sandbox: SandboxLike) {
+    super(sandbox, { tarball: new Uint8Array(sidecarTarballBytes) });
+  }
+  async run(input: string) {
+    const api = await this.sidecar<MySidecarAPI>();
+    return api.run(input);
+  }
 }
-
-    async run(input: string) {
-    	const api = await this.sidecar<MySidecarAPI>();
-    	return api.run(input);
-    }
-
-}
-
 export const withMyExtension = (s: SandboxLike) => new MyExtension(s);
 ```
 </TypeScriptExample>
@@ -160,48 +155,44 @@ export const withMyExtension = (s: SandboxLike) => new MyExtension(s);
 The sidecar itself is a small npm package that extends `SandboxSidecar` and calls `serveSandboxSidecar(...)`. It listens on the `EXT_SOCKET` Unix socket the container injects and serves a capnweb session per connection:
 
 <TypeScriptExample>
-```ts
+```
 import {
-	SandboxSidecar,
-	serveSandboxSidecar,
+  SandboxSidecar,
+  serveSandboxSidecar,
 } from "@cloudflare/sandbox/sidecar";
 
 class MySidecar extends SandboxSidecar {
-async run(input: string) {
-return { result: input.toUpperCase() };
+  async run(input: string) {
+    return { result: input.toUpperCase() };
+  }
 }
-}
-
 serveSandboxSidecar(new MySidecar());
-
-````
+```
 </TypeScriptExample>
 
 Streaming is expressed as a typed callback parameter on a sidecar method. The callback is stubbed across both the Worker to Durable Object and Durable Object to sidecar hops, so there is no separate streaming protocol to learn:
 
 <TypeScriptExample>
-```ts
+```
 import {
-	SandboxExtension,
-	type SandboxLike,
+  SandboxExtension,
+  type SandboxLike,
 } from "@cloudflare/sandbox/extensions";
 import type { InterpreterSidecarAPI } from "./shared";
 
 class Interpreter extends SandboxExtension {
-	constructor(sandbox: SandboxLike) {
-		super(sandbox, { tarball: new Uint8Array() });
-	}
-
-	async runCode(
-		code: string,
-		onEvent: (event: { kind: string; data: unknown }) => void,
-	) {
-		const api = await this.sidecar<InterpreterSidecarAPI>();
-		return api.runCode(code, onEvent);
-	}
+  constructor(sandbox: SandboxLike) {
+    super(sandbox, { tarball: new Uint8Array() });
+  }
+  async runCode(
+    code: string,
+    onEvent: (event: { kind: string; data: unknown }) => void,
+  ) {
+    const api = await this.sidecar<InterpreterSidecarAPI>();
+    return api.runCode(code, onEvent);
+  }
 }
 ```
-
 </TypeScriptExample>
 
 ## Practical examples
@@ -211,12 +202,12 @@ class Interpreter extends SandboxExtension {
 The Python/JavaScript interpreter ships as `@cloudflare/sandbox/interpreter`. Its container-side runtime (the process pool and language executors) runs as a sidecar that is provisioned the first time you use it, so you only pay for it when you opt in.
 
 <TypeScriptExample>
-```ts
+```
 import { Sandbox as BaseSandbox } from "@cloudflare/sandbox";
 import { withInterpreter } from "@cloudflare/sandbox/interpreter";
 
 export class Sandbox extends BaseSandbox<Env> {
-	interpreter = withInterpreter(this);
+  interpreter = withInterpreter(this);
 }
 ```
 </TypeScriptExample>
@@ -224,45 +215,43 @@ export class Sandbox extends BaseSandbox<Env> {
 From a Worker:
 
 <TypeScriptExample>
-```ts
+```
 import { getSandbox } from "@cloudflare/sandbox";
 
 const sandbox = getSandbox(env.Sandbox, "my-sandbox");
 
 const context = await sandbox.interpreter.createCodeContext({
-language: "python",
+  language: "python",
 });
-
 const result = await sandbox.interpreter.runCode('print("hello")', {
-context,
+  context,
 });
-
-````
-
+```
 </TypeScriptExample>
 
-Python execution still requires the `-python` container image variant. `runCode()` resolves to an `ExecutionResult` (a plain, serializable object) so it can safely cross the Worker → Durable Object boundary.
+Python execution still requires the `-python` container image variant. `runCode()` resolves to an `ExecutionResult` (a plain, serializable object) so it can safely cross the Worker to Durable Object boundary.
 
 ### Git client (SDK-only extension)
 
 Git ships as `@cloudflare/sandbox/git`. Because `git` is just shell commands, no sidecar is needed: the extension calls `exec()` with the right arguments and parses the results.
 
 <TypeScriptExample>
-```ts
+```
 import { Sandbox as BaseSandbox } from "@cloudflare/sandbox";
 import { withGit } from "@cloudflare/sandbox/git";
 
 export class Sandbox extends BaseSandbox<Env> {
-	git = withGit(this);
+  git = withGit(this);
 }
-````
-
+```
 </TypeScriptExample>
 
 From a Worker:
 
 <TypeScriptExample>
-```ts
+```
+import { getSandbox } from "@cloudflare/sandbox";
+
 const sandbox = getSandbox(env.Sandbox, "my-sandbox");
 
 await sandbox.git.checkout("https://github.com/owner/repo.git", { depth: 1 });
@@ -270,8 +259,7 @@ await sandbox.git.checkoutBranch("feature/my-work");
 
 const branch = await sandbox.git.getCurrentBranch();
 const branches = await sandbox.git.listBranches();
-
-````
+```
 </TypeScriptExample>
 
 ### Migrating from the base class
@@ -279,20 +267,18 @@ const branches = await sandbox.git.listBranches();
 In the `next` release, `sandbox.gitCheckout()` and the interpreter methods (`createCodeContext`, `runCode`, `runCodeStream`, `listCodeContexts`, `deleteCodeContext`) no longer exist on the base `Sandbox` class. To keep existing call sites working, attach the extension and add a delegate method:
 
 <TypeScriptExample>
-```ts
+```
 import { Sandbox as BaseSandbox } from "@cloudflare/sandbox";
 import { withGit } from "@cloudflare/sandbox/git";
 
 export class Sandbox extends BaseSandbox<Env> {
-	git = withGit(this);
-
-	// Optional: preserve the previous flat API.
-	gitCheckout(url: string, options?: { depth?: number }) {
-		return this.git.checkout(url, options);
-	}
+  git = withGit(this);
+  // Optional: preserve the previous flat API.
+  gitCheckout(url: string, options?: { depth?: number }) {
+    return this.git.checkout(url, options);
+  }
 }
-````
-
+```
 </TypeScriptExample>
 
 ## Related resources

--- a/src/content/docs/sandbox/concepts/extensions.mdx
+++ b/src/content/docs/sandbox/concepts/extensions.mdx
@@ -80,13 +80,13 @@ Sidecars are provisioned lazily the first time you call the extension, cached ac
 
 As a rule of thumb: if existing container APIs are enough to implement your feature, use an SDK-only extension. Reach for a sidecar only when you need a long-running process inside the container.
 
-## Authoring an extension
+## Author an extension
 
 Every extension follows the same shape: a class extending `SandboxExtension`, and a `withX(sandbox)` factory. The base class captures the sandbox and exposes `this.client` (the container API surface) and, for sidecar extensions, `this.sidecar<T>()` (a typed remote handle to the sidecar process).
 
 ### SDK-only extension
 
-An SDK-only extension calls existing container APIs. Here is a minimal example that shells out via `commands.execute`:
+An SDK-only extension calls existing container APIs. Here is a minimal example that reports basic system information by shelling out via `commands.execute`:
 
 <TypeScriptExample>
 ```
@@ -95,19 +95,19 @@ import {
   type SandboxLike,
 } from "@cloudflare/sandbox/extensions";
 
-class Greeter extends SandboxExtension {
+class SystemInfo extends SandboxExtension {
   constructor(sandbox: SandboxLike) {
     super(sandbox);
   }
-  async greet(name: string, sessionId: string) {
+  async kernelVersion(sessionId: string) {
     const { stdout } = await this.client.commands.execute(
-      `echo "hi ${name}"`,
+      "uname -a",
       sessionId,
     );
     return stdout.trim();
   }
 }
-export const withGreeter = (s: SandboxLike) => new Greeter(s);
+export const withSystemInfo = (s: SandboxLike) => new SystemInfo(s);
 ```
 </TypeScriptExample>
 
@@ -116,15 +116,17 @@ Wire it onto a `Sandbox` subclass:
 <TypeScriptExample>
 ```
 import { Sandbox as BaseSandbox } from "@cloudflare/sandbox";
-import { withGreeter } from "./greeter";
+import { withSystemInfo } from "./system-info";
 
 export class Sandbox extends BaseSandbox<Env> {
-  greeter = withGreeter(this);
+  systemInfo = withSystemInfo(this);
 }
 ```
 </TypeScriptExample>
 
-Callers use `sandbox.greeter.greet(name, sessionId)` from a Worker.
+Callers use `sandbox.systemInfo.kernelVersion(sessionId)` from a Worker.
+
+If your extension needs to pass caller-supplied values into a shell command, do not string-interpolate them into the command. Untrusted input can contain shell metacharacters and alter the command that runs. Validate the input against an allowlist, or escape it before use.
 
 ### Sidecar extension
 
@@ -262,7 +264,7 @@ const branches = await sandbox.git.listBranches();
 ```
 </TypeScriptExample>
 
-### Migrating from the base class
+### Migrate from the base class
 
 In the `next` release, `sandbox.gitCheckout()` and the interpreter methods (`createCodeContext`, `runCode`, `runCodeStream`, `listCodeContexts`, `deleteCodeContext`) no longer exist on the base `Sandbox` class. To keep existing call sites working, attach the extension and add a delegate method:
 

--- a/src/content/docs/sandbox/concepts/extensions.mdx
+++ b/src/content/docs/sandbox/concepts/extensions.mdx
@@ -1,0 +1,302 @@
+---
+title: Extensions
+description: Add opt-in capabilities to a Sandbox subclass with the extension framework.
+pcx_content_type: concept
+sidebar:
+  order: 7
+products:
+  - sandbox
+---
+
+import { TypeScriptExample, PackageManagers } from "~/components";
+
+The extension framework lets you attach opt-in capabilities to your `Sandbox` subclass instead of relying on features baked into the core SDK or container image. Extensions are how larger, optional features (such as the code interpreter and Git client) now ship in the Sandbox SDK.
+
+:::caution[Available in the `next` release only]
+The extension framework, the `withInterpreter()` extension, and the `withGit()` extension are only available in the [`@cloudflare/sandbox@next`](https://www.npmjs.com/package/@cloudflare/sandbox/v/next) prerelease of the SDK. Install it explicitly:
+
+<PackageManagers pkg="@cloudflare/sandbox@next" />
+
+The `next` channel will become the default `latest` release in a future version. Until then, code samples on this page will not work against the current stable release.
+:::
+
+## What extensions are for
+
+The base `Sandbox` class exposes a small, general-purpose surface: commands, files, processes, ports, and sessions. Extensions layer higher-level capabilities on top of that surface without bloating it:
+
+- **Keep the core lean.** You only pay for what you opt into. Extensions that are not attached are not shipped, provisioned, or executed.
+- **Isolate feature runtimes.** An extension can ship its own long-running process inside the container (a sidecar) without polluting the base container image, and without exposing extra ports.
+- **Encapsulate cross-layer logic.** An extension can drive existing container APIs from the Durable Object side, own its own container-side runtime, or do both.
+- **Provide a stable authoring pattern.** Every extension follows the same `SandboxExtension` + `withX(this)` shape, so features written by Cloudflare and features you write yourself look identical to a caller.
+
+The code interpreter and Git client are the first two Cloudflare-authored extensions. Both were previously methods on the base `Sandbox` class and are now opt-in extensions instead.
+
+## How extensions work
+
+Every extension is a subclass of `SandboxExtension` from `@cloudflare/sandbox/extensions`, attached to a `Sandbox` subclass via a `withX(this)` factory:
+
+<TypeScriptExample>
+```ts
+import { Sandbox as BaseSandbox } from "@cloudflare/sandbox";
+import { withInterpreter } from "@cloudflare/sandbox/interpreter";
+import { withGit } from "@cloudflare/sandbox/git";
+
+export class Sandbox extends BaseSandbox<Env> {
+	interpreter = withInterpreter(this);
+	git = withGit(this);
+}
+```
+</TypeScriptExample>
+
+From a Worker, you call extension methods as a nested namespace on the sandbox stub:
+
+<TypeScriptExample>
+```ts
+import { getSandbox } from "@cloudflare/sandbox";
+
+const sandbox = getSandbox(env.Sandbox, "my-sandbox");
+
+const ctx = await sandbox.interpreter.createCodeContext({ language: "python" });
+const result = await sandbox.interpreter.runCode('print("hello")', { context: ctx });
+
+await sandbox.git.checkout("https://github.com/owner/repo.git", { depth: 1 });
+
+````
+</TypeScriptExample>
+
+Under the hood, the SDK routes `sandbox.<extension>.<method>(...)` calls across the Worker → Durable Object boundary and dispatches them to the matching `SandboxExtension` instance. You can still add flatter delegate methods on your `Sandbox` subclass if you want to keep an existing API shape (`sandbox.runCode(...)`), but they are optional.
+
+Extension methods called from a Worker must return serializable data. You cannot hand back class instances that only make sense inside the Durable Object.
+
+### Two flavors: SDK-only and sidecar
+
+Extensions come in two flavors, depending on whether they need their own container-side runtime:
+
+- **SDK-only extensions** orchestrate existing container APIs (`commands`, `files`, `processes`, and so on) from the Durable Object side. Nothing extra runs inside the container. The Git extension works this way, because `git` is just shell commands: the extension calls `exec()` with the right arguments and parses the output.
+- **Sidecar extensions** ship a bundled runtime that runs as a supervised process inside the container. The SDK talks to it over a private channel, with no extra network ports and no HTTP. The code interpreter works this way, because its Python and JavaScript executors need a long-running process pool inside the container.
+
+Sidecars are provisioned lazily the first time you call the extension, cached across sandboxes, and restarted automatically if they crash. You never manage the lifecycle yourself.
+
+As a rule of thumb: if existing container APIs are enough to implement your feature, use an SDK-only extension. Reach for a sidecar only when you need a long-running process inside the container.
+
+## Authoring an extension
+
+Every extension follows the same shape: a class extending `SandboxExtension`, and a `withX(sandbox)` factory. The base class captures the sandbox and exposes `this.client` (the container API surface) and, for sidecar extensions, `this.sidecar<T>()` (a typed remote handle to the sidecar process).
+
+### SDK-only extension
+
+An SDK-only extension calls existing container APIs. Here is a minimal example that shells out via `commands.execute`:
+
+<TypeScriptExample>
+```ts
+import {
+	SandboxExtension,
+	type SandboxLike,
+} from "@cloudflare/sandbox/extensions";
+
+class Greeter extends SandboxExtension {
+	constructor(sandbox: SandboxLike) {
+		super(sandbox);
+	}
+
+	async greet(name: string, sessionId: string) {
+		const { stdout } = await this.client.commands.execute(
+			`echo "hi ${name}"`,
+			sessionId,
+		);
+		return stdout.trim();
+	}
+}
+
+export const withGreeter = (s: SandboxLike) => new Greeter(s);
+````
+
+</TypeScriptExample>
+
+Wire it onto a `Sandbox` subclass:
+
+<TypeScriptExample>
+```ts
+import { Sandbox as BaseSandbox } from "@cloudflare/sandbox";
+import { withGreeter } from "./greeter";
+
+export class Sandbox extends BaseSandbox<Env> {
+	greeter = withGreeter(this);
+}
+```
+</TypeScriptExample>
+
+Callers use `sandbox.greeter.greet(name, sessionId)` from a Worker.
+
+### Sidecar extension
+
+A sidecar extension additionally passes a tarball to `super()` and reaches its container-side runtime through `this.sidecar<T>()`:
+
+<TypeScriptExample>
+```ts
+import sidecarTarballBytes from "./sidecar-package.tgz";
+import {
+	SandboxExtension,
+	type SandboxLike,
+} from "@cloudflare/sandbox/extensions";
+import type { MySidecarAPI } from "./shared";
+
+class MyExtension extends SandboxExtension {
+constructor(sandbox: SandboxLike) {
+super(sandbox, { tarball: new Uint8Array(sidecarTarballBytes) });
+}
+
+    async run(input: string) {
+    	const api = await this.sidecar<MySidecarAPI>();
+    	return api.run(input);
+    }
+
+}
+
+export const withMyExtension = (s: SandboxLike) => new MyExtension(s);
+```
+</TypeScriptExample>
+
+The sidecar itself is a small npm package that extends `SandboxSidecar` and calls `serveSandboxSidecar(...)`. It listens on the `EXT_SOCKET` Unix socket the container injects and serves a capnweb session per connection:
+
+<TypeScriptExample>
+```ts
+import {
+	SandboxSidecar,
+	serveSandboxSidecar,
+} from "@cloudflare/sandbox/sidecar";
+
+class MySidecar extends SandboxSidecar {
+async run(input: string) {
+return { result: input.toUpperCase() };
+}
+}
+
+serveSandboxSidecar(new MySidecar());
+
+````
+</TypeScriptExample>
+
+Streaming is expressed as a typed callback parameter on a sidecar method. The callback is stubbed across both the Worker to Durable Object and Durable Object to sidecar hops, so there is no separate streaming protocol to learn:
+
+<TypeScriptExample>
+```ts
+import {
+	SandboxExtension,
+	type SandboxLike,
+} from "@cloudflare/sandbox/extensions";
+import type { InterpreterSidecarAPI } from "./shared";
+
+class Interpreter extends SandboxExtension {
+	constructor(sandbox: SandboxLike) {
+		super(sandbox, { tarball: new Uint8Array() });
+	}
+
+	async runCode(
+		code: string,
+		onEvent: (event: { kind: string; data: unknown }) => void,
+	) {
+		const api = await this.sidecar<InterpreterSidecarAPI>();
+		return api.runCode(code, onEvent);
+	}
+}
+```
+
+</TypeScriptExample>
+
+## Practical examples
+
+### Code interpreter (sidecar extension)
+
+The Python/JavaScript interpreter ships as `@cloudflare/sandbox/interpreter`. Its container-side runtime (the process pool and language executors) runs as a sidecar that is provisioned the first time you use it, so you only pay for it when you opt in.
+
+<TypeScriptExample>
+```ts
+import { Sandbox as BaseSandbox } from "@cloudflare/sandbox";
+import { withInterpreter } from "@cloudflare/sandbox/interpreter";
+
+export class Sandbox extends BaseSandbox<Env> {
+	interpreter = withInterpreter(this);
+}
+```
+</TypeScriptExample>
+
+From a Worker:
+
+<TypeScriptExample>
+```ts
+import { getSandbox } from "@cloudflare/sandbox";
+
+const sandbox = getSandbox(env.Sandbox, "my-sandbox");
+
+const context = await sandbox.interpreter.createCodeContext({
+language: "python",
+});
+
+const result = await sandbox.interpreter.runCode('print("hello")', {
+context,
+});
+
+````
+
+</TypeScriptExample>
+
+Python execution still requires the `-python` container image variant. `runCode()` resolves to an `ExecutionResult` (a plain, serializable object) so it can safely cross the Worker → Durable Object boundary.
+
+### Git client (SDK-only extension)
+
+Git ships as `@cloudflare/sandbox/git`. Because `git` is just shell commands, no sidecar is needed: the extension calls `exec()` with the right arguments and parses the results.
+
+<TypeScriptExample>
+```ts
+import { Sandbox as BaseSandbox } from "@cloudflare/sandbox";
+import { withGit } from "@cloudflare/sandbox/git";
+
+export class Sandbox extends BaseSandbox<Env> {
+	git = withGit(this);
+}
+````
+
+</TypeScriptExample>
+
+From a Worker:
+
+<TypeScriptExample>
+```ts
+const sandbox = getSandbox(env.Sandbox, "my-sandbox");
+
+await sandbox.git.checkout("https://github.com/owner/repo.git", { depth: 1 });
+await sandbox.git.checkoutBranch("feature/my-work");
+
+const branch = await sandbox.git.getCurrentBranch();
+const branches = await sandbox.git.listBranches();
+
+````
+</TypeScriptExample>
+
+### Migrating from the base class
+
+In the `next` release, `sandbox.gitCheckout()` and the interpreter methods (`createCodeContext`, `runCode`, `runCodeStream`, `listCodeContexts`, `deleteCodeContext`) no longer exist on the base `Sandbox` class. To keep existing call sites working, attach the extension and add a delegate method:
+
+<TypeScriptExample>
+```ts
+import { Sandbox as BaseSandbox } from "@cloudflare/sandbox";
+import { withGit } from "@cloudflare/sandbox/git";
+
+export class Sandbox extends BaseSandbox<Env> {
+	git = withGit(this);
+
+	// Optional: preserve the previous flat API.
+	gitCheckout(url: string, options?: { depth?: number }) {
+		return this.git.checkout(url, options);
+	}
+}
+````
+
+</TypeScriptExample>
+
+## Related resources
+
+- [Architecture](/sandbox/concepts/architecture/): how Workers, Durable Objects, and containers fit together
+- [Use code interpreter](/sandbox/guides/code-execution/): running Python and JavaScript via the interpreter extension
+- [Git workflows](/sandbox/guides/git-workflows/): cloning and managing repositories via the Git extension

--- a/src/content/docs/sandbox/concepts/index.mdx
+++ b/src/content/docs/sandbox/concepts/index.mdx
@@ -17,6 +17,7 @@ These pages explain how the Sandbox SDK works, why it's designed the way it is, 
 - [Preview URLs](/sandbox/concepts/preview-urls/) - How to expose sandboxed services on the public internet.
 - [Security model](/sandbox/concepts/security/) - Isolation, validation, and safety mechanisms
 - [Terminal connections](/sandbox/concepts/terminal/) - How browser terminal connections work
+- [Extensions](/sandbox/concepts/extensions/) - Add opt-in capabilities with the extension framework
 
 ## Related resources
 


### PR DESCRIPTION
### Summary

This PR adds documentation for the new extension framework added in Sandbox SDK.

_Note: These docs currently only apply to the 'next' branch & package, which is reference at the top of the page_

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).