### PR TITLE
[SSL] Update encryption mode pages to use 'Visitor' instead of 'Browser'

### DIFF
--- a/src/content/docs/ssl/origin-configuration/ssl-modes/flexible.mdx
+++ b/src/content/docs/ssl/origin-configuration/ssl-modes/flexible.mdx
@@ -8,7 +8,7 @@ sidebar:
 head:
   - tag: title
     content: Flexible - SSL/TLS encryption modes
-description: Traffic from browsers to Cloudflare can be encrypted via HTTPS, but traffic from Cloudflare to the origin server is not. This mode is common for origins that do not support TLS, though upgrading the origin configuration is recommended whenever possible.
+description: Traffic from visitors to Cloudflare can be encrypted via HTTPS, but traffic from Cloudflare to the origin server is not. This mode is common for origins that do not support TLS, though upgrading the origin configuration is recommended whenever possible.
 ---
 
 import { Render, TabItem, Tabs } from "~/components";
@@ -19,7 +19,7 @@ Setting your encryption mode to **Flexible** makes your site partially secure. C
 flowchart LR
     accTitle: Flexible SSL/TLS Encryption
     accDescr: With an encryption mode of Flexible, your application encrypts traffic between the visitor and Cloudflare, but not between Cloudflare and your server.
-    A[Browser] <--Encrypted--> B((Cloudflare))<--Unencrypted--> C[(Origin server)]
+    A[Visitor] <--Encrypted--> B((Cloudflare))<--Unencrypted--> C[(Origin server)]
 ```
 
 ## Use when

--- a/src/content/docs/ssl/origin-configuration/ssl-modes/full-strict.mdx
+++ b/src/content/docs/ssl/origin-configuration/ssl-modes/full-strict.mdx
@@ -19,7 +19,7 @@ When you set your encryption mode to **Full (strict)**, Cloudflare does everythi
 flowchart LR
     accTitle: Full - Strict SSL/TLS Encryption
     accDescr: With an encryption mode of Full (strict), your application encrypts traffic going to and coming from Cloudflare.
-    A[Browser] <--Encrypted--> B((Cloudflare))<--Encrypted--> C[("Origin server (verified) #9989;")]
+    A[Visitor] <--Encrypted--> B((Cloudflare))<--Encrypted--> C[("Origin server (verified) #9989;")]
 ```
 
 ## Use when

--- a/src/content/docs/ssl/origin-configuration/ssl-modes/full.mdx
+++ b/src/content/docs/ssl/origin-configuration/ssl-modes/full.mdx
@@ -8,7 +8,7 @@ sidebar:
 head:
   - tag: title
     content: Full - SSL/TLS encryption modes
-description: Cloudflare matches the browser request protocol when connecting to the origin. If the browser uses HTTP, Cloudflare connects to the origin via HTTP; if HTTPS, Cloudflare uses HTTPS without validating the origin’s certificate. This mode is common for origins that use self-signed or otherwise invalid certificates.
+description: Cloudflare matches the visitor request protocol when connecting to the origin. If the visitor uses HTTP, Cloudflare connects to the origin via HTTP; if HTTPS, Cloudflare uses HTTPS without validating the origin’s certificate. This mode is common for origins that use self-signed or otherwise invalid certificates.
 ---
 
 import { Stream, Render, TabItem, Tabs } from "~/components";

--- a/src/content/docs/ssl/origin-configuration/ssl-modes/off.mdx
+++ b/src/content/docs/ssl/origin-configuration/ssl-modes/off.mdx
@@ -8,7 +8,7 @@ sidebar:
 head:
   - tag: title
     content: Off - SSL/TLS encryption modes
-description: No encryption is used for traffic between browsers and Cloudflare or between Cloudflare and origins. Everything is cleartext HTTP.
+description: No encryption is used for traffic between visitors and Cloudflare or between Cloudflare and origins. Everything is cleartext HTTP.
 ---
 
 import { Render, TabItem, Tabs } from "~/components";
@@ -19,7 +19,7 @@ Setting your encryption mode to **Off (not recommended)** redirects any HTTPS re
     flowchart LR
         accTitle: No SSL/TLS Encryption
         accDescr: With an encryption mode of Off, your application does not encrypt traffic between the visitor and Cloudflare or between Cloudflare and your server.
-        A[Browser] <--Unencrypted--> B((Cloudflare))<--Unencrypted--> C[(Origin server)]
+        A[Visitor] <--Unencrypted--> B((Cloudflare))<--Unencrypted--> C[(Origin server)]
 ```
 
 ## Use when

--- a/src/content/docs/ssl/origin-configuration/ssl-modes/ssl-only-origin-pull.mdx
+++ b/src/content/docs/ssl/origin-configuration/ssl-modes/ssl-only-origin-pull.mdx
@@ -8,7 +8,7 @@ sidebar:
 head:
   - tag: title
     content: Strict (SSL-Only Origin Pull) - SSL/TLS encryption modes
-description: Regardless of whether the browser-to-Cloudflare connection uses HTTP or HTTPS, Cloudflare always connects to the origin over HTTPS with certificate validation.
+description: Regardless of whether the visitor-to-Cloudflare connection uses HTTP or HTTPS, Cloudflare always connects to the origin over HTTPS with certificate validation.
 ---
 
 import { Stream, Render, Tabs, TabItem } from "~/components";

--- a/src/content/partials/ssl/encryption-mode-definition.mdx
+++ b/src/content/partials/ssl/encryption-mode-definition.mdx
@@ -8,5 +8,5 @@ Your zone's **SSL/TLS Encryption Mode** controls how Cloudflare manages two conn
 ```mermaid
 flowchart LR
     accTitle: SSL/TLS Encryption mode
-    A[Browser] <--Connection 1--> B((Cloudflare))<--Connection 2--> C[(Origin server)]
+    A[Visitor] <--Connection 1--> B((Cloudflare))<--Connection 2--> C[(Origin server)]
 ```


### PR DESCRIPTION
### Summary

Update encryption mode pages to use 'Visitor' instead of 'Browser', since not all TLS clients connecting to Cloudflare are browsers. 'Visitor' is the more general term we use elsewhere in the docs.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
