### PR TITLE
[Workers] Mark Datadog OTLP traces intake as available

### DIFF
--- a/src/content/docs/workers/observability/exporting-opentelemetry-data/index.mdx
+++ b/src/content/docs/workers/observability/exporting-opentelemetry-data/index.mdx
@@ -33,7 +33,7 @@ Below are common OTLP endpoint formats for popular observability providers. Refe
 | [**Axiom**](/workers/observability/exporting-opentelemetry-data/axiom/)                 | `https://api.axiom.co/v1/traces`                             | `https://api.axiom.co/v1/logs`                               |
 | [**Sentry**](/workers/observability/exporting-opentelemetry-data/sentry/)               | `https://{HOST}/api/{PROJECT_ID}/integration/otlp/v1/traces` | `https://{HOST}/api/{PROJECT_ID}/integration/otlp/v1/logs`   |
 | [**PostHog**](/workers/observability/exporting-opentelemetry-data/posthog/)             | Not supported                                                | `https://{REGION}.i.posthog.com/i/v1/logs`                   |
-| [**Datadog**](https://docs.datadoghq.com/opentelemetry/setup/otlp_ingest/)              | Coming soon, pending release from Datadog                    | `https://otlp.{SITE}.datadoghq.com/v1/logs`                  |
+| [**Datadog**](https://docs.datadoghq.com/opentelemetry/setup/otlp_ingest/)              | `https://otlp.{SITE}.datadoghq.com/v1/traces`                | `https://otlp.{SITE}.datadoghq.com/v1/logs`                  |
 | [**New Relic**](https://docs.newrelic.com/docs/opentelemetry/best-practices/opentelemetry-otlp/) | `https://otlp.nr-data.net/v1/traces` | `https://otlp.nr-data.net/v1/logs` |
 | [**Splunk Observability**](https://dev.splunk.com/observability/reference/api/ingest_data/latest) | `https://ingest.{REALM}.signalfx.com/v2/trace/otlp` | N/A |
 | [**Splunk Platform**](https://github.com/splunk/splunk-connect-for-otlp) | `http://splunk.internal:4318/v1/traces` | `http://splunk.internal:4318/v1/logs` |


### PR DESCRIPTION
## Summary
- Datadog's direct OTLP traces intake endpoint is now generally available, so the "Coming soon, pending release from Datadog" note in the Available OpenTelemetry destinations table is outdated.
- Updates the Traces column for Datadog to list the OTLP traces endpoint (`https://otlp.{SITE}.datadoghq.com/v1/traces`), matching the format used for the other providers in the table.

## Test plan
- [x] Confirm the endpoint format matches Datadog's current OTLP traces intake documentation