### PR TITLE
Allow null schema field in catalog-models zod schema

### DIFF
--- a/src/schemas/catalog-models.ts
+++ b/src/schemas/catalog-models.ts
@@ -109,6 +109,7 @@ export const catalogModelsSchema = z.object({
 			input: z.record(z.string(), z.unknown()).optional(),
 			output: z.record(z.string(), z.unknown()).optional(),
 		})
+		.nullable()
 		.optional(),
 
 	// Metadata & Links


### PR DESCRIPTION
Fixes an astro content-collection validation failure when a catalog model ships `"schema": null` (observed on `elevenlabs-eleven-flash-v2-5.json`).

The `schema` field in `catalogModelsSchema` was `.optional()` but not `.nullable()`, so an explicit `null` from upstream broke `pnpm run check` and CI on #31933. This mirrors the `.nullable().optional()` pattern already used by `banner`, `default_example`, `request_formats`, and similar upstream-driven fields.

- Add `.nullable()` to `schema` in `src/schemas/catalog-models.ts`.
- No content or component changes.