### PR TITLE
chore: Add CODEOWNERS for networking partials and changelogs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -236,6 +236,7 @@ package.json @cloudflare/content-engineering
 /src/content/docs/network-flow/ @steve-cloudflare @jeffh-cloudflare @alpdot @cloudflare/product-owners
 /src/content/docs/cloudflare-wan/ @steve-cloudflare @jeffh-cloudflare @alpdot @cloudflare/cf1-reviewers @elithrar @cloudflare/product-owners
 /src/content/docs/multi-cloud-networking/ @steve-cloudflare @jeffh-cloudflare @cloudflare/cf1-reviewers @elithrar @cloudflare/product-owners
+/src/content/partials/networking-services/ @steve-cloudflare @jeffh-cloudflare @alpdot @cloudflare/product-owners
 
 # Migration guides
 


### PR DESCRIPTION
### Summary

Adds CODEOWNERS entries for Magic/Cloudflare networking products to ensure changes are routed for review:
1. Adds `/src/content/partials/networking-services/`, the shared partials directory. This directory previously had no owners.
2. Adds changelog directories for `cloudflare-network-firewall`, `cloudflare-wan`, `magic-transit`, `multi-cloud-networking`, and `network-interconnect`. These previously fell back to the root changelog owners.

Owners match the base set already used for the Magic products docs entries, plus the standard `@cloudflare/pm-changelogs` team for the changelog paths.