### PR TITLE
flue: add "Fix in your agent" block to review comment

### DIFF
--- a/.flue/lib/code-review-render.ts
+++ b/.flue/lib/code-review-render.ts
@@ -251,11 +251,130 @@ function renderSection(
 	renderSeverityTable(lines, "Suggestions", suggestions);
 }
 
+const PR_BASE_URL = "https://github.com/cloudflare/cloudflare-docs/pull";
+
+/**
+ * Render a single finding as a named subsection for the agent prompt.
+ * Uses the finding's stable id as an anchor so the user can reference it
+ * when asking the agent to skip and explain specific findings.
+ */
+function renderFindingForPrompt(f: ReconcileResult["active"][number]): string {
+	const lines: string[] = [];
+	const fileLabel =
+		f.path === "pr"
+			? "PR-level finding"
+			: f.line
+				? `\`${f.path}\` line ${f.line}`
+				: `\`${f.path}\``;
+	lines.push(`#### ${f.id} · ${f.rule}`);
+	lines.push(`- **File:** ${fileLabel}`);
+	lines.push(`- **Issue:** ${f.evidence}`);
+	lines.push(`- **Fix:** ${f.suggestion}`);
+	return lines.join("\n");
+}
+
+/**
+ * Render one stream's findings as a prompt section (e.g. "## Code Review").
+ * Returns an empty string when the stream has no active findings.
+ */
+function renderStreamForPrompt(
+	heading: string,
+	reconciled: ReconcileResult,
+	includeCritical: boolean,
+): string {
+	const { critical, warnings, suggestions } = activeBySeverity(reconciled);
+
+	const blocks: string[] = [];
+
+	if (includeCritical && critical.length > 0) {
+		blocks.push(`### Critical (${critical.length})`);
+		blocks.push("");
+		for (const f of critical) {
+			blocks.push(renderFindingForPrompt(f));
+			blocks.push("");
+		}
+	}
+	if (warnings.length > 0) {
+		blocks.push(`### Warnings (${warnings.length})`);
+		blocks.push("");
+		for (const f of warnings) {
+			blocks.push(renderFindingForPrompt(f));
+			blocks.push("");
+		}
+	}
+	if (suggestions.length > 0) {
+		blocks.push(`### Suggestions (${suggestions.length})`);
+		blocks.push("");
+		for (const f of suggestions) {
+			blocks.push(renderFindingForPrompt(f));
+			blocks.push("");
+		}
+	}
+
+	if (blocks.length === 0) return "";
+
+	return [`## ${heading}`, "", ...blocks].join("\n");
+}
+
+/**
+ * Render the collapsed "Fix in your agent" block.
+ *
+ * Only called when there is at least one active finding. The agent prompt is
+ * wrapped in a fenced ```markdown code block so GitHub renders a one-click
+ * copy button, matching the GitLab bot UX.
+ */
+function renderFixInAgentBlock(
+	reviews: RenderReviewInput,
+	prNumber?: number,
+): string {
+	const prRef =
+		prNumber != null
+			? `PR #${prNumber} (${PR_BASE_URL}/${prNumber})`
+			: "this PR";
+
+	const preamble = [
+		`Fix the following review findings in ${prRef}.`,
+		"",
+		"Before making changes, review each finding and present a brief summary table:",
+		"- For each finding, state whether you agree, disagree, or need clarification",
+		"- If you disagree (e.g. the fix requires disproportionate effort for minimal benefit,",
+		"  or the finding is factually incorrect), explain why",
+		"- If you need clarification before deciding, ask those questions",
+		"- Then share your plan for which issues to tackle and in what order",
+		"",
+		"After triaging, fix all legitimate findings. For any you decide to skip,",
+		"post a comment on this PR with the finding ID and your reasoning.",
+	].join("\n");
+
+	const sections = [
+		renderStreamForPrompt("Code Review", reviews.code, true),
+		renderStreamForPrompt("Conventions", reviews.conventions, false),
+		renderStreamForPrompt("Style Guide Review", reviews.style, false),
+	]
+		.filter(Boolean)
+		.join("\n---\n\n");
+
+	const promptBody = [preamble, "", "---", "", sections].join("\n");
+
+	// Fenced as ```markdown so GitHub renders a copy button.
+	const fenced = ["```markdown", promptBody, "```"].join("\n");
+
+	return [
+		"<details>",
+		"<summary>Fix in your agent</summary>",
+		"",
+		fenced,
+		"",
+		"</details>",
+	].join("\n");
+}
+
 /** Render the final review comment from all four reconciled finding streams. */
 export function renderComment(
 	reviews: RenderReviewInput,
 	reviewedHeadSha: string,
 	forceFullReview?: boolean,
+	prNumber?: number,
 ): string {
 	const shortSha = reviewedHeadSha.slice(0, 7);
 	const reviewedAt = new Date().toISOString();
@@ -318,6 +437,14 @@ export function renderComment(
 		"",
 		statusLine,
 	];
+
+	// ── "Fix in your agent" prompt (collapsed, copy-button fenced block) ─────
+	// Only rendered when there is at least one active finding — nothing useful
+	// to copy if the review is clean.
+	if (totalActive > 0) {
+		lines.push("");
+		lines.push(renderFixInAgentBlock(reviews, prNumber));
+	}
 
 	// ── Section 1: Code Review ────────────────────────────────────────────────
 	renderSection(

--- a/.flue/workflows/finalize-review.ts
+++ b/.flue/workflows/finalize-review.ts
@@ -465,6 +465,7 @@ export async function run({
 				},
 				input.headSha,
 				ctx.forceFullReview,
+				input.number,
 			);
 
 	// ── 7. Log or post ────────────────────────────────────────────────────────


### PR DESCRIPTION
### Summary

Adds a collapsed "Fix in your agent" block to the bot review comment whenever there is at least one active finding. The block contains a fenced ` ```markdown ` prompt the author can copy with one click and paste directly into their coding agent.

The prompt instructs the agent to triage each finding (agree / disagree / clarify), fix legitimate ones, and post a PR comment with the finding ID and reasoning for any it skips. Findings are grouped by stream (Code Review → Conventions → Style Guide Review) then by severity, matching the order of the existing review tables. Each finding includes its stable ID (e.g. `CR-abc123`) so the agent can reference specific items when explaining skip decisions.

The block is rendered only when `totalActive > 0` — clean reviews are unaffected. It mirrors the "Fix in your Agent" UX from the internal GitLab bot.

<img width="924" height="840" alt="Screenshot 2026-07-08 at 6 29 05 PM" src="https://github.com/user-attachments/assets/0e6ac4a7-ffbc-47a5-b719-4fe2d744718a" />

