### PR TITLE
[Browser Run] Clarify /crawl is REST API only, not available via binding

### DIFF
--- a/src/content/docs/browser-run/quick-actions/crawl-endpoint.mdx
+++ b/src/content/docs/browser-run/quick-actions/crawl-endpoint.mdx
@@ -13,7 +13,7 @@ import { Render } from "~/components";
 
 The `/crawl` endpoint scrapes content from a starting URL and follows links across the site, up to a configurable depth or page limit. Responses can be returned as HTML, Markdown, or JSON.
 
-<Render file="rest-api-token-permissions" product="browser-run" />
+The `/crawl` endpoint is available via the REST API. [Create a custom API Token](/fundamentals/api/get-started/create-token/) with the `Browser Rendering - Edit` permission.
 
 ## Endpoint
 

--- a/src/content/docs/browser-run/quick-actions/index.mdx
+++ b/src/content/docs/browser-run/quick-actions/index.mdx
@@ -19,6 +19,8 @@ The following are the available options:
 
 <DirectoryListing />
 
+[`/crawl`](/browser-run/quick-actions/crawl-endpoint/) is available via the REST API only.
+
 Use Quick Actions when you need a fast, simple way to perform common browser tasks such as capturing screenshots, extracting HTML, or generating PDFs without writing complex scripts. For more advanced automation, custom workflows, or persistent browser sessions, use [Puppeteer](/browser-run/puppeteer/), [Playwright](/browser-run/playwright/), or [CDP](/browser-run/cdp/).
 
 ## Before you begin


### PR DESCRIPTION
### Summary

The Quick Actions overview and the `/crawl` endpoint page both presented `/crawl` as usable via the Workers Binding (`env.BROWSER.quickAction()`). In reality, `crawl` is REST API only.

#### Changes

- **`quick-actions/crawl-endpoint.mdx`** — Replaced the shared `rest-api-token-permissions` partial (which advertised binding support) with a crawl-specific line stating it is available via the REST API, keeping the `Browser Rendering - Edit` API token guidance.
- **`quick-actions/index.mdx`** — Added a clarification below the endpoint listing noting `/crawl` is REST API only, so the "two ways to use Quick Actions" intro no longer implies binding support for every action.

### Screenshots (optional)

N/A — text-only changes.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).