### PR TITLE
[Workers AI] Update markdown conversion to reference Gemma 4 model

### DIFF
--- a/src/content/docs/workers-ai/features/markdown-conversion/how-it-works.mdx
+++ b/src/content/docs/workers-ai/features/markdown-conversion/how-it-works.mdx
@@ -43,7 +43,7 @@ Afterwards:
 - The image is sent to an **object-detection model**. Specifically, we use the [`@cf/facebook/detr-resnet-50`](/workers-ai/models/detr-resnet-50/) from Workers AI.
 - If any objects were detected in the previous step, they are appended to a prompt that is used to instruct an **image-to-text model** on how to describe the image.
 - If a preferred conversion language is specified in the request's conversion options, the previous prompt is enriched with a directive for the model to output the content in the desired language. Refer to [Conversion Options](/workers-ai/features/markdown-conversion/conversion-options/#images) for more details.
-- The final prompt is sent, along with the image data, to the [`@cf/google/gemma-3-12b-it`](/workers-ai/models/gemma-3-12b-it/) model, also from Workers AI.
+- The final prompt is sent, along with the image data, to the [`@cf/google/gemma-4-26b-a4b-it`](/workers-ai/models/gemma-4-26b-a4b-it/) model, also from Workers AI.
 
 ### PDFs
 


### PR DESCRIPTION
### Summary

- Update the image-to-text model reference in the markdown conversion "How it works" page from `@cf/google/gemma-3-12b-it` to `@cf/google/gemma-4-26b-a4b-it`, reflecting the model upgrade.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
