### PR TITLE
Workflows: document individual and batch instance deletion

### DIFF
--- a/src/content/changelog/workflows/2026-07-17-instance-delete.mdx
+++ b/src/content/changelog/workflows/2026-07-17-instance-delete.mdx
@@ -1,15 +1,22 @@
 ---
-title: Delete Workflow instances in batches
-description: Delete up to 100 Workflow instances and their stored state using a binding or Wrangler.
+title: Delete Workflow instances individually or in batches
+description: Delete one or up to 100 Workflow instances and their stored state using a binding or Wrangler.
 products:
   - workflows
   - workers
 date: 2026-07-17 12:00:00 UTC
 ---
 
-You can now delete up to 100 Workflow instances and their stored state in one operation via the [Workflows API](/workflows/build/workers-api/) or Wrangler CLI. After deletion, the stored state from those instances no longer counts toward your Workflows storage bill. Running instances are terminated before deletion.
+You can now delete one or up to 100 Workflow instances and their stored state via the [Workflows API](/workflows/build/workers-api/) or Wrangler CLI. After deletion, the stored state from those instances no longer counts toward your Workflows storage bill. Running instances are terminated before deletion.
 
-Delete instances via the [Workflows API](/workflows/build/workers-api/#deletebatch) by calling `deleteBatch()` on the Workflow binding:
+Delete one instance by calling [`delete()`](/workflows/build/workers-api/#delete) on its handle:
+
+```ts
+const instance = await env.MY_WORKFLOW.get("instance-abc");
+await instance.delete();
+```
+
+Delete multiple instances by calling [`deleteBatch()`](/workflows/build/workers-api/#deletebatch) on the Workflow binding:
 
 ```ts
 const result = await env.MY_WORKFLOW.deleteBatch([
@@ -21,13 +28,14 @@ console.log(result.deleted);
 console.log(result.errors);
 ```
 
-The result contains successfully deleted IDs and per-instance errors. IDs that do not exist are returned as errors, and duplicate IDs are processed once.
+The batch result contains successfully deleted IDs and per-instance errors. IDs that do not exist are returned as errors. Duplicate IDs are deleted once, and the result includes one entry for each input position.
 
-You can also delete multiple instances from Wrangler. Use `--local` against a local `wrangler dev` session:
+Wrangler accepts one or more instance IDs. Use `--local` against a local `wrangler dev` session:
 
 ```sh
+npx wrangler workflows instances delete my-workflow <INSTANCE_ID>
 npx wrangler workflows instances delete my-workflow <INSTANCE_ID> <INSTANCE_ID>
-npx wrangler workflows instances delete my-workflow <INSTANCE_ID> <INSTANCE_ID> --local
+npx wrangler workflows instances delete my-workflow <INSTANCE_ID> --local
 ```
 
-For more information, refer to [Delete Workflow instances](/workflows/build/trigger-workflows/#delete-workflow-instances) and the [`deleteBatch`](/workflows/build/workers-api/#deletebatch) Workers API reference.
+For more information, refer to [Delete Workflow instances](/workflows/build/trigger-workflows/#delete-workflow-instances), [`delete`](/workflows/build/workers-api/#delete), and [`deleteBatch`](/workflows/build/workers-api/#deletebatch).

--- a/src/content/changelog/workflows/2026-07-17-instance-delete.mdx
+++ b/src/content/changelog/workflows/2026-07-17-instance-delete.mdx
@@ -21,7 +21,7 @@ console.log(result.deleted);
 console.log(result.errors);
 ```
 
-The result contains successfully deleted IDs and per-instance errors. Deleting an ID whose instance no longer exists is treated as successful.
+The result contains successfully deleted IDs and per-instance errors. IDs that do not exist are returned as errors, and duplicate IDs are processed once.
 
 You can also delete multiple instances from Wrangler. Use `--local` against a local `wrangler dev` session:
 

--- a/src/content/changelog/workflows/2026-07-17-instance-delete.mdx
+++ b/src/content/changelog/workflows/2026-07-17-instance-delete.mdx
@@ -1,26 +1,33 @@
 ---
-title: Delete Workflow instances
-description: Delete a Workflow instance and its stored state using the binding or Wrangler.
+title: Delete Workflow instances in batches
+description: Delete up to 100 Workflow instances and their stored state using a binding or Wrangler.
 products:
   - workflows
   - workers
 date: 2026-07-17 12:00:00 UTC
 ---
 
-You can now delete a Workflow instance, removing its stored state, using the Workflows binding or Wrangler.
+You can now delete up to 100 Workflow instances and their stored state in one operation via the [Workflows API](/workflows/build/workers-api/) or Wrangler CLI. After deletion, the stored state from those instances no longer counts toward your Workflows storage bill. Running instances are terminated before deletion.
 
-From a Worker, call `delete()` on an instance handle:
+Delete instances via the [Workflows API](/workflows/build/workers-api/#deletebatch) by calling `deleteBatch()` on the Workflow binding:
 
 ```ts
-const instance = await env.MY_WORKFLOW.get("abc-123");
-await instance.delete();
+const result = await env.MY_WORKFLOW.deleteBatch([
+	"instance-abc",
+	"instance-def",
+]);
+
+console.log(result.deleted);
+console.log(result.errors);
 ```
 
-Or from Wrangler (also works against a local `wrangler dev` session with `--local`):
+The result contains successfully deleted IDs and per-instance errors. Deleting an ID whose instance no longer exists is treated as successful.
+
+You can also delete multiple instances from Wrangler. Use `--local` against a local `wrangler dev` session:
 
 ```sh
-npx wrangler workflows instances delete my-workflow <INSTANCE_ID>
-npx wrangler workflows instances delete my-workflow <INSTANCE_ID> --local
+npx wrangler workflows instances delete my-workflow <INSTANCE_ID> <INSTANCE_ID>
+npx wrangler workflows instances delete my-workflow <INSTANCE_ID> <INSTANCE_ID> --local
 ```
 
-For more information, refer to [Delete a Workflow instance](/workflows/build/trigger-workflows/#delete-a-workflow-instance) and the [`delete`](/workflows/build/workers-api/#delete) Workers API reference.
+For more information, refer to [Delete Workflow instances](/workflows/build/trigger-workflows/#delete-workflow-instances) and the [`deleteBatch`](/workflows/build/workers-api/#deletebatch) Workers API reference.

--- a/src/content/changelog/workflows/2026-07-17-instance-delete.mdx
+++ b/src/content/changelog/workflows/2026-07-17-instance-delete.mdx
@@ -16,6 +16,8 @@ const instance = await env.MY_WORKFLOW.get("instance-abc");
 await instance.delete();
 ```
 
+If a Workflow deletes its own instance, execution stops during `await instance.delete()`. Code after the call does not run.
+
 Delete multiple instances by calling [`deleteBatch()`](/workflows/build/workers-api/#deletebatch) on the Workflow binding:
 
 ```ts
@@ -30,11 +32,16 @@ console.log(result.errors);
 
 The batch result contains successfully deleted IDs and per-instance errors. IDs that do not exist are returned as errors. Duplicate IDs are deleted once, and the result includes one entry for each input position.
 
-Wrangler accepts one or more instance IDs. Use `--local` against a local `wrangler dev` session:
+Wrangler accepts positional instance IDs, a JSON file containing an array of IDs, or both, up to 100 IDs total. Use `--local` against a local `wrangler dev` session:
+
+```json title="instance-ids.json"
+["instance-abc", "instance-def"]
+```
 
 ```sh
 npx wrangler workflows instances delete my-workflow <INSTANCE_ID>
 npx wrangler workflows instances delete my-workflow <INSTANCE_ID> <INSTANCE_ID>
+npx wrangler workflows instances delete my-workflow --filename ./instance-ids.json
 npx wrangler workflows instances delete my-workflow <INSTANCE_ID> --local
 ```
 

--- a/src/content/changelog/workflows/2026-07-17-instance-delete.mdx
+++ b/src/content/changelog/workflows/2026-07-17-instance-delete.mdx
@@ -1,0 +1,26 @@
+---
+title: Delete Workflow instances
+description: Delete a Workflow instance and its stored state using the binding or Wrangler.
+products:
+  - workflows
+  - workers
+date: 2026-07-17 12:00:00 UTC
+---
+
+You can now delete a Workflow instance, removing its stored state, using the Workflows binding or Wrangler.
+
+From a Worker, call `delete()` on an instance handle:
+
+```ts
+const instance = await env.MY_WORKFLOW.get("abc-123");
+await instance.delete();
+```
+
+Or from Wrangler (also works against a local `wrangler dev` session with `--local`):
+
+```sh
+npx wrangler workflows instances delete my-workflow <INSTANCE_ID>
+npx wrangler workflows instances delete my-workflow <INSTANCE_ID> --local
+```
+
+For more information, refer to [Delete a Workflow instance](/workflows/build/trigger-workflows/#delete-a-workflow-instance) and the [`delete`](/workflows/build/workers-api/#delete) Workers API reference.

--- a/src/content/docs/workflows/build/trigger-workflows.mdx
+++ b/src/content/docs/workflows/build/trigger-workflows.mdx
@@ -250,7 +250,20 @@ To restart an instance from a specific step instead of the beginning, refer to [
 
 ### Delete Workflow instances
 
-You can delete up to 100 Workflow instances and their stored state in one call. Deleting a running instance terminates it before removing its state. IDs that do not exist are returned as per-instance errors, and duplicate IDs are processed once.
+Deleting an instance removes its stored state. A running instance is terminated before its state is removed.
+
+Delete one instance by calling `delete()` on its handle:
+
+<TypeScriptExample>
+
+```ts
+const instance = await env.MY_WORKFLOW.get("instance-abc");
+await instance.delete();
+```
+
+</TypeScriptExample>
+
+Delete up to 100 instances in one call with `deleteBatch()`:
 
 <TypeScriptExample>
 
@@ -266,15 +279,18 @@ console.log(result.errors); // Per-instance failures, if any
 
 </TypeScriptExample>
 
-You can also delete multiple instances from Wrangler:
+Missing IDs are returned as per-instance errors. Duplicate IDs are deleted once, and the result includes one entry for each input position.
+
+Wrangler accepts one or more instance IDs:
 
 ```sh
+npx wrangler workflows instances delete <WORKFLOW_NAME> <INSTANCE_ID>
 npx wrangler workflows instances delete <WORKFLOW_NAME> <INSTANCE_ID> <INSTANCE_ID>
 # For local Workflow instances during wrangler dev:
-npx wrangler workflows instances delete <WORKFLOW_NAME> <INSTANCE_ID> <INSTANCE_ID> --local
+npx wrangler workflows instances delete <WORKFLOW_NAME> <INSTANCE_ID> --local
 ```
 
-For the full result shape, refer to [`deleteBatch`](/workflows/build/workers-api/#deletebatch).
+For the full APIs, refer to [`delete`](/workflows/build/workers-api/#delete) and [`deleteBatch`](/workflows/build/workers-api/#deletebatch).
 
 ### Trigger a Workflow from another Workflow
 

--- a/src/content/docs/workflows/build/trigger-workflows.mdx
+++ b/src/content/docs/workflows/build/trigger-workflows.mdx
@@ -250,7 +250,7 @@ To restart an instance from a specific step instead of the beginning, refer to [
 
 ### Delete Workflow instances
 
-You can delete up to 100 Workflow instances and their stored state in one call. Deleting a running instance terminates it before removing its state.
+You can delete up to 100 Workflow instances and their stored state in one call. Deleting a running instance terminates it before removing its state. IDs that do not exist are returned as per-instance errors, and duplicate IDs are processed once.
 
 <TypeScriptExample>
 

--- a/src/content/docs/workflows/build/trigger-workflows.mdx
+++ b/src/content/docs/workflows/build/trigger-workflows.mdx
@@ -263,6 +263,8 @@ await instance.delete();
 
 </TypeScriptExample>
 
+If a Workflow deletes its own instance, execution stops during `await instance.delete()`. Code after the call does not run.
+
 Delete up to 100 instances in one call with `deleteBatch()`:
 
 <TypeScriptExample>
@@ -281,11 +283,16 @@ console.log(result.errors); // Per-instance failures, if any
 
 Missing IDs are returned as per-instance errors. Duplicate IDs are deleted once, and the result includes one entry for each input position.
 
-Wrangler accepts one or more instance IDs:
+Wrangler accepts one or more instance IDs or a JSON file containing an array of IDs. You can combine positional IDs with `--filename`, up to 100 IDs total.
+
+```json title="instance-ids.json"
+["instance-abc", "instance-def"]
+```
 
 ```sh
 npx wrangler workflows instances delete <WORKFLOW_NAME> <INSTANCE_ID>
 npx wrangler workflows instances delete <WORKFLOW_NAME> <INSTANCE_ID> <INSTANCE_ID>
+npx wrangler workflows instances delete <WORKFLOW_NAME> --filename ./instance-ids.json
 # For local Workflow instances during wrangler dev:
 npx wrangler workflows instances delete <WORKFLOW_NAME> <INSTANCE_ID> --local
 ```

--- a/src/content/docs/workflows/build/trigger-workflows.mdx
+++ b/src/content/docs/workflows/build/trigger-workflows.mdx
@@ -248,6 +248,23 @@ Restarting an instance will immediately cancel any in-progress steps, erase any 
 
 To restart an instance from a specific step instead of the beginning, refer to [`restart`](/workflows/build/workers-api/#restart) in the Workers API reference.
 
+### Delete a Workflow instance
+
+You can delete a Workflow instance, removing its stored state, by calling `delete` against a specific instance ID.
+
+```ts
+let instance = await env.MY_WORKFLOW.get("abc-123");
+await instance.delete(); // Returns Promise<void>
+```
+
+You can also delete an instance from Wrangler:
+
+```sh
+npx wrangler workflows instances delete <WORKFLOW_NAME> <INSTANCE_ID>
+# For a local Workflows instance during wrangler dev:
+npx wrangler workflows instances delete <WORKFLOW_NAME> <INSTANCE_ID> --local
+```
+
 ### Trigger a Workflow from another Workflow
 
 You can create a new Workflow instance from within a step of another Workflow. The parent Workflow will not block waiting for the child Workflow to complete — it continues execution immediately after the child instance is successfully created.

--- a/src/content/docs/workflows/build/trigger-workflows.mdx
+++ b/src/content/docs/workflows/build/trigger-workflows.mdx
@@ -248,22 +248,33 @@ Restarting an instance will immediately cancel any in-progress steps, erase any 
 
 To restart an instance from a specific step instead of the beginning, refer to [`restart`](/workflows/build/workers-api/#restart) in the Workers API reference.
 
-### Delete a Workflow instance
+### Delete Workflow instances
 
-You can delete a Workflow instance, removing its stored state, by calling `delete` against a specific instance ID.
+You can delete up to 100 Workflow instances and their stored state in one call. Deleting a running instance terminates it before removing its state.
+
+<TypeScriptExample>
 
 ```ts
-let instance = await env.MY_WORKFLOW.get("abc-123");
-await instance.delete(); // Returns Promise<void>
+const result = await env.MY_WORKFLOW.deleteBatch([
+	"instance-abc",
+	"instance-def",
+]);
+
+console.log(result.deleted); // [{ id: "instance-abc" }, { id: "instance-def" }]
+console.log(result.errors); // Per-instance failures, if any
 ```
 
-You can also delete an instance from Wrangler:
+</TypeScriptExample>
+
+You can also delete multiple instances from Wrangler:
 
 ```sh
-npx wrangler workflows instances delete <WORKFLOW_NAME> <INSTANCE_ID>
-# For a local Workflows instance during wrangler dev:
-npx wrangler workflows instances delete <WORKFLOW_NAME> <INSTANCE_ID> --local
+npx wrangler workflows instances delete <WORKFLOW_NAME> <INSTANCE_ID> <INSTANCE_ID>
+# For local Workflow instances during wrangler dev:
+npx wrangler workflows instances delete <WORKFLOW_NAME> <INSTANCE_ID> <INSTANCE_ID> --local
 ```
+
+For the full result shape, refer to [`deleteBatch`](/workflows/build/workers-api/#deletebatch).
 
 ### Trigger a Workflow from another Workflow
 

--- a/src/content/docs/workflows/build/workers-api.mdx
+++ b/src/content/docs/workflows/build/workers-api.mdx
@@ -509,6 +509,42 @@ Returns an array of `WorkflowInstance`.
 
 Unlike [`create`](/workflows/build/workers-api/#create), this operation is idempotent and will not fail if an ID is already in use. If an existing instance with the same ID is still within its [retention limit](/workflows/reference/limits/), it will be skipped and excluded from the returned array.
 
+### deleteBatch
+
+Delete up to 100 Workflow instances and their stored state.
+
+`deleteBatch(instanceIds: string[])` returns a `Promise<WorkflowBatchDeleteResult>`. The `instanceIds` argument contains the IDs of the Workflow instances to delete.
+
+<TypeScriptExample>
+
+```ts
+const result = await env.MY_WORKFLOW.deleteBatch([
+	"instance-abc",
+	"instance-def",
+]);
+```
+
+</TypeScriptExample>
+
+The operation returns successes and per-instance failures:
+
+```ts
+type WorkflowBatchDeleteResult = {
+	deleted: { id: string }[];
+	errors: {
+		index: number;
+		id: string;
+		code: number;
+		message: string;
+	}[];
+};
+```
+
+- `deleted` contains the IDs that were deleted successfully.
+- `errors` contains failures. The `index` matches the instance ID's position in the input array.
+
+Deletion is idempotent. An ID whose instance no longer exists is included in `deleted`. A running instance is terminated before its stored state is removed.
+
 ### get
 
 Get a specific Workflow instance by ID.
@@ -606,10 +642,6 @@ declare abstract class WorkflowInstance {
 	 * Restart the instance from the beginning, or from a specific step.
 	 */
 	public restart(options?: WorkflowInstanceRestartOptions): Promise<void>;
-	/**
-	 * Delete the instance.
-	 */
-	public delete(): Promise<void>;
 	/**
 	 * Returns the current status of the instance.
 	 */
@@ -722,18 +754,6 @@ interface WorkflowInstanceTerminateOptions {
 	 */
 	rollback?: boolean;
 }
-```
-
-### delete
-
-Delete a Workflow instance, removing its stored state.
-
-- <code>delete(): Promise&lt;void&gt;</code>
-
-```ts
-let instance = await env.MY_WORKFLOW.get("abc-123");
-
-await instance.delete();
 ```
 
 ### sendEvent

--- a/src/content/docs/workflows/build/workers-api.mdx
+++ b/src/content/docs/workflows/build/workers-api.mdx
@@ -532,7 +532,6 @@ The operation returns successes and per-instance failures:
 type WorkflowBatchDeleteResult = {
 	deleted: { id: string }[];
 	errors: {
-		index: number;
 		id: string;
 		code: number;
 		message: string;
@@ -541,9 +540,9 @@ type WorkflowBatchDeleteResult = {
 ```
 
 - `deleted` contains the IDs that were deleted successfully.
-- `errors` contains failures. The `index` matches the instance ID's first position in the input array.
+- `errors` contains failures identified by instance ID, with a stable error code and message.
 
-Duplicate IDs are processed once. An ID whose instance does not exist is included in `errors`. A running instance is terminated before its stored state is removed.
+Duplicate IDs are deleted once, and the result includes one entry for each input position. An ID whose instance does not exist is included in `errors`. A running instance is terminated before its stored state is removed.
 
 ### get
 
@@ -642,6 +641,10 @@ declare abstract class WorkflowInstance {
 	 * Restart the instance from the beginning, or from a specific step.
 	 */
 	public restart(options?: WorkflowInstanceRestartOptions): Promise<void>;
+	/**
+	 * Delete the instance and its stored state.
+	 */
+	public delete(): Promise<void>;
 	/**
 	 * Returns the current status of the instance.
 	 */
@@ -755,6 +758,21 @@ interface WorkflowInstanceTerminateOptions {
 	rollback?: boolean;
 }
 ```
+
+### delete
+
+Delete a Workflow instance and its stored state.
+
+- <code>delete(): Promise&lt;void&gt;</code>
+
+<TypeScriptExample>
+
+```ts
+const instance = await env.MY_WORKFLOW.get("instance-abc");
+await instance.delete();
+```
+
+</TypeScriptExample>
 
 ### sendEvent
 

--- a/src/content/docs/workflows/build/workers-api.mdx
+++ b/src/content/docs/workflows/build/workers-api.mdx
@@ -541,9 +541,9 @@ type WorkflowBatchDeleteResult = {
 ```
 
 - `deleted` contains the IDs that were deleted successfully.
-- `errors` contains failures. The `index` matches the instance ID's position in the input array.
+- `errors` contains failures. The `index` matches the instance ID's first position in the input array.
 
-Deletion is idempotent. An ID whose instance no longer exists is included in `deleted`. A running instance is terminated before its stored state is removed.
+Duplicate IDs are processed once. An ID whose instance does not exist is included in `errors`. A running instance is terminated before its stored state is removed.
 
 ### get
 

--- a/src/content/docs/workflows/build/workers-api.mdx
+++ b/src/content/docs/workflows/build/workers-api.mdx
@@ -607,6 +607,10 @@ declare abstract class WorkflowInstance {
 	 */
 	public restart(options?: WorkflowInstanceRestartOptions): Promise<void>;
 	/**
+	 * Delete the instance.
+	 */
+	public delete(): Promise<void>;
+	/**
 	 * Returns the current status of the instance.
 	 */
 	public status(): Promise<InstanceStatus>;
@@ -718,6 +722,18 @@ interface WorkflowInstanceTerminateOptions {
 	 */
 	rollback?: boolean;
 }
+```
+
+### delete
+
+Delete a Workflow instance, removing its stored state.
+
+- <code>delete(): Promise&lt;void&gt;</code>
+
+```ts
+let instance = await env.MY_WORKFLOW.get("abc-123");
+
+await instance.delete();
 ```
 
 ### sendEvent

--- a/src/content/docs/workflows/build/workers-api.mdx
+++ b/src/content/docs/workflows/build/workers-api.mdx
@@ -774,6 +774,8 @@ await instance.delete();
 
 </TypeScriptExample>
 
+If a Workflow deletes its own instance, execution stops during `await instance.delete()`. Code after the call does not run.
+
 ### sendEvent
 
 [Send an event](/workflows/build/events-and-parameters/) to a running Workflow instance.


### PR DESCRIPTION
### Summary

Documents individual and batch Workflow instance deletion:

- `env.MY_WORKFLOW.get(id).delete()` for one instance.
- `env.MY_WORKFLOW.deleteBatch(instanceIds)` for up to 100 instances with `{ deleted, errors }`.
- `wrangler workflows instances delete <name> [id..]` or a JSON array passed with `--filename` for up to 100 IDs, remotely or locally.
- Missing-ID errors, duplicate handling, running-instance deletion, and storage billing behavior.
- A Workflows changelog entry announcing both APIs.

### Screenshots (optional)

### Documentation checklist

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [x] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
