### PR TITLE
docs(cloudflare-one): document DNS resolution location for host egress selectors

### DIFF
--- a/src/content/docs/cloudflare-one/traffic-policies/egress-policies/host-selectors.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/egress-policies/host-selectors.mdx
@@ -108,6 +108,14 @@ The Cloudflare One Client must be set to _Traffic and DNS mode_ for traffic affe
 
 ## Known issues
 
+### DNS resolution location
+
+For the [Application](/cloudflare-one/traffic-policies/egress-policies/#application), [Content Categories](/cloudflare-one/traffic-policies/egress-policies/#content-categories), [Domain](/cloudflare-one/traffic-policies/egress-policies/#domain), and [Host](/cloudflare-one/traffic-policies/egress-policies/#host) selectors, Gateway captures the destination IP address during the initial DNS resolution step described above. The egress policy does not change this IP address, so the destination Gateway connects to is independent of the location of the egress data center or dedicated egress IP you select.
+
+If the resolved destination IP and the egress IP are located in different regions, connections to destinations that enforce geo-restriction or IP-allowlisting based on the connection source may be rejected.
+
+This can affect you if you use Domain or Host egress selectors, your users are located outside the region associated with your egress IP, and the destination applies geo-restriction or IP-based access controls.
+
 ### Google Chrome restricts local network access
 
 <Render file="gateway/egress-selector-chrome-issue" product="cloudflare-one" />

--- a/src/content/docs/cloudflare-one/traffic-policies/egress-policies/index.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/egress-policies/index.mdx
@@ -250,3 +250,5 @@ Gateway uses Rust to evaluate regular expressions. The Rust implementation is sl
 ### Selector prerequisites
 
 The [Application](#application), [Content Categories](#content-categories), [Domain](#domain), and [Host](#host) selectors require additional setup before they work in egress policies. Before deploying policies with these selectors, refer to [Host selectors](/cloudflare-one/traffic-policies/egress-policies/host-selectors).
+
+These selectors also resolve the destination IP address when Gateway processes the DNS query, not when the egress policy is applied. If the resolved destination IP and your egress IP are in different regions, connections to destinations that enforce geo-restriction or IP-allowlisting may fail. Refer to [DNS resolution location](/cloudflare-one/traffic-policies/egress-policies/host-selectors/#dns-resolution-location) for details.


### PR DESCRIPTION
## What

Adds a **DNS resolution location** note under *Known issues* on the [Host selectors](https://developers.cloudflare.com/cloudflare-one/traffic-policies/egress-policies/host-selectors/) page, cross-referenced from the [Egress policies](https://developers.cloudflare.com/cloudflare-one/traffic-policies/egress-policies/) parent page under *Selector prerequisites*.

## Why

The host-based egress selectors (Application, Content Categories, Domain, Host) document the token-IP two-step resolution mechanism but don't call out a consequence of it: the destination IP is captured at Gateway DNS resolution time and is **not** changed when the egress policy is applied, so destination selection is decoupled from egress location. When the resolved destination IP and the egress IP are in different regions, connections to geo-restricted or IP-allowlisted destinations can fail.

Surfaced by SFDC 02218769 — WARP users in one region egressing via a dedicated US egress IP with a beta Domain/Host selector, reaching CDN-fronted US destinations, and receiving 403s. A Gateway DNS log showed the destination hostname resolving to a CDN edge IP close to the user rather than the egress region.

Note: an alternative cause with the same symptom (the US egress IP not being on the destination's allowlist, which would fail regardless of DNS resolution) was not ruled out in that case, so this note documents the general mechanism and its consequence rather than asserting a confirmed root cause for that specific ticket.

## Content added

- For Host/Domain-matched (and Application/Content Categories) traffic, the destination IP is captured at DNS resolution time and is independent of the egress data center's location.
- When the resolved destination IP and the egress IP are in different regions, destinations enforcing geo-restriction or IP-allowlisting on the connection source may reject the connection.
- Applies to Domain/Host egress selector customers whose users are outside the egress region and whose destination enforces geo- or IP-based restrictions.

Jira: DEE-3675