### PR TITLE
[CF1] - Remove requirement for remotely managed tunnel to stream logs on the dashboard

### DIFF
--- a/src/content/partials/cloudflare-one/tunnel/logs/view-logs-dashboard.mdx
+++ b/src/content/partials/cloudflare-one/tunnel/logs/view-logs-dashboard.mdx
@@ -4,7 +4,7 @@
 import { GlossaryTooltip } from "~/components";
 
 
-Dashboard log streams are only available for <GlossaryTooltip term="remotely-managed tunnel">remotely-managed tunnels</GlossaryTooltip>. To stream tunnel logs from the dashboard:
+To stream tunnel logs from the dashboard:
 
 1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Networks** > **Connectors** > **Cloudflare Tunnels**.
 2. Select **View logs** next to the tunnel you want to monitor.


### PR DESCRIPTION
Removed requirement for remote tunnel dashboard.

### Summary

Remove requirement for remotely managed tunnel to stream logs on the dashboard

### Documentation checklist

- [X] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
