### PR TITLE
[Hyperdrive] Add support section to PlanetScale page

### DIFF
--- a/src/content/docs/hyperdrive/planetscale.mdx
+++ b/src/content/docs/hyperdrive/planetscale.mdx
@@ -65,7 +65,7 @@ When you create a PlanetScale database from the Cloudflare dashboard, you are bi
 
 ## Support for your connected PlanetScale databases
 
-Support for your PlanetScale databases via Cloudflare is provided by PlanetScale at their Standard level support or your procured PlanetScale support plan. For help with your PlanetScale database, refer to [PlanetScale Support](https://planetscale.com/docs/support) for more information or contact the PlanetScale support team directly via the [PlanetScale support portal](https://support.planetscale.com/).
+Support for your PlanetScale databases created via Cloudflare is provided by PlanetScale at their Standard level support or your procured PlanetScale support plan. For help with your PlanetScale database, refer to [PlanetScale Support](https://planetscale.com/docs/support) for more information or contact the PlanetScale support team directly via the [PlanetScale support portal](https://support.planetscale.com/).
 
 <CardGrid>
 

--- a/src/content/docs/hyperdrive/planetscale.mdx
+++ b/src/content/docs/hyperdrive/planetscale.mdx
@@ -63,6 +63,10 @@ Use [development branches](https://planetscale.com/docs/postgres/branching) to t
 
 When you create a PlanetScale database from the Cloudflare dashboard, you are billed via your Cloudflare account — you will see a line item on your Cloudflare invoice for your PlanetScale usage. The pricing for PlanetScale is the same when you create and use databases via Cloudflare as it is when you buy directly from PlanetScale. For more pricing details, refer to [PlanetScale's pricing](https://planetscale.com/pricing). You can introspect per-database billing usage via PlanetScale's [dashboard](https://planetscale.com/docs/billing#organization-usage-and-billing-page).
 
+## Support for your connected PlanetScale databases
+
+Support for your PlanetScale databases via Cloudflare is provided by PlanetScale at their Standard level support or your procured PlanetScale support plan. For help with your PlanetScale database, refer to [PlanetScale Support](https://planetscale.com/docs/support) for more information or contact the PlanetScale support team directly via the [PlanetScale support portal](https://support.planetscale.com/).
+
 <CardGrid>
 
 <LinkTitleCard


### PR DESCRIPTION
### Summary

Adding support section for PlanetScale created databases. 

### Screenshots (optional)

<img width="775" height="227" alt="image" src="https://github.com/user-attachments/assets/a868916e-e531-4fa8-8367-20fe8ae44a30" />
### Documentation checklist

<!-- Remove items that do not apply -->
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).