### PR TITLE
[R2] Changelog: Data Catalog compaction optimizes manifest files

### DIFF
--- a/src/content/changelog/r2/2026-07-07-r2-data-catalog-manifest-optimization.mdx
+++ b/src/content/changelog/r2/2026-07-07-r2-data-catalog-manifest-optimization.mdx
@@ -2,7 +2,7 @@
 title: R2 Data Catalog compaction now optimizes manifest files
 description: Compaction automatically rewrites and clusters Apache Iceberg manifest files to reduce metadata overhead and speed up query planning
 products:
-  - r2
+  - r2-data-catalog
 date: 2026-07-07
 ---
 

--- a/src/content/changelog/r2/2026-07-07-r2-data-catalog-manifest-optimization.mdx
+++ b/src/content/changelog/r2/2026-07-07-r2-data-catalog-manifest-optimization.mdx
@@ -3,7 +3,7 @@ title: R2 Data Catalog compaction now optimizes manifest files
 description: Compaction automatically rewrites and clusters Apache Iceberg manifest files to reduce metadata overhead and speed up query planning
 products:
   - r2-data-catalog
-date: 2026-07-07
+date: 2026-07-08
 ---
 
 [R2 Data Catalog](/r2/data-catalog/), a managed [Apache Iceberg](https://iceberg.apache.org/) catalog built into R2, now automatically optimizes manifest files as part of [compaction](/r2/data-catalog/table-maintenance/).

--- a/src/content/changelog/r2/2026-07-07-r2-data-catalog-manifest-optimization.mdx
+++ b/src/content/changelog/r2/2026-07-07-r2-data-catalog-manifest-optimization.mdx
@@ -1,0 +1,17 @@
+---
+title: R2 Data Catalog compaction now optimizes manifest files
+description: Compaction automatically rewrites and clusters Apache Iceberg manifest files to reduce metadata overhead and speed up query planning
+products:
+  - r2
+date: 2026-07-07
+---
+
+[R2 Data Catalog](/r2/data-catalog/), a managed [Apache Iceberg](https://iceberg.apache.org/) catalog built into R2, now automatically optimizes manifest files as part of [compaction](/r2/data-catalog/table-maintenance/).
+
+Manifest files track the data files that make up an Iceberg table. As a table accumulates many small or fragmented manifests, query engines must read more metadata during query planning, which slows down queries even before any data is scanned.
+
+When compaction runs, R2 Data Catalog now rewrites and clusters manifest files by partition as a best-effort pre-step. This consolidates fragmented manifests, reduces the number of manifests a query engine must open, and lowers metadata I/O overhead. Tables that are already well-clustered are skipped, so the operation only runs when it provides a benefit.
+
+This happens automatically for tables with compaction enabled — no configuration changes are required.
+
+To learn more about automatic maintenance operations, refer to the [table maintenance documentation](/r2/data-catalog/table-maintenance/).

--- a/src/content/changelog/r2/2026-07-07-r2-data-catalog-manifest-optimization.mdx
+++ b/src/content/changelog/r2/2026-07-07-r2-data-catalog-manifest-optimization.mdx
@@ -14,4 +14,4 @@ When compaction runs, R2 Data Catalog now rewrites and clusters manifest files b
 
 This happens automatically for tables with compaction enabled — no configuration changes are required.
 
-To learn more about automatic maintenance operations, refer to the [table maintenance documentation](/r2/data-catalog/table-maintenance/).
+For more information, refer to [Table maintenance](/r2/data-catalog/table-maintenance/).

--- a/src/content/changelog/r2/2026-07-13-r2-data-catalog-manifest-optimization.mdx
+++ b/src/content/changelog/r2/2026-07-13-r2-data-catalog-manifest-optimization.mdx
@@ -3,7 +3,7 @@ title: R2 Data Catalog compaction now optimizes manifest files
 description: Compaction automatically rewrites and clusters Apache Iceberg manifest files to reduce metadata overhead and speed up query planning
 products:
   - r2-data-catalog
-date: 2026-07-08
+date: 2026-07-13
 ---
 
 [R2 Data Catalog](/r2/data-catalog/), a managed [Apache Iceberg](https://iceberg.apache.org/) catalog built into R2, now automatically optimizes manifest files as part of [compaction](/r2/data-catalog/table-maintenance/).


### PR DESCRIPTION
### Summary

Adds a changelog entry announcing that **R2 Data Catalog** compaction now automatically optimizes Apache Iceberg **manifest files**.

When compaction runs, R2 Data Catalog now rewrites and clusters manifest files by partition as a best-effort pre-step. This consolidates fragmented manifests, reduces the number of manifests a query engine must open during planning, and lowers metadata I/O overhead. Well-clustered tables are skipped, and the optimization happens automatically for any table with compaction enabled — no configuration changes required.

Changelog-only change under `src/content/changelog/r2/`, following the format of prior R2 Data Catalog table-maintenance entries (for example, `2026-04-22-snapshot-expiration-cleans-data-files.mdx`).

### Documentation checklist

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? This PR is the changelog entry.
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
