### PR TITLE
chore: fix outdated-pr-refresh workflow dispatch and document permissions

### DIFF
--- a/.github/workflows/outdated-pr-refresh.yml
+++ b/.github/workflows/outdated-pr-refresh.yml
@@ -20,6 +20,12 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
+      # actions: write is required by `gh workflow run` to dispatch workflows.
+      # This permission is broader than ideal — it grants the ability to trigger
+      # any workflow in the repo, not just outdated-pr-check.yml. GitHub does not
+      # offer a more scoped alternative. The risk is low in practice: this workflow
+      # runs on a schedule from production with no user-controlled inputs, so there
+      # is no path for an external actor to influence what gets dispatched.
       actions: write
     steps:
       - name: Dispatch outdated check for stale PRs
@@ -77,7 +83,7 @@ jobs:
 
             if [ "$AGE" -gt 86400 ]; then
               echo "  Stale — dispatching outdated check"
-              gh workflow run outdated-pr-check.yml --ref "$PR_REF" \
+              gh workflow run outdated-pr-check.yml --repo "$REPO" --ref "$PR_REF" \
                 || echo "  Failed to dispatch for PR #${PR_NUMBER} — continuing"
             else
               echo "  Behind but within grace period — skipping"


### PR DESCRIPTION
### Summary

Two fixes to `outdated-pr-refresh.yml`, the daily workflow that dispatches the outdated check for stale PRs:

1. **`--repo` flag missing from `gh workflow run`** — without it, the command fails with `fatal: not a git repository` because the scheduled workflow has no checkout and `gh` can't infer the repo from the working directory.

2. **Document `actions: write` permission scope** — this permission is required to dispatch workflows but is broader than ideal (it grants the ability to trigger any workflow in the repo, not just `outdated-pr-check.yml`). Added a comment explaining why the breadth is acceptable and why no narrower alternative exists.
