### PR TITLE
[Web3] Add public Ethereum RPC comparison link to migration guide

### DIFF
--- a/src/content/docs/web3/reference/migration-guide.mdx
+++ b/src/content/docs/web3/reference/migration-guide.mdx
@@ -26,3 +26,5 @@ First, create a [Cloudflare account](/fundamentals/account/create-account/).
 Then create a new [Web3 custom gateway](/web3/how-to/manage-gateways/#create-a-gateway) with your existing hostname.
 
 Alternatively, you could also create a [Web3 custom gateway](/web3/how-to/manage-gateways/#create-a-gateway) for a new hostname and then modify your application to use your newly created hostname ([IPFS](/web3/how-to/use-ipfs-gateway/) or [Ethereum](/web3/how-to/use-ethereum-gateway/)).
+
+If your application used the public `cloudflare-eth.com` endpoint directly and you are evaluating replacement providers, refer to [OpenChainBench](https://openchainbench.com/benchmarks/ethereum-rpc) for a continuously updated, open-source comparison of free public Ethereum RPC endpoints.


### PR DESCRIPTION
### Summary

The legacy gateway migration guide covers custom hostnames, but users who called the public `cloudflare-eth.com` endpoint directly are left without a pointer for choosing a replacement provider. The endpoint no longer serves requests: an `eth_blockNumber` JSON-RPC call currently returns `{"error":{"code":-32046,"message":"Cannot fulfill request"}}`.

This PR adds a single line at the end of the migration guide linking to [OpenChainBench](https://openchainbench.com/benchmarks/ethereum-rpc), a continuously updated, open-source comparison of free public Ethereum RPC endpoints, so stranded users of the public endpoint have a neutral resource for evaluating alternatives. Nothing is removed or reworded.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).