### PR TITLE
IMAGES-2406: update docs with binding billing and cache changes

### DIFF
--- a/src/content/changelog/images/2026-07-01-binding-unique-transformations.mdx
+++ b/src/content/changelog/images/2026-07-01-binding-unique-transformations.mdx
@@ -1,0 +1,16 @@
+---
+title: Images binding is now billed per unique transformation
+description: >
+  The Images binding now follows the same unique-transformation billing model as URL-based transformations, and calls to `.info()` are free.
+products:
+  - images
+date: 2026-07-01
+---
+
+The [Images binding](/images/optimization/binding/) is now billed per unique transformation, matching the model already used for URL-based transformations. Repeat requests for the same combination of source image and parameters within the same calendar month are counted only once.
+
+Previously, every call to the binding counted as a separate transformation regardless of whether the image or parameters were unique. With this change, you can call the binding on hot paths without paying for each individual request.
+
+Calls to [`.info()`](/images/optimization/binding/#infostream) are no longer billed.
+
+For more information, refer to [Images pricing](/images/pricing/#images-transformed) and the [Images binding documentation](/images/optimization/binding/).

--- a/src/content/docs/images/examples/watermark-from-kv.mdx
+++ b/src/content/docs/images/examples/watermark-from-kv.mdx
@@ -5,14 +5,30 @@ title: Watermarks
 sidebar:
   order: 5
 description: Draw a watermark from KV on an image from R2
-reviewed: 2025-04-03
+reviewed: 2026-07-06
 products:
   - images
   - r2
   - kv
 ---
 
-import { TypeScriptExample } from "~/components";
+import { TypeScriptExample, WranglerConfig } from "~/components";
+
+Enable [Workers Cache](/workers/cache/) so repeat requests for the same watermarked image are served from cache without re-running the Worker or re-transforming the image:
+
+<WranglerConfig>
+
+```jsonc
+{
+	"cache": {
+		"enabled": true,
+	},
+}
+```
+
+</WranglerConfig>
+
+Then set `Cache-Control` headers on your response to control the cache lifetime:
 
 <TypeScriptExample>
 
@@ -23,20 +39,12 @@ interface Env {
 	IMAGES: ImagesBinding;
 }
 export default {
-	async fetch(request, env, ctx): Promise<Response> {
+	async fetch(request, env): Promise<Response> {
 		const watermarkKey = "my-watermark";
 		const sourceKey = "my-source-image";
 
-		const cache = await caches.open("transformed-images");
-		const cacheKey = new URL(sourceKey + "/" + watermarkKey, request.url);
-		const cacheResponse = await cache.match(cacheKey);
-
-		if (cacheResponse) {
-			return cacheResponse;
-		}
-
-		let watermark = await env.NAMESPACE.get(watermarkKey, "stream");
-		let source = await env.BUCKET.get(sourceKey);
+		const watermark = await env.NAMESPACE.get(watermarkKey, "stream");
+		const source = await env.BUCKET.get(sourceKey);
 
 		if (!watermark || !source) {
 			return new Response("Not found", { status: 404 });
@@ -48,9 +56,12 @@ export default {
 
 		const response = result.response();
 
-		ctx.waitUntil(cache.put(cacheKey, response.clone()));
-
-		return response;
+		return new Response(response.body, {
+			headers: {
+				...Object.fromEntries(response.headers),
+				"Cache-Control": "public, max-age=3600, stale-while-revalidate=86400",
+			},
+		});
 	},
 } satisfies ExportedHandler<Env>;
 ```

--- a/src/content/docs/images/optimization/binding.mdx
+++ b/src/content/docs/images/optimization/binding.mdx
@@ -25,7 +25,9 @@ Bindings can be configured in the Cloudflare dashboard for your Worker or in the
 
 :::note[Billing]
 
-Every call to the Images binding counts as one unique transformation. Refer to [Images pricing](/images/pricing/) for more information about billing.
+Calls to the Images binding are billed as [unique transformations](/images/pricing/#images-transformed): each unique combination of source image and parameters is billed only once per calendar month, and repeat requests within the same month do not incur additional usage. Calls to [`.info()`](#infostream) are free.
+
+Refer to [Images pricing](/images/pricing/) for more information about billing.
 
 :::
 
@@ -53,9 +55,44 @@ Within your Worker code, use `env.IMAGES.input()` to build an object that can ma
 
 ## Methods
 
-:::note
+:::caution[Enable caching]
 
-Responses from the Images binding are not automatically cached. Workers lets you interact directly with the [Cache API](/workers/runtime-apis/cache/) to customize cache behavior. You can implement logic in your script to store transformations in Cloudflare's cache.
+Responses from the Images binding are not automatically cached. Every uncached call performs a full decode and re-encode of the source image, which adds unnecessary latency to every request.
+
+We strongly recommend enabling [Workers Cache](/workers/cache/) so that repeat requests are served from cache without re-running your Worker or re-transforming the image. Add the following to your Wrangler configuration file:
+
+<WranglerConfig>
+
+```jsonc
+{
+	"cache": {
+		"enabled": true,
+	},
+}
+```
+
+</WranglerConfig>
+
+Then set `Cache-Control` headers on your response to control how long transformed images are cached:
+
+<TypeScriptExample>
+
+```ts
+const response = (
+	await env.IMAGES.input(stream)
+		.transform({ width: 800 })
+		.output({ format: "image/webp" })
+).response();
+
+return new Response(response.body, {
+	headers: {
+		...Object.fromEntries(response.headers),
+		"Cache-Control": "public, max-age=3600, stale-while-revalidate=86400",
+	},
+});
+```
+
+</TypeScriptExample>
 
 :::
 

--- a/src/content/docs/images/pricing.mdx
+++ b/src/content/docs/images/pricing.mdx
@@ -49,12 +49,11 @@ Images Stored and Images Delivered apply only to images that are stored in your 
 
 ### Images Transformed
 
-A unique transformation is a request to transform an original image based on a set of [supported parameters](/images/optimization/features/). This metric is used when using the Images binding or optimizing images that are stored outside of Images.
-When using the [Images binding](/images/optimization/binding/) in Workers, every call to the binding counts as a transformation, regardless of whether the image or parameters are unique.
+A unique transformation is a request to transform an original image based on a set of [supported parameters](/images/optimization/features/). This metric is used when using the [Images binding](/images/optimization/binding/) or optimizing images that are stored outside of Images.
 
 For example, if you transform `thumbnail.jpg` as 100x100, then this counts as one unique transformation. If you transform the same `thumbnail.jpg` as 200x200, then this counts as a separate unique transformation.
 
-You are billed on the number of unique transformations that are requested within each calendar month. Repeat requests for the same transformation within the same month are counted only once for that month.
+You are billed on the number of unique transformations that are requested within each calendar month. Repeat requests for the same transformation within the same month are counted only once for that month. Calls to the Images binding's [`.info()`](/images/optimization/binding/#infostream) method are not billed.
 
 The `format` parameter counts as only one billable transformation, even if multiple copies of an image are served. In other words, if `width=100,format=auto/thumbnail.jpg` is served to some users as AVIF and to others as WebP, then this counts as one unique transformation instead of two.
 


### PR DESCRIPTION
### Summary

Cached Workers has been released - we should update our examples.

We also have the binding billing change. That is reflected in this update too

### Documentation checklist

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
