### PR TITLE
docs(waf): note that beta tag may persist beyond the 7-day review period

### DIFF
--- a/src/content/docs/waf/change-log/index.mdx
+++ b/src/content/docs/waf/change-log/index.mdx
@@ -37,6 +37,10 @@ New and updated rules follow a seven-day release cycle, typically on Monday or T
 
 **Week 2 — Default action:** On the following release day, the rules change from the _Log_ action to their intended default action (shown in the **New Action** column of the changelog table). The `beta` and `new` tags are removed.
 
+:::note
+In some cases, the `beta` tag may persist beyond the standard seven-day review period — for example, when a rule is replacing an older deprecated rule that has not yet been retired. Use the `last_updated` field in the changelog to understand when a rule was last modified, rather than relying on the `beta` tag alone to infer its lifecycle stage.
+:::
+
 For updates to existing rules, Cloudflare first deploys the updated version as a separate `BETA` rule (noted in the rule description) with a `beta` tag, before updating the original rule on the next release cycle.
 
 ### Disabled rules


### PR DESCRIPTION
## What

Adds a note in the Release cycle section of the WAF changelog page clarifying that the `beta` tag may persist beyond the standard seven-day review period in certain scenarios, and advising customers to use `last_updated` to understand a rule's actual modification history.

## Why

The current docs present the 7-day beta-to-GA cycle as absolute. In practice, replacement rules pending the deprecation of an older rule can carry the `beta` tag for significantly longer. Customers who find rules tagged `beta` with `action=block` and old `last_updated` timestamps have no public explanation for this behavior, leading to confusion and support escalations.

## Files changed

- `src/content/docs/waf/change-log/index.mdx` — note block after the Week 2 paragraph in the Release cycle section (+4 lines)

## How to verify

Navigate to [/waf/change-log/](https://developers.cloudflare.com/waf/change-log/) and confirm the note appears between the Week 2 paragraph and the "For updates to existing rules" paragraph.

Closes DEE-3698