### PR TITLE
docs: document take-home code export in agent lee

### DIFF
--- a/src/content/docs/agent-lee/index.mdx
+++ b/src/content/docs/agent-lee/index.mdx
@@ -102,7 +102,7 @@ Agent Lee does not currently use your conversations, prompts, or account data to
 
 Agent Lee cannot:
 
-- Write Workers scripts or generate application code
+- Deploy applications on your behalf or run code for you (it can generate small starter projects and [export the source](/agent-lee/take-home-code/) for you to clone)
 - Replace [Cloudflare Support](https://support.cloudflare.com) for billing issues, account recovery, or outages
 - Access payment methods, billing history, or API tokens
 - Operate across multiple accounts: sessions are scoped to your authenticated account
@@ -129,6 +129,7 @@ Agent Lee is built on Cloudflare's own developer platform using the same primiti
 
 ## Related resources
 
+- [Export generated code](/agent-lee/take-home-code/)
 - [Agents SDK](/agents/)
 - [Human in the Loop](/agents/concepts/agentic-patterns/human-in-the-loop/)
 - [Workers AI](/workers-ai/)

--- a/src/content/docs/agent-lee/take-home-code.mdx
+++ b/src/content/docs/agent-lee/take-home-code.mdx
@@ -1,0 +1,78 @@
+---
+title: Export generated code
+description: Take the source code Agent Lee generates with you by exporting it to a temporary, Git-cloneable repository.
+pcx_content_type: how-to
+tags:
+  - AI
+sidebar:
+  order: 2
+head:
+  - tag: title
+    content: Export generated code
+products:
+  - agent-lee
+---
+
+import { Description, Steps } from "~/components";
+
+<Description>
+
+Take the source code Agent Lee generates with you by exporting it to a temporary, Git-cloneable repository.
+
+</Description>
+
+:::note[Beta]
+Code export is part of the Agent Lee beta. Behaviors and limits described here may change.
+:::
+
+When Agent Lee generates a small project for you — for example, a starter static site or a Worker — you can export the source so you can keep working on it locally. Agent Lee packages the generated files into a temporary repository and gives you a one-time command to clone it to your machine.
+
+This is a **take-home** flow: the repository is short-lived and lives in Cloudflare's infrastructure, not your account. It is meant for getting generated code onto your own machine, after which you push it to a Git host of your choice.
+
+## How it works
+
+- **Temporary repository.** When you export, Agent Lee writes the generated files to a repository that automatically expires roughly 36 hours after creation. After it expires, the code and clone command no longer work.
+- **On-demand clone command.** Agent Lee does not put a clone command or credential in the chat transcript. Instead, the export card shows a **Copy clone command** button that fetches a fresh command when you click it. The command embeds a short-lived read credential that is valid for about one hour.
+- **Export card.** The card shows the project name, the list of exported files, and a countdown to expiry so you know how long you have to clone.
+
+## Export and clone your code
+
+<Steps>
+
+1. Ask Agent Lee to build something that produces code, then ask it to export the code. For example: "Export this project so I can clone it."
+
+2. In the export card that appears, review the file list and the expiry countdown.
+
+3. Select **Copy clone command**. Agent Lee fetches a one-time command and copies it to your clipboard.
+
+4. Paste the command into your terminal and run it to clone the repository locally:
+
+   ```sh
+   git clone <copied-command>
+   ```
+
+5. Point the local repository at your own Git host and push it there to keep it:
+
+   ```sh
+   git remote set-url origin https://your-git-host.example/you/your-repo.git
+   git push -u origin main
+   ```
+
+</Steps>
+
+## Security and privacy
+
+- **No credential in chat.** The clone command and its read credential are delivered only when you select **Copy clone command** — never in the message text, conversation history, or model context. Agent Lee will not type the clone command into the chat, so do not ask it to.
+- **Short-lived access.** The read credential expires about an hour after it is issued. Generate a fresh command if it stops working.
+- **Automatic cleanup.** The temporary repository is deleted automatically after roughly 36 hours. Clone and push to your own host before it expires.
+
+## Limitations
+
+- Exported repositories are temporary and are not backed up. Once a repository expires, it cannot be recovered.
+- The clone credential is read-only and single-purpose. You cannot push back to the temporary repository — push to your own Git host instead.
+- Code export is intended for small, self-contained projects that Agent Lee generates during a conversation.
+
+## Related resources
+
+- [Agent Lee overview](/agent-lee/)
+- [Workers](/workers/)


### PR DESCRIPTION
## what

adds docs for agent lee's take-home code export.

- new how-to page: `agent-lee/take-home-code` (export generated code)
- overview: fixes the stale "can't generate application code" limitation and links the new page

## why

lee can now export generated code to a temporary, git-cloneable repo. the docs walk the flow end to end: export from the card, copy the one-time clone command, clone, point it at your own remote, push.

## notes for reviewers

- feature is still gated (not GA yet). opening as a draft so the docs are ready the moment export ships.
- the temporary repo expires ~36h after creation. the clone command carries a read credential that lasts ~1h and is only handed out on "copy clone command", never in chat.
- `pnpm run check` passes clean (0 errors). skipped the full local build (link check).
- left the unrelated `artifacts/` product (versioned storage) untouched.
