### PR TITLE
[AI Gateway] Add Datadog as a supported OTEL backend

### DIFF
--- a/src/content/docs/ai-gateway/observability/otel-integration.mdx
+++ b/src/content/docs/ai-gateway/observability/otel-integration.mdx
@@ -105,6 +105,7 @@ AI Gateway's OTEL integration works with any OpenTelemetry-compatible backend, i
 - [Honeycomb](https://www.honeycomb.io/)
 - [Braintrust](https://www.braintrust.dev/docs/integrations/sdk-integrations/opentelemetry)
 - [Langfuse](https://langfuse.com/integrations/native/opentelemetry)
+- [Datadog](https://docs.datadoghq.com/opentelemetry/setup/agentless/)
 
 :::note
 


### PR DESCRIPTION
## Summary
- Adds Datadog to the list of Common OTEL Backends on the AI Gateway OpenTelemetry integration page, alongside Honeycomb, Braintrust, and Langfuse.

## Test plan
- [ ] Verify the link renders correctly and matches the style of the other backend links