### PR TITLE
docs(cache): Clarify custom cache key behavior with single-file purge

### DIFF
--- a/src/content/docs/cache/how-to/cache-rules/index.mdx
+++ b/src/content/docs/cache/how-to/cache-rules/index.mdx
@@ -30,6 +30,19 @@ The following table describes Cache Rules availability per plan.
 
 <FeatureTable id="cache.cache_rules" />
 
+## Cache Rules and cache keys
+
+When a Cache Rule sets a [custom cache key](/cache/how-to/cache-keys/), the resulting cache entry is indexed by that key rather than the request URL alone. This means that [single-file purge via the dashboard](/cache/how-to/purge-cache/purge-by-single-file/) will not invalidate the cached resource because the dashboard only accepts URLs, not the headers or cookies that are part of the custom cache key.
+
+To purge resources cached with a custom cache key, you have the following options:
+
+- Use the API to [purge by URL](/api/resources/cache/methods/purge/#purge-cached-content-by-url), including all headers, cookies, and query strings that are part of your custom cache key. If any header or cookie is missing from the purge request, it is treated as an empty value in the cache key.
+- [Purge by prefix](/cache/how-to/purge-cache/purge_by_prefix/), which purges all resources under a URL path and is not affected by custom cache keys.
+- [Purge by tag](/cache/how-to/purge-cache/purge-by-tags/), which is not affected by custom cache keys.
+- [Purge everything](/cache/how-to/purge-cache/purge-everything/), which clears all cached resources for the zone.
+
+For more information, refer to the [cache keys](/cache/how-to/cache-keys/) and [purge cache key resources](/cache/how-to/purge-cache/purge-cache-key/) documentation.
+
 <Render
 	file="troubleshoot-rules-with-trace"
 	product="rules"

--- a/src/content/docs/cache/how-to/purge-cache/purge-by-single-file.mdx
+++ b/src/content/docs/cache/how-to/purge-cache/purge-by-single-file.mdx
@@ -1,5 +1,5 @@
 ---
-title: ​Purge by single-file
+title: Purge by single-file
 pcx_content_type: how-to
 description: Purge a single cached file by URL.
 products:
@@ -14,23 +14,7 @@ With purge by single-file, cached resources are instantly removed from the store
 
 For information on single-file purge rate limits, refer to the [limits](/cache/how-to/purge-cache/#single-file-purge-limits) section.
 
-A single-file purge performed through your Cloudflare dashboard does not clear objects that contain any of the following:
-
-- [Custom cache keys](/cache/how-to/cache-keys/)
-- [Origin header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Origin)
-- Any of these request headers:
-  - `X-Forwarded-Host`
-  - `X-Host`
-  - `X-Forwarded-Scheme`
-  - `X-Original-URL`
-  - `X-Rewrite-URL`
-  - `Forwarded`
-
-You can purge objects with these characteristics using an API call to ([purge files by URL](/api/resources/cache/methods/purge/)). In the data/header section of the API call, you must include all headers and cache keys contained in the cached resource, along with their matching values.
-
-:::caution
-Always use UTF-8 encoded URLs for single-file cache purges. Wildcards are not supported on single file purge, and you must use purge by hostname, prefix, or implement cache tags as an alternative solution.
-:::
+## How to purge a single file
 
 1. In the Cloudflare dashboard, go to the **Configuration** page.
 
@@ -43,14 +27,56 @@ Always use UTF-8 encoded URLs for single-file cache purges. Wildcards are not su
 6. Review your entries.
 7. Select **Purge**.
 
-:::note
-For information on how to use single-file purge to purge assets cached by a Workers fetch, refer to [Single file purge assets cached by a Worker](/workers/reference/how-the-cache-works/#single-file-purge-assets-cached-by-a-worker).
+## Limitations and alternatives
 
-For information on how to purge assets cached by [Cache API](/workers/runtime-apis/cache/) operations, refer to [Purge assets stored with the Cache API](/workers/reference/how-the-cache-works/#purge-assets-stored-with-the-cache-api).
+Single-file purge works for most resources, but there are situations where it cannot clear cached content. This section explains when single-file purge does not work and what to use instead.
+
+### Custom cache keys
+
+If you use [Cache Rules](/cache/how-to/cache-rules/) to set a [custom cache key](/cache/how-to/cache-keys/), single-file purge via the dashboard will not invalidate the cached resource. This is because custom cache keys include extra information (like headers or cookies) that the dashboard cannot send with a purge request.
+
+**What to do instead:**
+
+- **Use the API** to [purge files by URL](/api/resources/cache/methods/purge/#purge-cached-content-by-url), including all headers and cookies that are part of your custom cache key. If any header or cookie is missing from the purge request, it is treated as an empty value in the cache key.
+- **Use purge by prefix** ([purge by prefix](/cache/how-to/purge-cache/purge_by_prefix/)) to clear all resources under a URL path.
+- **Use purge by tag** ([purge by tag](/cache/how-to/purge-cache/purge-by-tags/)) if your resources are tagged.
+- **Use purge everything** ([purge everything](/cache/how-to/purge-cache/purge-everything/)) to clear all cached resources for the zone.
+
+### Cache Rules that match on request properties
+
+Single-file purge may also not work as expected if your Cache Rules match only on `GET` requests, or match on properties that are not present during a purge. For example, a Cache Rule with the expression `(http.host eq "example.com" and http.request.method eq "GET")` will not match during a single-file purge.
+
+**What to do instead:** Use [purge by prefix](/cache/how-to/purge-cache/purge_by_prefix/), [purge by tag](/cache/how-to/purge-cache/purge-by-tags/), or [purge everything](/cache/how-to/purge-cache/purge-everything/).
+
+### Resources with special headers
+
+A single-file purge performed through your Cloudflare dashboard does not clear objects that contain any of the following:
+
+- [Origin header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Origin)
+- Any of these request headers:
+  - `X-Forwarded-Host`
+  - `X-Host`
+  - `X-Forwarded-Scheme`
+  - `X-Original-URL`
+  - `X-Rewrite-URL`
+  - `Forwarded`
+
+You can purge objects with these characteristics using an API call to [purge files by URL](/api/resources/cache/methods/purge/). In the data/header section of the API call, you must include all headers and cache keys contained in the cached resource, along with their matching values.
+
+## Additional notes
+
+:::caution
+Always use UTF-8 encoded URLs for single-file cache purges. Wildcards are not supported on single file purge, and you must use purge by hostname, prefix, or implement cache tags as an alternative solution.
 :::
 
 :::caution
 If you have a [Transform Rule](/rules/transform/) in place that is modifying part of a URL path, you must use the non-transform (end user) URL when performing single file purge so that purge can take effect.
+:::
+
+:::note
+For information on how to use single-file purge to purge assets cached by a Workers fetch, refer to [Single file purge assets cached by a Worker](/workers/reference/how-the-cache-works/#single-file-purge-assets-cached-by-a-worker).
+
+For information on how to purge assets cached by [Cache API](/workers/runtime-apis/cache/) operations, refer to [Purge assets stored with the Cache API](/workers/reference/how-the-cache-works/#purge-assets-stored-with-the-cache-api).
 :::
 
 ## Resulting cache status


### PR DESCRIPTION
Cache Rules that set custom cache keys require API purge with headers/cookies rather than dashboard single-file purge. This clarification reduces customer escalations about why single-file purge does not invalidate cached resources.

### Summary

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
