### PR TITLE
docs(bots): add ephemeral_id availability and entitlement to Bot Management variables

### DIFF
--- a/src/content/docs/bots/reference/bot-management-variables.mdx
+++ b/src/content/docs/bots/reference/bot-management-variables.mdx
@@ -6,21 +6,21 @@ products:
   - bots
 sidebar:
   order: 2
-
 ---
 
-import { Render } from "~/components"
+import { Render } from "~/components";
 
 ## Ruleset Engine fields
 
 Bot Management provides access to several [new variables](/ruleset-engine/rules-language/fields/reference/?field-category=Bots) within the expression builder of Ruleset Engine-based products such as [WAF custom rules](/waf/custom-rules/).
 
 - **Bot Score** (`cf.bot_management.score`): An integer between 1-99 that indicates [Cloudflare's level of certainty](/bots/concepts/bot-score/) that a request comes from a bot.
-- **Verified Bot** (`cf.bot_management.verified_bot`): A boolean value that indicates whether a request originates from a Cloudflare allowed bot. 
-  
-  Cloudflare maintains a large allowlist of good, automated bots (such as Google Search Engine and Pingdom) that perform beneficial tasks. Cloudflare identifies and verifies these bots primarily through reverse DNS validation, ensuring the source IP matches the requesting service. 
-  
+- **Verified Bot** (`cf.bot_management.verified_bot`): A boolean value that indicates whether a request originates from a Cloudflare allowed bot.
+
+  Cloudflare maintains a large allowlist of good, automated bots (such as Google Search Engine and Pingdom) that perform beneficial tasks. Cloudflare identifies and verifies these bots primarily through reverse DNS validation, ensuring the source IP matches the requesting service.
+
   We also use additional validation methods, including checking ASN blocks and public lists. If these methods are unavailable, Cloudflare utilizes internal data and machine learning to identify and verify legitimate IP addresses from good bots. Most customers choose to [allow this traffic](/ruleset-engine/rules-language/fields/reference/cf.bot_management.verified_bot/).
+
 - **Serves Static Resource** (`cf.bot_management.static_resource`): An identifier that matches [file extensions](/bots/additional-configurations/static-resources/) for many types of static resources. Use this variable if you send emails that retrieve static images.
 - **ja3Hash** (`cf.bot_management.ja3_hash`) and **ja4** (`cf.bot_management.ja4`): A [**JA3/JA4 fingerprint**](/bots/additional-configurations/ja3-ja4-fingerprint/) helps you profile specific SSL/TLS clients across different destination IPs, Ports, and X509 certificates.
 - **Bot Detection IDs** (`cf.bot_management.detection_ids`): List of IDs that correlate to the Bot Management heuristic detections made on a request (you can have multiple heuristic detections on the same request).
@@ -68,3 +68,13 @@ Once you enable Bot Management, Cloudflare also surfaces bot information in its 
 - BotScore
 - BotScoreSrc
 - BotTags
+
+## Ephemeral IDs
+
+[Ephemeral IDs](/turnstile/additional-configuration/ephemeral-id/) are short-lived device identifiers returned in the [Turnstile Siteverify API](/turnstile/get-started/server-side-validation/) response under `metadata.ephemeral_id`. They are not Ruleset Engine fields and cannot be used in WAF custom rules or Workers directly.
+
+:::note
+Ephemeral IDs require **Enterprise Bot Management** with the Turnstile Enterprise add-on, or a standalone **Enterprise Turnstile** subscription. The feature must be enabled by your Cloudflare account team and cannot be self-activated.
+:::
+
+Refer to [Ephemeral IDs](/turnstile/additional-configuration/ephemeral-id/) for implementation details and the full enablement process.


### PR DESCRIPTION
## What

Adds an **Ephemeral IDs** section to the Bot Management variables reference page, cross-linking to the existing Turnstile ephemeral ID docs.

## Why

The Bot Management variables page documents all Ruleset Engine fields and Workers variables, but has no mention of `ephemeral_id`. Customers with Enterprise Bot Management who encounter `metadata.ephemeral_id` in their Turnstile Siteverify API responses have no path from the bots reference docs to understand the field, its subscription requirements, or how to enable it.

The new section clarifies:
- `ephemeral_id` is returned in the Siteverify API response, not a WAF or Workers field
- Requires Enterprise Bot Management + Turnstile Enterprise add-on, or standalone Enterprise Turnstile
- Must be enabled by the account team — cannot be self-activated

## Files changed

- `src/content/docs/bots/reference/bot-management-variables.mdx` — new `## Ephemeral IDs` section (+10 lines)

## How to verify

Navigate to [/bots/reference/bot-management-variables/](https://developers.cloudflare.com/bots/reference/bot-management-variables/) and confirm the Ephemeral IDs section appears at the bottom with correct links to the Turnstile ephemeral ID page.

Closes DEE-3695