### PR TITLE
Add Beta badge to Sequence Mitigation sidebar nav

### DIFF
--- a/src/content/docs/api-shield/security/sequence-mitigation/index.mdx
+++ b/src/content/docs/api-shield/security/sequence-mitigation/index.mdx
@@ -6,6 +6,8 @@ products:
   - api-shield
 sidebar:
   order: 4
+  group:
+    badge: Beta
 
 ---
 


### PR DESCRIPTION
Sequence Mitigation is a beta feature but was missing the Beta badge in the sidebar navigation. This adds the `group.badge: Beta` frontmatter so the badge renders next to the Sequence Mitigation group in the nav.