### PR TITLE
[Fundamentals] Add Organizations changelog: self-serve Distributor/MSSP/Agency member management

### DIFF
--- a/src/content/changelog/fundamentals/2026-04-06-organizations-public-beta.mdx
+++ b/src/content/changelog/fundamentals/2026-04-06-organizations-public-beta.mdx
@@ -5,6 +5,7 @@ products:
   - fundamentals
   - cloudflare-one
   - gateway
+  - organizations
 date: 2026-04-06
 ---
 

--- a/src/content/changelog/organizations/2026-07-17-distributor-mssp-self-serve-members.mdx
+++ b/src/content/changelog/organizations/2026-07-17-distributor-mssp-self-serve-members.mdx
@@ -1,0 +1,22 @@
+---
+title: Distributor, MSSP, and Agency partners can manage Organization members directly
+description: Distributor, MSSP, and Agency partners on Cloudflare Organizations can now add and manage Organization Members from the dashboard, without Cloudflare assistance.
+products:
+  - fundamentals
+  - organizations
+date: 2026-07-17
+---
+
+Distributor, MSSP, and Agency partners on Cloudflare [Organizations](/fundamentals/organizations/) can now add and manage Organization Members directly from the Cloudflare dashboard, without help from Cloudflare.
+
+Previously, adding a member to a Distributor, MSSP, or Agency Organization was a manual, Cloudflare-assisted process that required a request to Cloudflare and enrollment in a closed beta, and the dashboard **Add member** flow was blocked for these Organizations.
+
+Now, Organization admins can add members themselves from **Organization** > **Members** > **Add member**, with no beta enrollment required.
+
+New members receive access to the Organization's accounts through the same implicit-access model already used for enterprise Organizations. The **Accounts** list and the account switcher classify Distributor, MSSP, and Agency Organizations consistently with enterprise Organizations, so their accounts are labeled and grouped correctly in the dashboard.
+
+Agency partners also gain access to the Organizations dashboard, while retaining access to their existing Tenant management dashboard.
+
+Distributor, MSSP, and Agency Organizations are currently in beta.
+
+For more information, refer to [Manage Organization members](/fundamentals/organizations/manage-members/).

--- a/src/content/directory/organizations.yaml
+++ b/src/content/directory/organizations.yaml
@@ -1,0 +1,13 @@
+id: 9NidcW
+name: Organizations
+
+entry:
+  title: Organizations
+  group: Core platform
+  url: /fundamentals/organizations/
+  show: false
+
+meta:
+  title: Cloudflare Organizations docs
+  description: Centrally manage multiple Cloudflare accounts, members, analytics, and shared policies from a single Organization.
+  author: "@cloudflare"


### PR DESCRIPTION
## Summary

Adds a changelog entry announcing that Distributor, MSSP, and Agency partners on Cloudflare [Organizations](https://developers.cloudflare.com/fundamentals/organizations/) can now add and manage Organization Members directly from the dashboard, without help from Cloudflare. It also notes that Agency partners now have access to the Organizations dashboard while retaining access to their existing Tenant management dashboard for now.

## Changes

- **New changelog entry** `src/content/changelog/organizations/2026-07-17-distributor-mssp-self-serve-members.mdx`.
- **New Organizations product in the changelog filter** via `src/content/directory/organizations.yaml` (a `show: false` entry pointing at `/fundamentals/organizations/`, grouped under *Core platform*). This enables `/changelog/product/organizations/` and adds *Organizations* to the changelog product filter dropdown.
- **Tagged the existing** `2026-04-06-organizations-public-beta` **entry** with the new `organizations` product so it appears in the Organizations changelog view (it keeps its `fundamentals`, `cloudflare-one`, and `gateway` tags).

## Notes for reviewers

- The entry is dated **2026-07-17**. If the feature availability date shifts, update the date before merging (a future-dated entry only publishes on/after its date).
- `npm run check` passes with 0 errors.
