### PR TITLE
chore: automate AI model catalog sync

### DIFF
--- a/.github/workflows/sync-ai-model-catalog.yml
+++ b/.github/workflows/sync-ai-model-catalog.yml
@@ -1,0 +1,146 @@
+name: Sync AI model catalog
+
+on:
+  schedule:
+    - cron: "0 8 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: sync-ai-model-catalog
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Generate App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.CLOUDFLARE_DOCS_BOT_APP_ID }}
+          private-key: ${{ secrets.CLOUDFLARE_DOCS_BOT_APP_PRIVATE_KEY }}
+
+      - name: Check out production
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+          ref: production
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
+        with:
+          version: 11
+
+      - name: Set up Node
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version: 24.x
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Fetch catalog models
+        shell: bash
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.AI_MODEL_CATALOG_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.AI_MODEL_CATALOG_API_TOKEN }}
+        run: |
+          set -o pipefail
+          log="$RUNNER_TEMP/catalog-sync.log"
+          if ! pnpm exec tsx bin/fetch-catalog-models.ts 2>&1 | tee "$log"; then
+            echo "::error title=AI model catalog sync failed::See the job summary for model fetch failures."
+            {
+              echo "## AI model catalog sync failed"
+              echo
+              echo '```text'
+              tail -n 100 "$log"
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+
+      - name: Validate catalog content
+        run: pnpm run sync
+
+      - name: Detect catalog changes
+        id: changes
+        shell: bash
+        run: |
+          if [[ -n "$(git status --porcelain -- src/content/catalog-models)" ]]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Close obsolete pull request
+        if: steps.changes.outputs.changed == 'false'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          BRANCH: ci/sync-ai-model-catalog
+        run: |
+          set -euo pipefail
+          existing=$(gh pr list \
+            --base production \
+            --head "$BRANCH" \
+            --state open \
+            --json number \
+            --jq '.[0].number')
+          if [[ -n "$existing" ]]; then
+            gh pr close "$existing" --delete-branch
+          fi
+
+      - name: Commit and push catalog
+        if: steps.changes.outputs.changed == 'true'
+        env:
+          BRANCH: ci/sync-ai-model-catalog
+        run: |
+          set -euo pipefail
+          git config user.name "cloudflare-docs-bot[bot]"
+          git config user.email "cloudflare-docs-bot[bot]@users.noreply.github.com"
+          git fetch origin "$BRANCH:refs/remotes/origin/$BRANCH" || true
+          git switch -C "$BRANCH"
+          git add src/content/catalog-models
+          git commit --no-verify -m "chore(ai-gateway): sync model catalog"
+          git push --force-with-lease origin "HEAD:$BRANCH"
+
+      - name: Create pull request
+        if: steps.changes.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          BRANCH: ci/sync-ai-model-catalog
+        run: |
+          set -euo pipefail
+          existing=$(gh pr list \
+            --base production \
+            --head "$BRANCH" \
+            --state open \
+            --json number \
+            --jq '.[0].number')
+          if [[ -n "$existing" ]]; then
+            echo "Updated existing PR #$existing"
+            exit 0
+          fi
+
+          body="$RUNNER_TEMP/model-catalog-pr.md"
+          printf '%s\n' \
+            '### Summary' \
+            '' \
+            'Synchronizes the AI model catalog with the Unified Catalog API.' \
+            '' \
+            'This pull request is refreshed automatically by the daily catalog sync workflow.' \
+            '' \
+            '### Documentation checklist' \
+            '' \
+            '- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).' \
+            > "$body"
+          gh pr create \
+            --base production \
+            --head "$BRANCH" \
+            --title "[AI Gateway] Sync model catalog" \
+            --body-file "$body"

--- a/bin/fetch-catalog-models.ts
+++ b/bin/fetch-catalog-models.ts
@@ -63,7 +63,7 @@ interface CatalogModel {
 	default_example?: {
 		input?: Record<string, unknown>;
 		output?: Record<string, unknown>;
-	};
+	} | null;
 	code_snippets?: Array<{
 		label: string;
 		code: string;
@@ -71,7 +71,7 @@ interface CatalogModel {
 	schema?: {
 		input?: Record<string, unknown>;
 		output?: Record<string, unknown>;
-	};
+	} | null;
 	metadata: Record<string, unknown>;
 	external_info: string | null;
 	terms: string | null;
@@ -97,17 +97,138 @@ interface CatalogListResponse {
 	errors?: Array<{ message: string }>;
 }
 
-interface CatalogDetailResponse {
-	success: boolean;
-	result: CatalogModel;
-	errors?: Array<{ message: string }>;
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return value !== null && typeof value === "object" && !Array.isArray(value);
 }
+
+function isCatalogModel(value: unknown): value is CatalogModel {
+	if (value === null || typeof value !== "object" || Array.isArray(value)) {
+		return false;
+	}
+
+	const fields = value as Record<string, unknown>;
+	const nullableString = (field: unknown) =>
+		field === null || typeof field === "string";
+	const nullableNumber = (field: unknown) =>
+		field === null || (typeof field === "number" && Number.isFinite(field));
+	const optionalString = (field: unknown) =>
+		field === undefined || typeof field === "string";
+	const optionalBoolean = (field: unknown) =>
+		field === undefined || typeof field === "boolean";
+	const optionalRecord = (field: unknown) =>
+		field === undefined || isRecord(field);
+	const codeSnippets = (field: unknown) =>
+		field === undefined ||
+		(Array.isArray(field) &&
+			field.every(
+				(snippet) =>
+					isRecord(snippet) &&
+					typeof snippet.label === "string" &&
+					typeof snippet.code === "string",
+			));
+	const schema = (field: unknown) =>
+		field === undefined ||
+		field === null ||
+		(isRecord(field) &&
+			optionalRecord(field.input) &&
+			optionalRecord(field.output));
+	const defaultExample = (field: unknown) =>
+		field === undefined ||
+		field === null ||
+		(isRecord(field) &&
+			optionalRecord(field.input) &&
+			optionalRecord(field.output));
+	const banner = (field: unknown) =>
+		field === undefined ||
+		field === null ||
+		(isRecord(field) &&
+			typeof field.text === "string" &&
+			typeof field.severity === "string" &&
+			optionalString(field.title) &&
+			optionalBoolean(field.dismissible) &&
+			(field.link === undefined ||
+				(isRecord(field.link) &&
+					typeof field.link.url === "string" &&
+					typeof field.link.label === "string")));
+	const examples =
+		Array.isArray(fields.examples) &&
+		fields.examples.every(
+			(example) =>
+				isRecord(example) &&
+				typeof example.name === "string" &&
+				optionalString(example.description) &&
+				isRecord(example.input) &&
+				isRecord(example.output),
+		);
+
+	return (
+		typeof fields.model_id === "string" &&
+		nullableString(fields.provider_id) &&
+		typeof fields.name === "string" &&
+		typeof fields.description === "string" &&
+		typeof fields.task === "string" &&
+		Array.isArray(fields.tags) &&
+		fields.tags.every((tag) => typeof tag === "string") &&
+		nullableNumber(fields.context_length) &&
+		nullableNumber(fields.max_output_tokens) &&
+		typeof fields.supports_async === "boolean" &&
+		examples &&
+		optionalBoolean(fields.zdr) &&
+		(fields.zdr_comment === undefined || nullableString(fields.zdr_comment)) &&
+		banner(fields.banner) &&
+		(fields.request_formats === undefined ||
+			fields.request_formats === null ||
+			(Array.isArray(fields.request_formats) &&
+				fields.request_formats.every(
+					(format) => typeof format === "string",
+				))) &&
+		defaultExample(fields.default_example) &&
+		codeSnippets(fields.code_snippets) &&
+		schema(fields.schema) &&
+		isRecord(fields.metadata) &&
+		nullableString(fields.external_info) &&
+		nullableString(fields.terms) &&
+		nullableString(fields.cover_image_url) &&
+		nullableString(fields.schema_version) &&
+		optionalBoolean(fields.private) &&
+		optionalString(fields.created_at) &&
+		optionalString(fields.updated_at) &&
+		optionalRecord(fields.pricing)
+	);
+}
+
+function getCatalogErrorDetails(value: unknown): string | undefined {
+	if (!Array.isArray(value)) return undefined;
+	return value
+		.flatMap((error) => {
+			if (error === null || typeof error !== "object") return [];
+			const message = (error as Record<string, unknown>).message;
+			return typeof message === "string" ? [message] : [];
+		})
+		.map((message) => message.replace(/\s+/g, " ").trim())
+		.filter(Boolean)
+		.join("; ")
+		.slice(0, 500);
+}
+
+type ModelDetailResult =
+	| { readonly _tag: "ok"; readonly model: CatalogModel }
+	| { readonly _tag: "err"; readonly summary: string };
+
+type CatalogFetchResult = {
+	readonly models: Array<CatalogModel>;
+	readonly failures: ReadonlyArray<{
+		readonly modelId: string;
+		readonly summary: string;
+	}>;
+};
 
 const OUTPUT_DIR = path.join(process.cwd(), "src/content/catalog-models");
 const API_BASE_URL =
 	process.env.CF_API_BASE_URL || "https://api.cloudflare.com";
 const PER_PAGE = 100;
 const CONCURRENCY = 5;
+const DETAIL_TIMEOUT_MS = 30_000;
 
 function getPlannedDeprecationDate(model: CatalogModel): string | undefined {
 	const metadata = model.metadata as Record<string, unknown> | undefined;
@@ -242,30 +363,57 @@ async function fetchModelDetail(
 	accountId: string,
 	token: string,
 	modelId: string,
-): Promise<CatalogModel | null> {
+): Promise<ModelDetailResult> {
 	const encoded = encodeURIComponent(modelId);
 	const url = `${API_BASE_URL}/client/v4/accounts/${accountId}/ai/catalog/models/${encoded}`;
 
-	const response = await fetch(url, {
-		headers: getApiHeaders(token),
-	});
+	let failureKind = "network error";
+	try {
+		const response = await fetch(url, {
+			headers: getApiHeaders(token),
+			signal: AbortSignal.timeout(DETAIL_TIMEOUT_MS),
+		});
+		if (!response.ok) {
+			return {
+				_tag: "err",
+				summary: `HTTP ${response.status}${response.statusText ? ` ${response.statusText}` : ""}`,
+			};
+		}
 
-	if (!response.ok) {
-		console.error(`  Failed to fetch ${modelId}: ${response.status}`);
-		return null;
+		failureKind = "invalid response body";
+		const raw: unknown = await response.json();
+		if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+			return {
+				_tag: "err",
+				summary: "invalid detail response",
+			};
+		}
+		const data = raw as Record<string, unknown>;
+		if (data.success === false) {
+			const errorDetails = getCatalogErrorDetails(data.errors);
+			return {
+				_tag: "err",
+				summary: `API returned success=false${errorDetails ? `: ${errorDetails}` : ""}`,
+			};
+		}
+		if (data.success !== true || !isCatalogModel(data.result)) {
+			return {
+				_tag: "err",
+				summary: "invalid detail response",
+			};
+		}
+
+		return { _tag: "ok", model: data.result };
+	} catch (cause: unknown) {
+		const failure =
+			cause instanceof DOMException && cause.name === "TimeoutError"
+				? `request timed out after ${DETAIL_TIMEOUT_MS / 1_000}s`
+				: failureKind;
+		return { _tag: "err", summary: failure };
 	}
-
-	const data = (await response.json()) as CatalogDetailResponse;
-
-	if (!data.success) {
-		console.error(`  Error fetching ${modelId}:`, data.errors);
-		return null;
-	}
-
-	return data.result;
 }
 
-async function fetchFromApi(): Promise<CatalogModel[]> {
+async function fetchFromApi(): Promise<CatalogFetchResult> {
 	const API_TOKEN = process.env.CLOUDFLARE_API_TOKEN;
 	const ACCOUNT_ID = process.env.CLOUDFLARE_ACCOUNT_ID;
 
@@ -290,7 +438,10 @@ async function fetchFromApi(): Promise<CatalogModel[]> {
 
 	// Pass 2: fetch full details for each model
 	const models: CatalogModel[] = [];
-	const failed: string[] = [];
+	const failures: Array<{
+		readonly modelId: string;
+		readonly summary: string;
+	}> = [];
 
 	for (let i = 0; i < modelIds.length; i += CONCURRENCY) {
 		const batch = modelIds.slice(i, i + CONCURRENCY);
@@ -300,10 +451,10 @@ async function fetchFromApi(): Promise<CatalogModel[]> {
 
 		for (let j = 0; j < results.length; j++) {
 			const result = results[j];
-			if (result) {
-				models.push(result);
+			if (result._tag === "ok") {
+				models.push(result.model);
 			} else {
-				failed.push(batch[j]);
+				failures.push({ modelId: batch[j], summary: result.summary });
 			}
 		}
 
@@ -313,14 +464,7 @@ async function fetchFromApi(): Promise<CatalogModel[]> {
 
 	console.log();
 
-	if (failed.length > 0) {
-		console.log(`  Failed: ${failed.length} models`);
-		for (const id of failed) {
-			console.log(`    - ${id}`);
-		}
-	}
-
-	return models;
+	return { models, failures };
 }
 
 /**
@@ -436,6 +580,7 @@ function writeModels(models: CatalogModel[]): void {
 		// Drop the `pricing` field — it's returned by the catalog API but is
 		// not consumed by the docs site and isn't declared in the schema.
 		delete model.pricing;
+		if (model.schema === null) delete model.schema;
 
 		// Strip credentials from any pre-signed URLs in the response.
 		const redacted = redactCredentialUrls(model);
@@ -470,7 +615,29 @@ async function main() {
 	if (args.file) {
 		models = await loadFromFile(args.file);
 	} else {
-		models = await fetchFromApi();
+		const result = await fetchFromApi();
+		if (result.failures.length > 0) {
+			console.error(
+				[
+					`Catalog sync aborted: failed to fetch ${result.failures.length} of ${result.models.length + result.failures.length} model details.`,
+					...result.failures.map(
+						({ modelId, summary }) => `- ${modelId}: ${summary}`,
+					),
+					"Existing catalog was not modified.",
+				].join("\n"),
+			);
+			process.exitCode = 1;
+			return;
+		}
+		models = result.models;
+	}
+
+	if (models.length === 0) {
+		console.error(
+			"Catalog sync aborted: catalog contained no models.\nExisting catalog was not modified.",
+		);
+		process.exitCode = 1;
+		return;
 	}
 
 	writeModels(models);


### PR DESCRIPTION
### Summary

Automates daily synchronization of AI Gateway catalog model files from the Unified Catalog API. The workflow uses `cloudflare-docs-bot` to open or refresh a pull request when catalog changes are detected, and closes an obsolete catalog pull request when the source matches `production` again.

The catalog fetcher rejects malformed detail responses and empty catalogs before replacing the existing catalog, omits `schema` when the API returns `null`, and reports model-specific failures with a 30-second request timeout.

### Required configuration

Configure the `AI_MODEL_CATALOG_ACCOUNT_ID` and `AI_MODEL_CATALOG_API_TOKEN` Actions secrets. The workflow reuses the existing `cloudflare-docs-bot` GitHub App credentials.

### Validation

- `pnpm --config.verify-deps-before-run=false run test` (137 tests)
- `pnpm --config.verify-deps-before-run=false run sync`
- `pnpm --config.verify-deps-before-run=false exec eslint bin/fetch-catalog-models.ts`
- `pnpm --config.verify-deps-before-run=false run format:core:check`
- `git diff --check`
- CLI mock API controls: malformed model data is rejected without replacement, and a checked-in valid model is accepted

The live API fetch was not run locally because the catalog API token is only available through Actions secrets. Full type-check and lint remain blocked by existing generated `skills/turnstile-spin` errors unrelated to this change.
