### PR TITLE
[Magic Transit, Magic WAN] BGP over IPsec/GRE now in open beta

### DIFF
--- a/src/content/partials/networking-services/reference/traffic-steering.mdx
+++ b/src/content/partials/networking-services/reference/traffic-steering.mdx
@@ -620,7 +620,7 @@ The following table outlines the current availability and recommended use cases 
 | Feature | Release stage | Recommended use | Prerequisites |
 | --- | --- | --- | --- |
 | **BGP over CNI** | Closed Beta | Not available to new customers — contact your account team | Cloudflare Network Interconnect (CNI) v2 |
-| **BGP over Anycast IPsec/GRE** | Beta | Non-production workloads | [Unified Routing (beta)](#unified-routing-mode-beta) - contact your account team to enroll |
+| **BGP over Anycast IPsec/GRE** | Open Beta | Non-production workloads | [Unified Routing (beta)](#unified-routing-mode-beta) - contact your account team to enroll |
 
 ### BGP architecture
 

--- a/src/content/partials/networking-services/reference/traffic-steering.mdx
+++ b/src/content/partials/networking-services/reference/traffic-steering.mdx
@@ -620,7 +620,7 @@ The following table outlines the current availability and recommended use cases 
 | Feature | Release stage | Recommended use | Prerequisites |
 | --- | --- | --- | --- |
 | **BGP over CNI** | Closed Beta | Not available to new customers — contact your account team | Cloudflare Network Interconnect (CNI) v2 |
-| **BGP over Anycast IPsec/GRE** | Closed Beta | Lab / Testing only | [Unified Routing (beta)](#unified-routing-mode-beta) - contact your account team to enroll |
+| **BGP over Anycast IPsec/GRE** | Beta | Non-production workloads | [Unified Routing (beta)](#unified-routing-mode-beta) - contact your account team to enroll |
 
 ### BGP architecture
 


### PR DESCRIPTION
### Summary

BGP peering over Anycast IPsec/GRE tunnels has moved from closed beta to open beta. Updates the release-status table in the shared Magic Transit / Magic WAN traffic steering reference to reflect the new stage and a broader recommended use.

BGP over CNI remains in closed beta and is unchanged. Unified Routing is still required and continues to require account team enablement.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
