### PR TITLE
[Workers] Fix grammar in Wrangler auth profiles intro

### DIFF
--- a/src/content/docs/workers/wrangler/profiles.mdx
+++ b/src/content/docs/workers/wrangler/profiles.mdx
@@ -8,7 +8,7 @@ products:
 
 import { Steps, WranglerConfig } from "~/components";
 
-Wrangler authenticates as one user at a time. A profile is a named OAuth login that you scope to a chosen set of accounts can bind to a directory.
+Wrangler authenticates as one user at a time. A profile is a named OAuth login that you scope to a chosen set of accounts and can bind to a directory.
 
 Use profiles to switch between accounts for different projects without re-running [`wrangler login`](/workers/wrangler/commands/general/#login). Profiles live under [`wrangler auth`](/workers/wrangler/commands/general/#auth).
 


### PR DESCRIPTION
### Summary

Fixes a grammatical error in the intro of the Wrangler authentication profiles page.

Affected page: https://developers.cloudflare.com/workers/wrangler/profiles/

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
