### PR TITLE
[Browser Run] Clarify /scrape required fields

### DIFF
--- a/src/content/docs/browser-run/quick-actions/scrape-endpoint.mdx
+++ b/src/content/docs/browser-run/quick-actions/scrape-endpoint.mdx
@@ -24,8 +24,8 @@ https://api.cloudflare.com/client/v4/accounts/<accountId>/browser-rendering/scra
 
 You must provide `elements` and exactly one of `url` or `html`:
 
-- `url` (string) — URL to go to. Mutually exclusive with `html`.
-- `html` (string) — HTML content to load directly. Mutually exclusive with `url`.
+- `url` (string)
+- `html` (string)
 - `elements` (array of objects) — each object must include `selector` (string)
 
 ## Common use cases

--- a/src/content/docs/browser-run/quick-actions/scrape-endpoint.mdx
+++ b/src/content/docs/browser-run/quick-actions/scrape-endpoint.mdx
@@ -24,7 +24,7 @@ https://api.cloudflare.com/client/v4/accounts/<accountId>/browser-rendering/scra
 
 You must provide `elements` and exactly one of `url` or `html`:
 
-- `url` (string) — URL to navigate to. Mutually exclusive with `html`.
+- `url` (string) — URL to go to. Mutually exclusive with `html`.
 - `html` (string) — HTML content to load directly. Mutually exclusive with `url`.
 - `elements` (array of objects) — each object must include `selector` (string)
 

--- a/src/content/docs/browser-run/quick-actions/scrape-endpoint.mdx
+++ b/src/content/docs/browser-run/quick-actions/scrape-endpoint.mdx
@@ -22,9 +22,10 @@ https://api.cloudflare.com/client/v4/accounts/<accountId>/browser-rendering/scra
 
 ## Required fields
 
-You must provide either `url` or `elements`:
+You must provide `elements` and exactly one of `url` or `html`:
 
-- `url` (string)
+- `url` (string) — URL to navigate to. Mutually exclusive with `html`.
+- `html` (string) — HTML content to load directly. Mutually exclusive with `url`.
 - `elements` (array of objects) — each object must include `selector` (string)
 
 ## Common use cases
@@ -104,6 +105,7 @@ const client = new Cloudflare({
 
 const scrapes = await client.browserRendering.scrape.create({
 	account_id: process.env["CLOUDFLARE_ACCOUNT_ID"],
+	url: "https://example.com/",
 	elements: [{ selector: "h1" }, { selector: "a" }],
 });
 


### PR DESCRIPTION
### Summary

Corrects the documented required fields for the `/scrape` quick action.

The previous text said you must provide either `url` or `elements`, which was inaccurate. `elements` is always required, and you must supply exactly one content source: `url` or `html`. This updates the required-fields list to reflect that, and adds the missing `html` field.

Also fixes the TypeScript SDK example, which previously passed `elements` but neither `url` nor `html`, so it would fail input validation.

### Screenshots (optional)

N/A — text-only changes.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).