### PR TITLE
Fix script-src directive in web analytics FAQ

### DIFF
--- a/src/content/docs/web-analytics/faq.mdx
+++ b/src/content/docs/web-analytics/faq.mdx
@@ -114,7 +114,7 @@ If your site implements a Content Security Policy (CSP), you'll need to add some
 You'll first need to permit our script to execute by adding it to your `script-src` directive:
 
 ```
-script-src [...existing values...] https://static.cloudflareinsights.com/beacon.min.js
+script-src [...existing values...] https://static.cloudflareinsights.com/beacon.min.js/
 ```
 
 _Note: if you have a query string in the script as per the example above for Google Tag Manager, then you'll need to include this in the URL too, e.g. `script-src [...existing values...] https://static.cloudflareinsights.com/beacon.min.js?token=$SITE_TOKEN`_


### PR DESCRIPTION
### Summary

Corrected the script-src directive in web analytics FAQ to include a trailing slash to support versioned URLs like https://static.cloudflareinsights.com/beacon.min.js/v4513226cdae34746b4dedf0b4dfa099e1781791509496

### Documentation checklist

<!-- Remove items that do not apply -->

- [X] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).