### PR TITLE
docs(client-side-security): add use case for blocking third-party tracking pixels

### DIFF
--- a/src/content/docs/client-side-security/rules/index.mdx
+++ b/src/content/docs/client-side-security/rules/index.mdx
@@ -52,6 +52,14 @@ For details on the CSP directives Cloudflare creates for each type of rule actio
 | **Violations**     | Reported to Cloudflare without blocking | Logged by Cloudflare after blocking    |
 | **Use case**       | Validate a rule before enforcing it     | Enforce a positive security model      |
 
+## Use cases
+
+### Block third-party tracking pixels
+
+Content security rules can block third-party tracking pixels and analytics tags — such as Facebook Pixel or Google Tags — from loading on your pages. Create an allow rule that explicitly permits only the script sources your application requires. Any script not in your allowlist, including third-party tracking pixels, will be blocked and logged as a rule violation.
+
+Before switching a rule to the _Allow_ action, use the _Log_ action to validate that your allowlist does not inadvertently block essential application resources.
+
 ## Next steps
 
 Refer to the following pages for instructions on creating a content security rule:


### PR DESCRIPTION
## What

Adds a **Use cases** section to the content security rules page with a subsection explaining how allow rules can block third-party tracking pixels and analytics tags.

## Why

Customers and support engineers repeatedly ask whether Client-Side Security can block third-party tracking pixels such as Facebook Pixel or Google Tags. The answer is yes — via an allow rule — but this is not documented anywhere on the rules page. Without guidance, customers either do not discover the capability or configure rules incorrectly.

## Files changed

- `src/content/docs/client-side-security/rules/index.mdx` — new `## Use cases` section with `### Block third-party tracking pixels` subsection (+8 lines)

## How to verify

Navigate to [/client-side-security/rules/](https://developers.cloudflare.com/client-side-security/rules/) and confirm the Use cases section appears between the Comparison table and Next steps.

Closes DEE-3703