### PR TITLE
chore: test flue-only CI path filter

### DIFF
--- a/.flue/AGENTS.md
+++ b/.flue/AGENTS.md
@@ -1,4 +1,4 @@
-# AGENTS.md — Flue
+# AGENTS.md — Flue (cloudflare-docs-flue)
 
 This directory contains the Flue-powered docs bot for `cloudflare-docs`, deployed as a Cloudflare Worker.
 


### PR DESCRIPTION
Test PR to verify that a PR touching only `.flue/` files triggers `flue-ci.yml` (Pre Build, Build, Post Build) and skips the main `ci.yml` docs build.

The only change is a minor wording tweak in `.flue/AGENTS.md` — this should be reverted or closed without merging once the CI behavior is confirmed.