### PR TITLE
[Spectrum] Document IP Access Rules blocking health checks

### DIFF
--- a/src/content/docs/load-balancing/additional-options/spectrum.mdx
+++ b/src/content/docs/load-balancing/additional-options/spectrum.mdx
@@ -54,6 +54,9 @@ The exact settings will vary depending on your use case. Refer to the following 
 8. On the **Monitors** page, define the settings presented and select **Next**.
    - Review the monitors attached to your pools.
    - If needed, you can attach an existing monitor or [create a new monitor](/load-balancing/monitors/create-monitor/#create-a-monitor).
+   :::caution[IP Access Rules and health checks]
+   If your Spectrum application has [IP Access Rules](/spectrum/reference/configuration-options/#ip-access-rules) enabled, Cloudflare's health check probes must be allowed by your rules. Otherwise, health checks will be blocked and all endpoints will be marked as unhealthy. To resolve this, add [Cloudflare IP addresses](https://www.cloudflare.com/ips/) to your IP Access Rules allowlist. Refer to [Spectrum Troubleshooting](/spectrum/reference/troubleshooting/#health-checks-fail-when-ip-access-rules-are-enabled) for details.
+   :::
 
 9. On the **Traffic Steering** page, choose an option for [Traffic steering](/load-balancing/understand-basics/traffic-steering/steering-policies/) and select **Next**.
 

--- a/src/content/docs/spectrum/reference/configuration-options.mdx
+++ b/src/content/docs/spectrum/reference/configuration-options.mdx
@@ -90,6 +90,14 @@ If [IP Access rules](/waf/tools/ip-access-rules/create/) are enabled for a Spect
 Network analytics data for Spectrum does not reflect the outcomes of IP Access rules. Instead, to verify whether traffic was allowed or blocked based on these rules, consult the Spectrum event logs.
 :::
 
+:::caution[Health checks and IP Access Rules]
+When IP Access Rules are enabled with an allowlist model (allow specific IPs, block all others), Cloudflare Load Balancer health check probes may be blocked, causing all endpoints to appear unhealthy. To prevent this, add [Cloudflare IP addresses](https://www.cloudflare.com/ips/) to your allowlist. Refer to [Spectrum Troubleshooting](/spectrum/reference/troubleshooting/#health-checks-fail-when-ip-access-rules-are-enabled) for details.
+:::
+
+:::note
+[Custom rules](/waf/custom-rules/) (WAF rules) do not apply to Spectrum applications configured with the TCP/UDP application type. IP Access Rules are the only supported IP-based filtering mechanism for these applications. Refer to [Spectrum Limitations](/spectrum/reference/limitations/#ip-access-control) for details.
+:::
+
 ## Argo Smart Routing
 
 Once Argo Smart Routing is enabled for your application, traffic will automatically be routed through the fastest and most reliable network path available. Argo Smart Routing is available for TCP and UDP (beta) applications.

--- a/src/content/docs/spectrum/reference/troubleshooting.mdx
+++ b/src/content/docs/spectrum/reference/troubleshooting.mdx
@@ -27,3 +27,27 @@ When a Spectrum application uses a [virtual network origin](/spectrum/reference/
 ### Cloudflare WAN as the connector
 
 For tunnel health, BGP, and routing diagnostics on WAN-connected origins, refer to [Troubleshoot Cloudflare WAN](/cloudflare-wan/troubleshooting/).
+
+## Health checks fail when IP Access Rules are enabled
+
+### Symptoms
+
+- Cloudflare Load Balancer health checks report all endpoints as unhealthy with the error `Connection reset by peer`.
+- Removing IP Access Rules from the Spectrum application causes health checks to succeed.
+- The Spectrum application itself works correctly for client traffic that is allowed by the IP Access Rules.
+
+### Cause
+
+When you turn on [IP Access Rules](/spectrum/reference/configuration-options/#ip-access-rules) on a Spectrum application, all incoming connections are evaluated against your rules — including connections from Cloudflare's own health check probes. If your IP Access Rules use an allowlist model (allow specific IPs, block everything else), Cloudflare's health check source IPs will be blocked, causing health checks to fail.
+
+### Solution
+
+Add Cloudflare's IP ranges to your IP Access Rules allowlist. You can find the current list of Cloudflare IP addresses at [cloudflare.com/ips](https://www.cloudflare.com/ips/).
+
+Alternatively, if you only need to restrict client access (not health check access), consider configuring health checks to use a TCP check type that validates the connection can be established, and manage your access control at the origin level instead.
+
+:::note
+
+[Custom rules](/waf/custom-rules/) (WAF rules) do not apply to Spectrum applications configured with the TCP/UDP application type. For Spectrum, IP Access Rules are the only supported mechanism for IP-based filtering. Refer to [Spectrum Limitations](/spectrum/reference/limitations/#ip-access-control).
+
+:::


### PR DESCRIPTION
## Summary

Split out of #30683 at the reviewer's request — see [this comment](https://github.com/cloudflare/cloudflare-docs/pull/30683#issuecomment-4999486757):

> Could we just hold the IP Access Rules + health checks section? I need a bit more time to verify the mechanism, but I don't want to block everything else.

## Changes

- **`spectrum/reference/troubleshooting.mdx`** — New "Health checks fail when IP Access Rules are enabled" section (symptoms/cause/solution) covering the allowlist-model blocking Cloudflare's health check probes.
- **`spectrum/reference/configuration-options.mdx`** — Caution callout under IP Access rules warning about health check impact, plus a note that Custom Rules (WAF) do not apply to TCP/UDP Spectrum applications.
- **`load-balancing/additional-options/spectrum.mdx`** — Matching caution callout in the Monitors step of the Spectrum load balancing setup guide.

## Content area
Spectrum, Load Balancing