### PR TITLE
[Browser Run] Add accessibility tree endpoint docs

### DIFF
--- a/src/content/changelog/browser-run/2026-07-06-browser-run-accessibility-tree-endpoint.mdx
+++ b/src/content/changelog/browser-run/2026-07-06-browser-run-accessibility-tree-endpoint.mdx
@@ -8,7 +8,7 @@ date: 2026-07-06
 
 [Browser Run](/browser-run/) now supports a standalone `/accessibilityTree` endpoint, giving agent and automation workflows direct access to the browser's accessibility tree for a rendered webpage.
 
-For AI agents, the accessibility tree provides a token-efficient alternative to screenshots and a more semantic alternative to raw HTML. Instead of asking a model to infer clickable controls from pixels, you can provide the browser's structured representation of the page: roles, names, values, states, and hierarchy. This helps AI agents identify available elements and determine which actions they can take.
+For AI agents, the accessibility tree provides a token-efficient alternative to screenshots and a more semantic alternative to raw HTML. Instead of asking a model to infer interactive controls from pixels, you can provide the browser's structured representation of the page: roles, names, values, states, and hierarchy. This helps AI agents identify available elements and determine which actions they can take.
 
 Browser Run already supports accessibility trees through the [`/snapshot`](/browser-run/quick-actions/snapshot/) endpoint, which returns multiple page formats in one response. With the new `/accessibilityTree` endpoint, you can request the accessibility tree directly when you only need the semantic structure of a page.
 
@@ -21,7 +21,7 @@ curl -X POST 'https://api.cloudflare.com/client/v4/accounts/<accountId>/browser-
 }'
 ```
 
-```json output
+```json
 {
 	"success": true,
 	"result": {

--- a/src/content/changelog/browser-run/2026-07-06-browser-run-accessibility-tree-endpoint.mdx
+++ b/src/content/changelog/browser-run/2026-07-06-browser-run-accessibility-tree-endpoint.mdx
@@ -8,7 +8,9 @@ date: 2026-07-06
 
 [Browser Run](/browser-run/) now supports a standalone `/accessibilityTree` endpoint, giving agent and automation workflows direct access to the browser's accessibility tree for a rendered webpage.
 
-For AI agents, the accessibility tree provides a token-efficient alternative to screenshots and a more semantic alternative to raw HTML. Instead of asking a model to infer interactive controls from pixels, you can provide the browser's structured representation of the page: roles, names, values, states, and hierarchy. This helps AI agents identify available elements and determine which actions they can take.
+An accessibility tree is the browser's structured view of a rendered page: roles, names, states, values, and hierarchy. It is useful for accessibility tooling, but also for AI agents and automation workflows that need page structure without the noise of raw HTML or the cost of screenshots.
+
+For AI agents, this means less inference from pixels and less parsing HTML. You can provide the page structure directly, helping agents identify available elements and determine which actions they can take.
 
 Browser Run already supports accessibility trees through the [`/snapshot`](/browser-run/quick-actions/snapshot/) endpoint, which returns multiple page formats in one response. With the new `/accessibilityTree` endpoint, you can request the accessibility tree directly when you only need the semantic structure of a page.
 

--- a/src/content/changelog/browser-run/2026-07-06-browser-run-accessibility-tree-endpoint.mdx
+++ b/src/content/changelog/browser-run/2026-07-06-browser-run-accessibility-tree-endpoint.mdx
@@ -12,7 +12,7 @@ An accessibility tree is the browser's structured view of a rendered page: roles
 
 For AI agents, this means less inference from pixels and less parsing HTML. You can provide the page structure directly, helping agents identify available elements and determine which actions they can take.
 
-Browser Run already supports accessibility trees through the [`/snapshot`](/browser-run/quick-actions/snapshot/) endpoint, which returns multiple page formats in one response. With the new `/accessibilityTree` endpoint, you can request the accessibility tree directly when you only need the semantic structure of a page.
+With the new `/accessibilityTree` endpoint, you can request the accessibility tree directly when you only need the semantic structure of a page. If you need multiple page formats in a single API call, you can use the  [`/snapshot`](/browser-run/quick-actions/snapshot/) endpoint, which also returned Markdown, HTML, and screenshots. 
 
 ```bash
 curl -X POST 'https://api.cloudflare.com/client/v4/accounts/<accountId>/browser-run/accessibilityTree' \

--- a/src/content/changelog/browser-run/2026-07-06-browser-run-accessibility-tree-endpoint.mdx
+++ b/src/content/changelog/browser-run/2026-07-06-browser-run-accessibility-tree-endpoint.mdx
@@ -1,0 +1,49 @@
+---
+title: New Browser Run endpoint for accessibility trees
+description: Browser Run now supports a standalone /accessibilityTree endpoint for capturing the semantic structure of rendered webpages.
+products:
+  - browser-run
+date: 2026-07-06
+---
+
+[Browser Run](/browser-run/) now supports a standalone `/accessibilityTree` endpoint, giving agent and automation workflows direct access to the browser's accessibility tree for a rendered webpage.
+
+For AI agents, the accessibility tree provides a token-efficient alternative to screenshots and a more semantic alternative to raw HTML. Instead of asking a model to infer clickable controls from pixels, you can provide the browser's structured representation of the page: roles, names, values, states, and hierarchy. This helps AI agents identify available elements and determine which actions they can take.
+
+Browser Run already supports accessibility trees through the [`/snapshot`](/browser-run/quick-actions/snapshot/) endpoint, which returns multiple page formats in one response. With the new `/accessibilityTree` endpoint, you can request the accessibility tree directly when you only need the semantic structure of a page.
+
+```bash
+curl -X POST 'https://api.cloudflare.com/client/v4/accounts/<accountId>/browser-run/accessibilityTree' \
+  -H 'Authorization: Bearer <apiToken>' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "url": "https://example.com/"
+}'
+```
+
+```json output
+{
+	"success": true,
+	"result": {
+		"accessibilityTree": {
+			"role": "RootWebArea",
+			"name": "Example Domain",
+			"children": [
+				{
+					"role": "heading",
+					"name": "Example Domain",
+					"level": 1
+				},
+				{
+					"role": "link",
+					"name": "Learn more"
+				}
+			]
+		}
+	}
+}
+```
+
+Use `interestingOnly` to return only semantically meaningful nodes, or `root` to capture the accessibility tree for a specific subtree.
+
+Refer to the [`/accessibilityTree` documentation](/browser-run/quick-actions/accessibility-tree-endpoint/) for usage examples and supported parameters.

--- a/src/content/changelog/browser-run/2026-07-07-browser-run-accessibility-tree-endpoint.mdx
+++ b/src/content/changelog/browser-run/2026-07-07-browser-run-accessibility-tree-endpoint.mdx
@@ -3,7 +3,7 @@ title: New Browser Run endpoint for accessibility trees
 description: Browser Run now supports a standalone /accessibilityTree endpoint for capturing the semantic structure of rendered webpages.
 products:
   - browser-run
-date: 2026-07-06
+date: 2026-07-07
 ---
 
 [Browser Run](/browser-run/) now supports a standalone `/accessibilityTree` endpoint, giving agent and automation workflows direct access to the browser's accessibility tree for a rendered webpage.
@@ -12,7 +12,7 @@ An accessibility tree is the browser's structured view of a rendered page: roles
 
 For AI agents, this means less inference from pixels and less parsing HTML. You can provide the page structure directly, helping agents identify available elements and determine which actions they can take.
 
-With the new `/accessibilityTree` endpoint, you can request the accessibility tree directly when you only need the semantic structure of a page. If you need multiple page formats in a single API call, you can use the  [`/snapshot`](/browser-run/quick-actions/snapshot/) endpoint, which also returned Markdown, HTML, and screenshots. 
+With the new `/accessibilityTree` endpoint, you can request the accessibility tree directly when you only need the semantic structure of a page. If you need multiple page formats in a single API call, you can use the [`/snapshot`](/browser-run/quick-actions/snapshot/) endpoint, which also returns Markdown, HTML, and screenshots.
 
 ```bash
 curl -X POST 'https://api.cloudflare.com/client/v4/accounts/<accountId>/browser-run/accessibilityTree' \

--- a/src/content/docs/browser-run/quick-actions/accessibility-tree-endpoint.mdx
+++ b/src/content/docs/browser-run/quick-actions/accessibility-tree-endpoint.mdx
@@ -48,7 +48,7 @@ curl -X POST 'https://api.cloudflare.com/client/v4/accounts/<accountId>/browser-
 }'
 ```
 
-```json output
+```json
 {
 	"success": true,
 	"result": {
@@ -162,7 +162,7 @@ curl -X POST 'https://api.cloudflare.com/client/v4/accounts/<accountId>/browser-
 }'
 ```
 
-```json output
+```json
 {
 	"success": true,
 	"result": {
@@ -193,7 +193,7 @@ curl -X POST 'https://api.cloudflare.com/client/v4/accounts/<accountId>/browser-
 }'
 ```
 
-```json output
+```json
 {
 	"success": true,
 	"result": {

--- a/src/content/docs/browser-run/quick-actions/accessibility-tree-endpoint.mdx
+++ b/src/content/docs/browser-run/quick-actions/accessibility-tree-endpoint.mdx
@@ -1,0 +1,213 @@
+---
+pcx_content_type: how-to
+title: /accessibilityTree - Capture accessibility tree
+description: Capture the accessibility tree from a webpage after JavaScript execution using the Browser Run /accessibilityTree endpoint.
+sidebar:
+  order: 7
+products:
+  - browser-run
+---
+
+import { Tabs, TabItem, Render } from "~/components";
+
+The `/accessibilityTree` endpoint instructs the browser to navigate to a website and capture the page's accessibility tree after JavaScript execution. The accessibility tree includes accessibility-related information such as roles, names, values, states, and hierarchy.
+
+## Endpoint
+
+```txt
+https://api.cloudflare.com/client/v4/accounts/<accountId>/browser-run/accessibilityTree
+```
+
+## Required fields
+
+You must provide either `url` or `html`:
+
+- `url` (string)
+- `html` (string)
+
+## Common use cases
+
+- Provide AI agents with a structured page representation for navigation and browser automation workflows
+- Check roles, accessible names, values, and states exposed to assistive technologies
+- Identify interactive elements, such as buttons, links, menus, and form fields, that an automation workflow can act on
+
+## Basic usage
+
+### Capture the accessibility tree from a URL
+
+<Tabs syncKey="workersExamples"> <TabItem label="curl">
+
+Go to `https://example.com/` and return the page's accessibility tree.
+
+```bash
+curl -X POST 'https://api.cloudflare.com/client/v4/accounts/<accountId>/browser-run/accessibilityTree' \
+  -H 'Authorization: Bearer <apiToken>' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "url": "https://example.com/"
+}'
+```
+
+```json output
+{
+	"success": true,
+	"result": {
+		"accessibilityTree": {
+			"role": "RootWebArea",
+			"name": "Example Domain",
+			"children": [
+				{
+					"role": "heading",
+					"name": "Example Domain",
+					"level": 1
+				},
+				{
+					"role": "StaticText",
+					"name": "This domain is for use in documentation examples without needing permission. Avoid use in operations."
+				},
+				{
+					"role": "link",
+					"name": "Learn more"
+				}
+			]
+		}
+	},
+	"meta": {
+		"status": 200,
+		"title": "Example Domain"
+	}
+}
+```
+
+</TabItem> <TabItem label="TypeScript SDK">
+
+```typescript
+import Cloudflare from "cloudflare";
+
+const client = new Cloudflare({
+	apiToken: process.env["CLOUDFLARE_API_TOKEN"],
+});
+
+const accessibilityTree = await client.browserRendering.accessibilityTree.create({
+	account_id: process.env["CLOUDFLARE_ACCOUNT_ID"],
+	url: "https://example.com/",
+});
+
+console.log(accessibilityTree.accessibilityTree);
+```
+
+</TabItem> <TabItem label="Workers binding">
+
+```typescript
+interface Env {
+	BROWSER: BrowserRun;
+}
+
+export default {
+	async fetch(request, env): Promise<Response> {
+		return await env.BROWSER.quickAction("accessibilityTree", {
+			url: "https://example.com/",
+		});
+	},
+} satisfies ExportedHandler<Env>;
+```
+
+</TabItem> </Tabs>
+
+## Optional parameters
+
+The following optional parameters can be used in your `/accessibilityTree` request, in addition to the required `url` or `html` parameter.
+
+| Optional parameter | Type    | Description                                                                                                                                                                                                                                                |
+| ------------------ | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `interestingOnly`  | Boolean | When `true`, returns only semantically meaningful nodes. Defaults to `true`. If `root` is set and `interestingOnly` is omitted, defaults to `false`.                                                                                                       |
+| `root`             | String  | CSS selector that anchors the accessibility tree to a subtree. If the selector does not match an element, `accessibilityTree` returns `null`. To return only semantically meaningful nodes within the subtree, set `interestingOnly` to `true` explicitly. |
+
+## Advanced usage
+
+:::note[Looking for more parameters?]
+Visit the [Browser Run API reference](/api/resources/browser_rendering/) for all available parameters, such as setting HTTP credentials using `authenticate`, setting `cookies`, and customizing load behavior using `gotoOptions`.
+:::
+
+{/* TODO: Replace the general API reference link with the direct /accessibilityTree API reference URL when it is live. */}
+
+### Include all nodes
+
+By default, `interestingOnly` is `true`, which filters the response to semantically meaningful nodes. Set `interestingOnly` to `false` to include every node in the accessibility tree, including generic and presentational nodes.
+
+```bash
+curl -X POST 'https://api.cloudflare.com/client/v4/accounts/<accountId>/browser-run/accessibilityTree' \
+  -H 'Authorization: Bearer <apiToken>' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "url": "https://example.com/",
+    "interestingOnly": false
+}'
+```
+
+### Capture a subtree
+
+Use `root` to return the accessibility tree for a specific part of the page. The `root` parameter accepts a CSS selector.
+
+When `root` is set and `interestingOnly` is not provided, `interestingOnly` defaults to `false`. To filter a subtree to semantically meaningful nodes, set `interestingOnly` to `true` explicitly.
+
+```bash
+curl -X POST 'https://api.cloudflare.com/client/v4/accounts/<accountId>/browser-run/accessibilityTree' \
+  -H 'Authorization: Bearer <apiToken>' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "url": "https://example.com/",
+    "root": "h1",
+    "interestingOnly": true
+}'
+```
+
+```json output
+{
+	"success": true,
+	"result": {
+		"accessibilityTree": {
+			"role": "heading",
+			"name": "Example Domain",
+			"level": 1
+		}
+	},
+	"meta": {
+		"status": 200,
+		"title": "Example Domain"
+	}
+}
+```
+
+### Handle a root selector with no match
+
+If `root` does not match any element on the page, the request returns HTTP `200` and `accessibilityTree` is `null`.
+
+```bash
+curl -X POST 'https://api.cloudflare.com/client/v4/accounts/<accountId>/browser-run/accessibilityTree' \
+  -H 'Authorization: Bearer <apiToken>' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "url": "https://example.com/",
+    "root": "#does-not-exist"
+}'
+```
+
+```json output
+{
+	"success": true,
+	"result": {
+		"accessibilityTree": null
+	},
+	"meta": {
+		"status": 200,
+		"title": "Example Domain"
+	}
+}
+```
+
+<Render file="javascript-heavy-pages" product="browser-run" />
+
+<Render file="setting-custom-user-agent" product="browser-run" />
+
+<Render file="faq" product="browser-run" />

--- a/src/content/docs/browser-run/quick-actions/accessibility-tree-endpoint.mdx
+++ b/src/content/docs/browser-run/quick-actions/accessibility-tree-endpoint.mdx
@@ -8,7 +8,7 @@ products:
   - browser-run
 ---
 
-import { Tabs, TabItem, Render } from "~/components";
+import { Tabs, TabItem, Render, Details } from "~/components";
 
 The `/accessibilityTree` endpoint instructs the browser to navigate to a website and capture the page's accessibility tree after JavaScript execution. The accessibility tree includes accessibility-related information such as roles, names, values, states, and hierarchy.
 
@@ -145,9 +145,62 @@ curl -X POST 'https://api.cloudflare.com/client/v4/accounts/<accountId>/browser-
 }'
 ```
 
+<Details header="Response example">
+
+```json
+{
+	"success": true,
+	"result": {
+		"accessibilityTree": {
+			"role": "RootWebArea",
+			"name": "Example Domain",
+			"children": [
+				{
+					"role": "generic",
+					"name": "",
+					"children": [
+						{
+							"role": "heading",
+							"name": "Example Domain",
+							"level": 1
+						},
+						{
+							"role": "paragraph",
+							"name": "",
+							"children": [
+								{
+									"role": "StaticText",
+									"name": "This domain is for use in documentation examples without needing permission. Avoid use in operations."
+								}
+							]
+						},
+						{
+							"role": "paragraph",
+							"name": "",
+							"children": [
+								{
+									"role": "link",
+									"name": "Learn more"
+								}
+							]
+						}
+					]
+				}
+			]
+		}
+	},
+	"meta": {
+		"status": 200,
+		"title": "Example Domain"
+	}
+}
+```
+
+</Details>
+
 ### Capture a subtree
 
-Use `root` to return the accessibility tree for a specific part of the page. The `root` parameter accepts a CSS selector.
+Set `root` to a CSS selector string to return the accessibility tree for a specific part of the page.
 
 When `root` is set and `interestingOnly` is not provided, `interestingOnly` defaults to `false`. To filter a subtree to semantically meaningful nodes, set `interestingOnly` to `true` explicitly.
 

--- a/src/content/docs/browser-run/quick-actions/json-endpoint.mdx
+++ b/src/content/docs/browser-run/quick-actions/json-endpoint.mdx
@@ -5,7 +5,7 @@ description: Extract structured JSON data from webpages using AI with the Browse
 tags:
   - JSON
 sidebar:
-  order: 8
+  order: 9
 products:
   - browser-run
 ---

--- a/src/content/docs/browser-run/quick-actions/links-endpoint.mdx
+++ b/src/content/docs/browser-run/quick-actions/links-endpoint.mdx
@@ -3,7 +3,7 @@ pcx_content_type: how-to
 title: /links - Retrieve links from a webpage
 description: Extract all links from a webpage, including hidden ones, using the Browser Run /links endpoint.
 sidebar:
-  order: 9
+  order: 10
 products:
   - browser-run
 ---

--- a/src/content/docs/browser-run/quick-actions/scrape-endpoint.mdx
+++ b/src/content/docs/browser-run/quick-actions/scrape-endpoint.mdx
@@ -3,7 +3,7 @@ pcx_content_type: how-to
 title: /scrape - Scrape HTML elements
 description: Extract structured data from specific webpage elements using the Browser Run /scrape endpoint.
 sidebar:
-  order: 7
+  order: 8
 products:
   - browser-run
 ---

--- a/src/content/docs/browser-run/quick-actions/snapshot.mdx
+++ b/src/content/docs/browser-run/quick-actions/snapshot.mdx
@@ -154,7 +154,7 @@ curl -X POST 'https://api.cloudflare.com/client/v4/accounts/<accountId>/browser-
 
 Use the `formats` parameter to control which representations of the page are included in the response. Accepted values are `"content"`, `"screenshot"`, `"markdown"`, and `"accessibilityTree"`. If omitted, the default is `["content", "screenshot"]`.
 
-You must request at least two formats. If you only need a single format, use the corresponding single-format endpoint instead: [`/content`](/browser-run/quick-actions/content-endpoint/), [`/screenshot`](/browser-run/quick-actions/screenshot-endpoint/), or [`/markdown`](/browser-run/quick-actions/markdown-endpoint/). A single-format endpoint for the accessibility tree is not yet available.
+You must request at least two formats. If you only need a single format, use the corresponding single-format endpoint instead: [`/content`](/browser-run/quick-actions/content-endpoint/), [`/screenshot`](/browser-run/quick-actions/screenshot-endpoint/), [`/markdown`](/browser-run/quick-actions/markdown-endpoint/), or [`/accessibilityTree`](/browser-run/quick-actions/accessibility-tree-endpoint/).
 
 The following example requests a screenshot, Markdown, and the accessibility tree in one call:
 

--- a/src/content/release-notes/browser-run.yaml
+++ b/src/content/release-notes/browser-run.yaml
@@ -3,6 +3,10 @@ link: "/browser-run/changelog/"
 productName: Browser Run
 productLink: "/browser-run/"
 entries:
+  - publish_date: "2026-07-06"
+    title: "New endpoint: /accessibilityTree"
+    description: |-
+      * Added the [`/accessibilityTree` endpoint](/browser-run/quick-actions/accessibility-tree-endpoint/) to capture the accessibility tree from a rendered webpage. The accessibility tree includes roles, names, values, states, and hierarchy, giving AI agents and automation workflows a structured view of page elements without parsing raw HTML or interpreting screenshots. You can capture the full page tree, return only semantically meaningful nodes with `interestingOnly`, or capture a subtree with `root`.
   - publish_date: "2026-06-12"
     title: "New tutorial: Pre-render pages for crawlers"
     description: |-

--- a/src/content/release-notes/browser-run.yaml
+++ b/src/content/release-notes/browser-run.yaml
@@ -3,7 +3,7 @@ link: "/browser-run/changelog/"
 productName: Browser Run
 productLink: "/browser-run/"
 entries:
-  - publish_date: "2026-07-06"
+  - publish_date: "2026-07-07"
     title: "New endpoint: /accessibilityTree"
     description: |-
       * Added the [`/accessibilityTree` endpoint](/browser-run/quick-actions/accessibility-tree-endpoint/) to capture the accessibility tree from a rendered webpage. The accessibility tree includes roles, names, values, states, and hierarchy, giving AI agents and automation workflows a structured view of page elements without parsing raw HTML or interpreting screenshots. You can capture the full page tree, return only semantically meaningful nodes with `interestingOnly`, or capture a subtree with `root`.


### PR DESCRIPTION
## Summary

Adds Browser Run documentation for the new `/accessibilityTree` Quick Action endpoint.

Includes:
- New `/accessibilityTree` endpoint documentation page
- Browser Run release note entry
- Cloudflare-wide changelog entry
- `/snapshot` documentation update to link to the new single-format endpoint

## Documentation checklist

- [x] Is there a changelog entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you do not add one for something awesome and new (however small), how will our customers find out? Changelogs are automatically posted to RSS feeds, Discord, and X.
- [x] The change adheres to the documentation style guide.

## Validation

- `pnpm run check`
- `pnpm run lint`
- `pnpm run format:core:check`
- `pnpm run build`
- `pnpm exec tsx bin/check-link-validation/index.ts`