### PR TITLE
[WARP] Add Windows 2026.6.850.0 release notes

### DIFF
--- a/src/content/warp-releases/windows/ga/2026.6.822.0.yaml
+++ b/src/content/warp-releases/windows/ga/2026.6.822.0.yaml
@@ -35,6 +35,7 @@ releaseNotes: |-
   **Known issues**
 
 
+  - Single sign-on in the embedded WebView2 authentication browser may fail to use the Windows primary account, prompting for an interactive sign-in.
   - An error indicating that Microsoft Edge can't read and write to its data directory may be displayed during captive portal login; this error is benign and can be dismissed.
   - In rare cases, a registration may hang at "Checking your organization configuration" due to IPC errors. A system reboot should resolve the error, allowing registration to proceed.
   - Windows ARM may prompt the user to close running applications while trying to install this version. Simply click "Ok" with the default highlighted option.

--- a/src/content/warp-releases/windows/ga/2026.6.850.0.yaml
+++ b/src/content/warp-releases/windows/ga/2026.6.850.0.yaml
@@ -1,0 +1,7 @@
+releaseNotes: |-
+  This hotfix addresses a Windows authentication issue in the embedded WebView2 browser. Single sign-on could fail to use the Windows primary account, causing users to be prompted for an interactive sign-in. The embedded authentication browser now allows SSO providers to use the OS primary account when available.
+version: 2026.6.850.0
+releaseDate: 2026-07-07T18:35:35.920Z
+packageURL: https://downloads.cloudflareclient.com/v1/download/windows/version/2026.6.850.0
+packageSize: 59027456
+platformName: Windows


### PR DESCRIPTION
### Summary

Adds the `2026.6.850.0` Windows GA hotfix release notes, fetched from the downloads endpoint via `bin/fetch-warp-releases.js`. This hotfix addresses a WebView2 authentication issue where single sign-on could fail to use the Windows primary account.

Also adds that SSO problem as a known issue on the prior `2026.6.822.0` Windows release.

### Documentation checklist

- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
