### PR TITLE
chore: nimbus agent skills

### DIFF
--- a/src/nimbus/astro-config.ts
+++ b/src/nimbus/astro-config.ts
@@ -3,6 +3,7 @@ import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import react from "@astrojs/react";
 import icon from "astro-icon";
+import skills from "astro-skills";
 import nimbus, { defineConfig as defineNimbusConfig } from "nimbus-docs";
 import { hastPlugins } from "./plugins/satteri";
 import { createSitemapLastmodSerializer } from "../../sitemap.serializer";
@@ -201,6 +202,8 @@ export const markdown = {
 export const integrations = [
 	icon(),
 	react(),
+	// Injects /.well-known/agent-skills/* routes (index.json, SKILL.md, tarballs).
+	skills(),
 	nimbus(nimbusConfig, {
 		mdx: { optimize: true },
 		markdown: { hastPlugins },

--- a/src/nimbus/content.config.ts
+++ b/src/nimbus/content.config.ts
@@ -1,5 +1,6 @@
 import { defineCollection, reference, z } from "astro:content";
 import { glob } from "astro/loaders";
+import { skillsLoader } from "astro-skills";
 import { docsCollection, partialsCollection } from "nimbus-docs/content";
 import { warpReleasesSchema } from "~/schemas/warp-releases";
 import { compatibilityFlagsSchema } from "~/schemas/compatibility-flags";
@@ -237,6 +238,10 @@ export const collections = {
   // middlecache at build. Read by ProductAvailabilityText /
   // GranularControlApplicationsList.
   "product-availability": defineCollection(productAvailabilityCollectionConfig),
+  // Agent Skills Discovery — shared root `./skills` dir, served via astro-skills.
+  skills: defineCollection({
+    loader: skillsLoader({ base: "./skills" }),
+  }),
   "granular-control-applications": defineCollection(
     granularControlApplicationsCollectionConfig,
   ),


### PR DESCRIPTION
### Summary

The Nimbus build was not serving the Agent Skills Discovery routes —
`/.well-known/agent-skills/index.json`, `/.well-known/agent-skills/[skill]/SKILL.md`,
and `/.well-known/agent-skills/[skill].tar.gz` all 404'd. The `astro-skills`
integration and its `skills` content collection were only registered in the
production config, so the shared `_headers` content-type rule for
`agent-skills/index.json` was also dead.

This registers both in the Nimbus config, matching production.

## How

Reuses the `astro-skills` package as-is — no fork, no content duplication.

- `src/nimbus/content.config.ts`: adds the `skills` collection via
  `skillsLoader({ base: "./skills" })`. `base` resolves from the project root,
  so both builds read the same root `skills/` directory.
- `src/nimbus/astro-config.ts`: registers the `skills()` integration, which
  injects the three routes. Its route entrypoints depend only on the `skills`
  collection (`getCollection`), so they drop into Nimbus unchanged.

Skill content and the fetch script are untouched.


### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
