### PR TITLE
docs(api-shield): surface discovery requirements inline including Workers exclusion

### DIFF
--- a/src/content/docs/api-shield/security/api-discovery.mdx
+++ b/src/content/docs/api-shield/security/api-discovery.mdx
@@ -85,7 +85,15 @@ You can direct any feedback about your API Discovery results to your account tea
 
 ## Requirements
 
-API endpoints are discovered based on machine learning or session identifiers. Machine learning based API discovery has traffic requirements. For more information, refer to [Discovery requirements](/security/web-assets/manage-operations/#discovery-requirements/).
+API Discovery requires an active API Shield subscription at both the account and zone level. If your subscription is active at the account level but not assigned to the zone, Discovery will not run for that zone.
+
+For an endpoint to appear in Discovery results, every request must meet the following conditions:
+
+- The request must return a `2xx` response code from the Cloudflare edge.
+- The request must not originate directly from a Cloudflare Worker. Traffic sent through the Cloudflare traffic simulator or other Worker-based test harnesses will not be counted toward Discovery thresholds.
+- The endpoint must receive at least 500 requests within a continuous 10-day period.
+
+For more information, refer to [Discovery requirements](/security/web-assets/manage-operations/#discovery-requirements/).
 
 ## Availability
 


### PR DESCRIPTION
## What

Expand the Requirements section on the API Shield Discovery page to list the three discovery conditions inline:
- 2xx response required
- Requests from Cloudflare Workers are excluded
- 500 requests within a continuous 10-day period

Also adds a note that the API Shield subscription must be active at both account and zone level.

## Why

TSEs and customers using the Cloudflare traffic simulator or Worker-based test harnesses repeatedly hit the Workers exclusion condition without knowing it exists. The previous Requirements section only linked to the WAM discovery requirements page without surfacing the constraints inline — customers had to follow the link and find the relevant section.

Chat signal: https://chat.google.com/room/AAAAj1kIEx8/U_m7OWjLO-Q (Jul 7–8 2026, API Shield room) — SE reported traffic simulator not discovering endpoints; engineer responded by quoting all three requirements verbatim.

The conditions are already documented on the WAM side ([Discovery requirements](https://developers.cloudflare.com/security/web-assets/manage-operations/#discovery-requirements/)). This change surfaces them on the API Shield page so customers don't need to follow a cross-product link to understand why their endpoints aren't appearing.

## Files changed

- `src/content/docs/api-shield/security/api-discovery.mdx` — Requirements section expanded (+8 lines)

## How to verify

Read the Requirements section at [/api-shield/security/api-discovery/](https://developers.cloudflare.com/api-shield/security/api-discovery/) — three bullet conditions and the dual subscription note should appear before the cross-link to WAM.

Closes DEE-3708