### PR TITLE
[Client-Side Security] Add note about Page Shield add-on rename

### DIFF
--- a/src/content/docs/client-side-security/index.mdx
+++ b/src/content/docs/client-side-security/index.mdx
@@ -83,3 +83,5 @@ Learn how to [get started](/client-side-security/get-started/).
 ## Availability
 
 <FeatureTable id="security.page_shield" />
+
+The Page Shield add-on is now Client-Side Security Advanced. The features and entitlements are unchanged.


### PR DESCRIPTION
Adds a short note under the Availability section on the Client-side security overview page to clarify that the Page Shield add-on has been renamed to Client-Side Security Advanced.

- Adds a one-sentence note below the plan availability table.
- States that the features and entitlements are unchanged.