### PR TITLE
docs(realtimekit): added Breakout Room docs for React Native SDKs

### DIFF
--- a/src/content/docs/realtime/realtimekit/core/breakout-rooms.mdx
+++ b/src/content/docs/realtime/realtimekit/core/breakout-rooms.mdx
@@ -56,6 +56,13 @@ Before creating breakout rooms, validate the permissions of the current particip
 	/>
 </RTKCodeSnippet>
 
+<RTKCodeSnippet id="mobile-react-native">
+	<Render
+		file="realtimekit/react-native/breakout-room-permission-check"
+		product="realtime"
+	/>
+</RTKCodeSnippet>
+
 ### Create breakout rooms
 
 <RTKCodeSnippet id="web-web-components">
@@ -89,6 +96,13 @@ Before creating breakout rooms, validate the permissions of the current particip
 <RTKCodeSnippet id="mobile-ios">
 	<Render
 		file="realtimekit/ios/breakout-room-creation-sdk-api"
+		product="realtime"
+	/>
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-react-native">
+	<Render
+		file="realtimekit/web/breakout-room-creation-sdk-api"
 		product="realtime"
 	/>
 </RTKCodeSnippet>
@@ -132,6 +146,13 @@ If there are more than one host in the room creating breakouts, you can retrieve
 	/>
 </RTKCodeSnippet>
 
+<RTKCodeSnippet id="mobile-react-native">
+	<Render
+		file="realtimekit/web/breakout-room-fetch-meetings-sdk-api"
+		product="realtime"
+	/>
+</RTKCodeSnippet>
+
 ### Move participants to breakout rooms
 
 Once you have created breakout rooms, assign participants to the rooms.
@@ -171,6 +192,13 @@ Once you have created breakout rooms, assign participants to the rooms.
 	/>
 </RTKCodeSnippet>
 
+<RTKCodeSnippet id="mobile-react-native">
+	<Render
+		file="realtimekit/web/breakout-room-move-participant-sdk-api"
+		product="realtime"
+	/>
+</RTKCodeSnippet>
+
 ### Move participants, with a specific preset, to breakout rooms
 
 Once you have created breakout rooms, assign participants to the rooms.
@@ -206,6 +234,13 @@ Once you have created breakout rooms, assign participants to the rooms.
 <RTKCodeSnippet id="mobile-ios">
 	<Render
 		file="realtimekit/ios/breakout-room-move-preset-participant-sdk-api"
+		product="realtime"
+	/>
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-react-native">
+	<Render
+		file="realtimekit/web/breakout-room-move-preset-participant-sdk-api"
 		product="realtime"
 	/>
 </RTKCodeSnippet>
@@ -253,6 +288,13 @@ If a participant has been moved to a breakout room, the `changingMeeting` event 
 	/>
 </RTKCodeSnippet>
 
+<RTKCodeSnippet id="mobile-react-native">
+	<Render
+		file="realtimekit/react-native/breakout-room-handle-breakout-events"
+		product="realtime"
+	/>
+</RTKCodeSnippet>
+
 ### Close breakout rooms
 
 You can close/delete the breakout rooms. This will force participants in those meetings to come to the main room.
@@ -288,6 +330,13 @@ You can close/delete the breakout rooms. This will force participants in those m
 <RTKCodeSnippet id="mobile-ios">
 	<Render
 		file="realtimekit/ios/breakout-room-close-breakout"
+		product="realtime"
+	/>
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-react-native">
+	<Render
+		file="realtimekit/web/breakout-room-close-breakout"
 		product="realtime"
 	/>
 </RTKCodeSnippet>

--- a/src/content/docs/realtime/realtimekit/core/breakout-rooms.mdx
+++ b/src/content/docs/realtime/realtimekit/core/breakout-rooms.mdx
@@ -13,7 +13,7 @@ import RTKSDKSelector from "~/components/realtimekit/RTKSDKSelector/RTKSDKSelect
 import RTKCodeSnippet from "~/components/realtimekit/RTKCodeSnippet/RTKCodeSnippet.astro";
 import { Render } from "~/components";
 
-<RTKSDKSelector />
+<RTKSDKSelector disabledPlatforms={["mobile-flutter"]} />
 
 <Render file="realtimekit/web/breakout-room-preface" product="realtime" />
 

--- a/src/content/docs/realtime/realtimekit/ui-kit/api-reference/react-native/RtkBreakoutRoomsManager.mdx
+++ b/src/content/docs/realtime/realtimekit/ui-kit/api-reference/react-native/RtkBreakoutRoomsManager.mdx
@@ -1,0 +1,43 @@
+---
+pcx_content_type: reference
+title: RtkBreakoutRoomsManager
+description: API reference for RtkBreakoutRoomsManager component (React Native Library)
+products:
+  - realtime
+---
+
+Full-screen modal for managing breakout rooms. Hosts can create rooms, assign participants, rename rooms, shuffle participants randomly, and start, update, or close a breakout session. Participants without alter permissions see a simplified room-switcher view instead.
+
+The component is visibility-controlled by the `activeBreakoutRoomsManager` field in the UI state. Use `RtkBreakoutRoomsToggle` to open it, or set the state directly.
+
+## Properties
+
+| Property   | Type                | Required | Default           | Description                      |
+| ---------- | ------------------- | -------- | ----------------- | -------------------------------- |
+| `meeting`  | `RealtimeKitClient` | ✅       | -                 | The RealtimeKit meeting instance |
+| `iconPack` | `IconPack`          | ❌       | `defaultIconPack` | Custom icon pack                 |
+| `t`        | `RtkI18n`           | ❌       | -                 | i18n translation function        |
+| `states`   | `States`            | ❌       | -                 | UI state object                  |
+
+## Usage Examples
+
+### Basic Usage
+
+```tsx
+import { RtkBreakoutRoomsManager } from "@cloudflare/realtimekit-react-native-ui";
+
+function MyComponent() {
+	return <RtkBreakoutRoomsManager meeting={meeting} />;
+}
+```
+
+### With Custom Icon Pack
+
+```tsx
+import { RtkBreakoutRoomsManager } from "@cloudflare/realtimekit-react-native-ui";
+import { myIconPack } from "./icons";
+
+function MyComponent() {
+	return <RtkBreakoutRoomsManager meeting={meeting} iconPack={myIconPack} />;
+}
+```

--- a/src/content/docs/realtime/realtimekit/ui-kit/api-reference/react-native/RtkBreakoutRoomsToggle.mdx
+++ b/src/content/docs/realtime/realtimekit/ui-kit/api-reference/react-native/RtkBreakoutRoomsToggle.mdx
@@ -1,0 +1,40 @@
+---
+pcx_content_type: reference
+title: RtkBreakoutRoomsToggle
+description: API reference for RtkBreakoutRoomsToggle component (React Native Library)
+products:
+  - realtime
+---
+
+Control bar button that opens and closes the `RtkBreakoutRoomsManager`. Automatically hides if the local participant has neither `canAlterConnectedMeetings` nor `canSwitchConnectedMeetings` permission.
+
+## Properties
+
+| Property   | Type                           | Required | Default           | Description                      |
+| ---------- | ------------------------------ | -------- | ----------------- | -------------------------------- |
+| `meeting`  | `RealtimeKitClient`            | ✅       | -                 | The RealtimeKit meeting instance |
+| `size`     | `'lg' \| 'md' \| 'sm' \| 'xl'` | ❌       | -                 | Icon size                        |
+| `iconPack` | `IconPack`                     | ❌       | `defaultIconPack` | Custom icon pack                 |
+| `t`        | `RtkI18n`                      | ❌       | -                 | i18n translation function        |
+
+## Usage Examples
+
+### Basic Usage
+
+```tsx
+import { RtkBreakoutRoomsToggle } from "@cloudflare/realtimekit-react-native-ui";
+
+function MyComponent() {
+	return <RtkBreakoutRoomsToggle meeting={meeting} />;
+}
+```
+
+### With Size
+
+```tsx
+import { RtkBreakoutRoomsToggle } from "@cloudflare/realtimekit-react-native-ui";
+
+function MyComponent() {
+	return <RtkBreakoutRoomsToggle meeting={meeting} size="md" />;
+}
+```

--- a/src/content/docs/realtime/realtimekit/ui-kit/breakout-rooms.mdx
+++ b/src/content/docs/realtime/realtimekit/ui-kit/breakout-rooms.mdx
@@ -111,6 +111,36 @@ To assign participants manually:
 
 </RTKCodeSnippet>
 
+<RTKCodeSnippet id="mobile-react-native">
+
+1. In your RealtimeKit meeting, tap **Breakout Rooms**
+2. In the Create Breakout dialog, add the number of rooms you want and tap **Create**
+
+Once you have created breakout rooms, assign participants to the rooms. You can assign participants automatically (RealtimeKit splits them evenly) or manually (you choose who goes where).
+
+#### Assign participants automatically
+
+To assign participants automatically:
+
+1. In the Assign Participants dialog, tap the shuffle button
+2. RealtimeKit assigns participants to the rooms
+3. Edit room names by tapping the pencil icon beside the room name (optional)
+4. Move participants to different rooms if needed
+5. Tap **Start Breakout**
+6. Tap **Yes, start** in the confirmation dialog
+
+#### Assign participants manually
+
+To assign participants manually:
+
+1. In the Assign Participants dialog, select the participants you want to assign to a room
+2. In the Rooms section, tap **Assign**
+3. Repeat for all participants and rooms
+4. Tap **Start Breakout**
+5. Tap **Yes, start** in the confirmation dialog
+
+</RTKCodeSnippet>
+
 ## Integrate breakout rooms
 
 After setting up breakout rooms via the API, you need to integrate them into your application using the RealtimeKit SDK.
@@ -304,6 +334,32 @@ The `onChangingMeeting` callback fires when the SDK starts leaving the current r
 
 </RTKCodeSnippet>
 
+<RTKCodeSnippet id="mobile-react-native">
+
+The `useRealtimeKitClient` hook automatically handles the `meetingChanged` event and swaps the active client reference when a participant moves between breakout rooms. No manual event handling is required.
+
+```tsx
+import { useEffect } from "react";
+import { useRealtimeKitClient } from "@cloudflare/realtimekit-react-native";
+import { RtkMeeting } from "@cloudflare/realtimekit-react-native-ui";
+
+function App() {
+  const [meeting, initMeeting] = useRealtimeKitClient();
+
+  useEffect(() => {
+    initMeeting({ authToken: "<participant_auth_token>" });
+  }, []);
+
+  if (!meeting) return null;
+
+  return <RtkMeeting meeting={meeting} showSetupScreen={true} />;
+}
+```
+
+`RtkMeeting` displays a "Joining…" transition screen automatically when switching between breakout rooms. No extra setup is needed.
+
+</RTKCodeSnippet>
+
 ### Render the meeting UI
 
 Use the default meeting UI component which includes built-in breakout room support:
@@ -490,6 +546,30 @@ rtkUIKit.startMeeting()
 :::
 
 Built-in breakout room support is handled automatically by `RtkMeetingActivity`. When the SDK moves participants between rooms, it displays a transition overlay with a localized message. The host can manage breakout rooms via the `RtkBreakoutRoomsBottomSheet`, which is shown automatically when the Breakout Rooms control bar button is tapped.
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-react-native">
+
+```tsx
+import { useEffect } from "react";
+import { useRealtimeKitClient } from "@cloudflare/realtimekit-react-native";
+import { RtkMeeting } from "@cloudflare/realtimekit-react-native-ui";
+
+function App() {
+  const [meeting, initMeeting] = useRealtimeKitClient();
+
+  useEffect(() => {
+    initMeeting({ authToken: "<participant_auth_token>" });
+  }, []);
+
+  if (!meeting) return null;
+
+  return <RtkMeeting meeting={meeting} showSetupScreen={true} />;
+}
+```
+
+Built-in breakout room support is handled automatically by `RtkMeeting`. When a participant is moved between rooms, a "Joining…" transition screen is displayed automatically. The host can manage breakout rooms using `RtkBreakoutRoomsManager`, which is accessible via `RtkBreakoutRoomsToggle` in the control bar.
 
 </RTKCodeSnippet>
 

--- a/src/content/docs/realtime/realtimekit/ui-kit/breakout-rooms.mdx
+++ b/src/content/docs/realtime/realtimekit/ui-kit/breakout-rooms.mdx
@@ -145,7 +145,7 @@ To assign participants manually:
 
 After setting up breakout rooms via the API, you need to integrate them into your application using the RealtimeKit SDK.
 
-<RTKSDKSelector />
+<RTKSDKSelector disabledPlatforms={["mobile-flutter"]} />
 
 ### Initialize the SDK with breakout rooms support
 

--- a/src/content/partials/realtime/realtimekit/react-native/breakout-room-handle-breakout-events.mdx
+++ b/src/content/partials/realtime/realtimekit/react-native/breakout-room-handle-breakout-events.mdx
@@ -1,0 +1,23 @@
+---
+{}
+
+---
+The `useRealtimeKitClient` hook automatically handles the `meetingChanged` event and swaps the active client reference when the local participant is moved to a breakout room or back to the main meeting. No additional setup is needed.
+
+If you are using the `RtkMeeting` UI Kit component, the transition UI (the "Joining…" screen) is also handled automatically.
+
+To show a custom loading screen during the switch, listen to the `changingMeeting` event:
+
+```tsx
+useEffect(() => {
+  if (!meeting) return;
+
+  const onChangingMeeting = (meetingId: string) => {
+    console.log("Switching to meeting:", meetingId);
+    // Show a loading indicator
+  };
+
+  meeting.connectedMeetings.on("changingMeeting", onChangingMeeting);
+  return () => meeting.connectedMeetings.removeListener("changingMeeting", onChangingMeeting);
+}, [meeting]);
+```

--- a/src/content/partials/realtime/realtimekit/react-native/breakout-room-permission-check.mdx
+++ b/src/content/partials/realtime/realtimekit/react-native/breakout-room-permission-check.mdx
@@ -1,0 +1,19 @@
+---
+{}
+
+---
+```tsx
+const [meeting] = useRealtimeKitClient();
+
+// Check if any breakout rooms are currently active
+const areBreakoutRoomsActive = meeting?.connectedMeetings.isActive;
+
+// Check whether the local participant can create, rename, or delete rooms and move any participant
+const canAlterBreakoutRooms = meeting?.self.permissions.connectedMeetings.canAlterConnectedMeetings;
+
+// Check whether the local participant can move themselves to any breakout room
+const canSwitchRooms = meeting?.self.permissions.connectedMeetings.canSwitchConnectedMeetings;
+
+// Check whether the local participant can return to the parent meeting
+const canReturnToParent = meeting?.self.permissions.connectedMeetings.canSwitchToParentMeeting;
+```

--- a/src/content/partials/realtime/realtimekit/web/breakout-room-preface.mdx
+++ b/src/content/partials/realtime/realtimekit/web/breakout-room-preface.mdx
@@ -8,12 +8,6 @@ The breakout rooms feature, also known as connected meetings, is currently in be
 
 Breakout rooms allow participants of a meeting to split into smaller groups for targeted discussions and collaboration. With the rise of remote work and online learning, breakout rooms have become an essential tool for enhancing engagement and building community in virtual settings. They are an ideal choice for workshops, online classrooms, or when you need to speak privately with select participants outside the main meeting.
 
-:::note
-
-Breakout rooms are currently supported on web only.
-
-:::
-
 In RealtimeKit, breakout rooms are created as a separate meeting. Each breakout room is an independent meeting and can be managed like any other RealtimeKit meeting. RealtimeKit provides a set of SDK APIs to create, manage, and switch between breakout rooms.
 
 ## Key features


### PR DESCRIPTION
## Summary
- Removed note stating Web only support for Breakout Rooms
- Disabled Flutter platform for Breakout Rooms Section (Core).
- Added Breakout Room docs for React Native (Core SDK). 