### PR TITLE
[Durable Objects] Document restriction on new key-value backed namespaces

### DIFF
--- a/src/content/changelog/durable-objects/2026-07-09-restrict-new-kv-backed-namespaces.mdx
+++ b/src/content/changelog/durable-objects/2026-07-09-restrict-new-kv-backed-namespaces.mdx
@@ -1,0 +1,36 @@
+---
+title: New Durable Object namespaces must use the SQLite storage backend
+description: Accounts without an existing key-value backed Durable Object namespace can no longer create new ones and should use the SQLite storage backend instead.
+products:
+  - durable-objects
+  - workers
+date: 2026-07-09
+---
+
+import { WranglerConfig } from "~/components";
+
+If your account does not already have a key-value (KV) backed Durable Object namespace, you can no longer create new ones. New Durable Object namespaces must use the [SQLite storage backend](/durable-objects/best-practices/access-durable-objects-storage/#create-sqlite-backed-durable-object-class), which has been recommended for all new Durable Objects since it became [generally available](https://blog.cloudflare.com/sqlite-in-durable-objects/).
+
+Create a new class with a `new_sqlite_classes` migration:
+
+<WranglerConfig>
+
+```toml
+[[migrations]]
+tag = "v1"
+new_sqlite_classes = ["MyDurableObject"]
+```
+
+</WranglerConfig>
+
+SQLite-backed Durable Objects have feature parity with the key-value backend — including the [key-value storage API](/durable-objects/api/sqlite-storage-api/#synchronous-kv-api) — and additionally support relational [SQL queries](/durable-objects/api/sqlite-storage-api/#sql-api) and [point-in-time recovery](/durable-objects/api/sqlite-storage-api/#pitr-point-in-time-recovery-api) to restore an object's storage to any point in the past 30 days.
+
+If you attempt to create a new key-value backed namespace (a `new_classes` migration) on an affected account, the deployment fails with the following error:
+
+```txt
+Creating new key-value backed Durable Object namespaces is no longer supported on this account. Please create a namespace using a `new_sqlite_classes` migration instead.
+```
+
+This change only affects accounts that are not already using the key-value storage backend. Accounts with at least one existing key-value backed namespace can still create new ones for now, and the Workers Free plan has only ever supported SQLite-backed Durable Objects. It is part of a broader move toward SQLite as the single storage backend for Durable Objects, ahead of a future migration path for existing key-value backed objects.
+
+For more information, refer to [Durable Objects migrations](/durable-objects/reference/durable-objects-migrations/).

--- a/src/content/changelog/durable-objects/2026-07-09-restrict-new-kv-backed-namespaces.mdx
+++ b/src/content/changelog/durable-objects/2026-07-09-restrict-new-kv-backed-namespaces.mdx
@@ -9,7 +9,7 @@ date: 2026-07-09
 
 import { WranglerConfig } from "~/components";
 
-If your account does not already have a key-value (KV) backed Durable Object namespace, you can no longer create new ones. New Durable Object namespaces must use the [SQLite storage backend](/durable-objects/best-practices/access-durable-objects-storage/#create-sqlite-backed-durable-object-class), which has been recommended for all new Durable Objects since it became [generally available](https://blog.cloudflare.com/sqlite-in-durable-objects/).
+If your account does not already have a key-value (KV) backed Durable Object namespace, you can no longer create new ones. New Durable Object namespaces must use the [SQLite storage backend](/durable-objects/best-practices/access-durable-objects-storage/#create-sqlite-backed-durable-object-class), which has been recommended for all new Durable Objects since it became [generally available](https://blog.cloudflare.com/sqlite-in-durable-objects/) in 2024.
 
 Create a new class with a `new_sqlite_classes` migration:
 

--- a/src/content/docs/durable-objects/reference/durable-objects-migrations.mdx
+++ b/src/content/docs/durable-objects/reference/durable-objects-migrations.mdx
@@ -104,6 +104,10 @@ To create a new Durable Object binding `DURABLE_OBJECT_A`, your Wrangler configu
 
 <Render file="recommend-sqlite-do" product="durable-objects" />
 
+:::caution[New key-value backed namespaces are restricted]
+Creating a new key-value backed Durable Object namespace is only available to accounts that already have at least one key-value backed namespace. If your account does not, you must [create a SQLite-backed Durable Object class](#create-migration) with `new_sqlite_classes` instead.
+:::
+
 Use `new_classes` on the migration in your Worker's Wrangler file to create a Durable Object class with the key-value storage backend:
 
 <WranglerConfig>
@@ -188,6 +192,7 @@ To delete a Durable Object binding `DEPRECATED_OBJECT`, your Wrangler configurat
 }
 ```
 </WranglerConfig>
+
 </Details>
 
 ## Rename migration
@@ -401,7 +406,7 @@ You can transfer stored Durable Objects from `DurableObjectExample` to `Transfer
 - After a Rename or Transfer migration, requests to the destination Durable Object class will have access to the source Durable Object's stored data.
 
 - After a migration, any existing bindings to the original Durable Object class (for example, from other Workers) will automatically forward to the updated destination class. However, any Workers bound to the updated Durable Object class must update their Durable Object binding configuration in the `wrangler` configuration file for their next deployment.
-:::
+  :::
 
 :::note
 Note that `.toml` files do not allow line breaks in inline tables (the `{key = "value"}` syntax), but line breaks in the surrounding inline array are acceptable.

--- a/src/content/partials/durable-objects/do-plans-note.mdx
+++ b/src/content/partials/durable-objects/do-plans-note.mdx
@@ -6,7 +6,7 @@
 Durable Objects are available both on Workers Free and Workers Paid plans.
 
 - **Workers Free plan**: Only Durable Objects with [SQLite storage backend](/durable-objects/reference/durable-objects-migrations/#create-migration) are available.
-- **Workers Paid plan**: Durable Objects with either SQLite storage backend or [key-value storage backend](/durable-objects/reference/durable-objects-migrations/#create-durable-object-class-with-key-value-storage) are available.
+- **Workers Paid plan**: Durable Objects with the SQLite storage backend are available. The [key-value storage backend](/durable-objects/reference/durable-objects-migrations/#create-durable-object-class-with-key-value-storage) is only available to accounts that already have a key-value backed namespace.
 
 If you wish to downgrade from a Workers Paid plan to a Workers Free plan, you must first ensure that you have deleted all Durable Object namespaces with the key-value storage backend.
 :::

--- a/src/content/partials/durable-objects/recommend-sqlite-do.mdx
+++ b/src/content/partials/durable-objects/recommend-sqlite-do.mdx
@@ -7,5 +7,5 @@ Cloudflare recommends all new Durable Object namespaces use the [SQLite storage 
 
 Additionally, SQLite-backed Durable Objects allow you to store more types of data (such as tables), and offer Point In Time Recovery API which can restore a Durable Object's embedded SQLite database contents (both SQL data and key-value data) to any point in the past 30 days.
 
-The [key-value storage backend](/durable-objects/reference/durable-objects-migrations/#create-durable-object-class-with-key-value-storage) remains for backwards compatibility, and a migration path from KV storage backend to SQLite storage backend for existing Durable Object namespaces will be available in the future.
+Creating new [key-value storage backend](/durable-objects/reference/durable-objects-migrations/#create-durable-object-class-with-key-value-storage) namespaces is no longer supported for accounts without an existing key-value backed namespace. The key-value storage backend remains available for existing namespaces, and a migration path from the key-value storage backend to the SQLite storage backend will be available in the future.
 :::

--- a/src/content/partials/durable-objects/recommend-sqlite-do.mdx
+++ b/src/content/partials/durable-objects/recommend-sqlite-do.mdx
@@ -7,5 +7,5 @@ Cloudflare recommends all new Durable Object namespaces use the [SQLite storage 
 
 Additionally, SQLite-backed Durable Objects allow you to store more types of data (such as tables), and offer Point In Time Recovery API which can restore a Durable Object's embedded SQLite database contents (both SQL data and key-value data) to any point in the past 30 days.
 
-Creating new [key-value storage backend](/durable-objects/reference/durable-objects-migrations/#create-durable-object-class-with-key-value-storage) namespaces is no longer supported for accounts without an existing key-value backed namespace. The key-value storage backend remains available for existing namespaces, and a migration path from the key-value storage backend to the SQLite storage backend will be available in the future.
+Creating new namespaces with the [key-value storage backend](/durable-objects/reference/durable-objects-migrations/#create-durable-object-class-with-key-value-storage) is no longer supported for accounts without an existing key-value backed namespace. The key-value storage backend remains available for existing namespaces, and a migration path from the key-value storage backend to the SQLite storage backend will be available in the future.
 :::


### PR DESCRIPTION
### Summary

Documents that new key-value (KV) backed Durable Object namespaces can no longer be created by accounts that do not already have one — new namespaces must use the SQLite storage backend. Adds a changelog entry announcing the change and updates the supporting reference docs so they stay consistent:

- **New changelog entry** — `changelog/durable-objects/2026-07-09-restrict-new-kv-backed-namespaces.mdx`
- **Migrations reference** — adds a caution to the "Create Durable Object class with key-value storage" section
- **Shared partials** (`recommend-sqlite-do`, `do-plans-note`) — clarify that new KV-backed namespace creation is limited to accounts that already have one

Accounts with at least one existing KV-backed namespace are unaffected, and the Workers Free plan has always been SQLite-only. Related docs: [Durable Objects migrations](https://developers.cloudflare.com/durable-objects/reference/durable-objects-migrations/).

### Documentation checklist

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
