### PR TITLE
 clarify AI-powered transformation billing . mdx

### DIFF
--- a/src/content/partials/images/segment.mdx
+++ b/src/content/partials/images/segment.mdx
@@ -11,6 +11,13 @@ Automatically isolates the subject of an image by replacing the background with 
 
 This feature uses an open-source model called BiRefNet through [Workers AI](/workers-ai/). Read more about Cloudflare's [approach to responsible AI](https://www.cloudflare.com/trust-hub/responsible-ai/).
 
+:::note[Pricing]
+
+Parameters that use AI inference are billed as standard Images transformations. Each unique request counts toward your [Images Transformed](/images/pricing/#images-transformed) usage. There is no additional charge from [Workers AI](/workers-ai/platform/pricing/) or separate Neuron billing for these parameters.
+
+:::
+
+
 <table style="width:100%; table-layout:fixed; text-align:center; border:none">
   <tr style="border:none; background:none">
     <td style="width:50%; border:none; vertical-align:bottom">


### PR DESCRIPTION
Adding a note  explaining that
AI-powered parameters like `segment=foreground`
are billed as standard Images transformations. They do not incur separate Workers AI or Neuron charges.

This addresses customer confusion about whether `segment=foreground`, which uses BiRefNet via Workers AI, results in additional AI inference costs beyond the Images Transformed metric.

