### PR TITLE
[Fundamentals] Add self-serve member management context to MSSP/Distributors page

### DIFF
--- a/src/content/docs/fundamentals/organizations/for-mssp-distributors.mdx
+++ b/src/content/docs/fundamentals/organizations/for-mssp-distributors.mdx
@@ -119,6 +119,8 @@ Move customer accounts from one MSSP Organization to another when ownership chan
 
 ## Manage members
 
+Distributor and MSSP Organization admins can add and manage Organization members directly from the Cloudflare dashboard. No support ticket is required.
+
 ### Organization Super Administrator
 
 When your Organization is created, the initial user becomes the Organization Super Administrator. This role provides [implicit access](#implicit-access) to all accounts in your Organization and allows you to manage memberships at the Organization level.


### PR DESCRIPTION
## Summary

Adds a paragraph to the **Manage members** section of the [Organizations for MSSP and Distributors](https://developers.cloudflare.com/fundamentals/organizations/for-mssp-distributors/) page clarifying that Distributor and MSSP Organization admins can now add and manage Organization members directly from the dashboard without a support ticket.

## Changes

- `src/content/docs/fundamentals/organizations/for-mssp-distributors.mdx`: Added one paragraph at the top of the `## Manage members` section.

## Notes for reviewers

- This ships alongside [PR #32092](https://github.com/cloudflare/cloudflare-docs/pull/32092) (changelog entry for the same feature). Both should merge on **July 17, 2026**.
- The existing invite flow documentation on the page is already accurate — this paragraph adds context that member management is self-serve (previously required a support ticket).