### PR TITLE
Fix typos in Full-stack application page

### DIFF
--- a/src/content/docs/workers/static-assets/routing/full-stack-application.mdx
+++ b/src/content/docs/workers/static-assets/routing/full-stack-application.mdx
@@ -10,7 +10,7 @@ products:
 
 import { WranglerConfig, Render, DirectoryListing } from "~/components";
 
-Full-stack applications are web applications which are span both the client and server. The build process of these applications will produce a HTML files, accompanying client-side resources (e.g. JavaScript bundles, CSS stylesheets, images, fonts, etc.) and a Worker script. Data is typically fetched the Worker script at request-time and the initial page response is usually server-side rendered (SSR). From there, the client is then hydrated and a SPA-like experience ensues.
+Full-stack applications are web applications that span both the client and server. The build process of these applications will produce HTML files, accompanying client-side resources (e.g. JavaScript bundles, CSS stylesheets, images, fonts, etc.) and a Worker script. Data is typically fetched by the Worker script at request-time and the initial page response is usually server-side rendered (SSR). From there, the client is then hydrated and a SPA-like experience ensues.
 
 The following full-stack frameworks are natively supported by Workers:
 


### PR DESCRIPTION
Fixed minor grammatical errors and typos in the Full-stack application page.