### PR TITLE
docs: add Artifacts namespace delete API

### DIFF
--- a/src/content/docs/artifacts/api/rest-api.mdx
+++ b/src/content/docs/artifacts/api/rest-api.mdx
@@ -174,6 +174,25 @@ curl "$ARTIFACTS_ACCOUNT_BASE_URL/namespaces/$ARTIFACTS_NAMESPACE" \
   --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN"
 ```
 
+### Delete a namespace
+
+Route: `DELETE /artifacts/namespaces/:namespace`
+
+The namespace must be empty before you delete it.
+
+```sh
+curl --request DELETE "$ARTIFACTS_ACCOUNT_BASE_URL/namespaces/$ARTIFACTS_NAMESPACE" \
+  --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN"
+```
+
+Response status codes:
+
+| Status | Description                              |
+| ------ | ---------------------------------------- |
+| `204`  | Namespace deleted.                       |
+| `404`  | Namespace is missing or already deleted. |
+| `409`  | Namespace contains repositories.         |
+
 ## Repos
 
 ### Create a repo

--- a/src/content/docs/artifacts/api/rest-api.mdx
+++ b/src/content/docs/artifacts/api/rest-api.mdx
@@ -185,7 +185,7 @@ curl --request DELETE "$ARTIFACTS_ACCOUNT_BASE_URL/namespaces/$ARTIFACTS_NAMESPA
   --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN"
 ```
 
-Response status codes:
+The API returns the following response status codes:
 
 | Status | Description                              |
 | ------ | ---------------------------------------- |


### PR DESCRIPTION
## Summary
- Document DELETE /artifacts/namespaces/:namespace in the Artifacts REST API reference
- Note that namespaces must be empty before deletion
- Add 204, 404, and 409 response status semantics

## Validation
- prettier --check src/content/docs/artifacts/api/rest-api.mdx (passed in OpenCode session)
- git diff --check (passed)
- pnpm run check (passed in OpenCode session with Node-version warning override; 0 errors, 4 existing hints)
- RUN_LINK_CHECK=true pnpm run build attempted but timed out after 15 minutes while generating changelog pages