### PR TITLE
[WOBS] Document Semantic Conventions for Warning Attributes

### DIFF
--- a/src/content/changelog/workers/2026-07-07-warning-attributes.mdx
+++ b/src/content/changelog/workers/2026-07-07-warning-attributes.mdx
@@ -1,0 +1,18 @@
+---
+title: Workers tracing now surfaces warning attributes on spans
+description: Workers tracing attaches `cloudflare.warning.type` and `cloudflare.warning.message` attributes to spans when a non-fatal telemetry error condition is encountered, such as a span that was never closed.
+products:
+  - workers
+date: 2026-07-07
+---
+
+Workers tracing may now attach warning attributes to a span when a non-fatal error condition is encountered while recording telemetry for that span. These are diagnostic indicators about the span's telemetry state — for example, a span that was created but never closed before its parent invocation span ended.
+
+When a warning is present, both attributes are set together:
+
+- `cloudflare.warning.type` — A closed-set identifier indicating the type of warning condition. The currently defined value is `span_not_ended`, which indicates the span was still open when its parent invocation span closed and was force-closed by Workers tracing.
+- `cloudflare.warning.message` — A free-form, human-readable explanation of the warning condition.
+
+Use these attributes to detect instrumentation issues in your Workers, such as spans that are started but never ended.
+
+For more information, refer to [Warning attributes](/workers/observability/traces/spans-and-attributes/#warning-attributes).

--- a/src/content/docs/workers/observability/traces/spans-and-attributes.mdx
+++ b/src/content/docs/workers/observability/traces/spans-and-attributes.mdx
@@ -46,6 +46,23 @@ Cloudflare Workers provides automatic tracing instrumentation **out of the box**
 
 ---
 
+### Warning attributes
+
+Workers tracing may attach warning attributes to a span when a non-fatal error condition is encountered while recording telemetry for that span.
+These are diagnostic indicators about the span's telemetry state (for example, a span that was never closed).
+When present, both attributes are set together.
+
+- `cloudflare.warning.type` - A closed-set identifier indicating the type of warning condition encountered. See [Warning types](#warning-types) for the set of defined values.
+- `cloudflare.warning.message` - A free-form, human-readable explanation of the warning condition.
+
+#### Warning types
+
+The following values are defined for `cloudflare.warning.type`:
+
+- `span_not_ended` - The span was still open when its parent invocation span closed. Workers tracing force-closes the span and attaches this warning.
+
+---
+
 ### [Runtime API](/workers/runtime-apis/)
 
 #### [`fetch`](/workers/runtime-apis/handlers/fetch/)


### PR DESCRIPTION
### Summary

Documenting Semantic Conventions for Warning Attributes on a Span

### Documentation checklist

<!-- Remove items that do not apply -->

- [X] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [X] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
