### PR TITLE
Add CODEOWNERS for Organizations docs and changelog

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -72,6 +72,7 @@ package.json @cloudflare/content-engineering
 # Changelogs
 
 /src/content/changelog/ @cloudflare/pm-changelogs @cloudflare/product-owners
+/src/content/changelog/organizations/ @wtrousdale @cloudflare/pm-changelogs @cloudflare/product-owners
 /src/content/changelog/ai-search/ @cloudflare/pm-changelogs @rita3ko @irvinebroque @aninibread @mchenco @cloudflare/product-owners
 /src/content/changelog/dns/ @cloudflare/pm-changelogs @cloudflare/product-owners @hannes-cf @fattouche @xofyarg @dklbreitling @chreo @svenr-cf @kerolasa @matildeopbravo @vavrusa @mworsley-cloudflare @sebastiaanyn @vendemiat @Woutifier
 /src/content/changelog/waf/ @worenga @cloudflare/firewall @vs-mg @fb1337 @cloudflare/pm-changelogs @cloudflare/appsec-reviewers @elithrar @cloudflare/product-owners @hsaxenaCF @danielegm @ay-cf
@@ -130,6 +131,7 @@ package.json @cloudflare/content-engineering
 /src/content/docs/fundamentals/ @dcpena @sahidya @cloudflare/product-owners
 /src/content/docs/fundamentals/ @jhutchings1 @cloudflare/product-owners @KaydeeDee @adambouhmad
 /src/content/docs/fundamentals/ @dcpena @cloudflare/product-owners @KaydeeDee @adambouhmad
+/src/content/docs/fundamentals/organizations/ @wtrousdale @KaydeeDee @adambouhmad @cloudflare/product-owners
 /src/content/docs/learning-paths/ @cloudflare/product-owners
 /src/content/docs/network-error-logging/ @dcpena @cloudflare/product-owners
 /src/content/docs/network-interconnect/ @marciocloudflare @steve-cloudflare @jeffh-cloudflare @alpdot @cloudflare/product-owners

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -131,7 +131,7 @@ package.json @cloudflare/content-engineering
 /src/content/docs/fundamentals/ @dcpena @sahidya @cloudflare/product-owners
 /src/content/docs/fundamentals/ @jhutchings1 @cloudflare/product-owners @KaydeeDee @adambouhmad
 /src/content/docs/fundamentals/ @dcpena @cloudflare/product-owners @KaydeeDee @adambouhmad
-/src/content/docs/fundamentals/organizations/ @wtrousdale @KaydeeDee @adambouhmad @cloudflare/product-owners
+/src/content/docs/fundamentals/organizations/ @wtrousdale @jhutchings1 @KaydeeDee @adambouhmad @cloudflare/product-owners
 /src/content/docs/learning-paths/ @cloudflare/product-owners
 /src/content/docs/network-error-logging/ @dcpena @cloudflare/product-owners
 /src/content/docs/network-interconnect/ @marciocloudflare @steve-cloudflare @jeffh-cloudflare @alpdot @cloudflare/product-owners


### PR DESCRIPTION
### Summary

Add myself (`@wtrousdale`) as a CODEOWNER for Organizations product docs so PM/ENG can own reviews and approvals for that surface (per the product-team ownership model).

### Paths

- `/src/content/docs/fundamentals/organizations/` — Organizations docs (alongside existing fundamentals owners `@KaydeeDee` / `@adambouhmad` and `@cloudflare/product-owners`)
- `/src/content/changelog/organizations/` — Organizations changelog entries (alongside `@cloudflare/pm-changelogs` / `@cloudflare/product-owners`)

### Why

Organizations changelog and docs PRs currently fall through to broader fundamentals / generic changelog ownership. Product ENG needs to be listed on the specific paths to review and merge updates for this product area.