### PR TITLE
fix(organizations): capitalize Organization consistently as proper noun

### DIFF
--- a/src/content/docs/fundamentals/organizations/index.mdx
+++ b/src/content/docs/fundamentals/organizations/index.mdx
@@ -14,7 +14,7 @@ import { DirectoryListing, Plan } from "~/components";
 
 <Plan type="enterprise" />
 
-An organization is a top-level container in Cloudflare for managing multiple accounts. It allows administrators to govern accounts, members, and resources from a single location rather than managing each account individually. Organization Super Administrators have implicit access to all accounts within the organization. This means they do not need explicit membership on each account.
+An organization is a top-level container in Cloudflare for managing multiple accounts. It allows administrators to govern accounts, members, and resources from a single location rather than managing each account individually. Organization Super Administrators have implicit access to all accounts within the Organization. This means they do not need explicit membership on each account.
 
 :::note
 
@@ -25,9 +25,9 @@ Cloudflare Organizations is currently in public beta.
 ## Features
 
 - **Centralized account management**: Assign Enterprise Accounts to your Organization and manage them from a single dashboard.
-- **Implicit access**: Organization Super Administrators can access any account in the organization without requiring explicit per-account membership.
+- **Implicit access**: Organization Super Administrators can access any account in the Organization without requiring explicit per-account membership.
 - **Aggregate audit logs**: View, filter, and download aggregate HTTP analytics across all Organization child accounts.
-- **Organization-level membership**: Invite members to the organization once, granting them access to all child accounts.
+- **Organization-level membership**: Invite members to the Organization once, granting them access to all child accounts.
 - **Terraform support**: Manage Organizations with infrastructure as code from day one.
 
 ---

--- a/src/content/docs/fundamentals/organizations/manage-members.mdx
+++ b/src/content/docs/fundamentals/organizations/manage-members.mdx
@@ -10,9 +10,9 @@ products:
 
 ## Organization Super Administrator
 
-When you create an organization, you become an Organization Super Administrator. This role provides implicit access to all accounts in your organization and allows you to manage memberships at the organization level.
+When you create an Organization, you become an Organization Super Administrator. This role provides implicit access to all accounts in your Organization and allows you to manage memberships at the Organization level.
 
-Implicit access means you do not need explicit membership on each account. When you access any account within your organization, you automatically have Super Administrator permissions.
+Implicit access means you do not need explicit membership on each account. When you access any account within your Organization, you automatically have Super Administrator permissions.
 
 :::note
 Any Organization Super Administrator can add or remove other Organization Super Administrators at any time.
@@ -20,13 +20,13 @@ Any Organization Super Administrator can add or remove other Organization Super 
 
 ## Invite members
 
-You can invite additional members to your organization. Invited members receive implicit Super Administrator access to all accounts in the organization.
+You can invite additional members to your Organization. Invited members receive implicit Super Administrator access to all accounts in the Organization.
 
 1. From the organization overview, select **Members**.
 2. Select **Invite member**.
 3. Enter the email address.
 4. Select **Send invitation**.
 
-The user receives an email invitation. After accepting, they have implicit access to all accounts in the organization.
+The user receives an email invitation. After accepting, they have implicit access to all accounts in the Organization.
 
 Invited members must have 2FA or SSO enabled to join.

--- a/src/content/docs/fundamentals/organizations/manage-organization.mdx
+++ b/src/content/docs/fundamentals/organizations/manage-organization.mdx
@@ -8,7 +8,7 @@ products:
   - fundamentals
 ---
 
-## Rename your organization
+## Rename your Organization
 
 1. Go to **Organizations** > **Manage Organization**.
 2. Next to **Organization name**, select **Rename**.

--- a/src/content/docs/fundamentals/organizations/setup.mdx
+++ b/src/content/docs/fundamentals/organizations/setup.mdx
@@ -22,7 +22,7 @@ Before you create an organization:
 - Your accounts must not be part of a [tenant](/tenant).
 
 :::note
-All organization members must have 2FA or SSO enabled.
+All Organization members must have 2FA or SSO enabled.
 :::
 
 ## Create an organization
@@ -33,43 +33,43 @@ All organization members must have 2FA or SSO enabled.
 4. Enter a name for the organization.
 5. Select **Create**.
 
-The organization overview page displays after creation.
+The Organization overview page displays after creation.
 
 ## Assign accounts
 
-After creating an organization, you can assign accounts to manage them centrally:
+After creating an Organization, you can assign accounts to manage them centrally:
 
-1. From the organization overview, select **Assign an account**.
+1. From the Organization overview, select **Assign an account**.
 2. Search for an account name. Only Enterprise accounts where you are a Super Administrator will appear.
 3. Select the account.
 4. Select **Assign to organization**.
 
-The assigned account now appears on the organization overview page. From here, you can view the account, copy its ID, or rename it.
+The assigned account now appears on the Organization overview page. From here, you can view the account, copy its ID, or rename it.
 
-To remove an account from your organization, contact [Cloudflare Support](/support/contacting-cloudflare-support/).
+To remove an account from your Organization, contact [Cloudflare Support](/support/contacting-cloudflare-support/).
 
 ## Organization Super Administrator
 
-When you create an organization, you become the Organization Super Administrator. This role provides implicit access to all accounts in your organization.
+When you create an organization, you become the Organization Super Administrator. This role provides implicit access to all accounts in your Organization.
 
-Implicit access means you do not need explicit membership on each account. When you access any account within your organization, you automatically have Super Administrator permissions.
+Implicit access means you do not need explicit membership on each account. When you access any account within your Organization, you automatically have Super Administrator permissions.
 
 ### Invite members
 
-You can invite additional members to your organization. Invited members receive implicit Super Administrator access to all accounts in the organization.
+You can invite additional members to your Organization. Invited members receive implicit Super Administrator access to all accounts in the Organization.
 
-1. From the organization overview, select **Members**.
+1. From the Organization overview, select **Members**.
 2. Select **Invite member**.
 3. Enter the email address.
 4. Select **Send invitation**.
 
-The user receives an email invitation. After accepting, they have implicit access to all accounts in the organization.
+The user receives an email invitation. After accepting, they have implicit access to all accounts in the Organization.
 
 Invited members must have 2FA or SSO enabled to join.
 
 ## View audit logs
 
-You can view, filter, and download audit logs for HTTP traffic across all domains in your organization:
+You can view, filter, and download audit logs for HTTP traffic across all domains in your Organization:
 
 1. From the organization overview, select **Analytics & Logs**.
 2. Use filters to narrow results by date range, account, domain, or other criteria.
@@ -77,9 +77,9 @@ You can view, filter, and download audit logs for HTTP traffic across all domain
 
 The data includes traffic for proxied hostnames and may be based on a sample. This data does not reflect billable usage.
 
-## Manage your organization
+## Manage your Organization
 
-### Rename your organization
+### Rename your Organization
 
 1. Go to **Organizations** > **Manage Organization**.
 2. Next to **Organization name**, select **Rename**.


### PR DESCRIPTION
Standardize capitalization of 'Organization' across all Organizations docs pages to match the style already used in limitations.mdx.

**Rule:** Capitalize 'Organization' when referring to the Cloudflare feature; lowercase only in generic verb phrases.

**Files changed:** index.mdx, setup.mdx, manage-members.mdx, manage-organization.mdx (22 lines, text-only capitalization fix)