### PR TITLE
chore: add asamborski as CODEOWNER for Browser Isolation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -98,7 +98,9 @@ package.json @cloudflare/content-engineering
 /src/content/changelog/cloudflare-one/ @kennyj42 @asamborski @ranbel @cloudflare/pm-changelogs @cloudflare/cf1-reviewers @elithrar @cloudflare/product-owners
 /src/content/docs/cloudflare-one/cloud-and-saas-findings/ @Maddy-Cloudflare @codyanthony850 @cloudflare/cf1-reviewers @elithrar @cloudflare/product-owners
 /src/content/docs/cloudflare-one/traffic-policies/ @alexmoraru7 @Maddy-Cloudflare @codyanthony850 @cloudflare/cf1-reviewers @elithrar @cloudflare/product-owners
-/src/content/docs/cloudflare-one/remote-browser-isolation/ @codyanthony850 @cloudflare/cf1-reviewers @elithrar @cloudflare/product-owners
+/src/content/docs/cloudflare-one/remote-browser-isolation/ @asamborski @codyanthony850 @cloudflare/cf1-reviewers @elithrar @cloudflare/product-owners
+/src/content/partials/cloudflare-one/troubleshooting/browser-isolation.mdx @asamborski @codyanthony850 @cloudflare/cf1-reviewers @elithrar @cloudflare/product-owners
+/src/content/partials/cloudflare-one/access/self-hosted-app/browser-isolation-non-443.mdx @asamborski @codyanthony850 @cloudflare/cf1-reviewers @elithrar @cloudflare/product-owners
 /src/content/docs/cloudflare-one/data-loss-prevention/ @Maddy-Cloudflare @codyanthony850 @cloudflare/cf1-reviewers @elithrar @cloudflare/product-owners
 /src/content/docs/cloudflare-one/insights/dex/ @codyanthony850 @cloudflare/cf1-reviewers @elithrar @cloudflare/product-owners
 /src/content/docs/email-security/ @Maddy-Cloudflare @cloudflare/cf1-reviewers @elithrar @cloudflare/product-owners


### PR DESCRIPTION
### Summary

Adds @asamborski as a CODEOWNER for Browser Isolation docs and related partials.

- Added to `/src/content/docs/cloudflare-one/remote-browser-isolation/`
- Added new entries for two browser isolation partials that previously had no specific ownership:
  - `src/content/partials/cloudflare-one/troubleshooting/browser-isolation.mdx`
  - `src/content/partials/cloudflare-one/access/self-hosted-app/browser-isolation-non-443.mdx`
