### PR TITLE
Organizations: add IdP federation, remove Enterprise-only badge, fix sub-org nesting depth

### DIFF
--- a/src/content/docs/fundamentals/organizations/for-enterprise.mdx
+++ b/src/content/docs/fundamentals/organizations/for-enterprise.mdx
@@ -158,7 +158,7 @@ All users who will be Organization members must have [two-factor authentication 
 
 Organizations allows you to share WAF custom rulesets and Zero Trust Gateway policies (DNS, Network, HTTP, Resolver) across accounts in your Organization. Shared policies are read-only in receiving accounts and automatically stay in sync when updated in the source account.
 
-Organizations also supports [IdP federation](/cloudflare-one/integrations/identity-providers/idp-federation/), which lets you configure a single identity provider (such as Okta or Entra ID) in one account and share it across all accounts in your Organization. Shared IdP connections are read-only in recipient accounts and are automatically managed as accounts join or leave your Organization.
+Organizations also supports [IdP federation](/cloudflare-one/integrations/identity-providers/idp-federation/), which lets you configure a single identity provider (such as Okta or Entra ID) in one account and share it across all accounts in your Organization. Shared IdP connections are read-only in recipient accounts and are automatically provisioned or removed as accounts join or leave the Organization.
 
 For detailed instructions, refer to [Policy sharing](/fundamentals/organizations/policy-sharing/).
 

--- a/src/content/docs/fundamentals/organizations/for-enterprise.mdx
+++ b/src/content/docs/fundamentals/organizations/for-enterprise.mdx
@@ -158,6 +158,8 @@ All users who will be Organization members must have [two-factor authentication 
 
 Organizations allows you to share WAF custom rulesets and Zero Trust Gateway policies (DNS, Network, HTTP, Resolver) across accounts in your Organization. Shared policies are read-only in receiving accounts and automatically stay in sync when updated in the source account.
 
+Organizations also supports [IdP federation](/cloudflare-one/integrations/identity-providers/idp-federation/), which lets you configure a single identity provider (such as Okta or Entra ID) in one account and share it across all accounts in your Organization. Shared IdP connections are read-only in recipient accounts and are automatically managed as accounts join or leave your Organization.
+
 For detailed instructions, refer to [Policy sharing](/fundamentals/organizations/policy-sharing/).
 
 :::note

--- a/src/content/docs/fundamentals/organizations/for-mssp-distributors.mdx
+++ b/src/content/docs/fundamentals/organizations/for-mssp-distributors.mdx
@@ -32,24 +32,28 @@ MSSP/Distributor Organizations use a **multi-tier structure**:
 ```
 Distributor Organization
 ├── MSSP Organization A
-│   ├── Customer Account 1
-│   │   ├── Zone A
-│   │   └── Zone B
-│   └── Customer Account 2
-│       └── Zone C
+│   ├── Sub-Organization A1
+│   │   ├── Customer Account 1
+│   │   │   ├── Zone A
+│   │   │   └── Zone B
+│   │   └── Customer Account 2
+│   │       └── Zone C
+│   └── Customer Account 3
+│       └── Zone D
 ├── MSSP Organization B
-│   ├── Customer Account 3
-│   │   └── Zone D
-│   └── Customer Account 4
-│       ├── Zone E
+│   ├── Customer Account 4
+│   │   └── Zone E
+│   └── Customer Account 5
 │       └── Zone F
 └── MSSP Organization C
-    └── Customer Account 5
-        └── Zone G
+    └── Sub-Organization C1
+        └── Customer Account 6
+            └── Zone G
 ```
 
 **Key characteristics:**
 - Distributors create and manage child MSSP Organizations
+- MSSP Organizations can create up to 5 levels of nested sub-organizations
 - Each MSSP Organization manages its own customer accounts
 - MSSP Organization members have [implicit access](#implicit-access) to their customer accounts
 - Accounts can be moved between MSSP Organizations
@@ -236,6 +240,3 @@ If you encounter errors during setup or management, refer to [Troubleshooting](/
 
 ### Assign existing accounts
 MSSP/Distributor Organizations cannot assign existing accounts. Use account creation to add new accounts to your Organization.
-
-### Nested sub-organizations
-MSSP/Distributor Organizations support up to 5 levels of nested sub-organizations.

--- a/src/content/docs/fundamentals/organizations/for-mssp-distributors.mdx
+++ b/src/content/docs/fundamentals/organizations/for-mssp-distributors.mdx
@@ -165,6 +165,8 @@ Organizations allows you to share WAF custom rulesets and Zero Trust Gateway pol
 
 For Distributor Organizations, policies can be shared across MSSP Organization boundaries within the same Distributor Organization.
 
+Organizations also supports [IdP federation](/cloudflare-one/integrations/identity-providers/idp-federation/), which lets you configure a single identity provider (such as Okta or Entra ID) in one account and share it across all accounts in your Organization. Shared IdP connections are read-only in recipient accounts and are automatically managed as accounts join or leave your Organization.
+
 For detailed instructions, refer to [Policy sharing](/fundamentals/organizations/policy-sharing/).
 
 :::note
@@ -235,5 +237,5 @@ If you encounter errors during setup or management, refer to [Troubleshooting](/
 ### Assign existing accounts
 MSSP/Distributor Organizations cannot assign existing accounts. Use account creation to add new accounts to your Organization.
 
-### Create nested sub-organizations
-MSSP Organizations cannot create their own child Organizations. The hierarchy is limited to two tiers: Distributor → MSSP Organizations.
+### Nested sub-organizations
+MSSP/Distributor Organizations support up to 5 levels of nested sub-organizations.

--- a/src/content/docs/fundamentals/organizations/for-mssp-distributors.mdx
+++ b/src/content/docs/fundamentals/organizations/for-mssp-distributors.mdx
@@ -169,7 +169,7 @@ Organizations allows you to share WAF custom rulesets and Zero Trust Gateway pol
 
 For Distributor Organizations, policies can be shared across MSSP Organization boundaries within the same Distributor Organization.
 
-Organizations also supports [IdP federation](/cloudflare-one/integrations/identity-providers/idp-federation/), which lets you configure a single identity provider (such as Okta or Entra ID) in one account and share it across all accounts in your Organization. Shared IdP connections are read-only in recipient accounts and are automatically managed as accounts join or leave your Organization.
+Organizations also supports [IdP federation](/cloudflare-one/integrations/identity-providers/idp-federation/), which lets you configure a single identity provider (such as Okta or Entra ID) in one account and share it across all accounts in your Organization. Shared IdP connections are read-only in recipient accounts and are automatically provisioned or removed as accounts join or leave the Organization.
 
 For detailed instructions, refer to [Policy sharing](/fundamentals/organizations/policy-sharing/).
 

--- a/src/content/docs/fundamentals/organizations/index.mdx
+++ b/src/content/docs/fundamentals/organizations/index.mdx
@@ -50,17 +50,22 @@ Organization
 ```
 Distributor Organization
 ├── MSSP Organization A
-│   ├── Customer Account 1
-│   │   ├── Zone A
-│   │   └── Zone B
-│   └── Customer Account 2
-│       └── Zone C
+│   ├── Sub-Organization A1
+│   │   ├── Customer Account 1
+│   │   │   ├── Zone A
+│   │   │   └── Zone B
+│   │   └── Customer Account 2
+│   │       └── Zone C
+│   └── Customer Account 3
+│       └── Zone D
 └── MSSP Organization B
-    ├── Customer Account 3
-    │   └── Zone D
-    └── Customer Account 4
-        └── Zone E
+    ├── Customer Account 4
+    │   └── Zone E
+    └── Customer Account 5
+        └── Zone F
 ```
+
+MSSP/Distributor Organizations support up to 5 levels of nested sub-organizations.
 
 ## Core features
 

--- a/src/content/docs/fundamentals/organizations/index.mdx
+++ b/src/content/docs/fundamentals/organizations/index.mdx
@@ -10,9 +10,7 @@ products:
   - fundamentals
 ---
 
-import { DirectoryListing, Plan } from "~/components";
-
-<Plan type="enterprise" />
+import { DirectoryListing } from "~/components";
 
 An Organization is a top-level container in Cloudflare for managing multiple accounts. It allows administrators to govern accounts, members, and resources from a single location rather than managing each account individually. Organization Super Administrators have implicit access to all accounts within the Organization. This means they do not need explicit membership on each account.
 
@@ -71,6 +69,7 @@ Distributor Organization
 - **Aggregate analytics**: View, filter, and download aggregate HTTP analytics across all Organization child accounts.
 - **Organization-level membership**: Invite members to the Organization once, granting them access to all child accounts.
 - **WAF and Gateway policy sharing**: Create security policies once and share them across accounts in your Organization.
+- **IdP federation**: Share a single identity provider configuration across all accounts in your Organization. Refer to [IdP federation](/cloudflare-one/integrations/identity-providers/idp-federation/) for setup details.
 - **API, SDK, and Terraform support**: Manage Organizations programmatically with the [Cloudflare Organizations API](/api/resources/organizations/), SDKs, or Terraform provider.
 - **Enhanced account switcher**: Navigate between accounts with an Organization-aware account switcher in the dashboard.
 

--- a/src/content/docs/fundamentals/organizations/limitations.mdx
+++ b/src/content/docs/fundamentals/organizations/limitations.mdx
@@ -40,7 +40,7 @@ Each Organization supports a maximum of **500 accounts** and **5,000 zones**. Th
 | Organization creation | MSSP/Distributor Organizations are created by Cloudflare. Contact your account team to set up your Organization. |
 | Adding existing accounts | Assigning existing accounts is not available for MSSP/Distributor Organizations. Use account creation to add new accounts. |
 | Account creation | MSSP Organizations can self-serve create new customer accounts within their Organization. |
-| Sub-Organizations | Distributors can create child MSSP Organizations. MSSP Organizations cannot create their own child Organizations — the hierarchy is limited to two tiers: Distributor → MSSP Organizations. |
+| Sub-Organizations | Distributors can create child MSSP Organizations. MSSP/Distributor Organizations support up to 5 levels of nested sub-organizations. |
 | Moving accounts | Accounts can be moved between MSSP Organizations within the same Distributor Organization. |
 | Roles | Organization Super Administrator is the only role available. Additional roles (read-only, billing, audit log) will be available in a future release. |
 | Organization deletion | To delete an Organization, use the [API](/api/resources/organizations/methods/delete). Dashboard support is not yet available. |

--- a/src/content/docs/fundamentals/organizations/policy-sharing.mdx
+++ b/src/content/docs/fundamentals/organizations/policy-sharing.mdx
@@ -18,6 +18,8 @@ Organizations allows you to create security policies in one account and share th
 
 Policy sharing works the same way for both [Enterprise](/fundamentals/organizations/for-enterprise/) and [MSSP/Distributor](/fundamentals/organizations/for-mssp-distributors/) Organizations.
 
+In addition to WAF and Gateway policies, Organizations supports [IdP federation](/cloudflare-one/integrations/identity-providers/idp-federation/), which lets you configure a single identity provider (such as Okta or Entra ID) in one account and share it across all accounts in your Organization. Shared IdP connections are read-only in recipient accounts and are automatically provisioned or removed as accounts join or leave the Organization.
+
 ## Prerequisites
 
 Policy sharing requires the appropriate product entitlements on the accounts involved. Organizations does not grant access to WAF or Gateway features — your accounts must already have the required SKUs.


### PR DESCRIPTION
## Changes

This PR makes the following updates to the Organizations public documentation:

### 1. Remove incorrect "Enterprise-only" badge (`index.mdx`)
The `<Plan type="enterprise" />` component rendered an "Enterprise-only" badge at the top of the Organizations landing page. This is incorrect — Organizations is available to both Enterprise and MSSP/Distributor customers (as the page body already states). Removed the component.

### 2. Add IdP federation to Core features (`index.mdx`)
Added a new bullet for IdP federation to the Core features list, linking to the [IdP federation docs](/cloudflare-one/integrations/identity-providers/idp-federation/).

### 3. Add IdP federation to Policy sharing page (`policy-sharing.mdx`)
Added a paragraph after the intro explaining that Organizations also supports IdP federation for sharing identity provider configurations across accounts.

### 4. Add IdP federation to Enterprise page (`for-enterprise.mdx`)
Added IdP federation mention in the "Share policies" section.

### 5. Add IdP federation to MSSP/Distributors page (`for-mssp-distributors.mdx`)
Added IdP federation mention in the "Share policies" section.

### 6. Fix sub-organization nesting depth (`for-mssp-distributors.mdx`, `limitations.mdx`)
MSSP/Distributor Organizations now support up to 5 levels of nested sub-organizations. Updated the "What you cannot do" section and the limitations table which previously stated the hierarchy was limited to two tiers.

## References
- [IdP federation changelog (June 4, 2026)](https://developers.cloudflare.com/changelog/post/2026-06-04-idp-federation/)
- [IdP federation docs](https://developers.cloudflare.com/cloudflare-one/integrations/identity-providers/idp-federation/)