### PR TITLE
[Access] Add FIDO2 as MFA type for Infrastructure SSH Applications

### DIFF
--- a/src/content/changelog/cloudflare-one/2026-08-12-fido2-keys-infrastructure-ssh.mdx
+++ b/src/content/changelog/cloudflare-one/2026-08-12-fido2-keys-infrastructure-ssh.mdx
@@ -1,0 +1,14 @@
+---
+title: Independent MFA supports FIDO2 for infrastructure applications
+description: Enforce FIDO2 hardware key authentication on SSH connections to infrastructure applications.
+date: 2026-08-12
+products:
+  - cloudflare-one
+  - access
+---
+
+[Infrastructure](/cloudflare-one/access-controls/applications/non-http/infrastructure-apps/) applications support independent multi-factor authentication (MFA) with FIDO2 keys. You can allow `ssh_fido2_key`, `piv_key`, or both in application-level and policy-level MFA settings.
+
+Users enroll FIDO2 keys through the App Launcher and connect with the generated SSH identity. FIDO2 keys for SSH are separate from browser-based WebAuthn security keys and Personal Identity Verification (PIV) keys.
+
+For setup instructions, refer to [Enroll a FIDO2 key for infrastructure apps](/cloudflare-one/access-controls/access-settings/independent-mfa/#enroll-a-fido2-key-for-infrastructure-apps) and [Configure MFA for infrastructure applications](/cloudflare-one/access-controls/policies/mfa-requirements/#infrastructure-applications).

--- a/src/content/docs/cloudflare-one/access-controls/access-settings/independent-mfa.mdx
+++ b/src/content/docs/cloudflare-one/access-controls/access-settings/independent-mfa.mdx
@@ -24,6 +24,7 @@ Because you can [configure MFA at the application and policy level](/cloudflare-
 | Security key                       | Hardware security keys that support the [WebAuthn](https://www.w3.org/TR/webauthn-2/) standard. Users can enroll multiple security keys.                                                                                                                                                                    |
 | Biometrics                         | Built-in device authenticators that use [WebAuthn](https://www.w3.org/TR/webauthn-2/), including Apple Touch ID, Apple Face ID, and Windows Hello. Users can enroll multiple biometrics.                                                                                                                    |
 | Personal Identity Verification (PIV) key (infrastructure apps only) | YubiKey PIV keys used for public key authentication during SSH connections. Requires YubiKey firmware 4.3 or later. This method is only available for [infrastructure applications](/cloudflare-one/access-controls/applications/non-http/infrastructure-apps/). Users can enroll multiple PIV keys. |
+| FIDO2 key (infrastructure apps only) | YubiKey FIDO2 keys used for public key authentication during SSH connections. This method is only available for [infrastructure applications](/cloudflare-one/access-controls/applications/non-http/infrastructure-apps/) and is separate from the browser-based WebAuthn security key method. |
 
 ## Turn on independent MFA
 
@@ -73,6 +74,9 @@ Before you can [enforce independent MFA on applications and policies](/cloudflar
    - `biometrics` — Biometrics (Touch ID, Face ID, Windows Hello).
    - `security_key` — Security keys (hardware keys that support WebAuthn).
    - `piv_key` — PIV keys (YubiKeys).
+   - `ssh_fido2_key` — FIDO2 keys for SSH connections to infrastructure applications.
+
+   `piv_key` and `ssh_fido2_key` apply only to SSH connections to infrastructure applications. If allowed at the organization level, these MFA methods will only apply to infrastructure applications. They will not be available for other application types.
 
    Set `session_duration` to a duration string (for example, `30m`, `1h`, `24h`). To require MFA on every access, use `0m`.
 
@@ -100,14 +104,24 @@ If you plan to use PIV keys for [MFA for infrastructure applications](/cloudflar
 4. Select **Save**.
 
 :::note
-<Render file="access/piv-key-global-settings-warning" product="cloudflare-one" />
+
+<Render
+	file="access/infra-mfa-global-settings-warning"
+	product="cloudflare-one"
+/>
 :::
 
 ## Restrict authenticators by AAGUID
 
 An [AAGUID](https://fidoalliance.org/specs/fido-v2.0-id-20180227/fido-registry-v2.0-id-20180227.html#authenticator-attestation-guid) (Authenticator Attestation GUID) is a 128-bit identifier that indicates the make and model of a [WebAuthn](https://www.w3.org/TR/webauthn-2/) authenticator. By restricting enrollment to a specific set of AAGUIDs, you can require that users only enroll approved hardware, such as FIPS-validated security keys or company-issued devices.
 
-AAGUID restrictions apply at enrollment time only. Access verifies the AAGUID when a user registers an authenticator, not when they authenticate. As a result, AAGUID restrictions are configured at the organization level.
+Access checks the AAGUID when a user registers an authenticator. Because enrollment applies to the entire organization, you configure AAGUID restrictions at the organization level.
+
+For FIDO2 keys, Access also checks the AAGUID each time the user connects to an infrastructure application. If you remove a FIDO2 key from the allowed list, that key stops working even if the user enrolled it earlier.
+
+PIV keys do not present an AAGUID, so these restrictions do not apply to them.
+
+When `required_aaguids` is unset, Access does not enforce AAGUID restrictions.
 
 :::caution
 Some authenticators do not send an AAGUID during WebAuthn registration, such as YubiKey 4 and earlier models using U2F (CTAP1). Users cannot enroll these authenticators when AAGUID restrictions are turned on. Before turning on AAGUID restrictions, confirm that your required authenticators are in the [FIDO Alliance Metadata Service](https://fidoalliance.org/metadata/).
@@ -171,7 +185,7 @@ You can look up AAGUIDs for common authenticators in the [FIDO Alliance Metadata
 3. Select an existing [AAGUID list](#1-create-an-aaguid-list).
 4. Select **Save**.
 
-After you save, only authenticators whose AAGUIDs appear in the list can be enrolled. Users with previously enrolled authenticators outside the list can continue to use them until they are [deleted by an administrator](#delete-a-user-authenticator).
+After you save, only authenticators whose AAGUIDs appear in the list can be enrolled. Users with previously enrolled security keys or biometrics outside the list can continue to use them until they are [deleted by an administrator](#delete-a-user-authenticator). A previously enrolled FIDO2 key outside the list stops working on the next connection. To remove the restriction, unset the AAGUID list.
 
 </TabItem>
 <TabItem label="API">
@@ -376,7 +390,50 @@ To enroll an authenticator:
         PIV key enrollment requires additional client-side setup and is only used for [MFA with infrastructure applications](/cloudflare-one/access-controls/policies/mfa-requirements/#infrastructure-applications). For full instructions, refer to [Enroll a PIV key for infrastructure apps](#enroll-a-piv-key-for-infrastructure-apps).
         </Details>
 
+        <Details header="FIDO2 key (infrastructure applications only)">
+        FIDO2 key enrollment requires additional client-side setup and is only used for [MFA with infrastructure applications](/cloudflare-one/access-controls/policies/mfa-requirements/#infrastructure-applications). This method is separate from browser-based security key enrollment. For full instructions, refer to [Enroll a FIDO2 key for infrastructure apps](#enroll-a-fido2-key-for-infrastructure-apps).
+        </Details>
+
 You can now use these authenticators to log in to your organization's applications.
+
+### Enroll a FIDO2 key for infrastructure apps
+
+Before users can enroll, turn on the **FIDO2 key** authenticator in your organization's [global MFA settings](#turn-on-independent-mfa).
+
+The App Launcher generates the enrollment command for your account. Do not construct the enrollment command manually.
+
+:::note
+On macOS, install OpenSSH with Homebrew before you run the command. The `ssh-keygen` included with macOS does not support FIDO2 keys. On Linux, use an OpenSSH build that includes `libfido2` support.
+:::
+
+1. Go to your organization's App Launcher at `<your-team-name>.cloudflareaccess.com`.
+2. Log in with your identity provider or a one-time PIN (OTP).
+3. Go to **Account** > **MFA devices** > **Add an MFA device** > **FIDO2 key**.
+4. Select the tab for your operating system.
+5. Copy the enrollment command shown in the App Launcher.
+6. Run the command in a local terminal on the device you use for SSH.
+7. Follow the prompts, then copy the JSON output.
+8. Return to the App Launcher and paste the JSON into the enrollment field.
+9. Complete the enrollment.
+
+#### Configure your SSH client for a FIDO2 key
+
+The command creates the identity at `~/.ssh/id_ed25519_sk_cf`.
+
+Add the following configuration to your `~/.ssh/config` file:
+
+```txt
+Host *
+  IdentityFile ~/.ssh/id_ed25519_sk_cf
+```
+
+Alternatively, supply the identity when you connect:
+
+```sh
+ssh -i ~/.ssh/id_ed25519_sk_cf <username>@<target IP>
+```
+
+For more information on how OpenSSH uses FIDO2 hardware keys, refer to Yubico's [Securing SSH with FIDO2](https://developers.yubico.com/SSH/Securing_SSH_with_FIDO2.html).
 
 ### Enroll a PIV key for infrastructure apps
 

--- a/src/content/docs/cloudflare-one/access-controls/applications/non-http/infrastructure-apps.mdx
+++ b/src/content/docs/cloudflare-one/access-controls/applications/non-http/infrastructure-apps.mdx
@@ -63,7 +63,9 @@ Access for Infrastructure currently supports [SSH](/cloudflare-one/networks/conn
 
 ## 4. (Optional) Require independent MFA
 
-You can require users to authenticate with a [YubiKey PIV key](/cloudflare-one/access-controls/access-settings/independent-mfa/#enroll-a-piv-key-for-infrastructure-apps) before connecting with SSH to targets. You can configure MFA at the application level or at the policy level, allowing you to enforce stricter requirements for sensitive usernames.
+You can require independent MFA before users connect with SSH. The application configuration selects the supported infrastructure authenticators: PIV key (`piv_key`), FIDO2 key (`ssh_fido2_key`), or both.
+
+Application-level settings define the default authenticators and session duration. A policy can define custom settings for specific users or usernames.
 
 For setup instructions, refer to [Enforce MFA for infrastructure applications](/cloudflare-one/access-controls/policies/mfa-requirements/#infrastructure-applications).
 
@@ -72,6 +74,8 @@ For setup instructions, refer to [Enforce MFA for infrastructure applications](/
 Certain protocols require configuring the server to trust connections through Access for Infrastructure. For more information, refer to the protocol-specific tutorial:
 
 - [SSH](/cloudflare-one/networks/connectors/cloudflare-tunnel/use-cases/ssh/ssh-infrastructure-access/#7-configure-ssh-server)
+
+For SSH, this includes trusting the Cloudflare SSH CA and, if your server restricts certificate principals, [authorizing the SSH usernames](/cloudflare-one/networks/connectors/cloudflare-tunnel/use-cases/ssh/ssh-infrastructure-access/#confirm-the-account-authorizes-the-certificate-principal) you configured on the target.
 
 ## 6. Connect as a user
 

--- a/src/content/docs/cloudflare-one/access-controls/policies/mfa-requirements.mdx
+++ b/src/content/docs/cloudflare-one/access-controls/policies/mfa-requirements.mdx
@@ -19,7 +19,7 @@ Cloudflare Access supports two methods of enforcing multi-factor authentication 
 - **[Identity provider-based MFA](#identity-provider-based-mfa)** — Require specific MFA methods reported by your identity provider (IdP).
 - **[Independent MFA](#independent-mfa)** — Prompt users for a second factor directly in Access, without relying on a third-party identity provider.
 
-For SSH connections to [infrastructure applications](/cloudflare-one/access-controls/applications/non-http/infrastructure-apps/), Access also supports [independent MFA with PIV keys](#infrastructure-applications).
+For SSH connections to [infrastructure applications](/cloudflare-one/access-controls/applications/non-http/infrastructure-apps/), Access also supports [independent MFA with PIV and FIDO2 keys](#infrastructure-applications).
 
 ## Identity provider-based MFA
 
@@ -78,7 +78,7 @@ You can configure MFA requirements at three levels:
 | [Application](#configure-independent-mfa-for-an-application)                     | Require or turn off MFA for a specific application.            |
 | [Policy](#configure-independent-mfa-for-a-policy)                                | Require or turn off MFA for users who match a specific policy. |
 
-Settings at lower levels (policy) override settings at higher levels (organization), giving you granular control over MFA enforcement.
+MFA settings use this precedence: **Policy** > **Application** > **Organization**.
 
 ### Prerequisites
 
@@ -195,16 +195,20 @@ In this example:
 
 ## Infrastructure applications
 
-Infrastructure applications that use SSH support independent MFA with [YubiKey PIV keys](/cloudflare-one/access-controls/access-settings/independent-mfa/#enroll-a-piv-key-for-infrastructure-apps). When MFA is required, users must complete public key authentication with their enrolled PIV key before the connection is established. Users must [enroll their PIV key](/cloudflare-one/access-controls/access-settings/independent-mfa/#enroll-a-piv-key-for-infrastructure-apps) through the App Launcher before they can connect.
+Infrastructure applications that use SSH support two infrastructure-only MFA methods. `piv_key` uses an enrolled Personal Identity Verification (PIV) key. `ssh_fido2_key` uses an enrolled FIDO2 key. Neither method applies to other Access application types or browser WebAuthn authentication.
 
 You can configure MFA for infrastructure apps at the application level or at the policy level.
 
 ### Configure MFA for an infrastructure application
 
-Infrastructure applications use a PIV key authenticator (`piv_key`) that is specific to SSH connections. This authenticator type is not available for other Access application types.
+Select PIV key, FIDO2 key, or both when configuring custom MFA. The corresponding API arrays are `["piv_key"]`, `["ssh_fido2_key"]`, and `["piv_key", "ssh_fido2_key"]`.
 
 :::note
-<Render file="access/piv-key-global-settings-warning" product="cloudflare-one" />
+
+<Render
+	file="access/infra-mfa-global-settings-warning"
+	product="cloudflare-one"
+/>
 :::
 
 <Details header="Dashboard">
@@ -214,7 +218,7 @@ Infrastructure applications use a PIV key authenticator (`piv_key`) that is spec
 3. Go to the **Authentication** tab and select **MFA**.
 4. Select one of the following options:
    - **Respect global enforcement setting** — Uses the [organization-level](/cloudflare-one/access-controls/access-settings/independent-mfa/) MFA configuration. This is the default.
-   - **Custom MFA settings** — Override the global setting with a custom MFA session duration for this application.
+   - **Custom MFA settings** — Override the global setting for this application. Select **PIV key**, **FIDO2 key**, or both as the allowed authenticators, then set a custom MFA session duration.
    - **Disable MFA** — Users are not prompted for MFA when accessing this application.
 5. Select **Save**.
 
@@ -233,7 +237,7 @@ https://api.cloudflare.com/client/v4/accounts/{account_id}/access/apps/{app_id} 
   "mfa_config": {
     "mfa_disabled": false,
     "session_duration": "12h",
-    "allowed_authenticators": ["piv_key"]
+    "allowed_authenticators": ["piv_key", "ssh_fido2_key"]
   }
 }'
 ```
@@ -242,7 +246,7 @@ https://api.cloudflare.com/client/v4/accounts/{account_id}/access/apps/{app_id} 
 | ------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `mfa_disabled`            | Boolean | If `true`, MFA is not required for this application, even if global settings enforce MFA.                                                             |
 | `session_duration`        | String  | Duration before the user must re-authenticate with MFA (for example, `30m`, `1h`, `24h`). Set to `0m` to require MFA on every SSH connection.         |
-| `allowed_authenticators`  | Array   | List of allowed authenticator types. For infrastructure applications, `piv_key` is the only available modality.                                        |
+| `allowed_authenticators`  | Array   | Use `["piv_key"]`, `["ssh_fido2_key"]`, or `["piv_key", "ssh_fido2_key"]`.                                                                            |
 
 </Details>
 
@@ -257,7 +261,7 @@ You can set different MFA requirements for different SSH usernames by configurin
 3. Go to **Policies** and select the policy you want to configure.
 4. Under **Multi-factor authentication (MFA)**, select an option:
    - **Respect global enforcement setting** — Inherits the application or organization setting.
-   - **Custom MFA settings** — Set a custom MFA session duration for users who match this policy.
+   - **Custom MFA settings** — Select **PIV key**, **FIDO2 key**, or both as the allowed authenticators and set a custom MFA session duration for users who match this policy.
    - **Disable MFA** — Users who match this policy are not prompted for MFA.
 5. Select **Save**.
 
@@ -285,7 +289,7 @@ https://api.cloudflare.com/client/v4/accounts/{account_id}/access/policies/{poli
   "mfa_config": {
     "mfa_disabled": false,
     "session_duration": "1h",
-    "allowed_authenticators": ["piv_key"]
+    "allowed_authenticators": ["piv_key", "ssh_fido2_key"]
   },
   "connection_rules": {
     "ssh": {
@@ -300,7 +304,7 @@ https://api.cloudflare.com/client/v4/accounts/{account_id}/access/policies/{poli
 
 ### MFA session duration for SSH
 
-The MFA session duration determines how long after performing MFA a user can open new SSH connections without being prompted again. After the session expires, the user must re-authenticate with their PIV key on their next SSH connection. Existing SSH sessions are not affected by session expiration. Set the session duration to `0` to require MFA on every SSH connection.
+The MFA session duration determines how long users can open new SSH connections without another MFA prompt. Set the duration to `0m` to require MFA for every new connection. Expiration does not terminate an active connection.
 
 MFA sessions are bound to the user's device. If a user switches to a different device, they must re-authenticate regardless of the remaining session duration.
 

--- a/src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/use-cases/ssh/ssh-infrastructure-access.mdx
+++ b/src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/use-cases/ssh/ssh-infrastructure-access.mdx
@@ -11,7 +11,7 @@ sidebar:
   label: SSH with Access for Infrastructure
 ---
 
-import { Tabs, TabItem, Badge, Render, APIRequest, DashButton } from "~/components";
+import { Tabs, TabItem, Render, APIRequest, DashButton } from "~/components";
 
 [Access for Infrastructure](/cloudflare-one/access-controls/applications/non-http/infrastructure-apps/) provides granular control over how users can connect to your SSH servers. Like the [self-managed SSH keys](/cloudflare-one/networks/connectors/cloudflare-tunnel/use-cases/ssh/ssh-device-client/) method, it uses the Cloudflare One Client on user devices and Cloudflare Tunnel on the server to create a secure, private connection through Cloudflare's network. Access for Infrastructure adds application-level policies with per-target and per-username controls, as well as SSH command logging.
 
@@ -109,20 +109,20 @@ chmod 600 /etc/ssh/ca.pub
 
 ## 8. (Optional) Require independent MFA for SSH
 
-You can require users to authenticate with a [YubiKey PIV key](/cloudflare-one/access-controls/access-settings/independent-mfa/#enroll-a-piv-key-for-infrastructure-apps) before connecting to your SSH servers. When MFA is required, users must complete public key authentication with their enrolled PIV key before the connection is established.
+You can require users to authenticate with a PIV key or FIDO2 key before connecting to SSH servers. When configuring custom MFA, select **PIV key**, **FIDO2 key**, or both.
 
 To configure independent MFA for SSH, refer to [Enforce MFA for infrastructure applications](/cloudflare-one/access-controls/policies/mfa-requirements/#infrastructure-applications).
 
-Before users can connect with MFA enabled, they must:
+Before users can connect with MFA turned on, they must enroll their key and configure their SSH client.
 
-1. [Enroll a PIV key](/cloudflare-one/access-controls/access-settings/independent-mfa/#enroll-a-piv-key-for-infrastructure-apps) through the App Launcher.
-2. [Configure their SSH client](/cloudflare-one/access-controls/access-settings/independent-mfa/#configure-your-ssh-client) to use the enrolled PIV key.
+- For PIV keys, [enroll the key](/cloudflare-one/access-controls/access-settings/independent-mfa/#enroll-a-piv-key-for-infrastructure-apps) and [configure the SSH client](/cloudflare-one/access-controls/access-settings/independent-mfa/#configure-your-ssh-client).
+- For FIDO2 keys, [enroll the key](/cloudflare-one/access-controls/access-settings/independent-mfa/#enroll-a-fido2-key-for-infrastructure-apps) and [configure the SSH client](/cloudflare-one/access-controls/access-settings/independent-mfa/#configure-your-ssh-client-for-a-fido2-key).
 
-When the user runs `ssh <username>@<target IP>`, the SSH proxy checks if MFA is required for the matching policy. If required, the user must touch their YubiKey and enter their PIN (depending on the key's PIN policy). The proxy then completes the connection.
+When the user runs `ssh <username>@<target IP>`, the SSH proxy checks if MFA is required for the matching policy. If required, the user authenticates with their hardware key. Whether the key prompts for a touch, a PIN, or both depends on the PIV key policies you configured or on the FIDO2 key's own configuration. The proxy then completes the connection.
 
 ## 9. Connect as a user
 
-Users can use any SSH client to connect to the target, as long as they are logged into the Cloudflare One Client on their device. If the target is located within a particular virtual network, ensure that the Cloudflare One Client is [connected to that virtual network](/cloudflare-one/networks/connectors/cloudflare-tunnel/private-net/cloudflared/tunnel-virtual-networks/#connect-to-a-virtual-network) before initiating the connection. Users do not need to modify any SSH configs on their device. For example, to SSH from a terminal:
+Users can use any SSH client while logged in to the Cloudflare One Client. If the target uses a virtual network, [connect to that virtual network](/cloudflare-one/networks/connectors/cloudflare-tunnel/private-net/cloudflared/tunnel-virtual-networks/#connect-to-a-virtual-network) first.
 
 ```sh
 ssh <username>@<target IP>
@@ -461,6 +461,22 @@ Subsystem    sftp    /usr/lib/openssh/sftp-server
 ```
 
 </details>
+
+#### Confirm the account authorizes the certificate principal
+
+If your `sshd` logs show that the certificate was accepted as CA-signed but the connection still fails, the account may not authorize the certificate's principal. `sshd` reports this as:
+
+```txt
+Certificate invalid: name is not a listed principal
+```
+
+Check the effective configuration for the account you are connecting as, because these directives are often set within a `Match` block:
+
+```sh
+sudo sshd -T -C user=<USERNAME> | grep -i principals
+```
+
+If `authorizedprincipalsfile` or `authorizedprincipalscommand` is set to any value other than `none`, confirm that the SSH username appears in that file or in the command's output. If it is missing, add it, validate your configuration with `sudo sshd -t`, then [reload](#reload-your-ssh-server) your SSH server.
 
 #### Replace and test with example configuration
 

--- a/src/content/partials/cloudflare-one/access/infra-mfa-global-settings-warning.mdx
+++ b/src/content/partials/cloudflare-one/access/infra-mfa-global-settings-warning.mdx
@@ -1,0 +1,9 @@
+---
+{}
+---
+
+**PIV and FIDO2 key authenticators only work with infrastructure applications.**
+
+Non-infrastructure applications: If PIV and FIDO2 keys are the only allowed MFA methods in your global settings, users cannot log in to non-infrastructure applications. To fix this, add at least one other authenticator type to your global settings (for example, TOTP or biometrics), or configure custom MFA settings for non-infrastructure applications.
+
+Infrastructure applications: If MFA is globally required but your global settings do not include the infrastructure authenticator you want to use, users cannot access infrastructure applications that require MFA. To fix this, add the authenticator to your global MFA settings, or disable MFA for the specific application or policy.

--- a/src/content/partials/cloudflare-one/access/piv-key-global-settings-warning.mdx
+++ b/src/content/partials/cloudflare-one/access/piv-key-global-settings-warning.mdx
@@ -1,5 +1,0 @@
----
-{}
----
-
-The PIV key authenticator is only available for infrastructure applications. If PIV key is the only allowed MFA method in your organization's global settings, users who access non-infrastructure applications will not see any available MFA method and will be unable to log in. Ensure your global settings include at least one other authenticator type (for example, TOTP, security keys, or biometrics), or configure non-infrastructure applications with custom MFA settings. Conversely, if MFA is globally required and PIV key is not one of the allowed authenticators, users will be blocked from accessing infrastructure applications that require MFA. In this case, either add PIV key to your global MFA settings or disable MFA per application or policy to allow access.


### PR DESCRIPTION
### Summary

Updates Zero Trust documentation to add FIDO2 Key support for independent MFA on SSH infrastructure applications. Documents enrollment, SSH client configuration, authenticator selection, AAGUID restrictions, session behavior, and the distinction between FIDO2 Key, PIV, and browser WebAuthn Security keys.

### Documentation checklist

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
