### PR TITLE
AI Search: make custom domain deletion retryable

### DIFF
--- a/src/content/changelog/ai-search/2026-07-22-retry-custom-domain-deletion.mdx
+++ b/src/content/changelog/ai-search/2026-07-22-retry-custom-domain-deletion.mdx
@@ -1,0 +1,12 @@
+---
+title: Retry AI Search instance deletion when custom domain cleanup fails
+description: AI Search now keeps an instance intact when its custom domain cannot be removed, allowing deletion to be retried safely.
+products:
+  - ai-search
+date: 2026-07-22
+publish_future_dated_entry: true
+---
+
+When you delete an AI Search instance with a custom domain, AI Search now keeps the instance intact if custom domain cleanup cannot complete. The request returns an error instead of reporting a successful deletion, so you can retry without losing the configuration needed to remove the domain.
+
+For more information, refer to [managing AI Search instances with the REST API](/ai-search/api/instances/rest-api/).


### PR DESCRIPTION
## Changes
- Document that failed custom domain cleanup leaves the AI Search instance intact.
- Clarify that deletion can be retried safely.

Code MR: https://gitlab.cfdata.org/cloudflare/rag/ai-search/-/merge_requests/459