### PR TITLE
fix: update /rebase command copy and outdated PR check hint

### DIFF
--- a/.flue/lib/code-review-render.ts
+++ b/.flue/lib/code-review-render.ts
@@ -543,10 +543,7 @@ export function renderComment(
 		"| `/disable-auto-review` | Stops automatic reviews from triggering on future pushes to this PR. Codeowners can still run `/review` or `/full-review` manually. |",
 	);
 	lines.push(
-		"| `/rebase` | Rebases the PR branch against `production`. Stops if there are conflicts and reports which files conflict. |",
-	);
-	lines.push(
-		"| `/rebaseWithConflicts` | Rebases against `production` and attempts to resolve conflicts automatically using AI. Stops with an explanation if confidence is not high enough. |",
+		"| `/rebase` | Rebases the PR branch against `production`. On conflict, attempts to resolve automatically using AI. Stops with an explanation if confidence is not high enough. |",
 	);
 	lines.push("");
 	lines.push("</details>");
@@ -652,7 +649,7 @@ function rebaseStatusLine(
 			return `✅ **Rebase:** Rebased against \`production\` — full review triggered.`;
 		case "halted-conflict":
 			return [
-				`⚠️ **Rebase:** Rebase halted — conflicts detected. Resolve manually or use \`/rebaseWithConflicts\`.`,
+				`⚠️ **Rebase:** Rebase halted — conflicts detected. Please resolve manually.`,
 				...(detail ? [`> ${sanitizeRebaseDetail(detail)}`] : []),
 			].join("\n");
 		case "halted-wrong-base":

--- a/.flue/lib/code-review-render.ts
+++ b/.flue/lib/code-review-render.ts
@@ -647,11 +647,6 @@ function rebaseStatusLine(
 			return `⏳ **Rebase:** Rebasing against \`production\`${by}…`;
 		case "complete":
 			return `✅ **Rebase:** Rebased against \`production\` — full review triggered.`;
-		case "halted-conflict":
-			return [
-				`⚠️ **Rebase:** Rebase halted — conflicts detected. Please resolve manually.`,
-				...(detail ? [`> ${sanitizeRebaseDetail(detail)}`] : []),
-			].join("\n");
 		case "halted-wrong-base":
 			return `⚠️ **Rebase:** Rebase skipped — this PR targets \`${sanitizeRebaseDetail(detail ?? "a non-production branch")}\`, not \`production\`. Rebase is only supported for PRs targeting \`production\`.`;
 		case "halted-fork":

--- a/.flue/lib/code-review-state.ts
+++ b/.flue/lib/code-review-state.ts
@@ -14,7 +14,6 @@ export const BOT_COMMENT_MARKER = "<!-- cloudflare-docs-flue-code-review -->";
 export type RebaseStatus =
 	| "in-progress"
 	| "complete"
-	| "halted-conflict"
 	| "halted-wrong-base"
 	| "halted-fork"
 	| "halted-confidence"

--- a/.flue/wrangler.jsonc
+++ b/.flue/wrangler.jsonc
@@ -98,7 +98,7 @@
 			"deleted_classes": ["FlueRedirectSpecialistWorkflow"],
 		},
 		{
-			// Rebase workflow added: handles /rebase and /rebaseWithConflicts slash
+			// Rebase workflow added: handles the /rebase slash
 			// commands. Rebases a PR branch against production via the GitHub API
 			// and optionally uses AI to resolve conflicts.
 			"tag": "v9",

--- a/.github/workflows/outdated-pr-check.yml
+++ b/.github/workflows/outdated-pr-check.yml
@@ -76,9 +76,9 @@ jobs:
               if [ "$HOURS" -gt 36 ]; then
                 DAYS=$((AGE / 86400))
                 UNIT=$( [ "$DAYS" -eq 1 ] && echo "day" || echo "days" )
-                DESCRIPTION="Branch is ${DAYS} ${UNIT} out of date with production. Please rebase or merge."
+                DESCRIPTION="Branch is ${DAYS} ${UNIT} out of date with production. Please rebase or merge. Codeowners can comment /rebase on the PR to fix."
               else
-                DESCRIPTION="Branch is ${HOURS}h out of date with production. Please rebase or merge."
+                DESCRIPTION="Branch is ${HOURS}h out of date with production. Please rebase or merge. Codeowners can comment /rebase on the PR to fix."
               fi
             else
               STATE="success"

--- a/.github/workflows/outdated-pr-refresh.yml
+++ b/.github/workflows/outdated-pr-refresh.yml
@@ -76,9 +76,9 @@ jobs:
                 if [ "$HOURS" -gt 36 ]; then
                   DAYS=$((AGE / 86400))
                   UNIT=$( [ "$DAYS" -eq 1 ] && echo "day" || echo "days" )
-                  DESCRIPTION="Branch is ${DAYS} ${UNIT} out of date with production. Please rebase or merge."
+                  DESCRIPTION="Branch is ${DAYS} ${UNIT} out of date with production. Please rebase or merge. Codeowners can comment /rebase on the PR to fix."
                 else
-                  DESCRIPTION="Branch is ${HOURS}h out of date with production. Please rebase or merge."
+                  DESCRIPTION="Branch is ${HOURS}h out of date with production. Please rebase or merge. Codeowners can comment /rebase on the PR to fix."
                 fi
               else
                 STATE="success"


### PR DESCRIPTION
### Summary

Follow-up to #32121. Two copy fixes:

- **Bot commands table**: collapsed `/rebase` and `/rebaseWithConflicts` rows into a single `/rebase` row that describes the unified behavior (tries AI resolution on conflict)
- **Outdated PR check**: appended "Codeowners can comment `/rebase` on the PR to fix." to the failure descriptions in both `outdated-pr-check.yml` and `outdated-pr-refresh.yml`

### Documentation checklist

<!-- Not applicable — tooling/CI change only -->
