### PR TITLE
[Browser Run] Add REST API browser session to get-started

### DIFF
--- a/src/content/docs/browser-run/get-started.mdx
+++ b/src/content/docs/browser-run/get-started.mdx
@@ -8,7 +8,7 @@ products:
   - browser-run
 ---
 
-import { Render, Tabs, TabItem } from "~/components";
+import { Render, Tabs, TabItem, CURL } from "~/components";
 
 Cloudflare Browser Run (formerly Browser Rendering) allows you to programmatically control a headless browser, enabling you to do things like take screenshots, generate PDFs, and perform automated browser tasks. This guide will help you choose the right integration method and get you started with your first project.
 
@@ -52,6 +52,52 @@ Check out the full list of [Quick Actions endpoints](/browser-run/quick-actions/
 
 ## Browser Sessions
 
+Browser Sessions give you full control over a headless browser. You can connect from anywhere using the REST API, or from a Cloudflare Worker using a browser binding.
+
+<Tabs> <TabItem label="REST API">
+
+### Prerequisites
+
+- Sign up for a [Cloudflare account](https://dash.cloudflare.com/sign-up/workers-and-pages).
+- Create a [Cloudflare API Token](/fundamentals/api/get-started/create-token/) with `Browser Rendering - Edit` permissions.
+
+### Create a browser session
+
+A single API call gives you a live browser session you can see and interact with:
+
+<CURL
+	url="https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/browser-rendering/devtools/browser"
+	method="POST"
+	headers={{
+		Authorization: "Bearer $CLOUDFLARE_API_TOKEN",
+	}}
+	query={{
+		keep_alive: "600000",
+		targets: "true",
+	}}
+/>
+
+```json title="Response" {5}
+{
+	"sessionId": "1909cef7-23e8-4394-bc31-27404bf4348f",
+	"targets": [
+		{
+			"devtoolsFrontendUrl": "https://live.browser.run/ui/inspector?wss=..."
+		}
+	]
+}
+```
+
+Copy the `devtoolsFrontendUrl` and open it in your browser. You now have a real browser session running on Cloudflare that you can interact with directly: enter a URL, click around, and inspect the page.
+
+You can drive browser sessions programmatically using [CDP](/browser-run/cdp/), [Puppeteer](/browser-run/cdp/puppeteer/), or [Playwright](/browser-run/cdp/playwright/) from any environment. Browser sessions also support:
+
+- **[Live View](/browser-run/features/live-view/)**: See and interact with a remote session in real time, useful for debugging automation scripts or monitoring browser activity.
+- **[Session Recording](/browser-run/features/session-recording/)**: Record browser sessions for playback, so you can review what happened during an automation run.
+- **[Human in the Loop](/browser-run/features/human-in-the-loop/)**: Pause automation and hand control to a human for tasks that require manual intervention, like solving CAPTCHAs or completing login flows.
+
+</TabItem> <TabItem label="Workers binding">
+
 ### Prerequisites
 
 <Render file="prereqs" product="workers" />
@@ -62,6 +108,8 @@ Check out the full list of [Quick Actions endpoints](/browser-run/quick-actions/
 	file="example-workers-binding-screenshots-from-web"
 	product="browser-run"
 />
+
+</TabItem> </Tabs>
 
 ## Next steps
 


### PR DESCRIPTION
## Summary

Adds a REST API tab to the Browser Sessions section of the get-started page. Previously, the only get-started path for browser sessions was a 7-step Workers binding example (create project, install Puppeteer, create KV, configure wrangler, write code, test, deploy). This adds a simpler entry point: one curl to create a session, open the `devtoolsFrontendUrl` in your browser, and you have a live browser session.

## Changes

- Adds REST API / Workers binding tabs to the Browser Sessions section (matching the pattern already used in Quick Actions)
- REST API tab: single curl example, trimmed response highlighting `devtoolsFrontendUrl`, and a brief explanation of what to do with it
- Links out to Live View, Session Recording, and Human in the Loop features
- Links out to CDP, Puppeteer, and Playwright docs for programmatic control
- Existing Workers binding example is unchanged, just moved into a tab

## Review checklist
- [x] Only one file changed (`src/content/docs/browser-run/get-started.mdx`)
- [x] `pnpm run check` passes (0 errors)
- [x] Formatting unchanged (already formatted)
- [x] Previewed locally