### PR TITLE
[Analytics] Document account-based GraphQL API rate limiting

### DIFF
--- a/src/content/docs/analytics/graphql-api/account-based-rate-limiting.mdx
+++ b/src/content/docs/analytics/graphql-api/account-based-rate-limiting.mdx
@@ -1,0 +1,152 @@
+---
+pcx_content_type: concept
+title: Account-based rate limiting
+sidebar:
+  order: 32
+head:
+  - tag: title
+    content: GraphQL API - Account-based rate limiting
+description: Apply GraphQL Analytics API rate limits per account and per zone, so usage scales with the number of resources you query.
+products:
+  - analytics
+  - graphql-api
+---
+
+By default, the GraphQL Analytics API applies rate limits per user or per API
+token. As you grow — adding more zones and accounts — all of your analytics
+traffic competes for that single per-credential quota.
+
+**Account-based rate limiting** applies limits per account and per zone instead.
+Each account and zone gets its own independent budget, so a single user or token
+can query many resources at once without exhausting one shared quota. This is the
+recommended model if you query analytics across multiple zones or accounts.
+
+## Benefits
+
+- **Scales with your footprint.** Throughput grows with the number of accounts
+  and zones you query, instead of being capped by a single per-credential limit.
+- **Higher quotas for Enterprise.** Enterprise customers receive higher default
+  per-account (15 rps) and per-zone (10 rps) quotas.
+- **Easy limit increases.** Need more headroom? Get in touch, we can accommodate needed increases to your limits.
+
+## Enable account-based rate limiting
+
+Send the following HTTP header with your requests to the existing GraphQL API
+endpoint (`https://api.cloudflare.com/client/v4/graphql`):
+
+```txt
+X-Rate-Limit-Type: account-based
+```
+
+Your endpoint URL and credentials stay the same. Requests without this header
+continue to use the default per-user / per-token limits, so you can adopt this
+gradually.
+
+## Limits
+
+| Scope | Default limit |
+| --- | --- |
+| Each account | 1 request per second (300 requests per 5-minute window) |
+| Each zone | 1 request per second (300 requests per 5-minute window) |
+
+A single `accounts` block counts one request against the referenced account. A
+single `zones` block counts one request against the referenced zone; if the
+`zones` block is nested inside an `accounts` block, it counts against that
+account instead.
+
+Because limits apply per resource, the total throughput available to one user or
+token scales with the number of distinct accounts and zones you query.
+
+:::note
+If you send more than one request per second sustained to a **single** account
+or zone, request a higher limit for that resource (refer to
+[Request higher limits](#request-higher-limits)).
+:::
+
+## Query requirements
+
+Most queries work unchanged. Only queries that select a **list** or **range** of
+zones at the top (`viewer`) level need adjusting: nest those zones inside a
+single `accounts` block. The adjusted queries are valid under **both** rate
+limiting models.
+
+Querying a single zone — no change:
+
+```graphql
+{
+  viewer {
+    zones(filter: { zoneTag: "<ZONE_TAG>" }) {
+      # ...
+    }
+  }
+}
+```
+
+Querying a single account — no change:
+
+```graphql
+{
+  viewer {
+    accounts(filter: { accountTag: "<ACCOUNT_TAG>" }) {
+      # ...
+    }
+  }
+}
+```
+
+Querying a list or range of zones — nest inside the owning account:
+
+```graphql
+# Not supported: a list of zones at the viewer level
+{
+  viewer {
+    zones(filter: { zoneTag_in: ["<ZONE_A>", "<ZONE_B>"] }) {
+      # ...
+    }
+  }
+}
+
+# Supported: the same zones nested inside their account
+{
+  viewer {
+    accounts(filter: { accountTag: "<ACCOUNT_TAG>" }) {
+      zones(filter: { zoneTag_in: ["<ZONE_A>", "<ZONE_B>"] }) {
+        # ...
+      }
+    }
+  }
+}
+```
+
+The same applies to range filters such as `zoneTag_gt`. The query semantics are
+identical — you only need the account tag that owns the zones, which you already
+have.
+
+## Request higher limits
+
+If you need more than the default per-account or per-zone throughput, contact
+your Cloudflare account team to request an increase for the specific accounts and
+zones you query. Increases under this model are applied per resource and take
+effect quickly, without an engineering release.
+
+## Rate limit errors
+
+When a limit is exceeded, the API returns an error with `extensions.code` set to
+`budget`, naming the account or zone that was throttled:
+
+```json
+{
+  "data": null,
+  "errors": [
+    {
+      "extensions": { "code": "budget", "timestamp": "2026-01-01T01:01:01Z" },
+      "message": "Account <ACCOUNT_TAG> has exceeded its rate limit. Please try again after 5 minutes. Refer to this page for more details about rate limits: https://developers.cloudflare.com/analytics/graphql-api/limits/",
+      "path": null
+    }
+  ]
+}
+```
+
+The equivalent zone error reports `Zone <ZONE_TAG> has exceeded its rate limit`.
+Retry after the 5-minute window, spread traffic across resources, or
+[request a higher limit](#request-higher-limits).

--- a/src/content/docs/analytics/graphql-api/limits.mdx
+++ b/src/content/docs/analytics/graphql-api/limits.mdx
@@ -42,6 +42,17 @@ then wait 5 minutes before issuing another query.
 That rate limit is applied in addition to the [general rate limits enforced by
 the Cloudflare API](/fundamentals/api/reference/limits/).
 
+### Account-based rate limiting
+
+If you query analytics across many zones or accounts, you can opt into
+**account-based rate limiting**, where limits apply per account and per zone
+instead of per user or API token. Because each account and zone has its own
+budget, a single user or token can make far more requests overall, and limit
+increases can be applied per resource and take effect quickly.
+
+To learn how to enable it and the query requirements, refer to
+[Account-based rate limiting](/analytics/graphql-api/account-based-rate-limiting/).
+
 ## Node limits and availability
 
 Each data node has its limits, such as:


### PR DESCRIPTION
Add a standalone Account-based rate limiting page explaining how to opt in via the X-Rate-Limit-Type: account-based header, the per-account/per-zone limits, query requirements, and how to request higher limits. Link to it from the Limits page.

### Summary

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
