### PR TITLE
Fix link for facilitators in x402 documentation

### DIFF
--- a/src/content/docs/agents/tools/payments/x402/index.mdx
+++ b/src/content/docs/agents/tools/payments/x402/index.mdx
@@ -39,7 +39,7 @@ The facilitator is an optional but recommended third-party service that abstract
 - **`POST /verify`** — Confirms the client's payment payload is valid before the server fulfills the request.
 - **`POST /settle`** — Submits the verified payment transaction to the blockchain.
 
-The facilitator does not hold funds. It verifies and broadcasts the client's pre-signed transaction on behalf of the server. `https://x402.org/facilitator` is the public facilitator operated by Coinbase and is used in all Cloudflare examples. [Multiple facilitators](https://www.x402.org/ecosystem?filter=facilitators) are available across different networks.
+The facilitator does not hold funds. It verifies and broadcasts the client's pre-signed transaction on behalf of the server. `https://x402.org/facilitator` is the public facilitator operated by Coinbase and is used in all Cloudflare examples. [Multiple facilitators](https://docs.x402.org/dev-tools/facilitators) are available across different networks.
 
 ## Payment schemes and networks
 


### PR DESCRIPTION
### Summary

Fixed the x402 facilitator link so it points to the correct documentation / current facilitator guidance.

### Documentation checklist

https://developers.cloudflare.com/agents/tools/payments/x402/

- [ ] Is there a changelog entry?
  - No, this is a small docs/link correction, not a notable product change. Cloudflare’s changelog is for notable changes.
- [x] The change adheres to the documentation style guide.
  - Yes.
- [ ] If a larger change, an issue has been opened.
  - No, this is a small link fix.
- [ ] Files which have changed name or location have been allocated redirects.
  - No, no file move/rename.

The docs I checked are:
- https://developers.cloudflare.com/style-guide/
- https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/