### PR TITLE
[RealtimeKit] correct iOS release date

### DIFF
--- a/src/content/release-notes/realtimekit-ios-ui-kit.yaml
+++ b/src/content/release-notes/realtimekit-ios-ui-kit.yaml
@@ -3,7 +3,7 @@ link: "/realtime/realtimekit/release-notes/ios-ui-kit/"
 productName: RealtimeKit iOS UI Kit
 productLink: "/realtime/realtimekit/"
 entries:
-  - publish_date: "2026-06-24"
+  - publish_date: "2026-06-30"
     title: RealtimeKit iOS UI Kit 2.0.0
     description: |-
       **Breaking changes**


### PR DESCRIPTION
The tentative timeline of 24-06 was missed due to build issues and the release only went out on 30-06
