### PR TITLE
update privacy CODEOWNERS 

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -280,8 +280,10 @@ package.json @cloudflare/content-engineering
 
 # Privacy
 
-/src/content/docs/key-transparency/ @cloudflare/appsec-reviewers @elithrar @cloudflare/product-owners
-/src/content/docs/privacy-gateway/ @cloudflare/product-owners
+/src/content/docs/key-transparency/ @mgalicer @lschull @cloudflare/appsec-reviewers @elithrar @cloudflare/product-owners
+/src/content/docs/privacy-gateway/ @mgalicer @lschull @cloudflare/product-owners 
+/src/content/docs/privacy-proxy/ @mgalicer @lschull @cloudflare/product-owners
+/src/content/docs/privacy-pass/ @mgalicer @lschull @cloudflare/product-owners
 
 # Radar
 


### PR DESCRIPTION
### Summary

Update CODEOWNERS for privacy products w/ Lara  and myself. 

`/src/content/docs/privacy-pass/` is a reference to [PR 31751](https://github.com/cloudflare/cloudflare-docs/pull/31751) which should land shortly 


