### PR TITLE
Add Email Service to account API token compatibility

### DIFF
--- a/src/content/docs/fundamentals/api/get-started/account-owned-tokens.mdx
+++ b/src/content/docs/fundamentals/api/get-started/account-owned-tokens.mdx
@@ -59,6 +59,7 @@ Account API tokens are generally available for all accounts. Some services may n
 | DNS                                         | ✅            |
 | Durable Objects                             | ✅            |
 | Email Relay                                 | ✅            |
+| Email Service                               | ✅            |
 | Secure Web Gateway                          | ✅            |
 | Healthchecks                                | ✅            |
 | Hyperdrive                                  | ✅            |


### PR DESCRIPTION
### Summary

Adds Email Service as a supported product in the Account API tokens compatibility matrix.

### Screenshots (optional)

Not applicable; docs table update only.

### Documentation checklist

- [x] The change adheres to the documentation style guide.