### PR TITLE
[SSL] Remove Agentless via proxy endpoints PQC section and references

### DIFF
--- a/src/content/docs/ssl/post-quantum-cryptography/pqc-and-zero-trust.mdx
+++ b/src/content/docs/ssl/post-quantum-cryptography/pqc-and-zero-trust.mdx
@@ -18,7 +18,6 @@ Organizations can obtain end-to-end post-quantum encryption of their private net
 Post-quantum encryption is offered in all major Cloudflare One network configurations, including the following on-ramps:
 
 - Agentless [browser access to Cloudflare-proxied applications](#agentless-cloudflare-access) (including self-hosted apps behind Cloudflare Access)
-- Agentless [browser on-ramp to Cloudflare Gateway](#secure-web-gateway) via [proxy endpoints](/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/)
 - [Cloudflare One Client](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/) (on the end-user device)
 - [Cloudflare IPsec](/cloudflare-wan/reference/gre-ipsec-tunnels/) on-ramp
 
@@ -113,15 +112,11 @@ A [secure web gateway (SWG)](https://www.cloudflare.com/learning/access-manageme
 
 [Cloudflare Gateway](/cloudflare-one/traffic-policies/http-policies/) [supports post-quantum cryptography for HTTPS traffic](/cloudflare-one/traffic-policies/http-policies/tls-decryption/#post-quantum-support). As long as the third-party website that is being inspected supports post-quantum key agreement, Cloudflare's SWG also supports post-quantum key agreement.
 
-![Diagram of how post-quantum cryptography works with Cloudflare's Secure Web Gateway](~/assets/images/ssl/pqc-secure-web-gateway.png).
-
-Cloudflare Gateway's HTTPS filtering feature involves two post-quantum TLS connections, as follows:
+Cloudflare Gateway's HTTPS filtering feature involves two post-quantum connections, as follows:
 
 **1. Connection from the client to Gateway**
 
-A [modern web browser that supports post-quantum key agreement](/ssl/post-quantum-cryptography/pqc-support/#browsers) connects to Gateway via the [Agentless via proxy endpoints](/ssl/post-quantum-cryptography/pqc-cloudflare-products/#agentless-via-proxy-endpoints) on-ramp. The connection is secured by TLS 1.3 with post-quantum key agreement.
-
-The [Cloudflare One Client](#cloudflare-one-client) and [Cloudflare IPsec](#cloudflare-ipsec) on-ramps described in the sections above can also route traffic to Gateway with post-quantum protection.
+The client reaches Gateway through one of the post-quantum on-ramps: the [Cloudflare One Client](#cloudflare-one-client) or a [Cloudflare IPsec](#cloudflare-ipsec) tunnel. These on-ramps carry the client's traffic to Gateway with post-quantum key agreement.
 
 **2. Connection from Gateway to the origin server**
 

--- a/src/content/docs/ssl/post-quantum-cryptography/pqc-cloudflare-products.mdx
+++ b/src/content/docs/ssl/post-quantum-cryptography/pqc-cloudflare-products.mdx
@@ -40,7 +40,7 @@ Reference: [PQC for all websites and APIs](https://blog.cloudflare.com/post-quan
 - The Cloudflare API and dashboard.
 - [Cloudflare Access](/cloudflare-one/access-controls/applications/http-apps/self-hosted-public-app/) self-hosted applications (browser-to-edge leg).
 
-This section only covers the inbound TLS connection from the end-user client to Cloudflare's edge. When a Worker fetches data from a backend storage service ([D1](/d1/), [KV](/kv/), [Durable Objects](/durable-objects/), [R2](/r2/), [Workers AI](/workers-ai/), [Hyperdrive](/hyperdrive/), and similar), that connection is governed by the [Cloudflare internal network](#cloudflare-internal-network) section. When a Worker calls out to a third-party origin via `fetch()`, it is governed by the [Cloudflare to origin](#cloudflare-to-origin) section. The [Agentless via proxy endpoints](#agentless-via-proxy-endpoints) on-ramp to Cloudflare Gateway terminates inbound TLS in its own edge stack and is covered separately below.
+This section only covers the inbound TLS connection from the end-user client to Cloudflare's edge. When a Worker fetches data from a backend storage service ([D1](/d1/), [KV](/kv/), [Durable Objects](/durable-objects/), [R2](/r2/), [Workers AI](/workers-ai/), [Hyperdrive](/hyperdrive/), and similar), that connection is governed by the [Cloudflare internal network](#cloudflare-internal-network) section. When a Worker calls out to a third-party origin via `fetch()`, it is governed by the [Cloudflare to origin](#cloudflare-to-origin) section.
 
 ## Cloudflare internal network
 
@@ -114,22 +114,10 @@ Mesh inherits its post-quantum protection from the [Cloudflare One Client](#clou
 
 - The [Cloudflare One Client](#cloudflare-one-client).
 - A [Cloudflare IPsec](#cloudflare-ipsec) tunnel.
-- The [Agentless via proxy endpoints](#agentless-via-proxy-endpoints) on-ramp.
 
 The egress leg from Gateway to third-party origin servers is covered by [Cloudflare to origin](#cloudflare-to-origin) and is independent of the on-ramp.
 
 Reference: [PQC and Cloudflare One: Secure Web Gateway](/ssl/post-quantum-cryptography/pqc-and-zero-trust/#secure-web-gateway).
-
-### Agentless via proxy endpoints
-
-Cloudflare Gateway [proxy endpoints](/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/) let browsers route their egress HTTPS traffic through Cloudflare Gateway for inspection and filtering, without an agent installed on the device. Browsers are configured via a Proxy Auto-Configuration (PAC) file or system proxy settings to forward traffic to a Cloudflare-hosted proxy endpoint, which terminates TLS at Cloudflare's edge.
-
-| Protection    | Status            |
-| ------------- | ----------------- |
-| Key agreement | ✅ X25519MLKEM768 |
-| Signatures    | Not yet           |
-
-Reference: [Proxy endpoints](/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/), [PQC and Cloudflare One: Secure Web Gateway](/ssl/post-quantum-cryptography/pqc-and-zero-trust/#secure-web-gateway).
 
 ### Cloudflare IPsec
 


### PR DESCRIPTION
### Summary

Remove Agentless via proxy endpoints PQC section and references

Also temporarily remove the Secure Web Gateway diagram and update the client-to-Gateway text to cover only the Cloudflare One Client and Cloudflare IPsec on-ramps.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
