### PR TITLE
[Pages] Update project limit docs with alternative product guidance

### DIFF
--- a/src/content/docs/pages/platform/limits.mdx
+++ b/src/content/docs/pages/platform/limits.mdx
@@ -77,6 +77,15 @@ Your Pages site can be managed by an unlimited number of users via the Cloudflar
 
 ## Projects
 
-Cloudflare Pages has a soft limit of 100 projects within your account in order to prevent abuse. If you need this limit raised, contact your Cloudflare account team or use the Limit Increase Request Form at the top of this page.
+Cloudflare Pages has a limit of 100 projects per account. This limit is not routinely increased.
+
+If you need to host more than 100 sites, use one of these products designed for scale:
+
+- **[Workers for Platforms](/cloudflare-for-platforms/workers-for-platforms/)** — Deploy sites and applications at scale with no project limit. Supports [static assets](/cloudflare-for-platforms/workers-for-platforms/configuration/static-assets/).
+- **[Workers Static Assets](/workers/static-assets/)** — Deploy static sites as individual Workers. Paid plans support up to 500 Workers per account, each serving up to 100,000 static asset files.
+
+:::note
+The Workers project limit (100 on Free, 500 on paid plans) is separate from the Pages project limit. Refer to [Workers limits](/workers/platform/limits/#number-of-workers) for details.
+:::
 
 In order to protect against abuse of the service, Cloudflare limits the number of new Pages projects you can create within your first 48 hours of using the service. If you are temporarily blocked from creating new projects, this restriction will automatically lift once the initial 48-hour window has passed.


### PR DESCRIPTION
### Summary

Updates the Pages project limit docs to align with current product direction. DEE-3720.

- Recommend Workers for Platforms and Workers Static Assets as alternatives for scale
- Clarify that Workers and Pages project limits are separate

### Documentation checklist

- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
