### PR TITLE
[AI Gateway] Add GPT-5.6 model cards

### DIFF
--- a/src/content/catalog-models/openai-gpt-5.6-luna.json
+++ b/src/content/catalog-models/openai-gpt-5.6-luna.json
@@ -1,0 +1,404 @@
+{
+	"model_id": "openai/gpt-5.6-luna",
+	"provider_id": "openai",
+	"name": "GPT-5.6 Luna",
+	"description": "GPT-5.6 Luna is an OpenAI GPT-5.6 model optimized for cost-sensitive workloads, using the Responses API for efficient text generation.",
+	"task": "Text Generation",
+	"tags": [
+		"LLM",
+		"Coding",
+		"Reasoning",
+		"Multimodal",
+		"Responses API"
+	],
+	"context_length": 1050000,
+	"max_output_tokens": 128000,
+	"schema_version": "1.0.0",
+	"examples": [
+		{
+			"name": "Rate Limiting Summary",
+			"description": "Basic Responses API request for a concise summary task",
+			"input": {
+				"input": "Summarize the benefits of API rate limiting in three bullets.",
+				"max_output_tokens": 256
+			},
+			"output": {
+				"text": "- **Protects system stability:** Prevents overload, reduces outages, and ensures predictable performance during traffic spikes.\n- **Ensures fair access:** Stops individual users or applications from consuming disproportionate resources.\n- **Improves security and cost control:** Helps mitigate abuse, brute-force attacks, and unexpected infrastructure usage."
+			},
+			"raw_response": {
+				"id": "resp_0e481f0cb46bf357016a4fe99bd5fc8194b6ce2049aa65ab08",
+				"object": "response",
+				"created_at": 1783622043,
+				"status": "completed",
+				"background": false,
+				"billing": {
+					"payer": "developer"
+				},
+				"completed_at": 1783622044,
+				"error": null,
+				"frequency_penalty": 0,
+				"incomplete_details": null,
+				"instructions": null,
+				"max_output_tokens": 256,
+				"max_tool_calls": null,
+				"model": "gpt-5.6-luna",
+				"moderation": null,
+				"output": [
+					{
+						"id": "msg_0e481f0cb46bf357016a4fe99c2e288194a6fd0ce3f5f88786",
+						"type": "message",
+						"status": "completed",
+						"content": [
+							{
+								"type": "output_text",
+								"annotations": [],
+								"logprobs": [],
+								"text": "- **Protects system stability:** Prevents overload, reduces outages, and ensures predictable performance during traffic spikes.\n- **Ensures fair access:** Stops individual users or applications from consuming disproportionate resources.\n- **Improves security and cost control:** Helps mitigate abuse, brute-force attacks, and unexpected infrastructure usage."
+							}
+						],
+						"phase": "final_answer",
+						"role": "assistant"
+					}
+				],
+				"parallel_tool_calls": true,
+				"presence_penalty": 0,
+				"previous_response_id": null,
+				"prompt_cache_key": null,
+				"prompt_cache_retention": "in_memory",
+				"reasoning": {
+					"context": "all_turns",
+					"effort": "medium",
+					"mode": "standard",
+					"summary": null
+				},
+				"safety_identifier": null,
+				"service_tier": "default",
+				"store": false,
+				"temperature": 1,
+				"text": {
+					"format": {
+						"type": "text"
+					},
+					"verbosity": "medium"
+				},
+				"tool_choice": "auto",
+				"tool_usage": {
+					"image_gen": {
+						"input_tokens": 0,
+						"input_tokens_details": {
+							"image_tokens": 0,
+							"text_tokens": 0
+						},
+						"output_tokens": 0,
+						"output_tokens_details": {
+							"image_tokens": 0,
+							"text_tokens": 0
+						},
+						"total_tokens": 0
+					},
+					"web_search": {
+						"num_requests": 0
+					}
+				},
+				"tools": [],
+				"top_logprobs": 0,
+				"top_p": 0.98,
+				"truncation": "disabled",
+				"usage": {
+					"input_tokens": 19,
+					"input_tokens_details": {
+						"cache_write_tokens": 0,
+						"cached_tokens": 0
+					},
+					"output_tokens": 66,
+					"output_tokens_details": {
+						"reasoning_tokens": 0
+					},
+					"total_tokens": 85
+				},
+				"user": null,
+				"metadata": {}
+			},
+			"code_snippets": [
+				{
+					"label": "typescript",
+					"language": "typescript",
+					"code": "const response = await env.AI.run(\n  'openai/gpt-5.6-luna',\n  {\n    input: 'Summarize the benefits of API rate limiting in three bullets.',\n    max_output_tokens: 256,\n  },\n)\nconsole.log(response)"
+				},
+				{
+					"label": "curl",
+					"language": "bash",
+					"code": "curl https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/v1/responses \\\n  --header \"Authorization: Bearer $CLOUDFLARE_API_TOKEN\" \\\n  --header \"Content-Type: application/json\" \\\n  --data '{\n  \"model\": \"openai/gpt-5.6-luna\",\n  \"input\": \"Summarize the benefits of API rate limiting in three bullets.\",\n  \"max_output_tokens\": 256\n}'"
+				}
+			]
+		},
+		{
+			"name": "Pull Request Description",
+			"description": "Using instructions for a cost-sensitive drafting task",
+			"input": {
+				"input": "Write a brief pull request description for a bug fix that prevents duplicate webhook deliveries.",
+				"instructions": "Keep it under 100 words.",
+				"max_output_tokens": 256
+			},
+			"output": {
+				"text": "## Summary\nPrevents duplicate webhook deliveries by ensuring each event is processed only once, even when retries or concurrent requests occur.\n\n## Changes\n- Added idempotency checks for webhook events.\n- Prevented duplicate delivery attempts.\n- Added regression tests covering retries and concurrent processing.\n\n## Testing\nAll existing and new tests pass."
+			},
+			"raw_response": {
+				"id": "resp_0bed05adeda548a1016a4fe99d1e408194bb0375bad96ab71a",
+				"object": "response",
+				"created_at": 1783622045,
+				"status": "completed",
+				"background": false,
+				"billing": {
+					"payer": "developer"
+				},
+				"completed_at": 1783622046,
+				"error": null,
+				"frequency_penalty": 0,
+				"incomplete_details": null,
+				"instructions": "Keep it under 100 words.",
+				"max_output_tokens": 256,
+				"max_tool_calls": null,
+				"model": "gpt-5.6-luna",
+				"moderation": null,
+				"output": [
+					{
+						"id": "msg_0bed05adeda548a1016a4fe99daa748194992854423ba08e72",
+						"type": "message",
+						"status": "completed",
+						"content": [
+							{
+								"type": "output_text",
+								"annotations": [],
+								"logprobs": [],
+								"text": "## Summary\nPrevents duplicate webhook deliveries by ensuring each event is processed only once, even when retries or concurrent requests occur.\n\n## Changes\n- Added idempotency checks for webhook events.\n- Prevented duplicate delivery attempts.\n- Added regression tests covering retries and concurrent processing.\n\n## Testing\nAll existing and new tests pass."
+							}
+						],
+						"phase": "final_answer",
+						"role": "assistant"
+					}
+				],
+				"parallel_tool_calls": true,
+				"presence_penalty": 0,
+				"previous_response_id": null,
+				"prompt_cache_key": null,
+				"prompt_cache_retention": "in_memory",
+				"reasoning": {
+					"context": "all_turns",
+					"effort": "medium",
+					"mode": "standard",
+					"summary": null
+				},
+				"safety_identifier": null,
+				"service_tier": "default",
+				"store": false,
+				"temperature": 1,
+				"text": {
+					"format": {
+						"type": "text"
+					},
+					"verbosity": "medium"
+				},
+				"tool_choice": "auto",
+				"tool_usage": {
+					"image_gen": {
+						"input_tokens": 0,
+						"input_tokens_details": {
+							"image_tokens": 0,
+							"text_tokens": 0
+						},
+						"output_tokens": 0,
+						"output_tokens_details": {
+							"image_tokens": 0,
+							"text_tokens": 0
+						},
+						"total_tokens": 0
+					},
+					"web_search": {
+						"num_requests": 0
+					}
+				},
+				"tools": [],
+				"top_logprobs": 0,
+				"top_p": 0.98,
+				"truncation": "disabled",
+				"usage": {
+					"input_tokens": 33,
+					"input_tokens_details": {
+						"cache_write_tokens": 0,
+						"cached_tokens": 0
+					},
+					"output_tokens": 69,
+					"output_tokens_details": {
+						"reasoning_tokens": 0
+					},
+					"total_tokens": 102
+				},
+				"user": null,
+				"metadata": {}
+			},
+			"code_snippets": [
+				{
+					"label": "typescript",
+					"language": "typescript",
+					"code": "const response = await env.AI.run(\n  'openai/gpt-5.6-luna',\n  {\n    input:\n      'Write a brief pull request description for a bug fix that prevents duplicate webhook deliveries.',\n    instructions: 'Keep it under 100 words.',\n    max_output_tokens: 256,\n  },\n)\nconsole.log(response)"
+				},
+				{
+					"label": "curl",
+					"language": "bash",
+					"code": "curl https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/v1/responses \\\n  --header \"Authorization: Bearer $CLOUDFLARE_API_TOKEN\" \\\n  --header \"Content-Type: application/json\" \\\n  --data '{\n  \"model\": \"openai/gpt-5.6-luna\",\n  \"input\": \"Write a brief pull request description for a bug fix that prevents duplicate webhook deliveries.\",\n  \"instructions\": \"Keep it under 100 words.\",\n  \"max_output_tokens\": 256\n}'"
+				}
+			]
+		}
+	],
+	"default_example": null,
+	"code_snippets": [],
+	"supports_async": false,
+	"zdr": false,
+	"zdr_comment": null,
+	"external_info": "https://openai.com/",
+	"terms": "https://openai.com/policies/",
+	"cover_image_url": "https://pub-26f1392c1b674324be6786695bd72257.r2.dev/openai/gpt-5.6-luna.png",
+	"metadata": {
+		"API": "Responses",
+		"Architecture": "Transformer"
+	},
+	"request_formats": [
+		"responses"
+	],
+	"banner": null,
+	"created_at": "2026-07-10 02:51:21",
+	"schema": {
+		"input": {
+			"$schema": "https://json-schema.org/draft/2020-12/schema",
+			"type": "object",
+			"properties": {
+				"input": {
+					"anyOf": [
+						{
+							"type": "string"
+						},
+						{
+							"type": "array",
+							"items": {}
+						}
+					]
+				},
+				"instructions": {
+					"type": "string"
+				},
+				"temperature": {
+					"type": "number",
+					"minimum": 0,
+					"maximum": 2
+				},
+				"max_output_tokens": {
+					"type": "number",
+					"exclusiveMinimum": 0
+				},
+				"top_p": {
+					"type": "number",
+					"minimum": 0,
+					"maximum": 1
+				},
+				"stream": {
+					"type": "boolean"
+				},
+				"tools": {
+					"type": "array",
+					"items": {}
+				},
+				"tool_choice": {},
+				"text": {
+					"type": "object",
+					"properties": {
+						"format": {}
+					},
+					"additionalProperties": {}
+				},
+				"reasoning": {
+					"type": "object",
+					"properties": {
+						"effort": {
+							"type": "string",
+							"enum": [
+								"none",
+								"low",
+								"medium",
+								"high"
+							]
+						}
+					},
+					"additionalProperties": {}
+				}
+			},
+			"required": [
+				"input"
+			],
+			"additionalProperties": {}
+		},
+		"output": {
+			"$schema": "https://json-schema.org/draft/2020-12/schema",
+			"type": "object",
+			"properties": {
+				"id": {
+					"type": "string"
+				},
+				"object": {
+					"type": "string",
+					"const": "response"
+				},
+				"created_at": {
+					"type": "number"
+				},
+				"model": {
+					"type": "string"
+				},
+				"output": {
+					"type": "array",
+					"items": {}
+				},
+				"output_text": {
+					"type": "string"
+				},
+				"status": {
+					"type": "string",
+					"enum": [
+						"in_progress",
+						"completed",
+						"failed",
+						"incomplete"
+					]
+				},
+				"usage": {
+					"type": "object",
+					"properties": {
+						"input_tokens": {
+							"type": "number"
+						},
+						"output_tokens": {
+							"type": "number"
+						},
+						"total_tokens": {
+							"type": "number"
+						}
+					},
+					"required": [
+						"input_tokens",
+						"output_tokens",
+						"total_tokens"
+					],
+					"additionalProperties": {}
+				}
+			},
+			"required": [
+				"id",
+				"object",
+				"created_at",
+				"model",
+				"output"
+			],
+			"additionalProperties": {}
+		}
+	}
+}

--- a/src/content/catalog-models/openai-gpt-5.6-sol.json
+++ b/src/content/catalog-models/openai-gpt-5.6-sol.json
@@ -1,0 +1,419 @@
+{
+	"model_id": "openai/gpt-5.6-sol",
+	"provider_id": "openai",
+	"name": "GPT-5.6 Sol",
+	"description": "GPT-5.6 Sol is OpenAI's frontier GPT-5.6 model for complex professional work, using the Responses API for reasoning and stateful context management.",
+	"task": "Text Generation",
+	"tags": [
+		"LLM",
+		"Coding",
+		"Reasoning",
+		"Multimodal",
+		"Responses API"
+	],
+	"context_length": 1050000,
+	"max_output_tokens": 128000,
+	"schema_version": "1.0.0",
+	"examples": [
+		{
+			"name": "Launch Checklist",
+			"description": "Basic Responses API request for complex professional planning",
+			"input": {
+				"input": "Create a concise launch checklist for migrating a production API to a new region.",
+				"instructions": "Use five bullets and focus on risk reduction.",
+				"max_output_tokens": 512
+			},
+			"output": {
+				"text": "- **Validate readiness:** Confirm capacity, quotas, security controls, certificates, secrets, dependencies, and compliance requirements in the new region.\n- **Protect data:** Take verified backups; validate replication consistency, encryption, retention, and restore procedures before cutover.\n- **Test end to end:** Run load, latency, failover, integration, and smoke tests using production-like traffic and data.\n- **Control cutover:** Lower DNS TTLs, deploy gradually with canary traffic, freeze risky changes, and monitor errors, latency, saturation, and data integrity.\n- **Prepare rollback:** Define go/no-go thresholds, owners, communication channels, and a rehearsed rollback plan; retain the old region until stability is confirmed."
+			},
+			"raw_response": {
+				"id": "resp_0f038c9de2c94eb6016a4fe97e94f081909f0edfecbfb2abd9",
+				"object": "response",
+				"created_at": 1783622014,
+				"status": "completed",
+				"background": false,
+				"billing": {
+					"payer": "developer"
+				},
+				"completed_at": 1783622017,
+				"error": null,
+				"frequency_penalty": 0,
+				"incomplete_details": null,
+				"instructions": "Use five bullets and focus on risk reduction.",
+				"max_output_tokens": 512,
+				"max_tool_calls": null,
+				"model": "gpt-5.6-sol",
+				"moderation": null,
+				"output": [
+					{
+						"id": "rs_0f038c9de2c94eb6016a4fe97f2bac81909bf1c27c448cf46b",
+						"type": "reasoning",
+						"content": [],
+						"summary": []
+					},
+					{
+						"id": "msg_0f038c9de2c94eb6016a4fe97fa0688190a1b4958a6a0aa218",
+						"type": "message",
+						"status": "completed",
+						"content": [
+							{
+								"type": "output_text",
+								"annotations": [],
+								"logprobs": [],
+								"text": "- **Validate readiness:** Confirm capacity, quotas, security controls, certificates, secrets, dependencies, and compliance requirements in the new region.\n- **Protect data:** Take verified backups; validate replication consistency, encryption, retention, and restore procedures before cutover.\n- **Test end to end:** Run load, latency, failover, integration, and smoke tests using production-like traffic and data.\n- **Control cutover:** Lower DNS TTLs, deploy gradually with canary traffic, freeze risky changes, and monitor errors, latency, saturation, and data integrity.\n- **Prepare rollback:** Define go/no-go thresholds, owners, communication channels, and a rehearsed rollback plan; retain the old region until stability is confirmed."
+							}
+						],
+						"phase": "final_answer",
+						"role": "assistant"
+					}
+				],
+				"parallel_tool_calls": true,
+				"presence_penalty": 0,
+				"previous_response_id": null,
+				"prompt_cache_key": null,
+				"prompt_cache_retention": "in_memory",
+				"reasoning": {
+					"context": "all_turns",
+					"effort": "medium",
+					"mode": "standard",
+					"summary": null
+				},
+				"safety_identifier": null,
+				"service_tier": "default",
+				"store": false,
+				"temperature": 1,
+				"text": {
+					"format": {
+						"type": "text"
+					},
+					"verbosity": "medium"
+				},
+				"tool_choice": "auto",
+				"tool_usage": {
+					"image_gen": {
+						"input_tokens": 0,
+						"input_tokens_details": {
+							"image_tokens": 0,
+							"text_tokens": 0
+						},
+						"output_tokens": 0,
+						"output_tokens_details": {
+							"image_tokens": 0,
+							"text_tokens": 0
+						},
+						"total_tokens": 0
+					},
+					"web_search": {
+						"num_requests": 0
+					}
+				},
+				"tools": [],
+				"top_logprobs": 0,
+				"top_p": 0.98,
+				"truncation": "disabled",
+				"usage": {
+					"input_tokens": 34,
+					"input_tokens_details": {
+						"cache_write_tokens": 0,
+						"cached_tokens": 0
+					},
+					"output_tokens": 182,
+					"output_tokens_details": {
+						"reasoning_tokens": 32
+					},
+					"total_tokens": 216
+				},
+				"user": null,
+				"metadata": {}
+			},
+			"code_snippets": [
+				{
+					"label": "typescript",
+					"language": "typescript",
+					"code": "const response = await env.AI.run(\n  'openai/gpt-5.6-sol',\n  {\n    input: 'Create a concise launch checklist for migrating a production API to a new region.',\n    instructions: 'Use five bullets and focus on risk reduction.',\n    max_output_tokens: 512,\n  },\n)\nconsole.log(response)"
+				},
+				{
+					"label": "curl",
+					"language": "bash",
+					"code": "curl https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/v1/responses \\\n  --header \"Authorization: Bearer $CLOUDFLARE_API_TOKEN\" \\\n  --header \"Content-Type: application/json\" \\\n  --data '{\n  \"model\": \"openai/gpt-5.6-sol\",\n  \"input\": \"Create a concise launch checklist for migrating a production API to a new region.\",\n  \"instructions\": \"Use five bullets and focus on risk reduction.\",\n  \"max_output_tokens\": 512\n}'"
+				}
+			]
+		},
+		{
+			"name": "Operational Reasoning",
+			"description": "Using reasoning effort for a multi-step operational decision",
+			"input": {
+				"input": "A service has 99.9% monthly availability and just had 31 minutes of downtime. Has it exceeded the monthly error budget for a 30-day month? Show the calculation briefly.",
+				"max_output_tokens": 512,
+				"reasoning": {
+					"effort": "medium"
+				}
+			},
+			"output": {
+				"text": "- Total minutes in 30 days: \\(30 \\times 24 \\times 60 = 43{,}200\\)\n- Error budget at 99.9% availability: \\(43{,}200 \\times 0.001 = 43.2\\) minutes\n- Downtime used: 31 minutes\n\n**No**, it has not exceeded the monthly error budget. It has **12.2 minutes remaining**."
+			},
+			"raw_response": {
+				"id": "resp_0fcb12a6aa68f25a016a4fe98205b881978b6ab83321e02e3b",
+				"object": "response",
+				"created_at": 1783622018,
+				"status": "completed",
+				"background": false,
+				"billing": {
+					"payer": "developer"
+				},
+				"completed_at": 1783622020,
+				"error": null,
+				"frequency_penalty": 0,
+				"incomplete_details": null,
+				"instructions": null,
+				"max_output_tokens": 512,
+				"max_tool_calls": null,
+				"model": "gpt-5.6-sol",
+				"moderation": null,
+				"output": [
+					{
+						"id": "rs_0fcb12a6aa68f25a016a4fe98293e081979139ff657f9b612b",
+						"type": "reasoning",
+						"content": [],
+						"summary": []
+					},
+					{
+						"id": "msg_0fcb12a6aa68f25a016a4fe98354fc8197a4b488662491fdd8",
+						"type": "message",
+						"status": "completed",
+						"content": [
+							{
+								"type": "output_text",
+								"annotations": [],
+								"logprobs": [],
+								"text": "- Total minutes in 30 days: \\(30 \\times 24 \\times 60 = 43{,}200\\)\n- Error budget at 99.9% availability: \\(43{,}200 \\times 0.001 = 43.2\\) minutes\n- Downtime used: 31 minutes\n\n**No**, it has not exceeded the monthly error budget. It has **12.2 minutes remaining**."
+							}
+						],
+						"phase": "final_answer",
+						"role": "assistant"
+					}
+				],
+				"parallel_tool_calls": true,
+				"presence_penalty": 0,
+				"previous_response_id": null,
+				"prompt_cache_key": null,
+				"prompt_cache_retention": "in_memory",
+				"reasoning": {
+					"context": "all_turns",
+					"effort": "medium",
+					"mode": "standard",
+					"summary": null
+				},
+				"safety_identifier": null,
+				"service_tier": "default",
+				"store": false,
+				"temperature": 1,
+				"text": {
+					"format": {
+						"type": "text"
+					},
+					"verbosity": "medium"
+				},
+				"tool_choice": "auto",
+				"tool_usage": {
+					"image_gen": {
+						"input_tokens": 0,
+						"input_tokens_details": {
+							"image_tokens": 0,
+							"text_tokens": 0
+						},
+						"output_tokens": 0,
+						"output_tokens_details": {
+							"image_tokens": 0,
+							"text_tokens": 0
+						},
+						"total_tokens": 0
+					},
+					"web_search": {
+						"num_requests": 0
+					}
+				},
+				"tools": [],
+				"top_logprobs": 0,
+				"top_p": 0.98,
+				"truncation": "disabled",
+				"usage": {
+					"input_tokens": 44,
+					"input_tokens_details": {
+						"cache_write_tokens": 0,
+						"cached_tokens": 0
+					},
+					"output_tokens": 159,
+					"output_tokens_details": {
+						"reasoning_tokens": 63
+					},
+					"total_tokens": 203
+				},
+				"user": null,
+				"metadata": {}
+			},
+			"code_snippets": [
+				{
+					"label": "typescript",
+					"language": "typescript",
+					"code": "const response = await env.AI.run(\n  'openai/gpt-5.6-sol',\n  {\n    input:\n      'A service has 99.9% monthly availability and just had 31 minutes of downtime. Has it exceeded the monthly error budget for a 30-day month? Show the calculation briefly.',\n    max_output_tokens: 512,\n    reasoning: { effort: 'medium' },\n  },\n)\nconsole.log(response)"
+				},
+				{
+					"label": "curl",
+					"language": "bash",
+					"code": "curl https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/v1/responses \\\n  --header \"Authorization: Bearer $CLOUDFLARE_API_TOKEN\" \\\n  --header \"Content-Type: application/json\" \\\n  --data '{\n  \"model\": \"openai/gpt-5.6-sol\",\n  \"input\": \"A service has 99.9% monthly availability and just had 31 minutes of downtime. Has it exceeded the monthly error budget for a 30-day month? Show the calculation briefly.\",\n  \"max_output_tokens\": 512,\n  \"reasoning\": {\n    \"effort\": \"medium\"\n  }\n}'"
+				}
+			]
+		}
+	],
+	"default_example": null,
+	"code_snippets": [],
+	"supports_async": false,
+	"zdr": false,
+	"zdr_comment": null,
+	"external_info": "https://openai.com/",
+	"terms": "https://openai.com/policies/",
+	"cover_image_url": "https://pub-26f1392c1b674324be6786695bd72257.r2.dev/openai/gpt-5.6-sol.png",
+	"metadata": {
+		"API": "Responses",
+		"Architecture": "Transformer"
+	},
+	"request_formats": [
+		"responses"
+	],
+	"banner": null,
+	"created_at": "2026-07-10 02:48:18",
+	"schema": {
+		"input": {
+			"$schema": "https://json-schema.org/draft/2020-12/schema",
+			"type": "object",
+			"properties": {
+				"input": {
+					"anyOf": [
+						{
+							"type": "string"
+						},
+						{
+							"type": "array",
+							"items": {}
+						}
+					]
+				},
+				"instructions": {
+					"type": "string"
+				},
+				"temperature": {
+					"type": "number",
+					"minimum": 0,
+					"maximum": 2
+				},
+				"max_output_tokens": {
+					"type": "number",
+					"exclusiveMinimum": 0
+				},
+				"top_p": {
+					"type": "number",
+					"minimum": 0,
+					"maximum": 1
+				},
+				"stream": {
+					"type": "boolean"
+				},
+				"tools": {
+					"type": "array",
+					"items": {}
+				},
+				"tool_choice": {},
+				"text": {
+					"type": "object",
+					"properties": {
+						"format": {}
+					},
+					"additionalProperties": {}
+				},
+				"reasoning": {
+					"type": "object",
+					"properties": {
+						"effort": {
+							"type": "string",
+							"enum": [
+								"none",
+								"low",
+								"medium",
+								"high"
+							]
+						}
+					},
+					"additionalProperties": {}
+				}
+			},
+			"required": [
+				"input"
+			],
+			"additionalProperties": {}
+		},
+		"output": {
+			"$schema": "https://json-schema.org/draft/2020-12/schema",
+			"type": "object",
+			"properties": {
+				"id": {
+					"type": "string"
+				},
+				"object": {
+					"type": "string",
+					"const": "response"
+				},
+				"created_at": {
+					"type": "number"
+				},
+				"model": {
+					"type": "string"
+				},
+				"output": {
+					"type": "array",
+					"items": {}
+				},
+				"output_text": {
+					"type": "string"
+				},
+				"status": {
+					"type": "string",
+					"enum": [
+						"in_progress",
+						"completed",
+						"failed",
+						"incomplete"
+					]
+				},
+				"usage": {
+					"type": "object",
+					"properties": {
+						"input_tokens": {
+							"type": "number"
+						},
+						"output_tokens": {
+							"type": "number"
+						},
+						"total_tokens": {
+							"type": "number"
+						}
+					},
+					"required": [
+						"input_tokens",
+						"output_tokens",
+						"total_tokens"
+					],
+					"additionalProperties": {}
+				}
+			},
+			"required": [
+				"id",
+				"object",
+				"created_at",
+				"model",
+				"output"
+			],
+			"additionalProperties": {}
+		}
+	}
+}

--- a/src/content/catalog-models/openai-gpt-5.6-terra.json
+++ b/src/content/catalog-models/openai-gpt-5.6-terra.json
@@ -1,0 +1,405 @@
+{
+	"model_id": "openai/gpt-5.6-terra",
+	"provider_id": "openai",
+	"name": "GPT-5.6 Terra",
+	"description": "GPT-5.6 Terra is an OpenAI GPT-5.6 model that balances intelligence and cost, using the Responses API for reasoning and stateful context management.",
+	"task": "Text Generation",
+	"tags": [
+		"LLM",
+		"Coding",
+		"Reasoning",
+		"Multimodal",
+		"Responses API"
+	],
+	"context_length": 1050000,
+	"max_output_tokens": 128000,
+	"schema_version": "1.0.0",
+	"examples": [
+		{
+			"name": "Deployment Comparison",
+			"description": "Basic Responses API request for a balanced analysis task",
+			"input": {
+				"input": "Compare blue-green and canary deployments for a small engineering team.",
+				"instructions": "Answer in two concise paragraphs.",
+				"max_output_tokens": 512
+			},
+			"output": {
+				"text": "Blue-green deployments run two identical production environments: one active (\u201cblue\u201d) and one idle (\u201cgreen\u201d). A new version is deployed and tested on green, then traffic is switched over all at once. This makes rollback very fast\u2014switch traffic back to blue\u2014but requires maintaining duplicate infrastructure and handling database/schema compatibility carefully. For a small team, blue-green is often appealing when releases are infrequent, the system is simple enough to duplicate cheaply, and a clear cutover/rollback procedure matters more than gradual validation.\n\nCanary deployments release the new version to a small percentage of users or requests first, then progressively increase traffic while monitoring errors, latency, and business metrics. They reduce the blast radius of defects and provide real-production validation, but require traffic splitting, strong observability, automated rollout controls, and usually feature-flag or version-compatibility discipline. For a small team, canaries are best when the platform already supports them or when the cost of a faulty release is high; otherwise, blue-green generally offers a simpler operational model."
+			},
+			"raw_response": {
+				"id": "resp_06924a0adf314715016a4fe98e1d2c81978067f843c9a357f1",
+				"object": "response",
+				"created_at": 1783622030,
+				"status": "completed",
+				"background": false,
+				"billing": {
+					"payer": "developer"
+				},
+				"completed_at": 1783622032,
+				"error": null,
+				"frequency_penalty": 0,
+				"incomplete_details": null,
+				"instructions": "Answer in two concise paragraphs.",
+				"max_output_tokens": 512,
+				"max_tool_calls": null,
+				"model": "gpt-5.6-terra",
+				"moderation": null,
+				"output": [
+					{
+						"id": "msg_06924a0adf314715016a4fe98e76c4819780adfca3dd3ad1f3",
+						"type": "message",
+						"status": "completed",
+						"content": [
+							{
+								"type": "output_text",
+								"annotations": [],
+								"logprobs": [],
+								"text": "Blue-green deployments run two identical production environments: one active (\u201cblue\u201d) and one idle (\u201cgreen\u201d). A new version is deployed and tested on green, then traffic is switched over all at once. This makes rollback very fast\u2014switch traffic back to blue\u2014but requires maintaining duplicate infrastructure and handling database/schema compatibility carefully. For a small team, blue-green is often appealing when releases are infrequent, the system is simple enough to duplicate cheaply, and a clear cutover/rollback procedure matters more than gradual validation.\n\nCanary deployments release the new version to a small percentage of users or requests first, then progressively increase traffic while monitoring errors, latency, and business metrics. They reduce the blast radius of defects and provide real-production validation, but require traffic splitting, strong observability, automated rollout controls, and usually feature-flag or version-compatibility discipline. For a small team, canaries are best when the platform already supports them or when the cost of a faulty release is high; otherwise, blue-green generally offers a simpler operational model."
+							}
+						],
+						"phase": "final_answer",
+						"role": "assistant"
+					}
+				],
+				"parallel_tool_calls": true,
+				"presence_penalty": 0,
+				"previous_response_id": null,
+				"prompt_cache_key": null,
+				"prompt_cache_retention": "in_memory",
+				"reasoning": {
+					"context": "all_turns",
+					"effort": "medium",
+					"mode": "standard",
+					"summary": null
+				},
+				"safety_identifier": null,
+				"service_tier": "default",
+				"store": false,
+				"temperature": 1,
+				"text": {
+					"format": {
+						"type": "text"
+					},
+					"verbosity": "medium"
+				},
+				"tool_choice": "auto",
+				"tool_usage": {
+					"image_gen": {
+						"input_tokens": 0,
+						"input_tokens_details": {
+							"image_tokens": 0,
+							"text_tokens": 0
+						},
+						"output_tokens": 0,
+						"output_tokens_details": {
+							"image_tokens": 0,
+							"text_tokens": 0
+						},
+						"total_tokens": 0
+					},
+					"web_search": {
+						"num_requests": 0
+					}
+				},
+				"tools": [],
+				"top_logprobs": 0,
+				"top_p": 0.98,
+				"truncation": "disabled",
+				"usage": {
+					"input_tokens": 29,
+					"input_tokens_details": {
+						"cache_write_tokens": 0,
+						"cached_tokens": 0
+					},
+					"output_tokens": 211,
+					"output_tokens_details": {
+						"reasoning_tokens": 0
+					},
+					"total_tokens": 240
+				},
+				"user": null,
+				"metadata": {}
+			},
+			"code_snippets": [
+				{
+					"label": "typescript",
+					"language": "typescript",
+					"code": "const response = await env.AI.run(\n  'openai/gpt-5.6-terra',\n  {\n    input: 'Compare blue-green and canary deployments for a small engineering team.',\n    instructions: 'Answer in two concise paragraphs.',\n    max_output_tokens: 512,\n  },\n)\nconsole.log(response)"
+				},
+				{
+					"label": "curl",
+					"language": "bash",
+					"code": "curl https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/v1/responses \\\n  --header \"Authorization: Bearer $CLOUDFLARE_API_TOKEN\" \\\n  --header \"Content-Type: application/json\" \\\n  --data '{\n  \"model\": \"openai/gpt-5.6-terra\",\n  \"input\": \"Compare blue-green and canary deployments for a small engineering team.\",\n  \"instructions\": \"Answer in two concise paragraphs.\",\n  \"max_output_tokens\": 512\n}'"
+				}
+			]
+		},
+		{
+			"name": "Customer Incident Update",
+			"description": "Using instructions to tune the model's response style",
+			"input": {
+				"input": "Draft a short incident update for customers after elevated API latency.",
+				"instructions": "Be transparent, calm, and avoid unnecessary technical detail.",
+				"max_output_tokens": 512
+			},
+			"output": {
+				"text": "**Incident Update:**  \nEarlier today, some customers experienced elevated API latency. Our team identified the issue and applied mitigation steps, and API performance has returned to normal.\n\nWe\u2019ll continue monitoring closely and will share a follow-up with additional details if needed. We apologize for the disruption and appreciate your patience."
+			},
+			"raw_response": {
+				"id": "resp_0072e6076b1b184d016a4fe99105888190b25ef699c2a83380",
+				"object": "response",
+				"created_at": 1783622033,
+				"status": "completed",
+				"background": false,
+				"billing": {
+					"payer": "developer"
+				},
+				"completed_at": 1783622034,
+				"error": null,
+				"frequency_penalty": 0,
+				"incomplete_details": null,
+				"instructions": "Be transparent, calm, and avoid unnecessary technical detail.",
+				"max_output_tokens": 512,
+				"max_tool_calls": null,
+				"model": "gpt-5.6-terra",
+				"moderation": null,
+				"output": [
+					{
+						"id": "msg_0072e6076b1b184d016a4fe9916d6081909385f3b15352b1a7",
+						"type": "message",
+						"status": "completed",
+						"content": [
+							{
+								"type": "output_text",
+								"annotations": [],
+								"logprobs": [],
+								"text": "**Incident Update:**  \nEarlier today, some customers experienced elevated API latency. Our team identified the issue and applied mitigation steps, and API performance has returned to normal.\n\nWe\u2019ll continue monitoring closely and will share a follow-up with additional details if needed. We apologize for the disruption and appreciate your patience."
+							}
+						],
+						"phase": "final_answer",
+						"role": "assistant"
+					}
+				],
+				"parallel_tool_calls": true,
+				"presence_penalty": 0,
+				"previous_response_id": null,
+				"prompt_cache_key": null,
+				"prompt_cache_retention": "in_memory",
+				"reasoning": {
+					"context": "all_turns",
+					"effort": "medium",
+					"mode": "standard",
+					"summary": null
+				},
+				"safety_identifier": null,
+				"service_tier": "default",
+				"store": false,
+				"temperature": 1,
+				"text": {
+					"format": {
+						"type": "text"
+					},
+					"verbosity": "medium"
+				},
+				"tool_choice": "auto",
+				"tool_usage": {
+					"image_gen": {
+						"input_tokens": 0,
+						"input_tokens_details": {
+							"image_tokens": 0,
+							"text_tokens": 0
+						},
+						"output_tokens": 0,
+						"output_tokens_details": {
+							"image_tokens": 0,
+							"text_tokens": 0
+						},
+						"total_tokens": 0
+					},
+					"web_search": {
+						"num_requests": 0
+					}
+				},
+				"tools": [],
+				"top_logprobs": 0,
+				"top_p": 0.98,
+				"truncation": "disabled",
+				"usage": {
+					"input_tokens": 33,
+					"input_tokens_details": {
+						"cache_write_tokens": 0,
+						"cached_tokens": 0
+					},
+					"output_tokens": 64,
+					"output_tokens_details": {
+						"reasoning_tokens": 0
+					},
+					"total_tokens": 97
+				},
+				"user": null,
+				"metadata": {}
+			},
+			"code_snippets": [
+				{
+					"label": "typescript",
+					"language": "typescript",
+					"code": "const response = await env.AI.run(\n  'openai/gpt-5.6-terra',\n  {\n    input: 'Draft a short incident update for customers after elevated API latency.',\n    instructions: 'Be transparent, calm, and avoid unnecessary technical detail.',\n    max_output_tokens: 512,\n  },\n)\nconsole.log(response)"
+				},
+				{
+					"label": "curl",
+					"language": "bash",
+					"code": "curl https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/v1/responses \\\n  --header \"Authorization: Bearer $CLOUDFLARE_API_TOKEN\" \\\n  --header \"Content-Type: application/json\" \\\n  --data '{\n  \"model\": \"openai/gpt-5.6-terra\",\n  \"input\": \"Draft a short incident update for customers after elevated API latency.\",\n  \"instructions\": \"Be transparent, calm, and avoid unnecessary technical detail.\",\n  \"max_output_tokens\": 512\n}'"
+				}
+			]
+		}
+	],
+	"default_example": null,
+	"code_snippets": [],
+	"supports_async": false,
+	"zdr": false,
+	"zdr_comment": null,
+	"external_info": "https://openai.com/",
+	"terms": "https://openai.com/policies/",
+	"cover_image_url": "https://pub-26f1392c1b674324be6786695bd72257.r2.dev/openai/gpt-5.6-terra.png",
+	"metadata": {
+		"API": "Responses",
+		"Architecture": "Transformer"
+	},
+	"request_formats": [
+		"responses"
+	],
+	"banner": null,
+	"created_at": "2026-07-10 02:49:52",
+	"schema": {
+		"input": {
+			"$schema": "https://json-schema.org/draft/2020-12/schema",
+			"type": "object",
+			"properties": {
+				"input": {
+					"anyOf": [
+						{
+							"type": "string"
+						},
+						{
+							"type": "array",
+							"items": {}
+						}
+					]
+				},
+				"instructions": {
+					"type": "string"
+				},
+				"temperature": {
+					"type": "number",
+					"minimum": 0,
+					"maximum": 2
+				},
+				"max_output_tokens": {
+					"type": "number",
+					"exclusiveMinimum": 0
+				},
+				"top_p": {
+					"type": "number",
+					"minimum": 0,
+					"maximum": 1
+				},
+				"stream": {
+					"type": "boolean"
+				},
+				"tools": {
+					"type": "array",
+					"items": {}
+				},
+				"tool_choice": {},
+				"text": {
+					"type": "object",
+					"properties": {
+						"format": {}
+					},
+					"additionalProperties": {}
+				},
+				"reasoning": {
+					"type": "object",
+					"properties": {
+						"effort": {
+							"type": "string",
+							"enum": [
+								"none",
+								"low",
+								"medium",
+								"high"
+							]
+						}
+					},
+					"additionalProperties": {}
+				}
+			},
+			"required": [
+				"input"
+			],
+			"additionalProperties": {}
+		},
+		"output": {
+			"$schema": "https://json-schema.org/draft/2020-12/schema",
+			"type": "object",
+			"properties": {
+				"id": {
+					"type": "string"
+				},
+				"object": {
+					"type": "string",
+					"const": "response"
+				},
+				"created_at": {
+					"type": "number"
+				},
+				"model": {
+					"type": "string"
+				},
+				"output": {
+					"type": "array",
+					"items": {}
+				},
+				"output_text": {
+					"type": "string"
+				},
+				"status": {
+					"type": "string",
+					"enum": [
+						"in_progress",
+						"completed",
+						"failed",
+						"incomplete"
+					]
+				},
+				"usage": {
+					"type": "object",
+					"properties": {
+						"input_tokens": {
+							"type": "number"
+						},
+						"output_tokens": {
+							"type": "number"
+						},
+						"total_tokens": {
+							"type": "number"
+						}
+					},
+					"required": [
+						"input_tokens",
+						"output_tokens",
+						"total_tokens"
+					],
+					"additionalProperties": {}
+				}
+			},
+			"required": [
+				"id",
+				"object",
+				"created_at",
+				"model",
+				"output"
+			],
+			"additionalProperties": {}
+		}
+	}
+}


### PR DESCRIPTION
Adds the generated GPT-5.6 Sol, Terra, and Luna catalog entries so the models surface on the public models pages. The files were generated from the live Unified Catalog API. Validation: Astro check and Worker TypeScript passed.