### PR TITLE
[DLP] Correct Japanese detection entry names

### DIFF
--- a/src/content/docs/cloudflare-one/data-loss-prevention/detection-entries/predefined-detection-entries.mdx
+++ b/src/content/docs/cloudflare-one/data-loss-prevention/detection-entries/predefined-detection-entries.mdx
@@ -96,10 +96,10 @@ You can add any predefined detection entry directly to a custom [DLP profile](/c
 | Ireland Tax (PPS) | Detects Irish Personal Public Service numbers (PPS) such as "1234567FA". |
 | Ireland VAT | Detects Ireland VAT numbers such as "IE1234567T". |
 | Italy Fiscal Code | Detects Italian fiscal codes (Codice Fiscale) such as "BNZVCN32S10E573Z". |
-| Japan Address | Detects Japanese postal addresses identified by a postal code marker such as "〒100-0001". |
+| Japan Postal Code | Detects Japanese postal addresses identified by a postal code marker such as "〒100-0001". |
 | Japan My Number (Corp) | Detects Japanese corporate My Number identifiers (Hojin Bango) such as "7000012050002". |
 | Japan My Number (Person) | Detects Japanese individual My Number identifiers (Kojin Bango) such as "100000000005". |
-| Japan Names (Kanji) | Detects Japanese personal names written in kanji and labeled in context such as "氏名: 田中太郎". |
+| Japan Names (Kanji, labeled) | Detects Japanese personal names written in kanji and labeled in context such as "氏名: 田中太郎". |
 | Japan Passport | Detects Japanese passport numbers such as "TZ1234567". |
 | Java | Detects Java source code. |
 | JavaScript | Detects JavaScript source code. |


### PR DESCRIPTION
### Summary

Updates two Japanese predefined detection entry names so they align with the matching requirements described in the existing documentation.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
