### PR TITLE
ci: skip docs CI for flue-only PRs, add Flue CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches:
       - production
+    paths-ignore:
+      - ".flue/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/flue-ci.yml
+++ b/.github/workflows/flue-ci.yml
@@ -1,0 +1,72 @@
+name: Flue CI
+
+on:
+  pull_request:
+    branches:
+      - production
+    paths:
+      - ".flue/**"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pre-build:
+    name: Pre Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
+        with:
+          version: 11
+
+      - name: Set up node
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version: 24.x
+
+      - name: Install node_modules
+        run: pnpm install --frozen-lockfile
+        working-directory: .flue
+
+      - name: Typecheck
+        run: pnpm run typecheck
+        working-directory: .flue
+
+  build:
+    name: Build
+    needs: pre-build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
+        with:
+          version: 11
+
+      - name: Set up node
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version: 24.x
+
+      - name: Install node_modules
+        run: pnpm install --frozen-lockfile
+        working-directory: .flue
+
+      - name: Build
+        run: pnpm run build
+        working-directory: .flue
+
+  post-build:
+    name: Post Build
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: No post-build checks yet
+        run: echo "No post-build checks for flue yet."

--- a/.github/workflows/flue-ci.yml
+++ b/.github/workflows/flue-ci.yml
@@ -31,6 +31,8 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: 24.x
+          cache: pnpm
+          cache-dependency-path: .flue/pnpm-lock.yaml
 
       - name: Install node_modules
         run: pnpm install --frozen-lockfile
@@ -57,6 +59,8 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: 24.x
+          cache: pnpm
+          cache-dependency-path: .flue/pnpm-lock.yaml
 
       - name: Install node_modules
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/flue-ci.yml
+++ b/.github/workflows/flue-ci.yml
@@ -14,9 +14,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
-
 jobs:
   pre-build:
     name: Pre Build

--- a/.github/workflows/flue-ci.yml
+++ b/.github/workflows/flue-ci.yml
@@ -11,6 +11,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   pre-build:
     name: Pre Build

--- a/.github/workflows/flue-ci.yml
+++ b/.github/workflows/flue-ci.yml
@@ -7,6 +7,9 @@ on:
     paths:
       - ".flue/**"
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
### Summary

Adds a `paths-ignore: [".flue/**"]` filter to `ci.yml` and a new `flue-ci.yml` workflow so that PRs touching only `.flue/` skip the full docs build (Astro, link validation, deploy preview) and run a lightweight Flue-specific check instead.

**`ci.yml`** — adds `paths-ignore: [".flue/**"]` to the trigger. The workflow is not started at all when every changed file is under `.flue/`.

**`flue-ci.yml`** — new workflow triggered on `paths: [".flue/**"]` with three jobs that mirror the required status check names:

| Job | What it does |
|---|---|
| Pre Build | `pnpm run typecheck` in `.flue/` |
| Build | `pnpm run build` in `.flue/` — compiles the Worker via `flue build` |
| Post Build | No-op placeholder for future unit tests / evals |

Since branch protection matches required checks by job name, a flue-only PR gets "Pre Build", "Build", and "Post Build" checks from `flue-ci.yml` instead of `ci.yml`, so merging is not blocked.
