### PR TITLE
docs(bots): document JA3/JA4 unavailability on O2O traffic

### DIFF
--- a/src/content/docs/bots/additional-configurations/ja3-ja4-fingerprint/index.mdx
+++ b/src/content/docs/bots/additional-configurations/ja3-ja4-fingerprint/index.mdx
@@ -111,3 +111,11 @@ JA3 may also be useful if you want to immediately remedy false positives or fals
 Often, mobile application traffic will produce the same JA3 fingerprint across devices and users. This means you can identify your mobile application traffic by its JA3 fingerprint.
 
 Use the JA3 fingerprint to [allow traffic](/waf/custom-rules/use-cases/challenge-bad-bots/#adjust-for-mobile-traffic) from your mobile application, but block or challenge remaining traffic.
+
+## Limitations
+
+### Orange-to-orange (O2O) traffic
+
+When traffic routes through an O2O setup — where one Cloudflare zone proxies requests to another — JA3 and JA4 fingerprints may be unavailable. Cloudflare sees only the inner Cloudflare-to-Cloudflare TLS session on the receiving zone, not the original client handshake, so no fingerprint can be derived.
+
+If you rely on JA3/JA4 for bot detection on zones that receive O2O traffic, use `cf.bot_management.verified_bot`, `cf.bot_management.score`, or other bot fields that do not depend on the TLS handshake.


### PR DESCRIPTION
## What

Adds a **Limitations** section to the JA3/JA4 fingerprint page with a subsection explaining that fingerprints are unavailable on orange-to-orange (O2O) traffic, and recommending alternative bot fields.

## Why

When a Cloudflare zone proxies requests to another Cloudflare zone via O2O, the receiving zone sees only the inner Cloudflare-to-Cloudflare TLS session — not the original client handshake — so no JA3/JA4 fingerprint can be derived. Customers using JA3/JA4-based bot rules on O2O-receiving zones see missing fingerprints with no explanation in the docs, leading to confusion and support escalations.

## Files changed

- `src/content/docs/bots/additional-configurations/ja3-ja4-fingerprint/index.mdx` — new `## Limitations` section with O2O subsection (+9 lines)

## How to verify

Navigate to [/bots/additional-configurations/ja3-ja4-fingerprint/](https://developers.cloudflare.com/bots/additional-configurations/ja3-ja4-fingerprint/) and confirm the Limitations section appears at the bottom with the O2O explanation and alternative field recommendations.

Closes DEE-3696