### PR TITLE
[Markdown Conversion] add output format options

### DIFF
--- a/src/content/changelog/workers-ai/2026-07-13-markdown-conversion-text-output.mdx
+++ b/src/content/changelog/workers-ai/2026-07-13-markdown-conversion-text-output.mdx
@@ -1,0 +1,39 @@
+---
+title: Plain text output for Markdown Conversion
+description: Choose between Markdown and plain text output when converting documents
+date: 2026-07-10
+---
+
+import { TypeScriptExample } from "~/components";
+
+The [Markdown Conversion](/workers-ai/features/markdown-conversion/) service now supports a new `output` conversion option that controls the format of the converted content.
+
+Set `output.format` to `text` to receive plain text with Markdown syntax removed. The default value is `markdown`, so existing conversions are unchanged.
+
+Use the [`env.AI`](/workers-ai/features/markdown-conversion/usage/binding/) binding:
+
+<TypeScriptExample>
+
+```typescript
+await env.AI.toMarkdown(
+	{ name: "page.html", blob: new Blob([html]) },
+	{
+		conversionOptions: {
+			output: { format: "text" },
+		},
+	},
+);
+```
+
+</TypeScriptExample>
+
+Or call the REST API:
+
+```bash
+curl https://api.cloudflare.com/client/v4/accounts/{ACCOUNT_ID}/ai/tomarkdown \
+  -H 'Authorization: Bearer {API_TOKEN}' \
+  -F 'files=@index.html' \
+  -F 'conversionOptions={"output": {"format": "text"}}'
+```
+
+When you request text output, the `format` field of each result is set to `text`. For more details, refer to [Conversion Options](/workers-ai/features/markdown-conversion/conversion-options/#output).

--- a/src/content/docs/workers-ai/features/markdown-conversion/conversion-options.mdx
+++ b/src/content/docs/workers-ai/features/markdown-conversion/conversion-options.mdx
@@ -14,6 +14,20 @@ Options are organized by file type and are all optional.
 
 ## Available options
 
+### Output
+
+```typescript
+{
+  output?: {
+    format?: 'markdown' | 'text';
+  }
+}
+```
+
+- `format`: controls the format of the converted content. Defaults to `markdown`. Set to `text` to receive plain text with Markdown syntax removed.
+
+When `format` is `text`, the `format` field of the [`ConversionResult`](/workers-ai/features/markdown-conversion/usage/binding/#conversionresult-definition) is also set to `text`.
+
 ### Images
 
 ```typescript

--- a/src/content/docs/workers-ai/features/markdown-conversion/usage/binding.mdx
+++ b/src/content/docs/workers-ai/features/markdown-conversion/usage/binding.mdx
@@ -129,17 +129,17 @@ const result = await env.AI.toMarkdown({
 - `name` <Type text="string" />
   - Name of the converted document. Matches the input name.
 
-- `format` <Type text="'markdown' | 'error'" />
-  - The format of this `ConversionResult` object
+- `format` <Type text="'markdown' | 'text' | 'error'" />
+  - The format of this `ConversionResult` object. Equals `text` when you set the [`output.format`](/workers-ai/features/markdown-conversion/conversion-options/#output) option to `text`.
 
 - `mimetype` <Type text="string" />
   - The detected [mime type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/MIME_types/Common_types) of the document.
 
 - `tokens` <Type text="number" />
-  - The estimated number of tokens of the converted document. Only present if `format` is equal to `markdown`.
+  - The estimated number of tokens of the converted document. Not present if `format` is equal to `error`.
 
 - `data` <Type text="string" />
-  - The content of the converted document in Markdown format. Only present if `format` is equal to `markdown`.
+  - The content of the converted document. Not present if `format` is equal to `error`.
 
 - `error` <Type text="string" />
   - The error message explaining why this conversion failed. Only present if `format` is equal to `error`.


### PR DESCRIPTION
### Summary

Adds `output.format` as a conversion option.

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
