### PR TITLE
chore: extend outdated PR check to cover forks, add day formatting, rename check

### DIFF
--- a/.github/workflows/outdated-pr-check.yml
+++ b/.github/workflows/outdated-pr-check.yml
@@ -1,6 +1,6 @@
-name: CI
+name: Outdated PR Check
 
-# **What it does**: Posts a pr/outdated-check commit status when a PR is opened or updated.
+# **What it does**: Posts an Outdated PR Check commit status when a PR is opened or updated.
 #                   Fails if the branch is more than 24 hours out of date with production.
 # **Why we have it**: Gives contributors immediate feedback when their branch has drifted.
 #                     The daily refresh job (outdated-pr-refresh.yml) catches PRs that go
@@ -30,7 +30,7 @@ concurrency:
 
 jobs:
   check-outdated:
-    name: Outdated Check
+    name: Check
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -91,6 +91,6 @@ jobs:
             -H "Accept: application/vnd.github+json" \
             "/repos/${REPO}/statuses/${PR_SHA}" \
             -f state="$STATE" \
-            -f context="pr/outdated-check" \
+            -f context="Outdated PR Check" \
             -f description="$DESCRIPTION" \
             || echo "Failed to post status — skipping"

--- a/.github/workflows/outdated-pr-check.yml
+++ b/.github/workflows/outdated-pr-check.yml
@@ -1,26 +1,31 @@
 name: CI
 
-# **What it does**: Fails if a PR's branch is more than 24 hours out of date with production.
-# **Why we have it**: Prevents merging PRs whose base has drifted from production for too long.
-#                     The daily refresh job (outdated-pr-refresh.yml) dispatches this workflow
-#                     for any PR that has gone stale since its last push, so the check stays
-#                     current even when production advances without any PR activity.
-# **Who does it impact**: All contributors opening PRs against production.
+# **What it does**: Posts a pr/outdated-check commit status when a PR is opened or updated.
+#                   Fails if the branch is more than 24 hours out of date with production.
+# **Why we have it**: Gives contributors immediate feedback when their branch has drifted.
+#                     The daily refresh job (outdated-pr-refresh.yml) catches PRs that go
+#                     stale when production advances without any PR activity.
+# **Who does it impact**: All contributors opening PRs against production, including forks.
 
+# NOTE: pull_request_target is used instead of pull_request so that fork PRs receive a
+# commit status. pull_request gives forks a read-only token; pull_request_target runs with
+# base-repo permissions. This is safe here because the workflow never checks out or executes
+# any code from the PR — it only calls gh api. The danger with pull_request_target arises
+# when you add `actions/checkout` with `ref: github.event.pull_request.head.sha`, which
+# would run untrusted PR code with elevated permissions. Do not add a checkout step here.
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - production
     types:
       - opened
       - synchronize
       - reopened
-  workflow_dispatch:
 
 concurrency:
   # Use a hardcoded prefix rather than github.workflow to avoid colliding with
   # the main CI workflow, which also uses name: CI.
-  group: outdated-pr-check-${{ github.event.pull_request.number || github.ref }}
+  group: outdated-pr-check-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
@@ -29,58 +34,57 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      statuses: write
     steps:
       - name: Check if PR base is within 24 hours of production
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # For pull_request events use the PR head SHA; for workflow_dispatch
-          # github.sha is the SHA of the ref that was dispatched.
-          PR_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-          # Fork PRs have commits that live in a separate repo — the base repo's
-          # compare API cannot resolve them. The nightly refresh also skips fork PRs
-          # for the same reason. This is a known gap; fork contributors are expected
-          # to keep their branches current as a matter of course.
-          IS_FORK: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+          PR_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
           REPO="${{ github.repository }}"
 
-          if [ "$IS_FORK" = "true" ]; then
-            echo "Fork PR — outdated check does not apply"
-            exit 0
-          fi
-
           COMPARE=$(gh api "/repos/${REPO}/compare/production...${PR_SHA}") || {
-            echo "Compare API failed — skipping check"
+            echo "Compare API failed — skipping status post"
             exit 0
           }
           BEHIND_BY=$(echo "$COMPARE" | jq -r '.behind_by')
 
           if [ -z "$BEHIND_BY" ] || [ "$BEHIND_BY" = "null" ]; then
-            echo "Unexpected API response — skipping check"
+            echo "Unexpected API response — skipping status post"
             exit 0
           fi
 
           if [ "$BEHIND_BY" = "0" ]; then
-            echo "Branch is up to date with production"
-            exit 0
+            STATE="success"
+            DESCRIPTION="Branch is up to date with production"
+          else
+            MERGE_BASE_DATE=$(echo "$COMPARE" | jq -r '.merge_base_commit.commit.committer.date')
+
+            if [ -z "$MERGE_BASE_DATE" ] || [ "$MERGE_BASE_DATE" = "null" ]; then
+              echo "Could not determine merge base date — skipping status post"
+              exit 0
+            fi
+
+            MERGE_BASE_TS=$(date -d "$MERGE_BASE_DATE" +%s)
+            NOW=$(date +%s)
+            AGE=$((NOW - MERGE_BASE_TS))
+
+            if [ "$AGE" -gt 86400 ]; then
+              HOURS=$((AGE / 3600))
+              STATE="failure"
+              DESCRIPTION="Branch is ${HOURS}h out of date with production. Please rebase or merge."
+            else
+              STATE="success"
+              DESCRIPTION="Branch is behind production but within the 24-hour grace period"
+            fi
           fi
 
-          MERGE_BASE_DATE=$(echo "$COMPARE" | jq -r '.merge_base_commit.commit.committer.date')
-
-          if [ -z "$MERGE_BASE_DATE" ] || [ "$MERGE_BASE_DATE" = "null" ]; then
-            echo "Could not determine merge base date — skipping check"
-            exit 0
-          fi
-
-          MERGE_BASE_TS=$(date -d "$MERGE_BASE_DATE" +%s)
-          NOW=$(date +%s)
-          AGE=$((NOW - MERGE_BASE_TS))
-
-          if [ "$AGE" -gt 86400 ]; then
-            HOURS=$((AGE / 3600))
-            echo "Branch is ${HOURS}h out of date with production. Please rebase or merge."
-            exit 1
-          fi
-
-          echo "Branch is behind production but within the 24-hour grace period"
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/${REPO}/statuses/${PR_SHA}" \
+            -f state="$STATE" \
+            -f context="pr/outdated-check" \
+            -f description="$DESCRIPTION" \
+            || echo "Failed to post status — skipping"

--- a/.github/workflows/outdated-pr-check.yml
+++ b/.github/workflows/outdated-pr-check.yml
@@ -73,7 +73,13 @@ jobs:
             if [ "$AGE" -gt 86400 ]; then
               HOURS=$((AGE / 3600))
               STATE="failure"
-              DESCRIPTION="Branch is ${HOURS}h out of date with production. Please rebase or merge."
+              if [ "$HOURS" -gt 36 ]; then
+                DAYS=$((AGE / 86400))
+                UNIT=$( [ "$DAYS" -eq 1 ] && echo "day" || echo "days" )
+                DESCRIPTION="Branch is ${DAYS} ${UNIT} out of date with production. Please rebase or merge."
+              else
+                DESCRIPTION="Branch is ${HOURS}h out of date with production. Please rebase or merge."
+              fi
             else
               STATE="success"
               DESCRIPTION="Branch is behind production but within the 24-hour grace period"

--- a/.github/workflows/outdated-pr-refresh.yml
+++ b/.github/workflows/outdated-pr-refresh.yml
@@ -73,7 +73,13 @@ jobs:
               if [ "$AGE" -gt 86400 ]; then
                 HOURS=$((AGE / 3600))
                 STATE="failure"
-                DESCRIPTION="Branch is ${HOURS}h out of date with production. Please rebase or merge."
+                if [ "$HOURS" -gt 36 ]; then
+                  DAYS=$((AGE / 86400))
+                  UNIT=$( [ "$DAYS" -eq 1 ] && echo "day" || echo "days" )
+                  DESCRIPTION="Branch is ${DAYS} ${UNIT} out of date with production. Please rebase or merge."
+                else
+                  DESCRIPTION="Branch is ${HOURS}h out of date with production. Please rebase or merge."
+                fi
               else
                 STATE="success"
                 DESCRIPTION="Branch is behind production but within the 24-hour grace period"

--- a/.github/workflows/outdated-pr-refresh.yml
+++ b/.github/workflows/outdated-pr-refresh.yml
@@ -1,6 +1,6 @@
 name: Refresh PR Outdated Checks
 
-# **What it does**: Posts a pr/outdated-check commit status for every open PR once a day
+# **What it does**: Posts a Outdated PR Check commit status for every open PR once a day
 #                   (~4am CT), including fork PRs. Catches PRs that go stale when production
 #                   advances without any PR activity.
 # **Why we have it**: The per-commit check (outdated-pr-check.yml) only runs when a PR is
@@ -91,7 +91,7 @@ jobs:
               -H "Accept: application/vnd.github+json" \
               "/repos/${REPO}/statuses/${PR_SHA}" \
               -f state="$STATE" \
-              -f context="pr/outdated-check" \
+              -f context="Outdated PR Check" \
               -f description="$DESCRIPTION" \
               || { echo "  Failed to post status for PR #${PR_NUMBER} — continuing"; true; }
 

--- a/.github/workflows/outdated-pr-refresh.yml
+++ b/.github/workflows/outdated-pr-refresh.yml
@@ -1,12 +1,14 @@
 name: Refresh PR Outdated Checks
 
-# **What it does**: Dispatches the outdated check workflow for any open PR that has gone
-#                   stale since its last push (~4am CT daily).
-# **Why we have it**: Catches PRs that become outdated when production advances without
-#                     any PR activity. Because this runs once daily, the effective enforcement
-#                     window is 24–48 hours depending on when the PR was last rebased
-#                     relative to the job's schedule.
-# **Who does it impact**: All contributors with open PRs against production.
+# **What it does**: Posts a pr/outdated-check commit status for every open PR once a day
+#                   (~4am CT), including fork PRs. Catches PRs that go stale when production
+#                   advances without any PR activity.
+# **Why we have it**: The per-commit check (outdated-pr-check.yml) only runs when a PR is
+#                     updated. This job handles the case where production moves forward and
+#                     a PR becomes stale without the contributor pushing anything.
+#                     Because this runs once daily, the effective enforcement window is
+#                     24–48 hours depending on when the PR was last rebased vs. the schedule.
+# **Who does it impact**: All contributors with open PRs against production, including forks.
 
 on:
   schedule:
@@ -15,46 +17,34 @@ on:
 
 jobs:
   refresh-outdated:
-    name: Refresh outdated check for stale PRs
+    name: Refresh outdated check for all open PRs
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: read
-      # actions: write is required by `gh workflow run` to dispatch workflows.
-      # This permission is broader than ideal — it grants the ability to trigger
-      # any workflow in the repo, not just outdated-pr-check.yml. GitHub does not
-      # offer a more scoped alternative. The risk is low in practice: this workflow
-      # runs on a schedule from production with no user-controlled inputs, so there
-      # is no path for an external actor to influence what gets dispatched.
-      actions: write
+      # statuses: write is required to post commit statuses to PR head SHAs.
+      # Fork PR commits are reachable in the base repo via refs/pull/{n}/head,
+      # so this works for both internal and fork PRs.
+      statuses: write
     steps:
-      - name: Dispatch outdated check for stale PRs
+      - name: Post outdated status for all open PRs
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           REPO="${{ github.repository }}"
 
-          # Get all open PRs targeting production
+          # Get all open PRs targeting production (including forks)
           PRS=$(gh pr list \
+            --repo "$REPO" \
             --base production \
             --state open \
             --limit 500 \
-            --json number,headRefOid,headRefName,isCrossRepository)
+            --json number,headRefOid)
 
           echo "$PRS" | jq -c '.[]' | while read -r PR; do
             PR_NUMBER=$(echo "$PR" | jq -r '.number')
             PR_SHA=$(echo "$PR" | jq -r '.headRefOid')
-            PR_REF=$(echo "$PR" | jq -r '.headRefName')
-            IS_FORK=$(echo "$PR" | jq -r '.isCrossRepository')
-
-            # Fork PRs have their head branch in a different repo — workflow_dispatch
-            # can only target refs in the base repo. Skip them here; they are covered
-            # by the per-commit pull_request check when contributors push.
-            if [ "$IS_FORK" = "true" ]; then
-              echo "  Fork PR — skipping (covered by per-commit check)"
-              continue
-            fi
 
             echo "Checking PR #${PR_NUMBER} (${PR_SHA:0:7})"
 
@@ -66,26 +56,38 @@ jobs:
             BEHIND_BY=$(echo "$COMPARE" | jq -r '.behind_by')
 
             if [ "$BEHIND_BY" = "0" ]; then
-              echo "  Up to date — skipping"
-              continue
-            fi
-
-            MERGE_BASE_DATE=$(echo "$COMPARE" | jq -r '.merge_base_commit.commit.committer.date')
-
-            if [ -z "$MERGE_BASE_DATE" ] || [ "$MERGE_BASE_DATE" = "null" ]; then
-              echo "  Skipping PR #${PR_NUMBER}: missing merge base date"
-              continue
-            fi
-
-            MERGE_BASE_TS=$(date -d "$MERGE_BASE_DATE" +%s)
-            NOW=$(date +%s)
-            AGE=$((NOW - MERGE_BASE_TS))
-
-            if [ "$AGE" -gt 86400 ]; then
-              echo "  Stale — dispatching outdated check"
-              gh workflow run outdated-pr-check.yml --repo "$REPO" --ref "$PR_REF" \
-                || echo "  Failed to dispatch for PR #${PR_NUMBER} — continuing"
+              STATE="success"
+              DESCRIPTION="Branch is up to date with production"
             else
-              echo "  Behind but within grace period — skipping"
+              MERGE_BASE_DATE=$(echo "$COMPARE" | jq -r '.merge_base_commit.commit.committer.date')
+
+              if [ -z "$MERGE_BASE_DATE" ] || [ "$MERGE_BASE_DATE" = "null" ]; then
+                echo "  Skipping PR #${PR_NUMBER}: missing merge base date"
+                continue
+              fi
+
+              MERGE_BASE_TS=$(date -d "$MERGE_BASE_DATE" +%s)
+              NOW=$(date +%s)
+              AGE=$((NOW - MERGE_BASE_TS))
+
+              if [ "$AGE" -gt 86400 ]; then
+                HOURS=$((AGE / 3600))
+                STATE="failure"
+                DESCRIPTION="Branch is ${HOURS}h out of date with production. Please rebase or merge."
+              else
+                STATE="success"
+                DESCRIPTION="Branch is behind production but within the 24-hour grace period"
+              fi
             fi
+
+            gh api \
+              --method POST \
+              -H "Accept: application/vnd.github+json" \
+              "/repos/${REPO}/statuses/${PR_SHA}" \
+              -f state="$STATE" \
+              -f context="pr/outdated-check" \
+              -f description="$DESCRIPTION" \
+              || { echo "  Failed to post status for PR #${PR_NUMBER} — continuing"; true; }
+
+            echo "  Posted: $STATE — $DESCRIPTION"
           done


### PR DESCRIPTION
### Summary

Updates the outdated PR check workflows with three improvements:

**1. Fork PR support**

The previous implementation skipped fork PRs entirely because `workflow_dispatch` can't target branches in a fork repo, and `pull_request` gives forks a read-only token that can't post statuses.

- **`outdated-pr-check.yml`** — switched to `pull_request_target` so the workflow runs with base-repo token permissions, enabling status posting for fork PRs. Safe because the workflow never checks out or executes any PR code. No `workflow_dispatch` trigger — the nightly handles refresh.
- **`outdated-pr-refresh.yml`** — replaced `workflow_dispatch`-per-PR with direct commit status posting. Fork PR commits are reachable in the base repo via `refs/pull/{n}/head`, so the statuses API works for them. Now iterates all open PRs including forks.

Both workflows post to the same `Outdated PR Check` status context, so branch protection only needs one required check: **`Outdated PR Check`**.

**2. Days vs hours in failure message**

When a branch is more than 36 hours out of date, the message now shows days instead of hours (e.g. "Branch is 2 days out of date" instead of "Branch is 52h out of date"). Properly pluralizes day/days.

**3. Naming cleanup**

- Workflow renamed from `CI` to `Outdated PR Check` (removes collision with the main CI workflow's concurrency group)
- Status context renamed from `pr/outdated-check` to `Outdated PR Check`
