### PR TITLE
Agents: organize MCP client capabilities and add elicitation API reference

### DIFF
--- a/src/content/docs/agents/concepts/agentic-patterns/human-in-the-loop.mdx
+++ b/src/content/docs/agents/concepts/agentic-patterns/human-in-the-loop.mdx
@@ -321,14 +321,6 @@ class ExpenseAgent extends Agent<Env, ExpenseState> {
 
 </WranglerConfig>
 
-## Durable Code Mode approvals
-
-Use the [durable Code Mode runtime](/agents/tools/codemode/durable-runtime/) for coding agents and other Agents that use the Code Mode pattern. Mark a connector method with `requiresApproval: true` to pause model-generated code before it invokes the underlying tool.
-
-Your application can show the pending method and arguments to a user, then call `runtime.approve({ executionId })` or `runtime.reject({ executionId, seq })`. Approval starts another pass with the same source code and execution ID. Previously completed calls replay from the durable log, the approved connector call executes, and the generated code continues. Pending approvals and execution history survive request completion and Durable Object hibernation.
-
-For the execution and replay model, refer to [Approvals through abort and replay](/agents/tools/codemode/how-it-works/#approvals-through-abort-and-replay).
-
 ## MCP elicitation
 
 MCP elicitation lets an MCP server developer decide that a tool call needs more information or an out-of-band interaction. Your Agent acts as the MCP client: it presents the request to the user and returns their response. These interactions typically complete within minutes.
@@ -368,6 +360,105 @@ export class MyAgent extends Agent<Env> {
 </TypeScriptExample>
 
 For the complete form, URL, and browser forwarding patterns, refer to [MCP client elicitation](/agents/model-context-protocol/apis/client-api/#elicitation). For the server-side request API, refer to [McpAgent elicitation](/agents/model-context-protocol/apis/agent-api/#elicitation).
+
+## Durable Code Mode approvals
+
+Use the [durable Code Mode runtime](/agents/tools/codemode/durable-runtime/) for coding agents and other Agents that use the Code Mode pattern. Mark a connector method with `requiresApproval: true` to pause model-generated code before it invokes the underlying tool.
+
+The following example marks a GitHub MCP tool as approval-gated, adds the connector to a durable runtime, and exposes methods that a UI can use to inspect, approve, or reject the pending action:
+
+<TypeScriptExample>
+
+```ts
+import { AIChatAgent } from "@cloudflare/ai-chat";
+import {
+	createCodemodeRuntime,
+	DynamicWorkerExecutor,
+	McpConnector,
+	type CodemodeRuntimeHandle,
+	type ConnectorTool,
+	type McpConnectionLike,
+	type PendingAction,
+} from "@cloudflare/codemode";
+import { callable } from "agents";
+import { convertToModelMessages, stepCountIs, streamText } from "ai";
+import { model } from "./model";
+
+class GitHubConnector extends McpConnector<Env> {
+	constructor(
+		ctx: DurableObjectState,
+		env: Env,
+		private connection: McpConnectionLike,
+	) {
+		super(ctx, env);
+	}
+
+	override name() {
+		return "github";
+	}
+
+	protected override createConnection() {
+		return this.connection;
+	}
+
+	protected override tool(name: string, tool: ConnectorTool): ConnectorTool {
+		if (name === "create_issue") {
+			return { ...tool, requiresApproval: true };
+		}
+		return tool;
+	}
+}
+
+export class CodingAgent extends AIChatAgent<Env> {
+	private runtime(): CodemodeRuntimeHandle {
+		const server = this.mcp
+			.listServers()
+			.find((item) => item.name === "GitHub");
+		if (!server) throw new Error("GitHub MCP server is not registered.");
+
+		const connection = this.mcp.mcpConnections[server.id];
+		if (!connection) throw new Error("GitHub MCP connection is unavailable.");
+
+		return createCodemodeRuntime({
+			ctx: this.ctx,
+			executor: new DynamicWorkerExecutor({ loader: this.env.LOADER }),
+			connectors: [new GitHubConnector(this.ctx, this.env, connection)],
+		});
+	}
+
+	async onChatMessage() {
+		const result = streamText({
+			model,
+			messages: await convertToModelMessages(this.messages),
+			tools: { codemode: this.runtime().tool() },
+			stopWhen: stepCountIs(10),
+		});
+
+		return result.toUIMessageStreamResponse();
+	}
+
+	@callable()
+	async pendingApprovals(): Promise<PendingAction[]> {
+		return this.runtime().pending();
+	}
+
+	@callable()
+	async approveExecution(executionId: string) {
+		return this.runtime().approve({ executionId });
+	}
+
+	@callable()
+	async rejectExecution(executionId: string, seq: number): Promise<boolean> {
+		return this.runtime().reject({ executionId, seq });
+	}
+}
+```
+
+</TypeScriptExample>
+
+When generated code calls `github.create_issue()`, the runtime records the pending method and arguments, then pauses before the MCP tool executes. Approval starts another pass with the same source code and execution ID. Previously completed calls replay from the durable log, the approved call executes, and the generated code continues.
+
+Pending approvals and execution history survive request completion and Durable Object hibernation. For the execution and replay model, refer to [Approvals through abort and replay](/agents/tools/codemode/how-it-works/#approvals-through-abort-and-replay).
 
 ## Build Workflow approval UIs
 
@@ -486,19 +577,19 @@ class MultiApprovalAgent extends Agent<Env, State> {
 />
 
 <LinkCard
+	title="MCP clients"
+	href="/agents/model-context-protocol/apis/client-api/"
+	description="Handle elicitation requests in an Agent acting as an MCP client."
+/>
+
+<LinkCard
 	title="MCP servers"
 	href="/agents/model-context-protocol/apis/agent-api/"
-	description="Build MCP agents with elicitation."
+	description="Request form or URL elicitation from an MCP server."
 />
 
 <LinkCard
-	title="Email notifications"
-	href="/email-service/api/send-emails/workers-api/"
-	description="Send notifications for pending approvals."
-/>
-
-<LinkCard
-	title="Schedule tasks"
-	href="/agents/runtime/execution/schedule-tasks/"
-	description="Implement approval timeouts with schedules."
+	title="Durable Code Mode runtime"
+	href="/agents/tools/codemode/durable-runtime/"
+	description="Pause model-generated code for approval before connector calls."
 />

--- a/src/content/docs/agents/concepts/agentic-patterns/human-in-the-loop.mdx
+++ b/src/content/docs/agents/concepts/agentic-patterns/human-in-the-loop.mdx
@@ -385,12 +385,15 @@ import { convertToModelMessages, stepCountIs, streamText } from "ai";
 import { model } from "./model";
 
 class GitHubConnector extends McpConnector<Env> {
+	private connection: McpConnectionLike;
+
 	constructor(
 		ctx: DurableObjectState,
 		env: Env,
-		private connection: McpConnectionLike,
+		connection: McpConnectionLike,
 	) {
 		super(ctx, env);
+		this.connection = connection;
 	}
 
 	override name() {

--- a/src/content/docs/agents/concepts/agentic-patterns/human-in-the-loop.mdx
+++ b/src/content/docs/agents/concepts/agentic-patterns/human-in-the-loop.mdx
@@ -10,7 +10,7 @@ products:
 
 import { TypeScriptExample, WranglerConfig, LinkCard } from "~/components";
 
-Human-in-the-loop (HITL) patterns allow agents to pause execution and wait for human approval, confirmation, or input before proceeding. This is essential for compliance, safety, and oversight in agentic systems.
+Human-in-the-loop (HITL) patterns add approval or input at different layers of an Agent. You can respond to an MCP server request, hold application work in a durable Workflow, or approve a connector call before model-generated code invokes a tool.
 
 ## Why human-in-the-loop?
 
@@ -25,17 +25,17 @@ Common uses include financial approvals, content moderation, bulk data operation
 
 ## Choosing a pattern
 
-Choose the pattern based on where execution runs and how long approval may take:
+Choose the pattern based on who introduces the pause and where it occurs:
 
-| Pattern                | Best for                                               | Duration                          | Key API                         |
-| ---------------------- | ------------------------------------------------------ | --------------------------------- | ------------------------------- |
-| **Workflow approval**  | Multi-step processes and durable approval gates        | Hours, days, or weeks             | `waitForApproval()`             |
-| **Code Mode approval** | Side-effecting connector calls in model-generated code | Survives requests and hibernation | `requiresApproval`, `approve()` |
-| **MCP elicitation**    | Form input or out-of-band interactions for MCP servers | Form input or async URL flow      | `elicitInput()`                 |
+| Pattern                | Approval layer                             | Initiated by                | Typical wait            | Key API                                     |
+| ---------------------- | ------------------------------------------ | --------------------------- | ----------------------- | ------------------------------------------- |
+| **MCP elicitation**    | MCP request handled by your Agent client   | MCP server developer        | Minutes                 | `configureElicitationHandlers()`            |
+| **Workflow approval**  | Durable application task or tool operation | Agent application developer | Months or years         | `waitForApproval()`                         |
+| **Code Mode approval** | Connector call in model-generated code     | Code Mode Agent developer   | Until configured expiry | `requiresApproval`, `approve()`, `reject()` |
 
 ## Workflow-based approval
 
-For durable, multi-step processes, use [Cloudflare Workflows](/workflows/) with the `waitForApproval()` method. The workflow pauses until a human approves or rejects.
+Use [Cloudflare Workflows](/workflows/) when your application needs to hold a task or tool operation for as long as approval requires. `waitForApproval()` creates a durable gate backed by Cloudflare Workflows, so the wait can continue for months or longer without keeping an Agent running.
 
 ### Basic pattern
 
@@ -323,85 +323,43 @@ class ExpenseAgent extends Agent<Env, ExpenseState> {
 
 ## Durable Code Mode approvals
 
-Use the [durable Code Mode runtime](/agents/tools/codemode/durable-runtime/) when model-generated code may call connectors with side effects. Mark a connector method with `requiresApproval: true`. The runtime records the pending action and pauses before the method executes.
+Use the [durable Code Mode runtime](/agents/tools/codemode/durable-runtime/) for coding agents and other Agents that use the Code Mode pattern. Mark a connector method with `requiresApproval: true` to pause model-generated code before it invokes the underlying tool.
 
-Your application can show the pending method and arguments to a user, then call `runtime.approve({ executionId })` or `runtime.reject({ executionId, seq })`. Approval starts another pass with the same source code and execution ID. Previously completed calls replay from the durable log, the approved action executes, and the code continues. Pending approvals and execution history survive request completion and Durable Object hibernation.
+Your application can show the pending method and arguments to a user, then call `runtime.approve({ executionId })` or `runtime.reject({ executionId, seq })`. Approval starts another pass with the same source code and execution ID. Previously completed calls replay from the durable log, the approved connector call executes, and the generated code continues. Pending approvals and execution history survive request completion and Durable Object hibernation.
 
 For the execution and replay model, refer to [Approvals through abort and replay](/agents/tools/codemode/how-it-works/#approvals-through-abort-and-replay).
 
 ## MCP elicitation
 
-When building MCP servers with `McpAgent`, you can request user interaction during tool execution using **elicitation**. Form mode collects structured, non-sensitive input through the MCP client. URL mode asks the user to open an out-of-band flow, such as third-party authorization or payment.
+MCP elicitation lets an MCP server developer decide that a tool call needs more information or an out-of-band interaction. Your Agent acts as the MCP client: it presents the request to the user and returns their response. These interactions typically complete within minutes.
 
-### Form mode pattern
+Form mode collects structured, non-sensitive input. URL mode asks the user to open an out-of-band flow, such as third-party authorization or payment.
+
+Configure the user-facing handlers in `onStart()`:
 
 <TypeScriptExample>
 
 ```ts
-import { McpAgent } from "agents/mcp";
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { z } from "zod";
+import { Agent } from "agents";
+import type { ElicitRequest, ElicitResult } from "agents/mcp";
 
-type State = { counter: number };
+export class MyAgent extends Agent<Env> {
+	onStart() {
+		this.mcp.configureElicitationHandlers({
+			form: (request, serverId) =>
+				this.forwardElicitationToUser(request, serverId),
+			url: (request, serverId) =>
+				this.forwardElicitationToUser(request, serverId),
+		});
+	}
 
-export class CounterMCP extends McpAgent<Env, State, {}> {
-	server = new McpServer({
-		name: "counter-server",
-		version: "1.0.0",
-	});
-
-	initialState: State = { counter: 0 };
-
-	async init() {
-		this.server.tool(
-			"increase-counter",
-			"Increase the counter by a user-specified amount",
-			{ confirm: z.boolean().describe("Do you want to increase the counter?") },
-			async ({ confirm }, extra) => {
-				if (!confirm) {
-					return { content: [{ type: "text", text: "Cancelled." }] };
-				}
-
-				// Request additional input from the user
-				const userInput = await this.server.server.elicitInput(
-					{
-						message: "By how much do you want to increase the counter?",
-						requestedSchema: {
-							type: "object",
-							properties: {
-								amount: {
-									type: "number",
-									title: "Amount",
-									description: "The amount to increase the counter by",
-								},
-							},
-							required: ["amount"],
-						},
-					},
-					{ relatedRequestId: extra.requestId },
-				);
-
-				// Check if user accepted or cancelled
-				if (userInput.action !== "accept" || !userInput.content) {
-					return { content: [{ type: "text", text: "Cancelled." }] };
-				}
-
-				// Use the input
-				const amount = Number(userInput.content.amount);
-				this.setState({
-					...this.state,
-					counter: this.state.counter + amount,
-				});
-
-				return {
-					content: [
-						{
-							type: "text",
-							text: `Counter increased by ${amount}, now at ${this.state.counter}`,
-						},
-					],
-				};
-			},
+	private forwardElicitationToUser(
+		request: ElicitRequest,
+		serverId: string,
+	): Promise<ElicitResult> {
+		// Present the request in your UI and resolve after the user responds.
+		throw new Error(
+			`Implement elicitation for ${serverId}: ${request.params.message}`,
 		);
 	}
 }
@@ -409,9 +367,9 @@ export class CounterMCP extends McpAgent<Env, State, {}> {
 
 </TypeScriptExample>
 
-For URL mode and complete server-side requirements, refer to [McpAgent elicitation](/agents/model-context-protocol/apis/agent-api/#elicitation). Agents acting as MCP clients can handle both modes with [`configureElicitationHandlers()`](/agents/model-context-protocol/apis/client-api/#configureelicitationhandlers).
+For the complete form, URL, and browser forwarding patterns, refer to [MCP client elicitation](/agents/model-context-protocol/apis/client-api/#elicitation). For the server-side request API, refer to [McpAgent elicitation](/agents/model-context-protocol/apis/agent-api/#elicitation).
 
-## Building approval UIs
+## Build Workflow approval UIs
 
 ### Pending approvals list
 
@@ -457,7 +415,7 @@ function PendingApprovals() {
 }
 ```
 
-## Multi-approver patterns
+## Add multiple Workflow approvers
 
 For sensitive operations requiring multiple approvers:
 

--- a/src/content/docs/agents/concepts/agentic-patterns/human-in-the-loop.mdx
+++ b/src/content/docs/agents/concepts/agentic-patterns/human-in-the-loop.mdx
@@ -3,7 +3,7 @@ title: Human-in-the-loop patterns
 pcx_content_type: how-to
 sidebar:
   order: 2
-description: Implement human-in-the-loop functionality using Cloudflare Agents for workflow approvals and MCP elicitation
+description: Implement human-in-the-loop functionality using Workflow approvals, durable Code Mode approvals, and MCP elicitation.
 products:
   - agents
 ---
@@ -21,27 +21,17 @@ Human-in-the-loop (HITL) patterns allow agents to pause execution and wait for h
 
 ### Common use cases
 
-| Use Case            | Example                              |
-| ------------------- | ------------------------------------ |
-| Financial approvals | Expense reports, payment processing  |
-| Content moderation  | Publishing, email sending            |
-| Data operations     | Bulk deletions, exports              |
-| AI tool execution   | Confirming tool calls before running |
-| Access control      | Granting permissions, role changes   |
+Common uses include financial approvals, content moderation, bulk data operations, approval before side-effecting tool calls, and access-control changes.
 
 ## Choosing a pattern
 
-Cloudflare provides two main patterns for human-in-the-loop:
+Choose the pattern based on where execution runs and how long approval may take:
 
-| Pattern               | Best for                                     | Key API             |
-| --------------------- | -------------------------------------------- | ------------------- |
-| **Workflow approval** | Multi-step processes, durable approval gates | `waitForApproval()` |
-| **MCP elicitation**   | User input or out-of-band MCP interactions   | `elicitInput()`     |
-
-Decision guide:
-
-- Use **Workflow approval** when you need durable, multi-step processes with approval gates that can wait hours, days, or weeks
-- Use **MCP elicitation** when an MCP server needs structured, non-sensitive input through form mode or an out-of-band interaction through URL mode
+| Pattern                | Best for                                               | Duration                          | Key API                         |
+| ---------------------- | ------------------------------------------------------ | --------------------------------- | ------------------------------- |
+| **Workflow approval**  | Multi-step processes and durable approval gates        | Hours, days, or weeks             | `waitForApproval()`             |
+| **Code Mode approval** | Side-effecting connector calls in model-generated code | Survives requests and hibernation | `requiresApproval`, `approve()` |
+| **MCP elicitation**    | Form input or out-of-band interactions for MCP servers | Form input or async URL flow      | `elicitInput()`                 |
 
 ## Workflow-based approval
 
@@ -331,6 +321,14 @@ class ExpenseAgent extends Agent<Env, ExpenseState> {
 
 </WranglerConfig>
 
+## Durable Code Mode approvals
+
+Use the [durable Code Mode runtime](/agents/tools/codemode/durable-runtime/) when model-generated code may call connectors with side effects. Mark a connector method with `requiresApproval: true`. The runtime records the pending action and pauses before the method executes.
+
+Your application can show the pending method and arguments to a user, then call `runtime.approve({ executionId })` or `runtime.reject({ executionId, seq })`. Approval starts another pass with the same source code and execution ID. Previously completed calls replay from the durable log, the approved action executes, and the code continues. Pending approvals and execution history survive request completion and Durable Object hibernation.
+
+For the execution and replay model, refer to [Approvals through abort and replay](/agents/tools/codemode/how-it-works/#approvals-through-abort-and-replay).
+
 ## MCP elicitation
 
 When building MCP servers with `McpAgent`, you can request user interaction during tool execution using **elicitation**. Form mode collects structured, non-sensitive input through the MCP client. URL mode asks the user to open an out-of-band flow, such as third-party authorization or payment.
@@ -412,16 +410,6 @@ export class CounterMCP extends McpAgent<Env, State, {}> {
 </TypeScriptExample>
 
 For URL mode and complete server-side requirements, refer to [McpAgent elicitation](/agents/model-context-protocol/apis/agent-api/#elicitation). Agents acting as MCP clients can handle both modes with [`configureElicitationHandlers()`](/agents/model-context-protocol/apis/client-api/#configureelicitationhandlers).
-
-## Elicitation vs workflow approval
-
-| Aspect       | MCP elicitation                                   | Workflow approval             |
-| ------------ | ------------------------------------------------- | ----------------------------- |
-| **Context**  | MCP server tool execution                         | Multi-step workflow processes |
-| **Duration** | Form input is immediate; URL flows may be async   | Can wait hours/days/weeks     |
-| **UI**       | JSON Schema form or URL consent prompt            | Custom UI via agent state     |
-| **State**    | MCP session state                                 | Durable workflow state        |
-| **Use case** | Interactive input or out-of-band MCP interactions | Approval gates in pipelines   |
 
 ## Building approval UIs
 

--- a/src/content/docs/agents/concepts/agentic-patterns/human-in-the-loop.mdx
+++ b/src/content/docs/agents/concepts/agentic-patterns/human-in-the-loop.mdx
@@ -36,12 +36,12 @@ Cloudflare provides two main patterns for human-in-the-loop:
 | Pattern               | Best for                                     | Key API             |
 | --------------------- | -------------------------------------------- | ------------------- |
 | **Workflow approval** | Multi-step processes, durable approval gates | `waitForApproval()` |
-| **MCP elicitation**   | MCP servers requesting structured user input | `elicitInput()`     |
+| **MCP elicitation**   | User input or out-of-band MCP interactions   | `elicitInput()`     |
 
 Decision guide:
 
 - Use **Workflow approval** when you need durable, multi-step processes with approval gates that can wait hours, days, or weeks
-- Use **MCP elicitation** when building MCP servers that need to request additional structured input from users during tool execution
+- Use **MCP elicitation** when an MCP server needs structured, non-sensitive input through form mode or an out-of-band interaction through URL mode
 
 ## Workflow-based approval
 
@@ -333,9 +333,9 @@ class ExpenseAgent extends Agent<Env, ExpenseState> {
 
 ## MCP elicitation
 
-When building MCP servers with `McpAgent`, you can request additional user input during tool execution using **elicitation**. The MCP client renders a form based on your JSON Schema and returns the user's response.
+When building MCP servers with `McpAgent`, you can request user interaction during tool execution using **elicitation**. Form mode collects structured, non-sensitive input through the MCP client. URL mode asks the user to open an out-of-band flow, such as third-party authorization or payment.
 
-### Basic pattern
+### Form mode pattern
 
 <TypeScriptExample>
 
@@ -411,15 +411,17 @@ export class CounterMCP extends McpAgent<Env, State, {}> {
 
 </TypeScriptExample>
 
+For URL mode and complete server-side requirements, refer to [McpAgent elicitation](/agents/model-context-protocol/apis/agent-api/#elicitation). Agents acting as MCP clients can handle both modes with [`configureElicitationHandlers()`](/agents/model-context-protocol/apis/client-api/#configureelicitationhandlers).
+
 ## Elicitation vs workflow approval
 
-| Aspect       | MCP Elicitation               | Workflow Approval             |
-| ------------ | ----------------------------- | ----------------------------- |
-| **Context**  | MCP server tool execution     | Multi-step workflow processes |
-| **Duration** | Immediate (within tool call)  | Can wait hours/days/weeks     |
-| **UI**       | JSON Schema-based form        | Custom UI via agent state     |
-| **State**    | MCP session state             | Durable workflow state        |
-| **Use case** | Interactive input during tool | Approval gates in pipelines   |
+| Aspect       | MCP elicitation                                   | Workflow approval             |
+| ------------ | ------------------------------------------------- | ----------------------------- |
+| **Context**  | MCP server tool execution                         | Multi-step workflow processes |
+| **Duration** | Form input is immediate; URL flows may be async   | Can wait hours/days/weeks     |
+| **UI**       | JSON Schema form or URL consent prompt            | Custom UI via agent state     |
+| **State**    | MCP session state                                 | Durable workflow state        |
+| **Use case** | Interactive input or out-of-band MCP interactions | Approval gates in pipelines   |
 
 ## Building approval UIs
 

--- a/src/content/docs/agents/model-context-protocol/apis/client-api.mdx
+++ b/src/content/docs/agents/model-context-protocol/apis/client-api.mdx
@@ -869,9 +869,7 @@ export class MyAgent extends Agent {
 
 Configure handlers for server-initiated `elicitation/create` requests. Add a handler for each elicitation mode your Agent supports.
 
-<TypeScriptExample>
-
-```ts
+```txt
 this.mcp.configureElicitationHandlers(handlers?: {
   form?: (
     request: ElicitRequest,
@@ -883,8 +881,6 @@ this.mcp.configureElicitationHandlers(handlers?: {
   ) => Promise<ElicitResult>;
 }): void
 ```
-
-</TypeScriptExample>
 
 #### Parameters
 

--- a/src/content/docs/agents/model-context-protocol/apis/client-api.mdx
+++ b/src/content/docs/agents/model-context-protocol/apis/client-api.mdx
@@ -318,7 +318,7 @@ export class MyAgent extends Agent {
 
 Once connected, access the server's capabilities:
 
-### Getting available tools
+### Get available tools
 
 <TypeScriptExample>
 
@@ -329,7 +329,7 @@ const state = this.getMcpServers();
 for (const tool of state.tools) {
 	console.log(`Tool: ${tool.name}`);
 	console.log(`  From server: ${tool.serverId}`);
-	console.log(`  Title: ${tool.title ?? tool.name}`);
+	console.log(`  Title: ${tool.title ?? tool.annotations?.title ?? tool.name}`);
 	console.log(`  Description: ${tool.description}`);
 }
 ```
@@ -599,8 +599,10 @@ Use the server ID to inspect an individual connection:
 const state = this.getMcpServers();
 const server = state.servers[serverId];
 
-console.log(`${server.name}: ${server.state}`);
-// state: "ready" | "authenticating" | "connecting" | "connected" | "discovering" | "failed"
+if (server) {
+	console.log(`${server.name}: ${server.state}`);
+	// state: "ready" | "authenticating" | "connecting" | "connected" | "discovering" | "failed"
+}
 ```
 
 </TypeScriptExample>
@@ -867,6 +869,8 @@ export class MyAgent extends Agent {
 
 Configure handlers for server-initiated `elicitation/create` requests. Add a handler for each elicitation mode your Agent supports.
 
+<TypeScriptExample>
+
 ```ts
 this.mcp.configureElicitationHandlers(handlers?: {
   form?: (
@@ -879,6 +883,8 @@ this.mcp.configureElicitationHandlers(handlers?: {
   ) => Promise<ElicitResult>;
 }): void
 ```
+
+</TypeScriptExample>
 
 #### Parameters
 

--- a/src/content/docs/agents/model-context-protocol/apis/client-api.mdx
+++ b/src/content/docs/agents/model-context-protocol/apis/client-api.mdx
@@ -314,7 +314,81 @@ export class MyAgent extends Agent {
 
 </TypeScriptExample>
 
-## Elicitation
+## Using MCP capabilities
+
+Once connected, access the server's capabilities:
+
+### Getting available tools
+
+<TypeScriptExample>
+
+```ts
+const state = this.getMcpServers();
+
+// All tools from all connected servers
+for (const tool of state.tools) {
+	console.log(`Tool: ${tool.name}`);
+	console.log(`  From server: ${tool.serverId}`);
+	console.log(`  Title: ${tool.title ?? tool.name}`);
+	console.log(`  Description: ${tool.description}`);
+}
+```
+
+</TypeScriptExample>
+
+#### Integration with AI SDK
+
+To use MCP tools with the AI SDK, use `this.mcp.getAITools()` which converts MCP tools to AI SDK format:
+
+<TypeScriptExample>
+
+```ts
+import { generateText } from "ai";
+import { createWorkersAI } from "workers-ai-provider";
+
+export class MyAgent extends Agent<Env> {
+	async onRequest(request: Request) {
+		const workersai = createWorkersAI({ binding: this.env.AI });
+		const response = await generateText({
+			model: workersai("@cf/zai-org/glm-4.7-flash"),
+			prompt: "What's the weather in San Francisco?",
+			tools: this.mcp.getAITools(),
+		});
+
+		return new Response(response.text);
+	}
+}
+```
+
+</TypeScriptExample>
+
+:::note
+
+`getMcpServers().tools` returns raw MCP `Tool` objects for inspection. Use `this.mcp.getAITools()` when passing tools to the AI SDK.
+
+:::
+
+### Resources and prompts
+
+<TypeScriptExample>
+
+```ts
+const state = this.getMcpServers();
+
+// Available resources
+for (const resource of state.resources) {
+	console.log(`Resource: ${resource.name} (${resource.uri})`);
+}
+
+// Available prompts
+for (const prompt of state.prompts) {
+	console.log(`Prompt: ${prompt.name}`);
+}
+```
+
+</TypeScriptExample>
+
+### Elicitation
 
 [MCP elicitation](https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation) lets a server request user input while handling another request, such as a tool call. The current stable MCP specification defines form and URL modes.
 
@@ -353,7 +427,7 @@ class MyAgent extends Agent<Env> {
 
 The `serverId` identifies the connection that sent the request. Use it to tell the user which server is asking for input and to apply server-specific policy.
 
-### Capability negotiation and hibernation
+#### Capability negotiation and hibernation
 
 At the MCP `initialize` handshake, a connection advertises only the modes with configured handlers. A form-only handler advertises form mode. A URL-only handler advertises URL mode. A connection without handlers advertises no elicitation capability, which lets the server use its fallback.
 
@@ -377,7 +451,7 @@ await this.addMcpServer("portal", "https://portal.example.com/mcp", {
 
 An explicit `client.capabilities.elicitation` value takes precedence over handler-derived modes and persists with the server registration. Do not advertise a mode without a matching handler. If the server sends that mode, the connection returns an error because it cannot handle the request.
 
-### Form mode
+#### Form mode
 
 Form mode collects structured, non-sensitive data in the client. The request includes a restricted JSON Schema in `requestedSchema`. If the user submits the form, return `action: "accept"` with matching `content`:
 
@@ -396,7 +470,7 @@ this.mcp.configureElicitationHandlers({
 
 Allow the user to review and edit values before submission. Validate accepted content against `requestedSchema`. Do not use form mode to request passwords, API keys, access tokens, payment credentials, or other secrets.
 
-### URL mode
+#### URL mode
 
 URL mode asks the user to open an external page. Use it for out-of-band interactions that may collect secrets, such as third-party authorization or payment. Keep the URL in the dedicated elicitation path and out of model-visible messages and tool-result text.
 
@@ -413,7 +487,7 @@ Do not prefetch the URL or its metadata. Treat the URL as untrusted input. Produ
 
 For URL mode, `accept` means the user consented to open the URL. It does not mean the external interaction finished. A server may later send `notifications/elicitation/complete` with the request `elicitationId`.
 
-### Response actions
+#### Response actions
 
 Both modes support three actions:
 
@@ -425,7 +499,7 @@ Both modes support three actions:
 
 Include `content` only for an accepted form response. Omit it for URL, decline, and cancel responses.
 
-### Forward elicitation to a UI
+#### Forward elicitation to a UI
 
 A handler returns a promise, but the response often comes from a browser. Broadcast the request to connected clients, then resolve the promise through a `@callable` method:
 
@@ -497,118 +571,11 @@ Refer to the [`mcp-client` example](https://github.com/cloudflare/agents/tree/ma
 
 To send elicitation requests from an MCP server, refer to [`elicitInput`](/agents/model-context-protocol/apis/agent-api/#elicitinputoptions-context).
 
-## Using MCP capabilities
-
-Once connected, access the server's capabilities:
-
-### Getting available tools
-
-<TypeScriptExample>
-
-```ts
-const state = this.getMcpServers();
-
-// All tools from all connected servers
-for (const tool of state.tools) {
-	console.log(`Tool: ${tool.name}`);
-	console.log(`  From server: ${tool.serverId}`);
-	console.log(`  Title: ${tool.title ?? tool.name}`);
-	console.log(`  Description: ${tool.description}`);
-}
-```
-
-</TypeScriptExample>
-
-### Resources and prompts
-
-<TypeScriptExample>
-
-```ts
-const state = this.getMcpServers();
-
-// Available resources
-for (const resource of state.resources) {
-	console.log(`Resource: ${resource.name} (${resource.uri})`);
-}
-
-// Available prompts
-for (const prompt of state.prompts) {
-	console.log(`Prompt: ${prompt.name}`);
-}
-```
-
-</TypeScriptExample>
-
-### Server status
-
-<TypeScriptExample>
-
-```ts
-const state = this.getMcpServers();
-
-for (const [id, server] of Object.entries(state.servers)) {
-	console.log(`${server.name}: ${server.state}`);
-	// state: "ready" | "authenticating" | "connecting" | "connected" | "discovering" | "failed"
-}
-```
-
-</TypeScriptExample>
-
-### Integration with AI SDK
-
-To use MCP tools with the AI SDK, use `this.mcp.getAITools()` which converts MCP tools to AI SDK format:
-
-<TypeScriptExample>
-
-```ts
-import { generateText } from "ai";
-import { createWorkersAI } from "workers-ai-provider";
-
-export class MyAgent extends Agent<Env> {
-	async onRequest(request: Request) {
-		const workersai = createWorkersAI({ binding: this.env.AI });
-		const response = await generateText({
-			model: workersai("@cf/zai-org/glm-4.7-flash"),
-			prompt: "What's the weather in San Francisco?",
-			tools: this.mcp.getAITools(),
-		});
-
-		return new Response(response.text);
-	}
-}
-```
-
-</TypeScriptExample>
-
-:::note
-
-`getMcpServers().tools` returns raw MCP `Tool` objects for inspection. Use `this.mcp.getAITools()` when passing tools to the AI SDK.
-
-:::
-
 ## Managing servers
 
-### Removing a server
+MCP server registrations persist across Agent restarts. The SDK stores server configuration in SQLite, stores OAuth tokens securely, and restores connections when the Agent wakes.
 
-<TypeScriptExample>
-
-```ts
-await this.removeMcpServer(serverId);
-```
-
-</TypeScriptExample>
-
-This disconnects from the server and removes it from storage.
-
-### Persistence
-
-MCP servers persist across agent restarts:
-
-- Server configuration stored in SQLite
-- OAuth tokens stored securely
-- Connections restored automatically when agent wakes
-
-### Listing all servers
+### List all servers
 
 <TypeScriptExample>
 
@@ -621,6 +588,34 @@ for (const [id, server] of Object.entries(state.servers)) {
 ```
 
 </TypeScriptExample>
+
+### Get server status
+
+Use the server ID to inspect an individual connection:
+
+<TypeScriptExample>
+
+```ts
+const state = this.getMcpServers();
+const server = state.servers[serverId];
+
+console.log(`${server.name}: ${server.state}`);
+// state: "ready" | "authenticating" | "connecting" | "connected" | "discovering" | "failed"
+```
+
+</TypeScriptExample>
+
+### Remove a server
+
+<TypeScriptExample>
+
+```ts
+await this.removeMcpServer(serverId);
+```
+
+</TypeScriptExample>
+
+This disconnects from the server and removes it from storage.
 
 ## Client-side integration
 
@@ -867,6 +862,77 @@ export class MyAgent extends Agent {
 ```
 
 </TypeScriptExample>
+
+### `configureElicitationHandlers()`
+
+Configure handlers for server-initiated `elicitation/create` requests. Add a handler for each elicitation mode your Agent supports.
+
+```ts
+this.mcp.configureElicitationHandlers(handlers?: {
+  form?: (
+    request: ElicitRequest,
+    serverId: string,
+  ) => Promise<ElicitResult>;
+  url?: (
+    request: ElicitRequest,
+    serverId: string,
+  ) => Promise<ElicitResult>;
+}): void
+```
+
+#### Parameters
+
+- `handlers` (object, optional) — Elicitation handlers keyed by mode:
+  - `form` (function, optional) — Handles form-mode requests for structured, non-sensitive input.
+  - `url` (function, optional) — Handles URL-mode requests for out-of-band interactions.
+- `request` (`ElicitRequest`) — The MCP elicitation request. Inspect `request.params.mode` for the mode-specific fields.
+- `serverId` (string) — The ID of the MCP server connection that sent the request.
+
+Each handler returns a promise containing an `ElicitResult`. Return `accept`, `decline`, or `cancel`. Accepted form responses include `content` that matches `requestedSchema`. URL responses omit `content`.
+
+Passing `undefined` clears all configured handlers.
+
+#### Capability behavior
+
+The client advertises only modes with configured handlers during the MCP `initialize` handshake. Handler changes apply immediately to live connections, but servers receive updated advertised modes after those connections reconnect.
+
+The SDK stores the handler-derived modes with each MCP server registration. Restored connections advertise those modes after Durable Object hibernation, and callbacks reattach when `onStart()` runs.
+
+#### Usage
+
+Configure handlers in `onStart()`:
+
+<TypeScriptExample>
+
+```ts
+import { Agent } from "agents";
+import type { ElicitRequest, ElicitResult } from "agents/mcp";
+
+export class MyAgent extends Agent<Env> {
+	onStart() {
+		this.mcp.configureElicitationHandlers({
+			form: (request, serverId) =>
+				this.forwardElicitationToBrowser(request, serverId),
+			url: (request, serverId) =>
+				this.forwardElicitationToBrowser(request, serverId),
+		});
+	}
+
+	private forwardElicitationToBrowser(
+		request: ElicitRequest,
+		serverId: string,
+	): Promise<ElicitResult> {
+		// Forward the request to your UI and resolve after the user responds.
+		throw new Error(
+			`Implement elicitation for ${serverId}: ${request.params.message}`,
+		);
+	}
+}
+```
+
+</TypeScriptExample>
+
+For the complete browser forwarding pattern and mode-specific requirements, refer to [Elicitation](#elicitation).
 
 ## Custom OAuth provider
 


### PR DESCRIPTION
### Summary

Improves the information architecture and SDK reference for MCP client capabilities:

- nests **Elicitation** under **Using MCP capabilities**, after tools and resources
- nests **Integration with AI SDK** under **Get available tools**
- moves persistence into the **Managing servers** introduction
- orders server management by task: list all servers, inspect one server, then remove it
- adds a `configureElicitationHandlers()` API reference immediately after `configureOAuthCallback()`
- documents the method signature, handler arguments and results, capability negotiation, hibernation behavior, clearing handlers, and `onStart()` usage
- consolidates the human-in-the-loop guide to one comparison table organized by approval layer
- covers MCP client elicitation initiated by server developers, durable Workflow approval gates, and approvals before model-generated Code Mode calls invoke tools
- adds a complete Code Mode approval example with an MCP connector, runtime tool, pending actions, approve, and reject methods
- updates HITL next steps to link MCP clients, MCP servers, and the durable Code Mode runtime

### Verification

- `pnpm run format:core:check`
- `pnpm run check`

### Documentation checklist

- [x] Follows the documentation style guide.
- [x] Uses the public Agents SDK API and stable MCP 2025-11-25 specification.


