### PR TITLE
Hyperdrive: clarify application_name for drivers that set their own (e.g. Postgres.js)

### DIFF
--- a/src/content/docs/hyperdrive/examples/connect-to-postgres/index.mdx
+++ b/src/content/docs/hyperdrive/examples/connect-to-postgres/index.mdx
@@ -88,6 +88,24 @@ To identify active connections to your Postgres database server from Hyperdrive:
 - Hyperdrive's connections to your database will show up with `Cloudflare Hyperdrive` as the `application_name` in the `pg_stat_activity` table.
 - Run `SELECT DISTINCT usename, application_name FROM pg_stat_activity WHERE application_name = 'Cloudflare Hyperdrive'` to show whether Hyperdrive is currently holding a connection (or connections) open to your database.
 
+:::note
+
+Hyperdrive only sets the `application_name` to `Cloudflare Hyperdrive` when your driver does not send its own. Some drivers set a default `application_name` — for example, [Postgres.js](https://github.com/porsager/postgres) sends `postgres.js` unless you override it. Hyperdrive forwards the driver-provided value to your database, so those connections appear under that name (for example, `postgres.js`) instead of `Cloudflare Hyperdrive`. This does **not** mean the connection is bypassing Hyperdrive.
+
+To keep these connections identifiable as Hyperdrive, set the `application_name` explicitly in your driver. With Postgres.js:
+
+```ts
+const sql = postgres(env.HYPERDRIVE.connectionString, {
+	max: 5,
+	fetch_types: false,
+	connection: {
+		application_name: "Cloudflare Hyperdrive",
+	},
+});
+```
+
+:::
+
 ## Next steps
 
 - Refer to the list of [supported database integrations](/workers/databases/connecting-to-databases/) to understand other ways to connect to existing databases.


### PR DESCRIPTION
## Summary

Clarifies the "Identify connections from Hyperdrive" section of the Connect to PostgreSQL page.

The current text states unconditionally that Hyperdrive connections appear as `application_name = 'Cloudflare Hyperdrive'` in `pg_stat_activity`. That is only true for drivers that do **not** set their own `application_name` (for example, `node-postgres`/`pg`).

Some drivers send a default `application_name` in the Postgres startup packet. [Postgres.js](https://github.com/porsager/postgres) defaults to `postgres.js` (`env.PGAPPNAME || 'postgres.js'`). Hyperdrive forwards that client-supplied value to the database, so those connections show up as `postgres.js` — leading users to believe they are bypassing Hyperdrive when they are not.

## Reproduction

Same Hyperdrive config and database, comparing drivers via `SELECT application_name FROM pg_stat_activity WHERE pid = pg_backend_pid()`:

| Driver | `application_name` seen by Postgres |
| --- | --- |
| `pg` (node-postgres) | `Cloudflare Hyperdrive` |
| `postgres.js` + Drizzle | `postgres.js` |
| `postgres.js` + Drizzle, `connection.application_name` overridden | `Cloudflare Hyperdrive` |

## Change

Adds a note explaining the behavior and showing how to set `application_name` explicitly with Postgres.js so connections remain identifiable as Hyperdrive.
