### PR TITLE
docs(bots): note that JSD API invocations show as Unknown in Bot Analytics

### DIFF
--- a/src/content/docs/cloudflare-challenges/challenge-types/javascript-detections.mdx
+++ b/src/content/docs/cloudflare-challenges/challenge-types/javascript-detections.mdx
@@ -140,6 +140,10 @@ function jsdOnload(){
 `result` = `success` or `error` only refers to the execution of JavaScript Detections. It does not indicate whether a visitor is a human or a bot.
 :::
 
+:::note
+When JavaScript Detections is invoked via the API rather than the zone-wide toggle, the result may appear as **Unknown** in Bot Analytics. This is a known limitation. The underlying signal is still factored into bot scoring.
+:::
+
 ## Considerations
 
 JavaScript Detections does not guarantee a specific bot score.


### PR DESCRIPTION
## What

Adds a note under the **API** section of the JavaScript Detections page explaining that when JSD is invoked via the JavaScript API, results may appear as **Unknown** in Bot Analytics.

## Why

Customers using the JSD API for selective page injection sometimes report seeing "Unknown" in Bot Analytics and assume detection is broken. The underlying signal is still factored into bot scoring — the "Unknown" label is a display limitation, not a functional one. Without this note, customers open support cases or disable JSD unnecessarily.

## Files changed

- `src/content/docs/cloudflare-challenges/challenge-types/javascript-detections.mdx` — new note block after the existing API section note (+4 lines)

## How to verify

Navigate to [/cloudflare-challenges/challenge-types/javascript-detections/#api](https://developers.cloudflare.com/cloudflare-challenges/challenge-types/javascript-detections/#api) and confirm the new note appears after the existing result note.

Closes DEE-3694