### PR TITLE
docs(client-side-security): note that blocked scripts remain visible until 30-day retention expires

### DIFF
--- a/src/content/docs/client-side-security/detection/monitor-connections-scripts.mdx
+++ b/src/content/docs/client-side-security/detection/monitor-connections-scripts.mdx
@@ -72,6 +72,10 @@ To review the resources detected by Cloudflare:
 
 The All Reported Connections and All Reported Scripts dashboards show all the detected resources including infrequent or inactive ones, reported in the last 30 days. After 30 days without any report, Cloudflare will delete information about a previously reported resource, and it will no longer appear in any of the dashboards.
 
+:::note
+Scripts blocked by a [content security rule](/client-side-security/rules/) continue to appear in your monitored scripts list for as long as the browser keeps loading them. A blocked script is only removed after it has not been detected for 30 consecutive days.
+:::
+
 <Steps>
 	1. Go to the client-side resources page:
 


### PR DESCRIPTION
## What

Adds a note after the existing 30-day retention paragraph on the monitored scripts page, clarifying that scripts blocked by a content security rule continue to appear in the monitored list until they have not been detected for 30 consecutive days.

## Why

Customers who create a content security rule to block a script expect it to disappear from the monitored scripts list immediately. When it does not, they assume the rule is not working and open support cases. The 30-day retention window is already documented for inactive scripts, but not explicitly for actively blocked ones.

## Files changed

- `src/content/docs/client-side-security/detection/monitor-connections-scripts.mdx` — note block after the 30-day retention sentence (+4 lines)

## How to verify

Navigate to [/client-side-security/detection/monitor-connections-scripts/](https://developers.cloudflare.com/client-side-security/detection/monitor-connections-scripts/) and confirm the note appears directly after the paragraph describing the 30-day retention window.

Closes DEE-3699