### PR TITLE
[AI Gateway] Remove Claude Fable 5 availability note

### DIFF
--- a/src/content/catalog-models/anthropic-claude-fable-5.json
+++ b/src/content/catalog-models/anthropic-claude-fable-5.json
@@ -502,17 +502,7 @@
 	"request_formats": [
 		"anthropic-messages"
 	],
-	"banner": {
-		"id": "ce697a66-79d5-459b-83f4-e18437546c91",
-		"title": "NOTE",
-		"text": "Anthropic is limiting access to Claude Fable 5 due to a directive from the US Government. During that time, the model will return errors. ",
-		"severity": "warning",
-		"dismissible": true,
-		"link": {
-			"url": "https://www.anthropic.com/news/fable-mythos-access",
-			"label": "More info"
-		}
-	},
+	"banner": null,
 	"created_at": "2026-06-09 22:24:20",
 	"schema": {
 		"input": {


### PR DESCRIPTION
Updates the generated Claude Fable 5 catalog entry to remove the expired availability warning. The file was generated from the live Unified Catalog API. Validation: Astro check and Worker TypeScript passed.