### PR TITLE
docs(dns): update DNS Firewall docs for new dashboard UX

### DIFF
--- a/src/content/docs/dns/dns-firewall/faq.mdx
+++ b/src/content/docs/dns/dns-firewall/faq.mdx
@@ -30,7 +30,7 @@ As long as there is enough allocated memory, Cloudflare does not clear items fro
 
 ## Does the DNS Firewall cache SERVFAIL?
 
-Yes. `SERVFAIL` is treated like any other negative answer for caching purposes. The default TTL is 30 seconds. You can use the [API](/api/resources/dns_firewall/methods/edit/) to set a different `negative_cache_ttl`.
+Yes. `SERVFAIL` is treated like any other negative answer for caching purposes. The default TTL is 30 seconds. You can set a different negative cache TTL on your cluster in the Cloudflare dashboard, or via the [API](/api/resources/dns_firewall/methods/edit/) (`negative_cache_ttl` parameter).
 
 ## Does DNS Firewall support EDNS Client Subnet (ECS)?
 
@@ -49,11 +49,11 @@ EDNS limits the effectiveness of the DNS cache.
 
 :::
 
-Some resolvers might not be sending any EDNS data. When you set the `ecs_fallback` parameter to `true` via the [API](/api/resources/dns_firewall/methods/edit/), DNS Firewall will forward the IP subnet of the resolver instead only if there is no EDNS data present in incoming the DNS query.
+Some resolvers might not be sending any EDNS data. When you enable ECS fallback on your cluster in the Cloudflare dashboard — or set the `ecs_fallback` parameter to `true` via the [API](/api/resources/dns_firewall/methods/edit/) — DNS Firewall will forward the IP subnet of the resolver instead, only if there is no EDNS data present in the incoming DNS query.
 
 ## Does DNS Firewall cache negative answers?
 
-Yes. The default TTL is 30 seconds. You can set `negative_cache_ttl` via the [API](/api/resources/dns_firewall/methods/edit/). This will affect the TTL of responses with status `REFUSED`, `NXDOMAIN`, or `SERVFAIL`.
+Yes. The default TTL is 30 seconds. You can configure the negative cache TTL on your cluster in the Cloudflare dashboard, or via the [API](/api/resources/dns_firewall/methods/edit/) (`negative_cache_ttl` parameter). This will affect the TTL of responses with status `REFUSED`, `NXDOMAIN`, or `SERVFAIL`.
 
 ## How can I set PTR records for nameserver hostnames?
 

--- a/src/content/docs/dns/dns-firewall/random-prefix-attacks/setup.mdx
+++ b/src/content/docs/dns/dns-firewall/random-prefix-attacks/setup.mdx
@@ -26,7 +26,7 @@ In order to enable automatic mitigation of [random prefix attacks](/dns/dns-fire
       <DashButton url="/?to=/:account/dns-firewall/clusters" />
 
    2. Select the cluster you want to update, then select **Edit**.
-   3. Enable **Attack mitigation** and choose whether Cloudflare should only mitigate attacks when the upstream is unhealthy.
+   3. Turn on **Attack mitigation** and choose whether Cloudflare should only mitigate attacks when the upstream is unhealthy.
    4. Select **Save**.
 
    </TabItem> <TabItem label="API">
@@ -46,7 +46,7 @@ In order to enable automatic mitigation of [random prefix attacks](/dns/dns-fire
 
    </TabItem> </Tabs>
 
-Once attack mitigation is enabled, queries identified as being part of a random prefix attack will receive a `REFUSED` response.
+Once you turn on attack mitigation, Cloudflare returns a `REFUSED` response to queries that are part of a random prefix attack.
 
 :::note
 

--- a/src/content/docs/dns/dns-firewall/random-prefix-attacks/setup.mdx
+++ b/src/content/docs/dns/dns-firewall/random-prefix-attacks/setup.mdx
@@ -1,7 +1,7 @@
 ---
 pcx_content_type: how-to
 title: Setup
-description: Enable automatic mitigation of random prefix attacks via the API.
+description: Enable automatic mitigation of random prefix attacks in the Cloudflare dashboard or via the API.
 products:
   - dns-firewall
 sidebar:
@@ -12,30 +12,44 @@ head:
 
 ---
 
-import { APIRequest } from "~/components";
+import { APIRequest, Tabs, TabItem, DashButton } from "~/components";
 
 In order to enable automatic mitigation of [random prefix attacks](/dns/dns-firewall/random-prefix-attacks/about/):
 
 1. Set up [DNS Firewall](/dns/dns-firewall/setup/).
-2. Send a [`PATCH` request](/api/resources/dns_firewall/methods/edit/) to update your DNS Firewall cluster.
+2. Enable attack mitigation on your DNS Firewall cluster.
+
+   <Tabs syncKey="dashPlusAPI"> <TabItem label="Dashboard">
+
+   1. In the Cloudflare dashboard, go to the **DNS Firewall Clusters** page.
+
+      <DashButton url="/?to=/:account/dns-firewall/clusters" />
+
+   2. Select the cluster you want to update, then select **Edit**.
+   3. Enable **Attack mitigation** and choose whether Cloudflare should only mitigate attacks when the upstream is unhealthy.
+   4. Select **Save**.
+
+   </TabItem> <TabItem label="API">
+
+   Send a [`PATCH` request](/api/resources/dns_firewall/methods/edit/) to update your DNS Firewall cluster:
 
    <APIRequest
    	path="/accounts/{account_id}/dns_firewall/{dns_firewall_id}"
    	method="PATCH"
    	json={{
-      "attack_mitigation": {
-        "enabled": true,
-        "only_when_upstream_unhealthy": true,
-      }
+         "attack_mitigation": {
+           "enabled": true,
+           "only_when_upstream_unhealthy": true,
+         }
    	}}
    />
 
-Once you receive a `200` success response from the API, queries identified as being part of a random prefix attack will receive a `REFUSED` response.
+   </TabItem> </Tabs>
+
+Once attack mitigation is enabled, queries identified as being part of a random prefix attack will receive a `REFUSED` response.
 
 :::note
 
-
-If you do not specify otherwise in your API call, Cloudflare automatically sets the `"only_when_upstream_unhealthy"` parameter to true, which means that Cloudflare will only mitigate attacks when we detect that the upstream is unresponsive (possibly as a result of an attack). This setting can also be changed via the API, using a request similar to the ones shown above.
-
+If you do not specify otherwise, Cloudflare automatically sets the `only_when_upstream_unhealthy` parameter to true, which means that Cloudflare will only mitigate attacks when we detect that the upstream is unresponsive (possibly as a result of an attack).
 
 :::

--- a/src/content/docs/dns/dns-firewall/setup.mdx
+++ b/src/content/docs/dns/dns-firewall/setup.mdx
@@ -39,7 +39,7 @@ Prior to setting up DNS Firewall, you need:
    - **Maximum Cache TTL**: Recommended setting of **4 hours**. Larger values increase the cache hit ratio, but also increase the time required for DNS changes to propagate.
    - **ANY queries**: Recommended setting is **Off** because these are often used as part of DDoS attacks. Also refer to this [blog post](https://blog.cloudflare.com/rfc8482-saying-goodbye-to-any/).
 4. Optionally, configure any of the [additional options](#additional-options) available on the same form.
-5. Click **Continue**.
+5. Select **Continue**.
 6. On the following screen, save the values for **Your new DNS Firewall IP Addresses**.
 
 :::note[Note:]

--- a/src/content/docs/dns/dns-firewall/setup.mdx
+++ b/src/content/docs/dns/dns-firewall/setup.mdx
@@ -38,8 +38,9 @@ Prior to setting up DNS Firewall, you need:
    - **Minimum Cache TTL**: Recommended setting of **30 seconds**.
    - **Maximum Cache TTL**: Recommended setting of **4 hours**. Larger values increase the cache hit ratio, but also increase the time required for DNS changes to propagate.
    - **ANY queries**: Recommended setting is **Off** because these are often used as part of DDoS attacks. Also refer to this [blog post](https://blog.cloudflare.com/rfc8482-saying-goodbye-to-any/).
-4. Click **Continue**.
-5. On the following screen, save the values for **Your new DNS Firewall IP Addresses**.
+4. Optionally, configure any of the [additional options](#additional-options) available on the same form.
+5. Click **Continue**.
+6. On the following screen, save the values for **Your new DNS Firewall IP Addresses**.
 
 :::note[Note:]
 
@@ -73,6 +74,11 @@ Configure security policy in your DNS servers and Firewall to allow only [Cloudf
 
 ## Additional options
 
-When you use the API, you can also specify other parameters, such as rate limit (in queries per second per data center). You can find the parameters descriptions and examples in the [API documentation](/api/resources/dns_firewall/methods/create/).
+Beyond the required fields, you can configure the following settings on your DNS Firewall cluster — in the Cloudflare dashboard when you create or edit a cluster, or via the API:
 
-To configure rate limiting and other options for already existing clusters, use the [Update DNS Firewall Cluster](/api/resources/dns_firewall/methods/edit/) endpoint.
+- **Rate limit** (queries per second per data center).
+- **Negative cache TTL** for `REFUSED`, `NXDOMAIN`, and `SERVFAIL` responses.
+- **EDNS Client Subnet (ECS) fallback** — forward the resolver's IP subnet when the incoming query does not include ECS data. Refer to the [FAQ](/dns/dns-firewall/faq/#does-dns-firewall-support-edns-client-subnet-ecs) for details.
+- **Attack mitigation** for [random prefix attacks](/dns/dns-firewall/random-prefix-attacks/).
+
+For the full parameter reference, refer to the [Create](/api/resources/dns_firewall/methods/create/) and [Update](/api/resources/dns_firewall/methods/edit/) DNS Firewall Cluster API endpoints.


### PR DESCRIPTION
### Summary

Follow-up to #31921 (which added the changelog entry for the new DNS Firewall UX). The DNS Firewall docs still referred to several settings as API-only that are now configurable in the dashboard. This PR updates them.

### Changes

- **`src/content/docs/dns/dns-firewall/setup.mdx`** — Rewrite the *Additional options* section so it lists rate limit, negative cache TTL, EDNS Client Subnet fallback, and attack mitigation as dashboard-or-API options. Add a step in the Dashboard tab pointing to those options on the create/edit form.
- **`src/content/docs/dns/dns-firewall/faq.mdx`** — Update the three answers that said settings were API-only (`SERVFAIL` TTL, `ecs_fallback`, and negative cache TTL) to also mention the dashboard.
- **`src/content/docs/dns/dns-firewall/random-prefix-attacks/setup.mdx`** — Wrap the existing instructions in a `dashPlusAPI` `Tabs` block, adding a Dashboard tab for the new **Attack mitigation** toggle alongside the existing API `PATCH` flow.

No other DNS Firewall pages needed changes — dashboard deep-links elsewhere already use `/dns-firewall/clusters` and `/dns-firewall/analytics`.

### Documentation checklist

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry? Yes — the changelog entry landed in #31921.
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
