### PR TITLE
docs(log-explorer): document that MatchedRules is not populated by cache rules

### DIFF
--- a/src/content/docs/log-explorer/faq.mdx
+++ b/src/content/docs/log-explorer/faq.mdx
@@ -15,6 +15,10 @@ import { DashButton } from "~/components";
 
 All fields listed in [Datasets](/logs/logpush/logpush-job/datasets/) for the [supported datasets](/log-explorer/manage-datasets/#supported-datasets) are viewable in Log Explorer.
 
+## Why is the `MatchedRules` field empty for some requests?
+
+`MatchedRules` is populated only by security and transformation rules (WAF, Rate Limiting, Transform Rules, Snippets). Cache rules do not populate this field. If you are investigating cache behavior, use the `Cache*` fields such as `CacheCacheStatus` instead.
+
 ## Why does my query not complete or time out?
 
 Log Explorer performs best when query parameters focus on narrower ranges of time. You may experience query timeouts when your query would return a large quantity of data. Consider refining your query to improve performance.


### PR DESCRIPTION
## What

Adds a FAQ entry to the Log Explorer FAQ page explaining that `MatchedRules` is only populated by security and transformation rules, not cache rules.

## Why

Customers querying `MatchedRules` to investigate cache rule behavior get empty results with no explanation. The HTTP requests dataset field definition is auto-generated and cannot be edited directly, making the FAQ the appropriate location for this clarification.

## Files changed

- `src/content/docs/log-explorer/faq.mdx` — new FAQ entry before the query timeout section (+4 lines)

## How to verify

Navigate to [/log-explorer/faq/](https://developers.cloudflare.com/log-explorer/faq/) and confirm the new entry appears near the top of the FAQ.

Closes DEE-3705