### PR TITLE
docs(bots): warn that blocking /cdn-cgi paths degrades JS Detection

### DIFF
--- a/src/content/docs/cloudflare-challenges/challenge-types/javascript-detections.mdx
+++ b/src/content/docs/cloudflare-challenges/challenge-types/javascript-detections.mdx
@@ -172,3 +172,12 @@ Enabling JavaScript Detections (JSD) will strip [ETags](/cache/reference/etag-he
 If the origin response includes a `Cache-Control: no-transform` directive, Cloudflare does not inject the JavaScript Detections script. The `cf.bot_management.js_detection.passed` field will show as `missing` for these requests.
 
 To use JavaScript Detections, remove the `no-transform` directive from `Cache-Control` response headers on pages where you want JavaScript Detections to run. For more information, refer to [Cache-Control directives](/cache/concepts/cache-control/#interaction-with-other-cloudflare-features).
+
+### If you block `/cdn-cgi/` paths
+
+:::caution
+
+Blocking requests to `/cdn-cgi/challenge-platform/` or `/cdn-cgi/rum` — via WAF custom rules, firewall rules, or origin-level configuration — will silently degrade JavaScript Detection accuracy. No error is surfaced to the visitor; the script simply fails to execute, and `cf.bot_management.js_detection.passed` will return `false` for all affected requests.
+
+Ensure these paths are reachable from the visitor's browser. If you have WAF rules that match broadly on `/cdn-cgi/` prefixes, add an exception for these two paths.
+:::


### PR DESCRIPTION
## What

Adds a warning callout under the **Limitations** section of the JavaScript Detections page explaining that blocking `/cdn-cgi/challenge-platform/` or `/cdn-cgi/rum` silently degrades JS Detection accuracy.

## Why

Customers who apply broad WAF or firewall rules matching `/cdn-cgi/` paths can inadvertently prevent the JavaScript Detections script from executing. When this happens, `cf.bot_management.js_detection.passed` returns `false` for all affected requests with no visible error to the visitor, leading to unexpected bot score behavior and misfire of enforcement rules.

## Files changed

- `src/content/docs/cloudflare-challenges/challenge-types/javascript-detections.mdx` — new `### If you block /cdn-cgi/ paths` section with a caution callout

## How to verify

Navigate to [/cloudflare-challenges/challenge-types/javascript-detections/](https://developers.cloudflare.com/cloudflare-challenges/challenge-types/javascript-detections/) and confirm the new caution block appears at the bottom of the Limitations section.

Closes DEE-3693