### PR TITLE
Warn that .dev.vars.example entries become deployed secrets (Deploy button)

### DIFF
--- a/src/content/docs/workers/platform/deploy-buttons.mdx
+++ b/src/content/docs/workers/platform/deploy-buttons.mdx
@@ -89,6 +89,10 @@ Cloudflare will read the Wrangler configuration file of your source repo to dete
 COOKIE_SIGNING_KEY=my-secret # comment
 ```
 
+:::caution
+Every uncommented entry in your `.dev.vars.example` (or `.env.example`) is presented to the user as a required secret during deployment and stored on the deployed Worker. Treat this file as your project's setup prompt, not a local development scratchpad: only include the secrets a first deployment genuinely needs, comment out optional integrations users can add later, and never include local-only values (such as auth-bypass flags or `localhost` URLs) that would be unsafe in production.
+:::
+
 [Secrets Store](/secrets-store/) secrets can be configured in the Wrangler configuration file as normal:
 
 <WranglerConfig>


### PR DESCRIPTION
### Summary

Adds a caution callout to the [Deploy to Cloudflare buttons](https://developers.cloudflare.com/workers/platform/deploy-buttons/) page, in the "Worker environment variables and secrets" section, warning that every uncommented entry in `.dev.vars.example` (or `.env.example`) is presented as a required secret during deployment and stored on the deployed Worker.

The page documents *that* secrets come from `.dev.vars.example`, but not the consequence. That file is conventionally a local-development template. Nothing reads it directly; developers copy it to a gitignored `.dev.vars` and edit the copy. So authors pre-fill it with dev-friendly values and can unknowingly ship them to production. In my case this deployed an auth-bypass flag and `localhost` URLs to every one-click deployment of my app. Writeup: https://daniel-yang.com/writing/cloudflare-deploy-button-disabled-auth/

Closes #31988.

### Documentation checklist

- [ ] ~Changelog entry~ — N/A (documentation clarification, not a product change)
- [x] The change adheres to the documentation style guide.
- [x] A related issue (#31988) has been opened.
- [ ] ~Redirects~ — N/A (no files renamed or moved)