### PR TITLE
[wrangler] Add dependency metadata to worker uploads

### DIFF
--- a/src/content/changelog/workers/2026-07-07-wrangler-deploy-upload-dependencies-metadata.mdx
+++ b/src/content/changelog/workers/2026-07-07-wrangler-deploy-upload-dependencies-metadata.mdx
@@ -1,0 +1,27 @@
+---
+title: Send npm package dependency metadata with Worker uploads
+description: Wrangler now collects npm dependency information at deploy time and includes it in upload metadata for supply chain visibility.
+products:
+  - workers
+date: 2026-07-07
+---
+
+import { WranglerConfig } from "~/components";
+
+Wrangler now collects npm package dependency information from your project's `package.json` during [`wrangler deploy`](/workers/wrangler/commands/general/#deploy) and [`wrangler versions upload`](/workers/wrangler/commands/general/#upload), and includes it in the upload metadata sent to the Cloudflare API. This data, each dependency's name, declared version range, and exact installed version, enables dependency analytics and future supply chain security features such as vulnerability alerting.
+
+To opt out, set [`dependencies_instrumentation.enabled`](/workers/wrangler/configuration/#top-level-only-keys) to `false` in your Wrangler configuration file:
+
+<WranglerConfig>
+
+```jsonc
+{
+	"dependencies_instrumentation": {
+		"enabled": false
+	}
+}
+```
+
+</WranglerConfig>
+
+For more details, refer to [Wrangler configuration](/workers/wrangler/configuration/#top-level-only-keys).

--- a/src/content/changelog/workers/2026-07-07-wrangler-deploy-upload-dependencies-metadata.mdx
+++ b/src/content/changelog/workers/2026-07-07-wrangler-deploy-upload-dependencies-metadata.mdx
@@ -3,7 +3,7 @@ title: Send npm package dependency metadata with Worker uploads
 description: Wrangler now collects npm dependency information at deploy time and includes it in upload metadata for supply chain visibility.
 products:
   - workers
-date: 2026-07-07
+date: 2026-07-09
 ---
 
 import { WranglerConfig } from "~/components";

--- a/src/content/docs/workers/wrangler/configuration.mdx
+++ b/src/content/docs/workers/wrangler/configuration.mdx
@@ -139,6 +139,10 @@ Top-level keys apply to the Worker as a whole (and therefore all environments). 
 - `send_metrics` <Type text="boolean" /> <MetaInfo text="optional" />
   - Whether Wrangler should send usage data to Cloudflare for this project. Defaults to `true`. You can learn more about this in our [data policy](https://github.com/cloudflare/workers-sdk/tree/main/packages/wrangler/telemetry.md).
 
+- `dependencies_instrumentation` <Type text="object" /> <MetaInfo text="optional" />
+  - Configures npm package dependency instrumentation when deploying or uploading a Worker version. Defaults to enabled.
+  - `enabled` <Type text="boolean" /> — Whether Wrangler should collect and send npm package dependency metadata (package names and versions). Defaults to `true`.
+
 - `site` <Type text="object" /> <MetaInfo text="optional deprecated" />
   - See the [Workers Sites](#workers-sites) section below for more information. Cloudflare Pages and Workers Assets is preferred over this approach.
   - This is not supported by the [Cloudflare Vite plugin](/workers/vite-plugin/).


### PR DESCRIPTION
### Summary

Adds changelog and details for the deployment metadata being introduced in https://github.com/cloudflare/workers-sdk/pull/14591

