### PR TITLE
[R2] Document read-only API tokens for Data Catalog

### DIFF
--- a/src/content/changelog/r2/2026-07-09-r2-data-catalog-read-only-tokens.mdx
+++ b/src/content/changelog/r2/2026-07-09-r2-data-catalog-read-only-tokens.mdx
@@ -3,7 +3,7 @@ title: R2 Data Catalog now supports read-only API tokens
 description: Connect query engines to R2 Data Catalog using read-only API tokens
 products:
   - r2
-date: 2026-07-09
+date: 2026-07-13
 ---
 
 [R2 Data Catalog](/r2/data-catalog/) now accepts read-only API tokens, so query engines and clients that only read data no longer need a read-write token. Previously, every catalog operation required an **Admin Read & Write** token, which meant read-only clients were granted more access than they needed.

--- a/src/content/changelog/r2/2026-07-09-r2-data-catalog-read-only-tokens.mdx
+++ b/src/content/changelog/r2/2026-07-09-r2-data-catalog-read-only-tokens.mdx
@@ -1,0 +1,20 @@
+---
+title: R2 Data Catalog now supports read-only API tokens
+description: Connect query engines to R2 Data Catalog using read-only API tokens
+products:
+  - r2
+date: 2026-07-09
+---
+
+[R2 Data Catalog](/r2/data-catalog/) now accepts read-only API tokens, so query engines and clients that only read data no longer need a read-write token. Previously, every catalog operation required an **Admin Read & Write** token, which meant read-only clients were granted more access than they needed.
+
+You can now authenticate your Iceberg engine based on your workload:
+
+- **Read-only** operations (such as listing namespaces, loading tables, and querying data) work with an **Admin Read only** token (R2 Data Catalog read and R2 storage read).
+- **Write** operations (such as creating or dropping tables and committing transactions) continue to require an **Admin Read & Write** token.
+
+This lets you follow the principle of least privilege — for example, using a read-write token for the pipeline that writes to your tables and read-only tokens for engines like [R2 SQL](/r2-sql/), [DuckDB](/r2/data-catalog/config-examples/duckdb/), or [PyIceberg](/r2/data-catalog/config-examples/pyiceberg/) that query them.
+
+Note that credentials vended by the catalog inherit the R2 storage permissions of the token used to authenticate. To ensure read-only access to your underlying data, scope the R2 storage permission to read-only as well.
+
+For details on choosing and creating the right token, refer to [Authenticate your Iceberg engine](/r2/data-catalog/manage-catalogs/#authenticate-your-iceberg-engine).

--- a/src/content/docs/r2/api/tokens.mdx
+++ b/src/content/docs/r2/api/tokens.mdx
@@ -66,7 +66,7 @@ Jurisdictional buckets can only be accessed via the corresponding jurisdictional
 
 :::note[Considerations]
 
-- Currently **Admin Read & Write** or **Admin Read only** permission is required to use [R2 Data Catalog](/r2/data-catalog/).
+- [R2 Data Catalog](/r2/data-catalog/) requires an **Admin Read & Write** or **Admin Read only** permission. Read-only catalog operations (such as listing namespaces, loading tables, and querying data) work with **Admin Read only**, while write operations (such as creating or dropping tables and committing transactions) require **Admin Read & Write**. For details, refer to [Authenticate your Iceberg engine](/r2/data-catalog/manage-catalogs/#authenticate-your-iceberg-engine).
 - The **Object Read & Write** and **Object Read only** permissions are only supported by the [S3-compatible API](/r2/api/s3/api/), not the [Cloudflare REST API](/api/resources/r2/).
 :::
 ## Create API tokens via API

--- a/src/content/docs/r2/data-catalog/get-started.mdx
+++ b/src/content/docs/r2/data-catalog/get-started.mdx
@@ -91,7 +91,7 @@ Iceberg clients (including [PyIceberg](https://py.iceberg.apache.org/)) must aut
 
 4. Select the **R2 Token** text to edit your API token name.
 
-5. Under **Permissions**, choose the **Admin Read & Write** permission.
+5. Under **Permissions**, choose the **Admin Read & Write** permission. This guide creates and writes to tables, so it requires read and write access. For query-only clients, you can instead use an **Admin Read only** token. For details on choosing the right permission level, refer to [Authenticate your Iceberg engine](/r2/data-catalog/manage-catalogs/#authenticate-your-iceberg-engine).
 
 6. Select **Create API Token**.
 

--- a/src/content/docs/r2/data-catalog/manage-catalogs.mdx
+++ b/src/content/docs/r2/data-catalog/manage-catalogs.mdx
@@ -253,12 +253,25 @@ npx wrangler r2 bucket catalog snapshot-expiration disable <BUCKET_NAME> <NAMESP
 
 To connect your Iceberg engine to R2 Data Catalog, you must provide a Cloudflare API token with **both** R2 Data Catalog permissions and R2 storage permissions. Iceberg engines interact with R2 Data Catalog to perform table operations. The catalog also provides engines with SigV4 credentials, which are required to access the underlying data files stored in R2.
 
+R2 Data Catalog supports both read-only and read-write tokens:
+
+- **Read-only** operations (for example, listing namespaces, loading tables, and querying data) require a token with read access to R2 Data Catalog and R2 storage.
+- **Write** operations (for example, creating or dropping tables and committing transactions) require a token with read and write access to R2 Data Catalog and R2 storage.
+
+Use a read-only token for query engines and clients that only read data (such as R2 SQL, DuckDB, or PyIceberg readers), and a read-write token for engines and pipelines that create tables or write data.
+
+:::note[Vended credentials inherit your token's R2 storage permissions]
+
+When an engine loads credentials from the catalog, R2 Data Catalog returns SigV4 credentials that inherit the R2 storage permissions of the API token used to authenticate. A token with read-only R2 Data Catalog access but read-write R2 storage access can still be used to write objects (including catalog metadata files) to the underlying bucket. To ensure read-only access to your data, scope the R2 storage permission to read-only as well.
+
+:::
+
 ### Create API token in the dashboard
 
-Create an [R2 API token](/r2/api/tokens/#permissions) with **Admin Read & Write** permissions. These permissions include both:
+Create an [R2 API token](/r2/api/tokens/#permissions) with the permissions matching your workload:
 
-- Access to R2 Data Catalog (read/write)
-- Access to R2 storage (read/write)
+- **Admin Read & Write** — for engines and pipelines that read and write data. Includes read and write access to both R2 Data Catalog and R2 storage.
+- **Admin Read only** — for query engines and clients that only read data. Includes read access to both R2 Data Catalog and R2 storage.
 
 Providing the resulting token value to your Iceberg engine gives it the ability to manage catalog metadata and handle data operations (reads or writes to R2).
 
@@ -266,7 +279,9 @@ Providing the resulting token value to your Iceberg engine gives it the ability 
 
 To create an API token programmatically for use with R2 Data Catalog, you need to specify both R2 Data Catalog and R2 storage permission groups in your [Access Policy](/r2/api/tokens/#access-policy).
 
-#### Example Access Policy
+#### Example read-write Access Policy
+
+Use read and write permission groups for engines and pipelines that create tables or write data:
 
 ```json
 [
@@ -285,6 +300,33 @@ To create an API token programmatically for use with R2 Data Catalog, you need t
 			{
 				"id": "2efd5506f9c8494dacb1fa10a3e7d5b6",
 				"name": "Workers R2 Storage Bucket Item Write"
+			}
+		]
+	}
+]
+```
+
+#### Example read-only Access Policy
+
+Use read permission groups for query engines and clients that only read data:
+
+```json
+[
+	{
+		"id": "f267e341f3dd4697bd3b9f71dd96247f",
+		"effect": "allow",
+		"resources": {
+			"com.cloudflare.edge.r2.bucket.4793d734c0b8e484dfc37ec392b5fa8a_default_my-bucket": "*",
+			"com.cloudflare.edge.r2.bucket.4793d734c0b8e484dfc37ec392b5fa8a_eu_my-eu-bucket": "*"
+		},
+		"permission_groups": [
+			{
+				"id": "45db74139a62490b9b60eb7c4f34994b",
+				"name": "Workers R2 Data Catalog Read"
+			},
+			{
+				"id": "6a018a9f2fc74eb6b293b0c548f38b39",
+				"name": "Workers R2 Storage Bucket Item Read"
 			}
 		]
 	}


### PR DESCRIPTION
### Summary

Documents read-only API token support for R2 Data Catalog, now that read-only tokens are accepted for all accounts.

- Rewrote **Authenticate your Iceberg engine** to cover read-only vs. read-write tokens, when to use each, and added a read-only example Access Policy
- Added a note that vended credentials inherit the token's R2 storage permissions (scope storage to read-only for read-only data access)
- Clarified the R2 API tokens **Considerations** note: **Admin Read only** works for read operations, **Admin Read & Write** required for writes
- Updated the Data Catalog get-started guide to mention **Admin Read only** as an option for query-only clients
- Added a changelog entry

### Documentation checklist

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
