### PR TITLE
docs(ddos-protection): note read-only rules cannot be adjusted via override

### DIFF
--- a/src/content/docs/ddos-protection/managed-rulesets/http/http-overrides/override-examples.mdx
+++ b/src/content/docs/ddos-protection/managed-rulesets/http/http-overrides/override-examples.mdx
@@ -84,6 +84,10 @@ To remedy a false positive:
 	</TabItem>
 </Tabs>
 
+:::note
+Some rules belong to the [read-only category](/ddos-protection/managed-rulesets/http/rule-categories/) and cannot have their sensitivity level or action adjusted via override. If you are unable to modify the rule causing the false positive, [contact Cloudflare Support](/support/contacting-cloudflare-support/) for assistance.
+:::
+
 Once saved, the rule takes effect within one or two minutes. The rule adjustment should provide immediate remedy, which you can view in the [analytics dashboard](/ddos-protection/reference/analytics/).
 
 #### Update the adjusted rules later


### PR DESCRIPTION
## What

Add a note to the HTTP DDoS false positive remediation steps clarifying that some rules belong to the read-only category and cannot have their sensitivity level or action adjusted via override. Directs customers to contact Support when this is the case.

## Why

The false positive guide instructs customers to find the triggering rule and decrease its sensitivity level. Rules in the `read-only` category are silently unaffected by overrides, leaving customers with no resolution path and no explanation.

The [rule categories page](https://developers.cloudflare.com/ddos-protection/managed-rulesets/http/rule-categories/) already defines the read-only category but the false positive page did not cross-reference it.

## Files changed

- `src/content/docs/ddos-protection/managed-rulesets/http/http-overrides/override-examples.mdx` — added 4-line note after the false positive Tabs block

## How to verify

Read the updated section under "Legitimate traffic is incorrectly identified as an attack" — a Note callout should appear after step 8 linking to the rule categories page and Support.

Closes DEE-3707