### PR TITLE
[Data Localization] Clarify regionalized IP binding CIDR granularity

### DIFF
--- a/src/content/docs/data-localization/regional-services/ip-bindings.mdx
+++ b/src/content/docs/data-localization/regional-services/ip-bindings.mdx
@@ -26,6 +26,20 @@ A prefix binding maps a CIDR (within a BYOIP prefix you own) to a [region key](#
 
 Bindings are managed through the Data Localization Suite API under `/accounts/{account_id}/dls/`.
 
+## Choose which CIDR to bind
+
+A binding covers a range of addresses within a prefix, not just a single address — you do **not** need to create one binding per IP address. The `cidr` you bind must:
+
+- Fall within the prefix identified by `prefix_id`.
+- Be **more specific than the prefix itself** — a sub-range within it. For example, within a `/24` prefix you can bind any range from a `/25` down to a single address (a `/32` for IPv4, or a `/128` for IPv6). Binding the entire prefix (the full `/24`) is rejected with a [conflict error](#handle-a-conflict-error), because the whole prefix range is already in use once Cloudflare advertises it.
+
+How you choose the CIDR depends on how you want to split the prefix across regions:
+
+- **One region for the whole prefix** — cover the prefix with sub-ranges that all point to the same region. For example, bind both `203.0.113.0/25` and `203.0.113.128/25` to `eu` to regionalize every address in a `/24`.
+- **Different regions for different addresses** — bind each range to the region you want (for example, `203.0.113.0/25` to `eu` and `203.0.113.128/25` to `us`). Cloudflare applies the most specific binding that matches a given address, so a narrower binding takes precedence over a broader one that overlaps it.
+
+Each CIDR can have only one binding. If you try to create a second binding for a CIDR that is already bound, the API returns a [conflict error](#handle-a-conflict-error). To change the region for an existing binding, [update it](#update-the-region-for-a-binding) instead of creating a new one.
+
 ## Prerequisites
 
 Before you create a binding, make sure that:
@@ -39,10 +53,10 @@ Before you create a binding, make sure that:
 
 These endpoints are authorized at the account level. The permissions you need depend on the operation:
 
-| Operation                                          | Required token permissions                    |
-| -------------------------------------------------- | --------------------------------------------- |
-| List regions, get a region, list or get bindings   | **DLS: Read**                                 |
-| Create, update, or delete a prefix binding         | **DLS: Write** _and_ **IP Prefixes: Write**   |
+| Operation                                        | Required token permissions                  |
+| ------------------------------------------------ | ------------------------------------------- |
+| List regions, get a region, list or get bindings | **DLS: Read**                               |
+| Create, update, or delete a prefix binding       | **DLS: Write** _and_ **IP Prefixes: Write** |
 
 Write operations require **IP Prefixes: Write** in addition to **DLS: Write** because the binding is created against a BYOIP prefix that you own in [Addressing](/byoip/) — Cloudflare verifies that you have permission to modify that prefix. A token with only **DLS: Write** can read regions and bindings but will be rejected when it tries to create or change a binding.
 
@@ -98,7 +112,7 @@ Retrieve a region by its `region_key` or ID.
 
 ## Create a prefix binding
 
-Bind a CIDR from one of your BYOIP prefixes to a region. The `cidr` must fall within the prefix identified by `prefix_id`.
+Bind a CIDR from one of your BYOIP prefixes to a region. The `cidr` must fall within the prefix identified by `prefix_id` and be [more specific than the prefix itself](#choose-which-cidr-to-bind).
 
 <CURL
 	url="https://api.cloudflare.com/client/v4/accounts/{account_id}/dls/regional_services/prefix_bindings"
@@ -106,7 +120,7 @@ Bind a CIDR from one of your BYOIP prefixes to a region. The `cidr` must fall wi
 	headers={{ Authorization: "Bearer $CLOUDFLARE_API_TOKEN" }}
 	json={{
 		prefix_id: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-		cidr: "203.0.113.0/24",
+		cidr: "203.0.113.0/25",
 		region_key: "eu",
 	}}
 />
@@ -119,7 +133,7 @@ Bind a CIDR from one of your BYOIP prefixes to a region. The `cidr` must fall wi
 	"result": {
 		"id": "f0e1d2c3-b4a5-6789-0abc-def123456789",
 		"prefix_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-		"cidr": "203.0.113.0/24",
+		"cidr": "203.0.113.0/25",
 		"region_key": "eu"
 	}
 }
@@ -134,6 +148,35 @@ Connectivity to these addresses is not interrupted while the binding propagates 
 For this reason, create the binding **first** and allow it to finish propagating before you configure address maps for the affected addresses.
 
 :::
+
+### Handle a conflict error
+
+Because [each CIDR can have only one binding](#choose-which-cidr-to-bind), a create request for a CIDR that is already bound fails with an HTTP `409` conflict:
+
+```json title="Response"
+{
+	"result": null,
+	"success": false,
+	"errors": [
+		{
+			"code": 1108,
+			"message": "conflict: binding already exists for CIDR 203.0.113.0/24"
+		}
+	],
+	"messages": []
+}
+```
+
+You get this error in two cases:
+
+- **You tried to bind the entire prefix.** The full prefix range (for example, the whole `/24`) is already in use once Cloudflare advertises your prefix, so it cannot be bound to a region directly. Bind a more specific range within the prefix instead — a `/25` down to a single `/32` — and cover the prefix with several sub-ranges if you need to regionalize all of its addresses.
+- **The CIDR is already bound.** A binding for that exact range already exists, for example from an earlier request that succeeded.
+
+To resolve it:
+
+- [List your existing bindings](#list-prefix-bindings) to see what is already configured.
+- To move an existing binding to a different region, [update it](#update-the-region-for-a-binding) rather than creating a new one.
+- To bind a different range, choose a CIDR that is not already bound. To replace an existing binding with a different CIDR, [delete it](#delete-a-binding) first, then create the new one.
 
 ## List prefix bindings
 
@@ -152,7 +195,7 @@ For this reason, create the binding **first** and allow it to finish propagating
 		{
 			"id": "f0e1d2c3-b4a5-6789-0abc-def123456789",
 			"prefix_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-			"cidr": "203.0.113.0/24",
+			"cidr": "203.0.113.0/25",
 			"region_key": "eu"
 		}
 	],
@@ -193,7 +236,7 @@ Change the region a binding points to. Only the `region_key` can be updated. To 
 	"result": {
 		"id": "f0e1d2c3-b4a5-6789-0abc-def123456789",
 		"prefix_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-		"cidr": "203.0.113.0/24",
+		"cidr": "203.0.113.0/25",
 		"region_key": "us"
 	}
 }


### PR DESCRIPTION
### Summary

Clarifies the CIDR granularity rules for [Regionalized IP Bindings](https://developers.cloudflare.com/data-localization/regional-services/ip-bindings/) after field confusion about `409` conflicts when binding a BYOIP prefix to a region.

The previous guidance implied you could bind an entire prefix (for example, a whole `/24`) to a region. In practice a regional binding must be **more specific than the prefix**: the full prefix range is already in use by the prefix's own advertisement, so a create request at the prefix length returns `409 / 1108 "conflict: binding already exists for CIDR ..."`. Verified against live binding data (base `/24` binding + regional `/32` and `/31` sub-range bindings on the same prefix).

Changes:

- Rewrite **Choose which CIDR to bind** to state the binding must be a sub-range within the prefix (a `/25` down to a `/32` / `/128`), and show how to cover a whole prefix with multiple sub-ranges.
- Add a **Handle a conflict error** section explaining the two causes of the `409` (tried to bind the whole prefix; the CIDR is already bound) and how to resolve each.
- Update the create/list/update examples to use a sub-range (`203.0.113.0/25`) instead of the whole `/24`.

### Documentation checklist

- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
