### PR TITLE
docs(bots): clarify JA4 Signals Intelligence fields cannot be used in WAF rules

### DIFF
--- a/src/content/docs/bots/additional-configurations/ja3-ja4-fingerprint/signals-intelligence.mdx
+++ b/src/content/docs/bots/additional-configurations/ja3-ja4-fingerprint/signals-intelligence.mdx
@@ -40,3 +40,7 @@ Signals Intelligence fields show observations about a particular JA4 that Cloudf
 | `ips_quantile_1h`                         | The quantile position of the JA4 fingerprint based on the number of unique client IP addresses across all fingerprints in the last hour. Higher values indicate a relatively higher number of distinct client IPs compared to other fingerprints. |
 
 <Render file="signals-intelligence-and-ja4" product="bots" />
+
+:::note
+Signals Intelligence fields are available for analysis in [Security Analytics](/waf/analytics/security-analytics/) and [Security Events](/waf/analytics/security-events/). They cannot be used as filter fields in WAF custom rule expressions.
+:::


### PR DESCRIPTION
## What

Adds a note at the bottom of the Signals Intelligence page clarifying that these fields are analytics-only — available in Security Analytics and Security Events, but not usable as filter fields in WAF custom rule expressions.

## Why

Customers browsing the Signals Intelligence field reference assume these fields can be used in WAF custom rules (as other `cf.bot_management.*` fields can). When they cannot find them in the rule builder, they open support cases. The note sets the expectation clearly at the point of discovery.

## Files changed

- `src/content/docs/bots/additional-configurations/ja3-ja4-fingerprint/signals-intelligence.mdx` — new note block after the field table and render (+4 lines)

## How to verify

Navigate to [/bots/additional-configurations/ja3-ja4-fingerprint/signals-intelligence/](https://developers.cloudflare.com/bots/additional-configurations/ja3-ja4-fingerprint/signals-intelligence/) and confirm the note appears at the bottom of the page.

Closes DEE-3697