### PR TITLE
[Changelog] Add WebSocket Analytics Logpush dataset entry

### DIFF
--- a/src/content/changelog/logs/2026-07-07-websocket-analytics-dataset.mdx
+++ b/src/content/changelog/logs/2026-07-07-websocket-analytics-dataset.mdx
@@ -1,0 +1,22 @@
+---
+title: New WebSocket Analytics Logpush dataset
+description: Push per-connection WebSocket close reason, close source, and session metadata to any Logpush destination.
+products:
+  - logs
+date: 2026-07-07
+---
+
+Enterprise customers can now push per-connection WebSocket analytics to any [Logpush destination](/logs/logpush/logpush-job/enable-destinations/) using the new `websocket_analytics` dataset. Each log record is emitted when a WebSocket connection closes and includes fields that were previously only available to Cloudflare engineers via internal tooling.
+
+Key fields include:
+
+- **`ConnectionCloseReason`** — why the connection ended: `peerReset`, `peerNoError`, `timedOut`, `upstreamReset`, `protocolViolation`, `unspecifiedError`, or `none`.
+- **`ConnectionCloseSource`** — which side initiated the close: `upstream`, `downstream`, `me`, or `both`.
+- **`ConnectionTransportCloseCode`** — the TLS alert code or TCP-level close code for additional precision.
+- **`RayID`** — correlate WebSocket connection events with your existing HTTP Request logs.
+
+The dataset also includes directional byte counts (`BytesSentClient`, `BytesReceivedClient`, `BytesSentOrigin`, `BytesReceivedOrigin`), connection timestamps, client IP, colo code, and request metadata from the original WebSocket upgrade.
+
+This data lets you build alerts on connection close patterns — for example, detecting spikes in TCP resets (`ConnectionCloseReason == "peerReset"`) grouped by host and data center — directly in your existing log analysis tools.
+
+For the full list of available fields, refer to [WebSocket Analytics](/logs/logpush/logpush-job/datasets/zone/websocket_analytics/).


### PR DESCRIPTION
### Summary

Adds a changelog entry for the new WebSocket Analytics Logpush dataset (SHIP-14935). This dataset exposes per-connection WebSocket close reason, close source, transport close code, and session metadata via Logpush — available to Enterprise customers.

### Documentation checklist

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
