### PR TITLE
warn that edited Email Routing records remain service-linked.mdx

### DIFF
--- a/src/content/docs/email-service/configuration/domains.mdx
+++ b/src/content/docs/email-service/configuration/domains.mdx
@@ -321,6 +321,10 @@ Removing a domain from Email Sending deletes the `cf-bounce` MX, SPF, DKIM, and 
 
 Disabling Email Routing on a domain stops processing incoming emails and removes every routing-related DNS record (MX, SPF, DKIM) that Email Service added to the root domain. If you plan to switch to a different email provider, [unlock the records](#locked-dns-records) and add the new provider's records before disabling Email Routing so that mail flow is not interrupted.
 
+:::note
+Unlocking an Email Service-created record and editing it to point to another provider does not remove its association with Email Service. The record will still be treated as managed by Email Service and will be deleted when you disable Email Routing.
+:::
+
 ### Transfer domain ownership
 
 1. The domain must remain in the same Cloudflare account.


### PR DESCRIPTION
Clarify that unlocking and editing an Email Service-created DNS record does not remove its association with Email Service.

Previously, the migration guidance suggested unlocking records and adding new provider records before disabling Email Routing. However, it was not clear that editing an unlocked record (for example, changing the SPF TXT record to point to Microsoft 365 or another provider) would still cause that record to be deleted when Email Routing is disabled, because the record remains internally linked to the service.

Add a caution note explaining this behavior.

