### PR TITLE
[1.1.1.1] Add changelog page and CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -74,6 +74,7 @@ package.json @cloudflare/content-engineering
 /src/content/changelog/ @cloudflare/pm-changelogs @cloudflare/product-owners
 /src/content/changelog/ai-search/ @cloudflare/pm-changelogs @rita3ko @irvinebroque @aninibread @mchenco @cloudflare/product-owners
 /src/content/changelog/dns/ @cloudflare/pm-changelogs @cloudflare/product-owners @hannes-cf @fattouche @xofyarg @dklbreitling @chreo @svenr-cf @kerolasa @matildeopbravo @vavrusa @mworsley-cloudflare @sebastiaanyn @vendemiat @Woutifier
+/src/content/changelog/1.1.1.1/ @cloudflare/pm-changelogs @cloudflare/product-owners @hannes-cf @fattouche @xofyarg @dklbreitling @chreo @svenr-cf @kerolasa @matildeopbravo @vavrusa @mworsley-cloudflare @sebastiaanyn @vendemiat @Woutifier
 /src/content/changelog/waf/ @worenga @cloudflare/firewall @vs-mg @fb1337 @cloudflare/pm-changelogs @cloudflare/appsec-reviewers @elithrar @cloudflare/product-owners @hsaxenaCF @danielegm @ay-cf
 /src/content/changelog/waiting-room/ @angelampcosta @dcpena @cloudflare/firewall @cloudflare/appsec-reviewers @cloudflare/pm-changelogs @hsaxenaCF @danielegm @cloudflare/product-owners
 /src/content/changelog/logs/ @soheiokamoto @angelampcosta @rianvdm @dcpena @sahidya @cloudflare/pm-changelogs @cloudflare/product-owners
@@ -81,6 +82,7 @@ package.json @cloudflare/content-engineering
 /src/content/changelog/log-explorer/ @angelampcosta @dcpena @sahidya @cloudflare/pm-changelogs @cloudflare/product-owners
 /src/assets/images/changelog/ @cloudflare/pm-changelogs @cloudflare/product-owners
 /src/assets/images/changelog/dns/ @cloudflare/pm-changelogs @cloudflare/product-owners @hannes-cf @fattouche @xofyarg @dklbreitling @chreo @svenr-cf @kerolasa @matildeopbravo @vavrusa @mworsley-cloudflare @sebastiaanyn @vendemiat @Woutifier
+/src/assets/images/changelog/1.1.1.1/ @cloudflare/pm-changelogs @cloudflare/product-owners @hannes-cf @fattouche @xofyarg @dklbreitling @chreo @svenr-cf @kerolasa @matildeopbravo @vavrusa @mworsley-cloudflare @sebastiaanyn @vendemiat @Woutifier
 /src/assets/images/ @cloudflare/pm-changelogs @cloudflare/product-owners
 /src/assets/images/images/ @dcpena @cloudflare/product-owners @renandincer @third774 @deannalam @dochne
 

--- a/src/content/docs/1.1.1.1/changelog.mdx
+++ b/src/content/docs/1.1.1.1/changelog.mdx
@@ -3,6 +3,7 @@ pcx_content_type: changelog
 description: Track the latest updates and changes to Cloudflare 1.1.1.1 features.
 products:
   - 1.1.1.1
+slug: 1.1.1.1
 title: Changelog
 sidebar:
   order: 25

--- a/src/content/docs/1.1.1.1/changelog.mdx
+++ b/src/content/docs/1.1.1.1/changelog.mdx
@@ -3,7 +3,7 @@ pcx_content_type: changelog
 description: Track the latest updates and changes to Cloudflare 1.1.1.1 features.
 products:
   - 1.1.1.1
-slug: 1.1.1.1
+slug: 1.1.1.1/changelog
 title: Changelog
 sidebar:
   order: 25

--- a/src/content/docs/1.1.1.1/changelog.mdx
+++ b/src/content/docs/1.1.1.1/changelog.mdx
@@ -1,0 +1,15 @@
+---
+pcx_content_type: changelog
+description: Track the latest updates and changes to Cloudflare 1.1.1.1 features.
+products:
+  - 1.1.1.1
+title: Changelog
+sidebar:
+  order: 25
+---
+
+import { ProductChangelog } from "~/components";
+
+{/* Actual content lives in /src/content/changelog/1.1.1.1/. Update the file there for new entries to appear here. */}
+
+<ProductChangelog product="1.1.1.1"/>


### PR DESCRIPTION
Set up the changelog infrastructure for 1.1.1.1 (DNS Resolver), mirroring the existing DNS changelog setup. Changelog entries go in `src/content/changelog/1.1.1.1/` and are rendered by the ProductChangelog component. CODEOWNERS uses the same team as DNS.
