### PR TITLE
[Pipelines] Clarify SQL transforms billing on pricing page

### DIFF
--- a/src/content/docs/pipelines/platform/pricing.mdx
+++ b/src/content/docs/pipelines/platform/pricing.mdx
@@ -13,7 +13,7 @@ products:
 
 Pipelines charges based on two dimensions:
 
-1. **SQL transforms**: The volume of data processed by stateless SQL transformations (optional).
+1. **SQL transforms**: The volume of data processed by stateless SQL.
 2. **Sinks**: The volume of data delivered to each sink destination.
 
 Ingress into a Pipeline stream is free. Standard [R2 storage and operations](/r2/pricing/) charges apply for data written to R2 buckets. [R2 Data Catalog](/r2/data-catalog/platform/pricing/) charges apply when writing to Iceberg tables.
@@ -26,10 +26,10 @@ All included usage is on a monthly basis.
 | ---------------------------- | ------------- |
 | **Streams (ingress)**        |               |
 | Included                     | Unlimited     |
-| **SQL transforms** [^1]      |               |
+| **SQL transforms**           |               |
 | Included                     | 50 GB / month |
 | Additional                   | $0.04 / GB    |
-| **Sinks (egress)** [^2]      |               |
+| **Sinks (egress)** [^1]      |               |
 | Included                     | 50 GB / month |
 | R2 &mdash; JSON format       | $0.03 / GB    |
 | R2 &mdash; Parquet / Iceberg | $0.06 / GB    |
@@ -40,9 +40,9 @@ Streams provide durable, distributed log storage that buffers incoming messages.
 
 ### SQL transforms
 
-SQL transforms let you filter, reshape, and compute over data before it reaches a sink. Any query that filters, renames, casts, or computes columns counts as a transform.
+SQL transforms let you filter, reshape, and compute over data before it reaches a sink. Any query currently counts as a transform.
 
-Pricing covers stateless transforms only (for example, filter, reshape, unnest, cast, and compute). Future stateful operations such as aggregations, joins, and windows may be priced separately.
+Pricing covers stateless transforms (for example, filter, reshape, unnest, cast, and compute). Future stateful operations such as aggregations, joins, and windows may be priced separately.
 
 ### Sinks
 
@@ -53,18 +53,7 @@ Sink pricing is based on the volume of uncompressed data delivered to the destin
 
 ## Billing examples
 
-### Example 1: Simple JSON log forwarding
-
-A pipeline ingests 200 GB of log data per month and writes it directly to an R2 bucket in JSON format with no SQL transforms.
-
-| Dimension      | Usage  | Included  | Billable | Cost      |
-| -------------- | ------ | --------- | -------- | --------- |
-| Streams        | 200 GB | Unlimited | 0 GB     | $0.00     |
-| SQL transforms | 0 GB   | 50 GB     | 0 GB     | $0.00     |
-| Sinks (JSON)   | 200 GB | 50 GB     | 150 GB   | $4.50     |
-| **Total**      |        |           |          | **$4.50** |
-
-### Example 2: Filtered ingest to Iceberg with SQL
+### Example: Filtered ingest to Iceberg with SQL
 
 A pipeline ingests 500 GB of event data per month. A SQL transform filters and reshapes the data, reducing output to 300 GB written to an R2 Data Catalog Iceberg table.
 
@@ -79,6 +68,4 @@ A pipeline ingests 500 GB of event data per month. A SQL transform filters and r
 
 To learn more about how usage is billed, refer to [Cloudflare Billing Policy](/billing/understand/billing-policy/).
 
-[^1]: Optional. Includes stateless SQL transforms only (for example, filter, reshape, unnest, cast, compute).
-
-[^2]: Sink egress is measured on uncompressed data.
+[^1]: Sink egress is measured on uncompressed data.

--- a/src/content/docs/pipelines/platform/pricing.mdx
+++ b/src/content/docs/pipelines/platform/pricing.mdx
@@ -53,7 +53,7 @@ Sink pricing is based on the volume of uncompressed data delivered to the destin
 
 ## Billing examples
 
-### Example: Filtered ingest to Iceberg with SQL
+### Example: filtered ingest to Iceberg with SQL
 
 A pipeline ingests 500 GB of event data per month. A SQL transform filters and reshapes the data, reducing output to 300 GB written to an R2 Data Catalog Iceberg table.
 


### PR DESCRIPTION
Adjusted SQL Transforms descriptions throughout the Pipelines pricing page to make it more clear that any SQL statement will incur billing charges