### PR TITLE
[R2] Remove stale Super Slurper jurisdiction limitation

### DIFF
--- a/src/content/docs/r2/reference/data-location.mdx
+++ b/src/content/docs/r2/reference/data-location.mdx
@@ -157,7 +157,6 @@ Cloudflare Enterprise customers may contact their account team or [Cloudflare Su
 
 The following services do not interact with R2 resources with assigned jurisdictions:
 
-- [Super Slurper](/r2/data-migration/) (_coming soon_)
 - [Logpush](/logs/logpush/logpush-job/enable-destinations/r2/). As a workaround to this limitation, you can set up a [Logpush job using an S3-compatible endpoint](/data-localization/how-to/r2/#send-logs-to-r2-via-s3-compatible-endpoint) to store logs in an R2 bucket in the jurisdiction of your choice.
 
 ### Additional considerations


### PR DESCRIPTION
### Summary

Slurper is able to interact with R2 resources with assigned jurisdictions.

### Documentation checklist

<!-- Remove items that do not apply -->

- [not needed] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [x] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [x] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
