### PR TITLE
[Access] Provide explicit guidance for how to require MFA on every login for Access applications

### DIFF
--- a/src/content/docs/cloudflare-one/access-controls/policies/mfa-requirements.mdx
+++ b/src/content/docs/cloudflare-one/access-controls/policies/mfa-requirements.mdx
@@ -135,6 +135,29 @@ Access checks MFA sessions from most specific to least specific:
 2. **Application MFA session duration** — If set, applies to all users accessing the application.
 3. **Global MFA session duration** — The default for all applications that do not specify their own duration.
 
+#### Require MFA on every login
+
+To require MFA every time a user logs in to an application, set the authentication duration to **Require every login**. This prevents Access from caching a successful MFA session.
+
+- **Organization** — Go to **Zero Trust** > **Access controls** > **Access settings** > **Allow multi-factor authentication (MFA)**. Set **Authentication duration** to **Require every login**. This applies to all applications unless overridden at the application or policy level. For more details, refer to [independent MFA settings](/cloudflare-one/access-controls/access-settings/independent-mfa/).
+- **Application** — Go to **Zero Trust** > **Access controls** > **Applications** > select your application > **Configure** > **Authentication** > **MFA** tab. Select **Custom MFA settings** and set **Authentication duration** to **Require every login**.
+- **Policy** — Go to **Zero Trust** > **Access controls** > **Policies** > select your policy > **Configure**. Under **Multi-factor authentication (MFA)**, select **Custom MFA settings** and set **Authentication duration** to **Require every login**.
+
+To configure this for an application via the API, first send a `GET` request to retrieve the full application configuration, then send a `PUT` request with the complete application body including the updated `mfa_config`. Set `session_duration` to `"0m"`:
+
+```bash
+curl --request PUT \
+https://api.cloudflare.com/client/v4/accounts/{account_id}/access/apps/{app_id} \
+--header "Authorization: Bearer <API_TOKEN>" \
+--header "Content-Type: application/json" \
+--data '{
+  "mfa_config": {
+    "mfa_disabled": false,
+    "session_duration": "0m"
+  }
+}'
+```
+
 ### Precedence example
 
 Consider the following configuration:


### PR DESCRIPTION
### Summary

The [MFA session duration section](https://developers.cloudflare.com/cloudflare-one/access-controls/policies/mfa-requirements/#mfa-session-duration) says you can "require users to complete MFA on each Access login" but never tells you how for non-SSH (web) applications. The only concrete instruction today is for SSH/infrastructure apps (0m for every SSH connection).

This adds a **Require MFA on every login** subsection under MFA session duration with:

- Dashboard steps at each level (organization, application, policy) — set **Authentication duration** to **Require every login**
- An API example using `session_duration: "0m"` in the `mfa_config` object
- A note clarifying that this only affects the login flow, not existing sessions

**File changed:** `src/content/docs/cloudflare-one/access-controls/policies/mfa-requirements.mdx`

### Screenshots (optional)

N/A

### Documentation checklist
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).