### PR TITLE
fix: nimbus build ux tweaks

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
 		"mermaid": "11.15.0",
 		"micromark-extension-mdxjs": "3.0.0",
 		"nanostores": "1.3.0",
-		"nimbus-docs": "0.1.22",
+		"nimbus-docs": "0.1.25",
 		"node-html-parser": "7.1.0",
 		"openapi-types": "12.1.3",
 		"parse-duration": "2.1.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -273,8 +273,8 @@ importers:
         specifier: 1.3.0
         version: 1.3.0
       nimbus-docs:
-        specifier: 0.1.22
-        version: 0.1.22(astro@6.4.7(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.62.2)(tsx@4.22.4)(yaml@2.9.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(shiki@4.3.1)
+        specifier: 0.1.25
+        version: 0.1.25(astro@6.4.7(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.62.2)(tsx@4.22.4)(yaml@2.9.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(shiki@4.3.1)
       node-html-parser:
         specifier: 7.1.0
         version: 7.1.0
@@ -5098,8 +5098,8 @@ packages:
     resolution: {integrity: sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA==}
     engines: {node: '>= 10'}
 
-  nimbus-docs@0.1.22:
-    resolution: {integrity: sha512-XLtC4CXg9BM+nhNH0zmVwb6H9eXRPAH0UpbgbhtkKJapckDViKLhryW8WcNZa9KBnfnIIH9Eqxq65IzJQS7O+g==}
+  nimbus-docs@0.1.25:
+    resolution: {integrity: sha512-rdXcVBgLOWsg17T68eGdnYgv4aa5astg3ZZD0O2cc0yvCLyxeVpmqFuAiXgM/W87SN5qYM3Tig0Hfi4vDjsObQ==}
     hasBin: true
     peerDependencies:
       astro: '>=6.4.0'
@@ -12301,7 +12301,7 @@ snapshots:
 
   neotraverse@0.6.18: {}
 
-  nimbus-docs@0.1.22(astro@6.4.7(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.62.2)(tsx@4.22.4)(yaml@2.9.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(shiki@4.3.1):
+  nimbus-docs@0.1.25(astro@6.4.7(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.62.2)(tsx@4.22.4)(yaml@2.9.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(shiki@4.3.1):
     dependencies:
       '@astrojs/markdown-satteri': 0.2.1
       '@astrojs/mdx': 6.0.1(@astrojs/markdown-satteri@0.2.1)(astro@6.4.7(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.62.2)(tsx@4.22.4)(yaml@2.9.0))

--- a/src/nimbus/astro-config.ts
+++ b/src/nimbus/astro-config.ts
@@ -86,6 +86,7 @@ const nimbusConfig = defineNimbusConfig({
 	sidebar: {
 		items: sidebarItems,
 		overviewLabel: "Overview",
+		indexDisplay: "overview-leaf",
 		scope: "section",
 		isolate: { boundaries: ["learning-paths/*"] },
 		defaultCollapsed: true,

--- a/src/nimbus/components/404.astro
+++ b/src/nimbus/components/404.astro
@@ -14,7 +14,11 @@
       class="font-[inherit] cursor-pointer border-none bg-transparent p-0 text-blue-500 underline hover:no-underline dark:text-orange-500"
       >search</button
     > or try our LLM-friendly
-    <a href="/llms.txt"> llms.txt directory</a>.
+    <a
+      href="/llms.txt"
+      class="text-blue-500 underline hover:no-underline dark:text-orange-500"
+      >llms.txt directory</a
+    >.
   </p>
 </div>
 

--- a/src/nimbus/components/cf/Feature.astro
+++ b/src/nimbus/components/cf/Feature.astro
@@ -25,7 +25,7 @@ const title = cta ?? `Use ${header}`;
 ---
 
 <div class="feature mb-7 border-t border-border pt-6">
-  <h3 class="m-0 mb-2 text-[1.3125rem] leading-[1.3] font-bold tracking-[-0.02em]">
+  <h3 class="m-0 mb-2 text-[1.3125rem] leading-[1.3] font-semibold tracking-[-0.02em]">
     {header}
   </h3>
   <div class="feature-description mb-3 text-base leading-[1.65] text-foreground">

--- a/src/nimbus/components/cf/Plan.astro
+++ b/src/nimbus/components/cf/Plan.astro
@@ -1,21 +1,6 @@
 ---
-/**
- * Plan — small inline badge showing a feature's CF plan availability.
- * Renders to a single styled string (e.g. "Available on all plans",
- * "Enterprise-only").
- *
- * CF source: cloudflare-docs/src/components/Plan.astro
- *
- * Two upstream input shapes:
- *   1. `<Plan type="all" | "paid" | "pro" | ... />` — static taxonomy lookup
- *      against the `mappings` table. Fully supported here.
- *   2. `<Plan id="some-feature-id" />` — dynamic lookup via a yaml
- *      `plans.yaml` indexed by `indexPlans()`. **Not supported yet** —
- *      requires porting the CF plans data file + util. Until then, the
- *      `id` branch falls through to a placeholder string so authors see
- *      what's missing.
- */
 import { z } from "astro/zod";
+import { getEntry } from "astro:content";
 
 const MAPPINGS = {
   all: "Available on all plans",
@@ -39,14 +24,23 @@ const props = z
 
 const input = props.parse(Astro.props);
 
+function getByPath(obj: any, path: string) {
+  return path.split(".").reduce((acc, key) => (acc == null ? acc : acc[key]), obj);
+}
+
 let availability: string;
 if ("type" in input) {
   availability = MAPPINGS[input.type];
 } else {
-  // Pending: port `cloudflare-docs/src/content/plans/*.yaml` + the
-  // `indexPlans()` lookup util. Until then, surface a stub label so it's
-  // visible which Plan calls are still unresolved.
-  availability = `[Plan id="${input.id}" pending data port]`;
+  const entry = await getEntry("plans", "index");
+  if (!entry) {
+    throw new Error(`[Plan] Failed to load plans JSON.`);
+  }
+  const value = getByPath(entry.data, input.id);
+  if (typeof value !== "string") {
+    throw new Error(`[Plan] id "${input.id}" did not resolve to a string in plans JSON.`);
+  }
+  availability = value;
 }
 ---
 

--- a/src/nimbus/components/cf/RSSButton.astro
+++ b/src/nimbus/components/cf/RSSButton.astro
@@ -37,7 +37,7 @@ const iconName = input.icon.includes(":") ? input.icon : "ph:rss-simple";
 
 <a
   href={"href" in input ? input.href : `/changelog/rss/${input.changelog}.xml`}
-  class="inline-flex items-center justify-center gap-1 rounded-sm font-semibold no-underline"
+  class="ms-3 inline-flex items-center justify-center gap-1 rounded-sm font-semibold no-underline"
   target="_blank"
 >
   {input.text}

--- a/src/nimbus/components/cf/ResourcesBySelector.tsx
+++ b/src/nimbus/components/cf/ResourcesBySelector.tsx
@@ -328,7 +328,7 @@ export default function ResourcesBySelector({
 	return (
 		<div className={filterPlacement === "left" ? "md:grid md:grid-cols-[208px_1fr] md:gap-10" : ""}>
 			{filterPlacement === "left" && filters && (
-				<aside className="hidden md:block md:sticky md:top-20 md:self-start">
+				<aside className="hidden md:block">
 					{/* Search */}
 					<div className="relative mb-6">
 						<IconSearch className="pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2 text-muted-foreground" />

--- a/src/nimbus/components/models/ModelDetailPage.astro
+++ b/src/nimbus/components/models/ModelDetailPage.astro
@@ -13,7 +13,8 @@
  *   - slug:     the URL slug segment(s) under basePath.
  */
 import type { MarkdownHeading } from "astro";
-import { getCfRouteNavigation } from "~/util/sidebar";
+import { getSidebar } from "nimbus-docs";
+import { docsSidebarTransform, getCfRouteNavigation } from "~/util/sidebar";
 import DocsLayout from "~/layouts/DocsLayout.astro";
 import { Badge } from "~/components/ui/badge";
 import { Code } from "~/components/ui/code";
@@ -180,12 +181,18 @@ const rawLinks = apiModes
 // `/ai` section lands on `/ai/models/` with no "Models" group, so append one
 // for Home › AI › Models; `/workers-ai/models/` already has it.
 const trail = basePath === "/ai/models" ? [{ label: "Models" }] : [];
-const { sidebar, breadcrumbs } = await getCfRouteNavigation({
+const { breadcrumbs } = await getCfRouteNavigation({
   path: `${basePath}/${slug}/`,
   section: `${basePath}/`,
   collection: "docs",
   prevNext: false,
   trail,
+});
+// getRouteNavigation ignores transforms, so build the sidebar directly to
+// get the Agent resources group + badges.
+const sidebar = await getSidebar(`${basePath}/`, {
+  collection: "docs",
+  transform: docsSidebarTransform,
 });
 
 const markdownPath = `${basePath}/${slug}/index.md`;

--- a/src/nimbus/components/ui/breadcrumbs/Breadcrumbs.astro
+++ b/src/nimbus/components/ui/breadcrumbs/Breadcrumbs.astro
@@ -11,34 +11,42 @@ interface Props extends HTMLAttributes<"nav"> {
 
 const { items, maxVisible = 4, class: className, ...attrs } = Astro.props;
 
-// Determine if we need to collapse the middle
+// Collapsed shape: Home + first + … + parent + current.
 const shouldCollapse = items.length > maxVisible;
-// When collapsed: Home + first segment + ... + last 2 (parent + current)
-const headCount = 2; // Home + first segment
-const tailCount = 2; // parent + current page
+const headCount = 2;
+const tailCount = 2;
 const headItems = shouldCollapse ? items.slice(0, headCount) : items;
 const collapsedItems = shouldCollapse ? items.slice(headCount, items.length - tailCount) : [];
 const tailItems = shouldCollapse ? items.slice(items.length - tailCount) : [];
 ---
 
 {items.length > 1 && (
-  <nav aria-label="Breadcrumb" class={cn("text-xs font-medium", className)} {...attrs}>
-    <ol class="flex flex-wrap items-center gap-y-0.5 text-muted-foreground">
-      {headItems.map((crumb, i) => (
-        <li class="flex items-center">
-          {i > 0 && <span class="mx-1.5 text-muted-foreground/50">/</span>}
-          {(!shouldCollapse && i === items.length - 1) || !crumb.href ? (
-            <span class="text-foreground truncate max-w-[12rem]">{crumb.label}</span>
-          ) : (
-            <a href={crumb.href} class="hover:text-foreground transition-colors truncate max-w-[12rem]">
-              {crumb.label}
-            </a>
-          )}
-        </li>
-      ))}
+  <nav aria-label="Breadcrumb" class={cn("min-w-0 text-xs font-medium", className)} {...attrs}>
+    {/* Only the current crumb shrinks; no overflow-hidden so the … popover can escape the row. */}
+    <ol class="flex items-center text-muted-foreground">
+      {headItems.map((crumb, i) => {
+        const isCurrent = !shouldCollapse && i === items.length - 1;
+        return (
+          <li class={cn("flex items-center", isCurrent ? "min-w-0" : "flex-shrink-0")}>
+            {i > 0 && <span class="mx-1.5 flex-shrink-0 text-muted-foreground/50">/</span>}
+            {isCurrent || !crumb.href ? (
+              <span
+                class={cn("text-foreground", isCurrent ? "min-w-0 truncate" : "whitespace-nowrap")}
+                aria-current={isCurrent ? "page" : undefined}
+              >
+                {crumb.label}
+              </span>
+            ) : (
+              <a href={crumb.href} class="whitespace-nowrap hover:text-foreground transition-colors">
+                {crumb.label}
+              </a>
+            )}
+          </li>
+        );
+      })}
 
       {shouldCollapse && collapsedItems.length > 0 && (
-        <li class="flex items-center">
+        <li class="flex items-center flex-shrink-0">
           <span class="mx-1.5 text-muted-foreground/50">/</span>
           <details class="relative group">
             <summary
@@ -67,18 +75,26 @@ const tailItems = shouldCollapse ? items.slice(items.length - tailCount) : [];
         </li>
       )}
 
-      {shouldCollapse && tailItems.map((crumb, i) => (
-        <li class="flex items-center">
-          <span class="mx-1.5 text-muted-foreground/50">/</span>
-          {i === tailItems.length - 1 || !crumb.href ? (
-            <span class="text-foreground truncate max-w-[12rem]">{crumb.label}</span>
-          ) : (
-            <a href={crumb.href} class="hover:text-foreground transition-colors truncate max-w-[12rem]">
-              {crumb.label}
-            </a>
-          )}
-        </li>
-      ))}
+      {shouldCollapse && tailItems.map((crumb, i) => {
+        const isCurrent = i === tailItems.length - 1;
+        return (
+          <li class={cn("flex items-center", isCurrent ? "min-w-0" : "flex-shrink-0")}>
+            <span class="mx-1.5 flex-shrink-0 text-muted-foreground/50">/</span>
+            {isCurrent || !crumb.href ? (
+              <span
+                class={cn("text-foreground", isCurrent ? "min-w-0 truncate" : "whitespace-nowrap")}
+                aria-current={isCurrent ? "page" : undefined}
+              >
+                {crumb.label}
+              </span>
+            ) : (
+              <a href={crumb.href} class="whitespace-nowrap hover:text-foreground transition-colors">
+                {crumb.label}
+              </a>
+            )}
+          </li>
+        );
+      })}
     </ol>
   </nav>
 )}

--- a/src/nimbus/pages/ai/models/index.astro
+++ b/src/nimbus/pages/ai/models/index.astro
@@ -9,7 +9,7 @@
  */
 import { getSidebar } from "nimbus-docs";
 import DocsLayout from "~/layouts/DocsLayout.astro";
-import { externalAppLinksTransform, getCfBreadcrumbs } from "~/util/sidebar";
+import { docsSidebarTransform, getCfBreadcrumbs } from "~/util/sidebar";
 import ModelCatalog from "~/components/models/ModelCatalog.astro";
 import { getResolvedModels, toModelCardData } from "~/util/models";
 
@@ -18,7 +18,7 @@ export const prerender = true;
 const models = (await getResolvedModels()).map(toModelCardData);
 
 const sectionSlug = "/ai/models/";
-const sidebar = await getSidebar(sectionSlug, { collection: "docs", transform: externalAppLinksTransform });
+const sidebar = await getSidebar(sectionSlug, { collection: "docs", transform: docsSidebarTransform });
 const breadcrumbs = await getCfBreadcrumbs(sectionSlug);
 ---
 

--- a/src/nimbus/pages/workers-ai/models/index.astro
+++ b/src/nimbus/pages/workers-ai/models/index.astro
@@ -2,7 +2,7 @@
 import { getSidebar } from "nimbus-docs";
 import DocsLayout from "~/layouts/DocsLayout.astro";
 import { Aside } from "~/components";
-import { externalAppLinksTransform, getCfBreadcrumbs } from "~/util/sidebar";
+import { docsSidebarTransform, getCfBreadcrumbs } from "~/util/sidebar";
 import ModelCatalog from "~/components/models/ModelCatalog.astro";
 import { getLegacyModels, toModelCardData } from "~/util/models";
 
@@ -13,7 +13,7 @@ const models = (await getLegacyModels()).map(toModelCardData);
 const sectionSlug = "/workers-ai/models/";
 const sidebar = await getSidebar(sectionSlug, {
   collection: "docs",
-  transform: externalAppLinksTransform,
+  transform: docsSidebarTransform,
 });
 const breadcrumbs = await getCfBreadcrumbs(sectionSlug);
 ---

--- a/src/nimbus/styles/globals.css
+++ b/src/nimbus/styles/globals.css
@@ -90,7 +90,7 @@
 	--nb-h1-weight: 600;
 	--nb-h1-tracking: -0.025em;
 	--nb-h2-size: 1.3rem;
-	--nb-h2-weight: 650;
+	--nb-h2-weight: 600;
 	--nb-h2-tracking: -0.015em;
 	--nb-h3-size: 1.1rem;
 	--nb-h3-weight: 600;

--- a/src/nimbus/styles/prose.css
+++ b/src/nimbus/styles/prose.css
@@ -221,6 +221,11 @@
   white-space: nowrap;
 }
 
+.docs-content
+  :where(tbody:not([class]):has(tr:nth-child(5)) tr:nth-child(even) td:not([class])) {
+  background: var(--nb-accent);
+}
+
 .docs-content :where(tbody:not([class]) tr:not([class]):last-child td:not([class])) {
   border-bottom: none;
 }
@@ -229,6 +234,11 @@
   :where(td:not([class]), th:not([class]))
   :where(code:not([class])) {
   overflow-wrap: normal;
+}
+
+/* Inline bold — 600 matches the heading weights */
+.docs-content :where(strong:not([class]), b:not([class])) {
+  font-weight: 600;
 }
 
 .docs-content :where(a:not([class])) {

--- a/src/nimbus/util/sidebar.astro.test.ts
+++ b/src/nimbus/util/sidebar.astro.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "vitest";
+
+import { externalAppLinksTransform } from "./sidebar";
+import type { SidebarItem } from "nimbus-docs/types";
+
+const ARROW = " \u2197";
+
+const run = (tree: SidebarItem[]) =>
+  externalAppLinksTransform({
+    tree,
+    sectionSlug: "test",
+    currentSlug: "test/page",
+  });
+
+const link = (over: Partial<SidebarItem> = {}): SidebarItem =>
+  ({ type: "link", label: "Link", href: "/docs/page/", order: 0, ...over }) as SidebarItem;
+
+describe("externalAppLinksTransform", () => {
+  test("appends the arrow to internal redirects and keeps them same-tab links", async () => {
+    const [item] = await run([link({ label: "Redirect", href: "/other/", _neverActive: true })]);
+    expect(item).toMatchObject({ type: "link", label: `Redirect${ARROW}` });
+  });
+
+  test("re-marks /api/ links as external with the arrow", async () => {
+    const [item] = await run([link({ label: "API", href: "/api/foo/" })]);
+    expect(item).toMatchObject({ type: "external", label: `API${ARROW}`, href: "/api/foo/" });
+  });
+
+  test("leaves ordinary in-docs links untouched", async () => {
+    const input = link({ label: "Normal", href: "/docs/normal/" });
+    const [item] = await run([input]);
+    expect(item).toEqual(input);
+  });
+
+  test("recurses into groups", async () => {
+    const [group] = await run([
+      {
+        type: "group",
+        label: "Group",
+        order: 0,
+        children: [link({ label: "Redirect", href: "/other/", _neverActive: true })],
+      } as SidebarItem,
+    ]);
+    if (group.type !== "group") throw new Error("expected group");
+    expect(group.children[0]).toMatchObject({ label: `Redirect${ARROW}` });
+  });
+
+  test("is idempotent (no double arrow)", async () => {
+    const input = [link({ label: "Redirect", href: "/other/", _neverActive: true })];
+    const [item] = await run(await run(input));
+    expect(item.label).toBe(`Redirect${ARROW}`);
+  });
+});

--- a/src/nimbus/util/sidebar.ts
+++ b/src/nimbus/util/sidebar.ts
@@ -42,7 +42,7 @@ function firstSegment(path: string): string | undefined {
   return path.replace(/^\/+|\/+$/g, "").split("/")[0] || undefined;
 }
 
-// Mirrors nimbus-docs' internal `nodeHref`.
+// Resolve a sidebar node to its href (internal links only).
 function nodeHref(node: SidebarItem): string | undefined {
   if (node.type === "link") return node.href;
   if (node.type === "external") return undefined;
@@ -89,6 +89,11 @@ export function getCfRouteNavigation(
 }
 
 const EXTERNAL_LINK_ARROW = " \u2197";
+
+// Append the external-link arrow, unless already present.
+function appendExternalArrow(label: string): string {
+  return label.endsWith(EXTERNAL_LINK_ARROW) ? label : label + EXTERNAL_LINK_ARROW;
+}
 
 // `docs-for-agents` is itself the agent-facing surface, so it gets no group.
 const NO_LLM_RESOURCES = new Set(["docs-for-agents"]);
@@ -139,17 +144,8 @@ function isExternalAppHref(href: string): boolean {
   );
 }
 
-/**
- * Re-mark sidebar leaves that point at a separate same-origin app (the
- * `/api/` reference) as **external** — new tab + `↗` arrow — matching
- * Starlight, which gives every `external_link` the external treatment.
- *
- * nimbus-docs classifies a *relative* `external_link` (`/api/`) as an
- * internal cross-section redirect (same tab, no arrow). That's correct for
- * in-docs redirects, but wrong for `/api/`, which is a separate application,
- * not another docs page. This transform restores the Starlight affordance
- * for those leaves only, leaving genuine in-docs redirects untouched.
- */
+// Mark leaves pointing at a separate same-origin app (`/api/`) as external:
+// new tab + `↗` arrow. In-docs redirects are left as same-tab links.
 function markExternalAppLinks(items: SidebarItem[]): SidebarItem[] {
   return items.map((item) => {
     if (item.type === "group") {
@@ -158,9 +154,7 @@ function markExternalAppLinks(items: SidebarItem[]): SidebarItem[] {
     if (item.type === "link" && isExternalAppHref(item.href)) {
       return {
         type: "external",
-        label: item.label.endsWith(EXTERNAL_LINK_ARROW)
-          ? item.label
-          : item.label + EXTERNAL_LINK_ARROW,
+        label: appendExternalArrow(item.label),
         href: item.href,
         badge: item.badge,
         order: item.order,
@@ -170,23 +164,33 @@ function markExternalAppLinks(items: SidebarItem[]): SidebarItem[] {
   });
 }
 
-/**
- * Standalone transform for routes that don't append the Agent resources
- * group — just the external-app (`/api/`) re-marking.
- */
+// Append the external-link arrow to internal cross-section redirects
+// (relative `external_link` → same-tab `type: "link"` flagged `_neverActive`).
+function markInternalRedirects(items: SidebarItem[]): SidebarItem[] {
+  return items.map((item) => {
+    if (item.type === "group") {
+      return { ...item, children: markInternalRedirects(item.children) };
+    }
+    if (item.type === "link" && item._neverActive) {
+      return {
+        ...item,
+        label: appendExternalArrow(item.label),
+      };
+    }
+    return item;
+  });
+}
+
+// External-app (`/api/`) re-marking + internal-redirect arrows, without the
+// Agent resources group. The "Overview" convention is applied by nimbus-docs
+// via `sidebar.indexDisplay: "overview-leaf"`.
 export const externalAppLinksTransform: SidebarTransform = ({ tree }) =>
-  markExternalAppLinks(tree);
+  markInternalRedirects(markExternalAppLinks(tree));
 
 // --- Badges -----------------------------------------------------------------
-// Parity with root `src/util/sidebar.ts`: map badge text → variant, and
-// auto-inject a "Beta" badge on products marked beta in product-availability.
 
-/**
- * Map a default-variant badge's text to its conventional variant
- * (`Beta→caution`, `New→note`, `Deprecated`/`Legacy→danger`). Non-default
- * variants and unmapped text pass through unchanged. Mirrors root's
- * `inferBadgeVariant`.
- */
+// Map a default-variant badge's text to its variant; non-default variants and
+// unmapped text pass through unchanged.
 function inferBadgeVariant(badge: SidebarBadge): SidebarBadge {
   const text = typeof badge === "string" ? badge : badge.text;
   const variant = typeof badge === "string" ? "default" : (badge.variant ?? "default");
@@ -204,9 +208,8 @@ function inferBadgeVariant(badge: SidebarBadge): SidebarBadge {
   }
 }
 
-// External-app links carry a fixed badge by URL shape, mirroring root's
-// `getBadge`: the `/api` OpenAPI reference is "API", the MCP server repo is
-// "MCP". This badge takes precedence over authored/auto-Beta badges.
+// Fixed badge for external-app links by URL shape (`/api` → "API", MCP server
+// repo → "MCP"). Takes precedence over authored/auto-Beta badges.
 function getExternalBadge(href: string): SidebarBadge | undefined {
   if (href.startsWith("/api")) return { text: "API", variant: "note" };
   if (href.includes("/mcp-server-cloudflare")) return { text: "MCP", variant: "note" };
@@ -259,13 +262,14 @@ function applyBadges(
   });
 }
 
-/**
- * Main docs route: Agent resources group + external-app (`/api/`) re-marking +
- * badge variant mapping / auto-Beta injection.
- */
+// Agent resources + external-app re-marking + badges. The "Overview" convention
+// (leaf lift + section-root pinning) is applied downstream by nimbus-docs via
+// `sidebar.indexDisplay: "overview-leaf"`, which runs after this transform — so
+// `applyBadges` still keys group badges off `indexHref` before it is cleared.
 export const docsSidebarTransform: SidebarTransform = async (ctx) => {
   const withAgentResources = await agentResourcesTransform(ctx);
   const withExternal = markExternalAppLinks(withAgentResources);
+  const withRedirects = markInternalRedirects(withExternal);
   const betaUrls = await getBetaBadgeUrls();
-  return applyBadges(withExternal, betaUrls);
+  return applyBadges(withRedirects, betaUrls);
 };


### PR DESCRIPTION
### Summary

A batch of UX/polish fixes to the Nimbus docs frontend, plus a `nimbus-docs`
bump (`0.1.22` → `0.1.25`) that enables the new sidebar `indexDisplay`
convention.

**Sidebar**

- Adopt the upstream `sidebar.indexDisplay: "overview-leaf"` config now that
  nimbus-docs applies the "Overview" leaf-lift / section-root pinning itself,
  and remove the local logic that duplicated it.
- Add `markInternalRedirects` so internal cross-section redirects
  (relative `external_link` leaves) get the `↗` arrow, matching external-app
  links.
- Route the model index/detail pages through `docsSidebarTransform` instead of
  `externalAppLinksTransform` so they pick up the Agent resources group and
  badges. `ModelDetailPage` now builds its sidebar via `getSidebar` directly
  because `getRouteNavigation` ignores transforms.

**Plan component**

- Implement the `<Plan id="…" />` lookup against the `plans` content collection
  (previously a placeholder stub) so plan-availability badges resolve to real
  strings.

**Breadcrumbs**

- Rework the collapse/truncation layout so only the current crumb shrinks and
  the "…" popover can escape the row instead of being clipped.

**Typography / styling**

- H2 weight `650` → `600` and `Feature` heading `bold` → `semibold` for
  consistent heading weights; inline `<strong>`/`<b>` set to `600` to match.
- Zebra-stripe large prose tables (5+ rows).
- Style the 404 `llms.txt` link, add spacing to the RSS button, and drop the
  sticky positioning on the left resources filter.

Dropped the checlist cos this doesn't impact prod
