### PR TITLE
feat: add unit tests for trusted flue functions

### DIFF
--- a/.flue/AGENTS.md
+++ b/.flue/AGENTS.md
@@ -116,6 +116,12 @@ Do not rely on pre-trained Flue knowledge. Flue has changed substantially across
 - Keep model output structured with Valibot when trusted code consumes it. Skill instructions must match the schema exactly; do not ask for Markdown when the workflow expects JSON-like structured data.
 - Keep side-effecting operations (GitHub labels, comments, close/update actions) in trusted TypeScript code, not in model tools.
 
+## Testing
+
+Pure, deterministic TypeScript functions in `.flue/lib/` — those that do not require AI, GitHub API calls, R2, or Workers bindings to exercise — should have Vitest unit tests. When adding or modifying trusted TS logic (rendering, state parsing, result merging, diff selection, concurrency utilities, webhook parsing, etc.), write or update tests in a matching `*.test.ts` file alongside the source. Run tests with `pnpm run test` from the `.flue/` directory.
+
+Functions that require bindings (Durable Objects, R2, AI, the Flue harness) are not unit-testable in isolation and do not need tests; cover their logic paths through integration or by extracting the pure sub-functions and testing those.
+
 ## Review Rule Policy
 
 Do not add agent review rules for issues that are already reliably caught by CI, including build failures, type checking, linting, link validation, and schema validation. Agent review rules should focus on style, clarity, maintainability, and conventions that CI cannot enforce.

--- a/.flue/lib/code-review-inproc.test.ts
+++ b/.flue/lib/code-review-inproc.test.ts
@@ -1,0 +1,352 @@
+import { describe, expect, it, vi } from "vitest";
+
+// Mock modules that transitively import cloudflare:workers (sandbox/runtime
+// bindings not needed for testing pure data-transformation functions).
+vi.mock("../connectors/cloudflare-shell", () => ({
+	getShellSandbox: vi.fn(),
+	getDefaultWorkspace: vi.fn(),
+}));
+vi.mock("./github-repo-tools", () => ({ makeCodeReviewTools: vi.fn() }));
+vi.mock("./github", () => ({ getRepoFileContent: vi.fn() }));
+
+import {
+	mergeCodeReviewResults,
+	parseAddedLines,
+	selectCodeReviewFiles,
+} from "./code-review-inproc";
+import type {
+	CodeReviewFinding,
+	CodeReviewResult,
+} from "./code-review-results";
+
+// ── parseAddedLines ────────────────────────────────────────────────────────────
+
+describe("parseAddedLines", () => {
+	it("returns empty array for empty patch", () => {
+		expect(parseAddedLines("")).toEqual([]);
+	});
+
+	it("returns empty array for deletion-only patch", () => {
+		const patch = `@@ -1,3 +1,0 @@
+-line one
+-line two
+-line three`;
+		expect(parseAddedLines(patch)).toEqual([]);
+	});
+
+	it("parses a simple addition", () => {
+		const patch = `@@ -1,0 +1,2 @@
++first line
++second line`;
+		expect(parseAddedLines(patch)).toEqual([
+			{ line: 1, content: "first line" },
+			{ line: 2, content: "second line" },
+		]);
+	});
+
+	it("assigns correct line numbers with context lines", () => {
+		const patch = `@@ -10,5 +10,6 @@
+ context line
+ context line
++new line here
+ context line
+ context line`;
+		const added = parseAddedLines(patch);
+		expect(added).toEqual([{ line: 12, content: "new line here" }]);
+	});
+
+	it("handles multiple hunks with correct line numbers", () => {
+		const patch = `@@ -1,2 +1,3 @@
++added at top
+ context
+ context
+@@ -20,2 +21,3 @@
+ context
++added in middle
+ context`;
+		const added = parseAddedLines(patch);
+		expect(added).toEqual([
+			{ line: 1, content: "added at top" },
+			{ line: 22, content: "added in middle" },
+		]);
+	});
+
+	it("skips +++ and --- file header lines", () => {
+		const patch = `--- a/src/foo.ts
++++ b/src/foo.ts
+@@ -1,1 +1,2 @@
+ existing
++new line`;
+		const added = parseAddedLines(patch);
+		expect(added).toEqual([{ line: 2, content: "new line" }]);
+	});
+
+	it("strips the leading + from added line content", () => {
+		const patch = `@@ -1,0 +1,1 @@
++  indented content`;
+		expect(parseAddedLines(patch)).toEqual([
+			{ line: 1, content: "  indented content" },
+		]);
+	});
+
+	it("does not advance line counter for deleted lines", () => {
+		const patch = `@@ -1,3 +1,2 @@
+ context
+-deleted line
++added line`;
+		expect(parseAddedLines(patch)).toEqual([
+			{ line: 2, content: "added line" },
+		]);
+	});
+
+	it("ignores no-newline-at-end-of-file marker", () => {
+		const patch = `@@ -1,1 +1,2 @@
+ context
++new line
+\\ No newline at end of file`;
+		expect(parseAddedLines(patch)).toEqual([{ line: 2, content: "new line" }]);
+	});
+
+	it("handles a realistic MDX diff", () => {
+		const patch = `@@ -5,6 +5,10 @@
+ import { Tabs } from "~/components";
+ 
++import { Details } from "~/components";
++
+ ## Overview
+ 
++Use the Details component to collapse long sections.
++
+ This page explains...`;
+		const added = parseAddedLines(patch);
+		// Hunk starts at new-file line 5. Two context lines advance to 7 before
+		// the first addition, then two more context lines advance to 11 before
+		// the second pair of additions.
+		expect(added).toEqual([
+			{ line: 7, content: `import { Details } from "~/components";` },
+			{ line: 8, content: "" },
+			{
+				line: 11,
+				content: "Use the Details component to collapse long sections.",
+			},
+			{ line: 12, content: "" },
+		]);
+	});
+});
+
+// ── selectCodeReviewFiles ──────────────────────────────────────────────────────
+
+type PrFile = Parameters<typeof selectCodeReviewFiles>[0][number];
+
+function makeFile(overrides: Partial<PrFile> = {}): PrFile {
+	return {
+		filename: "src/content/docs/workers/index.mdx",
+		status: "modified",
+		additions: 10,
+		deletions: 2,
+		changes: 12,
+		patch: "@@ -1,1 +1,2 @@\n context\n+added",
+		...overrides,
+	};
+}
+
+describe("selectCodeReviewFiles", () => {
+	it("returns empty array for no files", () => {
+		expect(selectCodeReviewFiles([])).toEqual([]);
+	});
+
+	it("excludes removed files", () => {
+		const files = [makeFile({ status: "removed", additions: 0 })];
+		expect(selectCodeReviewFiles(files)).toEqual([]);
+	});
+
+	it("excludes files with zero additions", () => {
+		const files = [makeFile({ additions: 0 })];
+		expect(selectCodeReviewFiles(files)).toEqual([]);
+	});
+
+	it("excludes files with no patch", () => {
+		const files = [makeFile({ patch: undefined })];
+		expect(selectCodeReviewFiles(files)).toEqual([]);
+	});
+
+	it("excludes lockfiles by name", () => {
+		for (const name of [
+			"pnpm-lock.yaml",
+			"package-lock.json",
+			"yarn.lock",
+			"bun.lock",
+			"Cargo.lock",
+		]) {
+			expect(selectCodeReviewFiles([makeFile({ filename: name })])).toEqual([]);
+		}
+	});
+
+	it("excludes files in dist/, skills/, node_modules/, .wrangler/", () => {
+		for (const prefix of [
+			"dist/index.js",
+			"skills/my-skill/SKILL.md",
+			"node_modules/foo/index.js",
+			".flue/.wrangler/state/foo.db",
+		]) {
+			expect(selectCodeReviewFiles([makeFile({ filename: prefix })])).toEqual(
+				[],
+			);
+		}
+	});
+
+	it("excludes binary and image file types", () => {
+		for (const ext of [
+			"png",
+			"jpg",
+			"jpeg",
+			"gif",
+			"svg",
+			"webp",
+			"woff2",
+			"wasm",
+		]) {
+			expect(
+				selectCodeReviewFiles([
+					makeFile({ filename: `src/assets/image.${ext}` }),
+				]),
+			).toEqual([]);
+		}
+	});
+
+	it("excludes files under src/assets/", () => {
+		expect(
+			selectCodeReviewFiles([
+				makeFile({ filename: "src/assets/images/hero.png" }),
+			]),
+		).toEqual([]);
+	});
+
+	it("sorts by additions descending", () => {
+		const files = [
+			makeFile({ filename: "a.ts", additions: 5 }),
+			makeFile({ filename: "b.ts", additions: 20 }),
+			makeFile({ filename: "c.ts", additions: 1 }),
+		];
+		const result = selectCodeReviewFiles(files);
+		expect(result.map((f) => f.filename)).toEqual(["b.ts", "a.ts", "c.ts"]);
+	});
+
+	it("caps at maxFiles (default 20)", () => {
+		const files = Array.from({ length: 25 }, (_, i) =>
+			makeFile({ filename: `file-${i}.ts`, additions: i + 1 }),
+		);
+		expect(selectCodeReviewFiles(files)).toHaveLength(20);
+	});
+
+	it("respects custom maxFiles", () => {
+		const files = Array.from({ length: 10 }, (_, i) =>
+			makeFile({ filename: `file-${i}.ts`, additions: i + 1 }),
+		);
+		expect(selectCodeReviewFiles(files, 3)).toHaveLength(3);
+	});
+
+	it("includes normal source and MDX files", () => {
+		const files = [
+			makeFile({ filename: "src/content/docs/workers/index.mdx" }),
+			makeFile({ filename: ".flue/lib/github.ts" }),
+			makeFile({ filename: "src/components/Foo.astro" }),
+		];
+		expect(selectCodeReviewFiles(files)).toHaveLength(3);
+	});
+});
+
+// ── mergeCodeReviewResults ─────────────────────────────────────────────────────
+
+function makeResult(
+	findings: CodeReviewFinding[],
+	reviewedFiles: string[],
+): CodeReviewResult {
+	return {
+		findings,
+		summary: "placeholder",
+		reviewedFiles,
+	};
+}
+
+function makeFinding(
+	overrides: Partial<CodeReviewFinding> = {},
+): CodeReviewFinding {
+	return {
+		id: "CR-abc123",
+		severity: "warning",
+		path: "src/content/docs/workers/index.mdx",
+		rule: "Test rule",
+		evidence: "Test evidence",
+		suggestion: "Test suggestion",
+		...overrides,
+	};
+}
+
+describe("mergeCodeReviewResults", () => {
+	it("returns empty result for empty input", () => {
+		const result = mergeCodeReviewResults([]);
+		expect(result.findings).toEqual([]);
+		expect(result.reviewedFiles).toEqual([]);
+		expect(result.summary).toBe("No code review issues found.");
+	});
+
+	it("passes through a single result", () => {
+		const finding = makeFinding({ id: "CR-001" });
+		const result = mergeCodeReviewResults([
+			makeResult([finding], ["src/foo.ts"]),
+		]);
+		expect(result.findings).toEqual([finding]);
+		expect(result.reviewedFiles).toEqual(["src/foo.ts"]);
+	});
+
+	it("deduplicates findings by ID across results", () => {
+		const finding = makeFinding({ id: "CR-dup" });
+		const result = mergeCodeReviewResults([
+			makeResult([finding], ["a.ts"]),
+			makeResult([finding], ["b.ts"]),
+		]);
+		expect(result.findings).toHaveLength(1);
+	});
+
+	it("last write wins for duplicate IDs", () => {
+		const v1 = makeFinding({ id: "CR-001", rule: "First" });
+		const v2 = makeFinding({ id: "CR-001", rule: "Second" });
+		const result = mergeCodeReviewResults([
+			makeResult([v1], ["a.ts"]),
+			makeResult([v2], ["b.ts"]),
+		]);
+		expect(result.findings[0].rule).toBe("Second");
+	});
+
+	it("deduplicates reviewed files", () => {
+		const result = mergeCodeReviewResults([
+			makeResult([], ["shared.ts", "a.ts"]),
+			makeResult([], ["shared.ts", "b.ts"]),
+		]);
+		expect(result.reviewedFiles).toHaveLength(3);
+		expect(result.reviewedFiles).toContain("shared.ts");
+	});
+
+	it("produces correct summary with counts", () => {
+		const result = mergeCodeReviewResults([
+			makeResult(
+				[
+					makeFinding({ id: "CR-001", severity: "critical" }),
+					makeFinding({ id: "CR-002", severity: "warning" }),
+					makeFinding({ id: "CR-003", severity: "warning" }),
+					makeFinding({ id: "CR-004", severity: "suggestion" }),
+				],
+				["a.ts"],
+			),
+		]);
+		expect(result.summary).toBe(
+			"1 critical, 2 warning(s), and 1 suggestion(s) found across 1 file(s).",
+		);
+	});
+
+	it("summary says no issues found when findings empty", () => {
+		const result = mergeCodeReviewResults([makeResult([], ["a.ts"])]);
+		expect(result.summary).toBe("No code review issues found.");
+	});
+});

--- a/.flue/lib/code-review-inproc.test.ts
+++ b/.flue/lib/code-review-inproc.test.ts
@@ -45,7 +45,7 @@ describe("parseAddedLines", () => {
 	});
 
 	it("assigns correct line numbers with context lines", () => {
-		const patch = `@@ -10,5 +10,6 @@
+		const patch = `@@ -10,4 +10,5 @@
  context line
  context line
 +new line here
@@ -108,7 +108,7 @@ describe("parseAddedLines", () => {
 	});
 
 	it("handles a realistic MDX diff", () => {
-		const patch = `@@ -5,6 +5,10 @@
+		const patch = `@@ -5,5 +5,9 @@
  import { Tabs } from "~/components";
  
 +import { Details } from "~/components";

--- a/.flue/lib/code-review-render.test.ts
+++ b/.flue/lib/code-review-render.test.ts
@@ -1,0 +1,414 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { BOT_COMMENT_MARKER } from "./code-review-state";
+import {
+	renderComment,
+	renderFailureComment,
+	renderPendingComment,
+	renderRebaseStatusUpdate,
+	renderReviewLimitComment,
+} from "./code-review-render";
+import type { ReconcileResult, RenderReviewInput } from "./code-review-render";
+
+const FIXED_DATE = "2024-06-15T12:00:00.000Z";
+const HEAD_SHA = "a".repeat(40);
+const SHORT_SHA = HEAD_SHA.slice(0, 7);
+
+beforeEach(() => {
+	vi.useFakeTimers();
+	vi.setSystemTime(new Date(FIXED_DATE));
+});
+
+afterEach(() => {
+	vi.useRealTimers();
+});
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function emptyReconcile(
+	overrides: Partial<ReconcileResult> = {},
+): ReconcileResult {
+	return {
+		active: [],
+		ignored_by_reviewer: [],
+		resolved: [],
+		summary: "No issues.",
+		...overrides,
+	};
+}
+
+function makeFinding(
+	overrides: Partial<ReconcileResult["active"][number]> = {},
+): ReconcileResult["active"][number] {
+	return {
+		id: "CR-abc123def456",
+		severity: "warning",
+		path: "src/content/docs/workers/index.mdx",
+		rule: "Missing semicolon",
+		evidence: "Semicolon absent",
+		suggestion: "Add semicolon",
+		...overrides,
+	};
+}
+
+function cleanReviews(): RenderReviewInput {
+	return {
+		code: emptyReconcile(),
+		style: emptyReconcile(),
+		conventions: emptyReconcile(),
+	};
+}
+
+// ── renderPendingComment ───────────────────────────────────────────────────────
+
+describe("renderPendingComment", () => {
+	it("contains the bot marker", () => {
+		expect(renderPendingComment(HEAD_SHA, false)).toContain(BOT_COMMENT_MARKER);
+	});
+
+	it("embeds the head SHA", () => {
+		const body = renderPendingComment(HEAD_SHA, false);
+		expect(body).toContain(`<!-- reviewed-head-sha: ${HEAD_SHA} -->`);
+	});
+
+	it("embeds status: pending", () => {
+		expect(renderPendingComment(HEAD_SHA, false)).toContain(
+			"<!-- status: pending -->",
+		);
+	});
+
+	it("shows initial review message when not an update", () => {
+		expect(renderPendingComment(HEAD_SHA, false)).toContain(
+			`Review in progress for commit \`${SHORT_SHA}\``,
+		);
+	});
+
+	it("shows update message when isUpdate is true", () => {
+		expect(renderPendingComment(HEAD_SHA, true)).toContain(
+			`Reviewing new changes (commit \`${SHORT_SHA}\`)`,
+		);
+	});
+
+	it("shows full review message when forceFullReview is true", () => {
+		expect(renderPendingComment(HEAD_SHA, false, true)).toContain(
+			`Full review in progress`,
+		);
+	});
+
+	it("preserves existing non-pending body below a separator", () => {
+		const existing = [
+			BOT_COMMENT_MARKER,
+			`<!-- reviewed-head-sha: ${"b".repeat(40)} -->`,
+			`<!-- reviewed-at: 2024-01-01T00:00:00.000Z -->`,
+			"",
+			"## Review",
+			"",
+			"✅ No issues found in prior review.",
+		].join("\n");
+		const body = renderPendingComment(HEAD_SHA, true, false, existing);
+		expect(body).toContain("✅ No issues found in prior review.");
+		expect(body).toContain("---");
+	});
+
+	it("does not duplicate content if existingBody is already pending", () => {
+		const existing = renderPendingComment("b".repeat(40), false);
+		const body = renderPendingComment(HEAD_SHA, true, false, existing);
+		// Should NOT contain the old pending text body in a preserved block
+		expect(body.split("<!-- status: pending -->")).toHaveLength(2);
+	});
+});
+
+// ── renderFailureComment ───────────────────────────────────────────────────────
+
+describe("renderFailureComment", () => {
+	it("contains the bot marker", () => {
+		expect(renderFailureComment(HEAD_SHA)).toContain(BOT_COMMENT_MARKER);
+	});
+
+	it("embeds status: failure", () => {
+		expect(renderFailureComment(HEAD_SHA)).toContain(
+			"<!-- status: failure -->",
+		);
+	});
+
+	it("mentions the short SHA", () => {
+		expect(renderFailureComment(HEAD_SHA)).toContain(`\`${SHORT_SHA}\``);
+	});
+
+	it("contains ❌ indicator", () => {
+		expect(renderFailureComment(HEAD_SHA)).toContain("❌");
+	});
+});
+
+// ── renderComment ──────────────────────────────────────────────────────────────
+
+describe("renderComment", () => {
+	it("contains the bot marker", () => {
+		expect(renderComment(cleanReviews(), HEAD_SHA)).toContain(
+			BOT_COMMENT_MARKER,
+		);
+	});
+
+	it("embeds the reviewed head SHA", () => {
+		const body = renderComment(cleanReviews(), HEAD_SHA);
+		expect(body).toContain(`<!-- reviewed-head-sha: ${HEAD_SHA} -->`);
+	});
+
+	it("shows ✅ status line when no findings", () => {
+		expect(renderComment(cleanReviews(), HEAD_SHA)).toContain(
+			"✅ No issues found",
+		);
+	});
+
+	it("includes all three section headings", () => {
+		const body = renderComment(cleanReviews(), HEAD_SHA);
+		expect(body).toContain("### Code Review");
+		expect(body).toContain("### Conventions");
+		expect(body).toContain("### Style Guide Review");
+	});
+
+	it("shows 🚨 critical count in status line", () => {
+		const reviews: RenderReviewInput = {
+			...cleanReviews(),
+			code: emptyReconcile({
+				active: [makeFinding({ severity: "critical", id: "CR-001" })],
+			}),
+		};
+		expect(renderComment(reviews, HEAD_SHA)).toContain("🚨 1 critical");
+	});
+
+	it("shows ⚠️ warning count in status line", () => {
+		const reviews: RenderReviewInput = {
+			...cleanReviews(),
+			code: emptyReconcile({
+				active: [makeFinding({ severity: "warning", id: "CR-001" })],
+			}),
+		};
+		expect(renderComment(reviews, HEAD_SHA)).toContain("⚠️ 1 warning");
+	});
+
+	it("shows 💡 suggestion count in status line", () => {
+		const reviews: RenderReviewInput = {
+			...cleanReviews(),
+			style: emptyReconcile({
+				active: [makeFinding({ severity: "suggestion", id: "SG-001" })],
+			}),
+		};
+		expect(renderComment(reviews, HEAD_SHA)).toContain("💡 1 suggestion");
+	});
+
+	it("does not render 'Fix in your agent' block when no findings", () => {
+		expect(renderComment(cleanReviews(), HEAD_SHA)).not.toContain(
+			"Fix in your agent",
+		);
+	});
+
+	it("renders 'Fix in your agent' block when findings exist", () => {
+		const reviews: RenderReviewInput = {
+			...cleanReviews(),
+			code: emptyReconcile({
+				active: [makeFinding({ id: "CR-001" })],
+			}),
+		};
+		expect(renderComment(reviews, HEAD_SHA)).toContain("Fix in your agent");
+	});
+
+	it("renders commands block", () => {
+		const body = renderComment(cleanReviews(), HEAD_SHA);
+		expect(body).toContain("Commands");
+		expect(body).toContain("`/review`");
+		expect(body).toContain("`/full-review`");
+	});
+
+	it("shows ⚠️ failure suffix when a section degraded", () => {
+		const reviews: RenderReviewInput = {
+			...cleanReviews(),
+			codeFailed: true,
+		};
+		expect(renderComment(reviews, HEAD_SHA)).toContain(
+			"Part of the review could not complete",
+		);
+	});
+
+	it("renders acknowledged block when ignored_by_reviewer is non-empty", () => {
+		const ignored = {
+			...makeFinding({ id: "CR-001" }),
+			reviewer_note: "Not applicable here",
+		};
+		const reviews: RenderReviewInput = {
+			...cleanReviews(),
+			code: emptyReconcile({ ignored_by_reviewer: [ignored] }),
+		};
+		expect(renderComment(reviews, HEAD_SHA)).toContain(
+			"Acknowledged by author",
+		);
+		expect(renderComment(reviews, HEAD_SHA)).toContain("Not applicable here");
+	});
+
+	it("✅ no outstanding when ignored but no active findings", () => {
+		const ignored = {
+			...makeFinding({ id: "CR-001" }),
+			reviewer_note: "OK",
+		};
+		const reviews: RenderReviewInput = {
+			...cleanReviews(),
+			code: emptyReconcile({ ignored_by_reviewer: [ignored] }),
+		};
+		expect(renderComment(reviews, HEAD_SHA)).toContain(
+			"✅ No outstanding issues",
+		);
+	});
+
+	it("includes forceFullReview wording when flag is set", () => {
+		expect(renderComment(cleanReviews(), HEAD_SHA, true)).toContain(
+			"full PR diff",
+		);
+	});
+
+	it("includes PR number in Fix-in-agent block", () => {
+		const reviews: RenderReviewInput = {
+			...cleanReviews(),
+			code: emptyReconcile({ active: [makeFinding({ id: "CR-001" })] }),
+		};
+		expect(renderComment(reviews, HEAD_SHA, false, 9999)).toContain("PR #9999");
+	});
+});
+
+// ── renderReviewLimitComment ───────────────────────────────────────────────────
+
+describe("renderReviewLimitComment", () => {
+	it("contains the bot marker", () => {
+		expect(renderReviewLimitComment()).toContain(BOT_COMMENT_MARKER);
+	});
+
+	it("contains the paused message", () => {
+		expect(renderReviewLimitComment()).toContain(
+			"Automatic reviews for this PR are paused",
+		);
+	});
+
+	it("preserves existing non-pending review body", () => {
+		const existing = [
+			BOT_COMMENT_MARKER,
+			`<!-- reviewed-head-sha: ${"a".repeat(40)} -->`,
+			`<!-- reviewed-at: 2024-01-01T00:00:00.000Z -->`,
+			"",
+			"## Review",
+			"",
+			"✅ No issues found.",
+		].join("\n");
+		const body = renderReviewLimitComment(existing);
+		expect(body).toContain("✅ No issues found.");
+	});
+});
+
+// ── renderRebaseStatusUpdate ───────────────────────────────────────────────────
+
+describe("renderRebaseStatusUpdate", () => {
+	it("in-progress: contains ⏳", () => {
+		expect(
+			renderRebaseStatusUpdate("in-progress", undefined, "alice", null),
+		).toContain("⏳");
+	});
+
+	it("in-progress: mentions the sender", () => {
+		expect(
+			renderRebaseStatusUpdate("in-progress", undefined, "alice", null),
+		).toContain("@alice");
+	});
+
+	it("complete: contains ✅", () => {
+		expect(
+			renderRebaseStatusUpdate("complete", undefined, undefined, null),
+		).toContain("✅");
+	});
+
+	it("failed: contains ❌", () => {
+		expect(
+			renderRebaseStatusUpdate("failed", "timeout error", undefined, null),
+		).toContain("❌");
+	});
+
+	it("failed: includes the detail", () => {
+		expect(
+			renderRebaseStatusUpdate("failed", "network error", undefined, null),
+		).toContain("network error");
+	});
+
+	it("halted-wrong-base: mentions the base ref", () => {
+		expect(
+			renderRebaseStatusUpdate("halted-wrong-base", "main", undefined, null),
+		).toContain("`main`");
+	});
+
+	it("halted-fork: warns about fork", () => {
+		expect(
+			renderRebaseStatusUpdate("halted-fork", undefined, undefined, null),
+		).toContain("fork");
+	});
+
+	it("halted-confidence: contains ⚠️ and the reason", () => {
+		const body = renderRebaseStatusUpdate(
+			"halted-confidence",
+			"Too many conflicting files",
+			undefined,
+			null,
+		);
+		expect(body).toContain("⚠️");
+		expect(body).toContain("Too many conflicting files");
+	});
+
+	it("injects status below ## Review in an existing body", () => {
+		const existing = [
+			BOT_COMMENT_MARKER,
+			`<!-- reviewed-head-sha: ${"a".repeat(40)} -->`,
+			`<!-- reviewed-at: 2024-01-01T00:00:00.000Z -->`,
+			"",
+			"## Review",
+			"",
+			"✅ No issues found.",
+		].join("\n");
+		const body = renderRebaseStatusUpdate(
+			"in-progress",
+			undefined,
+			"alice",
+			existing,
+		);
+		// The rebase status line should appear and the original review content preserved
+		expect(body).toContain("⏳");
+		expect(body).toContain("✅ No issues found.");
+		const reviewIdx = body.indexOf("## Review");
+		const rebaseIdx = body.indexOf("⏳");
+		expect(rebaseIdx).toBeGreaterThan(reviewIdx);
+	});
+
+	it("refreshes updated-at timestamp", () => {
+		const existing = [
+			BOT_COMMENT_MARKER,
+			"<!-- updated-at: 2023-01-01T00:00:00.000Z -->",
+			"",
+			"## Review",
+			"",
+			"✅ No issues found.",
+		].join("\n");
+		const body = renderRebaseStatusUpdate(
+			"complete",
+			undefined,
+			undefined,
+			existing,
+		);
+		expect(body).toContain(`<!-- updated-at: ${FIXED_DATE} -->`);
+		expect(body).not.toContain("2023-01-01");
+	});
+
+	it("strips backticks from detail to avoid broken inline code spans", () => {
+		const body = renderRebaseStatusUpdate(
+			"halted-confidence",
+			"branch `feature/test` conflicts",
+			undefined,
+			null,
+		);
+		// Backticks stripped, content preserved
+		expect(body).toContain("feature/test");
+		expect(body).not.toContain("`feature/test`");
+	});
+});

--- a/.flue/lib/code-review-results.test.ts
+++ b/.flue/lib/code-review-results.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from "vitest";
+import { assignCodeReviewFindingIds } from "./code-review-results";
+import { assignFindingIds } from "./style-guide-results";
+
+// ── assignCodeReviewFindingIds ─────────────────────────────────────────────────
+
+describe("assignCodeReviewFindingIds", () => {
+	it("returns empty array for empty input", async () => {
+		expect(await assignCodeReviewFindingIds([])).toEqual([]);
+	});
+
+	it("assigns a CR- prefixed ID to each finding", async () => {
+		const findings = await assignCodeReviewFindingIds([
+			{
+				severity: "warning",
+				path: "src/foo.ts",
+				rule: "No floating promises",
+				evidence: "Unhandled promise",
+				suggestion: "Add await or void",
+			},
+		]);
+		expect(findings[0].id).toMatch(/^CR-[0-9a-f]{12}$/);
+	});
+
+	it("produces stable IDs for the same input", async () => {
+		const finding = {
+			severity: "critical" as const,
+			path: "src/lib/github.ts",
+			rule: "Unescaped brace",
+			evidence: "{ in MDX prose",
+			suggestion: "Wrap in backticks",
+		};
+		const [a] = await assignCodeReviewFindingIds([finding]);
+		const [b] = await assignCodeReviewFindingIds([finding]);
+		expect(a.id).toBe(b.id);
+	});
+
+	it("produces different IDs for different rule/path/evidence", async () => {
+		const base = {
+			severity: "warning" as const,
+			path: "src/foo.ts",
+			rule: "Rule A",
+			evidence: "evidence A",
+			suggestion: "fix A",
+		};
+		const [a] = await assignCodeReviewFindingIds([base]);
+		const [b] = await assignCodeReviewFindingIds([{ ...base, rule: "Rule B" }]);
+		const [c] = await assignCodeReviewFindingIds([
+			{ ...base, path: "src/bar.ts" },
+		]);
+		expect(a.id).not.toBe(b.id);
+		expect(a.id).not.toBe(c.id);
+		expect(b.id).not.toBe(c.id);
+	});
+
+	it("ID is stable regardless of line number", async () => {
+		const base = {
+			severity: "suggestion" as const,
+			path: "src/foo.ts",
+			rule: "Missing alt text",
+			evidence: "img without alt",
+			suggestion: "Add alt attribute",
+		};
+		const [withLine] = await assignCodeReviewFindingIds([
+			{ ...base, line: 10 },
+		]);
+		const [withDifferentLine] = await assignCodeReviewFindingIds([
+			{ ...base, line: 99 },
+		]);
+		const [withNoLine] = await assignCodeReviewFindingIds([base]);
+		expect(withLine.id).toBe(withDifferentLine.id);
+		expect(withLine.id).toBe(withNoLine.id);
+	});
+
+	it("trims evidence whitespace for stable IDs", async () => {
+		const base = {
+			severity: "warning" as const,
+			path: "src/foo.ts",
+			rule: "Bad import",
+			suggestion: "Fix it",
+		};
+		const [a] = await assignCodeReviewFindingIds([
+			{ ...base, evidence: "  missing module  " },
+		]);
+		const [b] = await assignCodeReviewFindingIds([
+			{ ...base, evidence: "missing module" },
+		]);
+		expect(a.id).toBe(b.id);
+	});
+
+	it("preserves all finding fields on the output", async () => {
+		const finding = {
+			severity: "critical" as const,
+			path: "src/lib/foo.ts",
+			line: 42,
+			rule: "Dangerous eval",
+			evidence: "eval() called",
+			suggestion: "Remove eval",
+		};
+		const [result] = await assignCodeReviewFindingIds([finding]);
+		expect(result).toMatchObject(finding);
+		expect(typeof result.id).toBe("string");
+	});
+});
+
+// ── assignFindingIds (style guide) ─────────────────────────────────────────────
+
+describe("assignFindingIds", () => {
+	it("returns empty array for empty input", async () => {
+		expect(await assignFindingIds([])).toEqual([]);
+	});
+
+	it("assigns an SG- prefixed ID to each finding", async () => {
+		const [result] = await assignFindingIds([
+			{
+				severity: "warning",
+				path: "src/content/docs/workers/index.mdx",
+				rule: "No $ in terminal commands",
+				evidence: "$ pnpm install",
+				suggestion: "Remove the $ prefix",
+			},
+		]);
+		expect(result.id).toMatch(/^SG-[0-9a-f]{12}$/);
+	});
+
+	it("SG IDs are stable for the same input", async () => {
+		const finding = {
+			severity: "suggestion" as const,
+			path: "src/content/docs/workers/index.mdx",
+			rule: "Oxford comma",
+			evidence: "a, b and c",
+			suggestion: "Use a, b, and c",
+		};
+		const [a] = await assignFindingIds([finding]);
+		const [b] = await assignFindingIds([finding]);
+		expect(a.id).toBe(b.id);
+	});
+
+	it("SG IDs differ from CR IDs for the same content", async () => {
+		const content = {
+			severity: "warning" as const,
+			path: "src/foo.ts",
+			rule: "Same rule",
+			evidence: "Same evidence",
+			suggestion: "Same suggestion",
+		};
+		const [sg] = await assignFindingIds([content]);
+		const [cr] = await assignCodeReviewFindingIds([content]);
+		// Different prefix alone is sufficient, but the hash may also differ
+		expect(sg.id.startsWith("SG-")).toBe(true);
+		expect(cr.id.startsWith("CR-")).toBe(true);
+	});
+});

--- a/.flue/lib/code-review-state.test.ts
+++ b/.flue/lib/code-review-state.test.ts
@@ -83,6 +83,7 @@ function makeComment(
 		body: "A human comment",
 		user: { login: "contributor", type: "User" },
 		created_at: "2024-01-01T10:00:00Z",
+		updated_at: "2024-01-01T10:00:00Z",
 		...overrides,
 	};
 }

--- a/.flue/lib/code-review-state.test.ts
+++ b/.flue/lib/code-review-state.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from "vitest";
+import {
+	BOT_COMMENT_MARKER,
+	extractReviewedAt,
+	extractReviewedHeadSha,
+	partitionComments,
+} from "./code-review-state";
+import type { GitHubIssueComment } from "./github";
+
+// ── extractReviewedHeadSha ─────────────────────────────────────────────────────
+
+describe("extractReviewedHeadSha", () => {
+	it("returns null for null input", () => {
+		expect(extractReviewedHeadSha(null)).toBeNull();
+	});
+
+	it("returns null for empty string", () => {
+		expect(extractReviewedHeadSha("")).toBeNull();
+	});
+
+	it("returns null when marker is absent", () => {
+		expect(extractReviewedHeadSha("no markers here")).toBeNull();
+	});
+
+	it("extracts a valid 40-char SHA", () => {
+		const sha = "a".repeat(40);
+		expect(extractReviewedHeadSha(`<!-- reviewed-head-sha: ${sha} -->`)).toBe(
+			sha,
+		);
+	});
+
+	it("extracts SHA from a realistic bot comment body", () => {
+		const sha = "1234567890abcdef1234567890abcdef12345678";
+		const body = [
+			BOT_COMMENT_MARKER,
+			`<!-- reviewed-head-sha: ${sha} -->`,
+			`<!-- reviewed-at: 2024-01-01T00:00:00.000Z -->`,
+			"",
+			"## Review",
+			"",
+			"✅ No issues found.",
+		].join("\n");
+		expect(extractReviewedHeadSha(body)).toBe(sha);
+	});
+});
+
+// ── extractReviewedAt ──────────────────────────────────────────────────────────
+
+describe("extractReviewedAt", () => {
+	it("returns null for null input", () => {
+		expect(extractReviewedAt(null)).toBeNull();
+	});
+
+	it("returns null when marker is absent", () => {
+		expect(extractReviewedAt("no markers here")).toBeNull();
+	});
+
+	it("extracts the reviewed-at timestamp", () => {
+		const ts = "2024-06-15T12:34:56.789Z";
+		expect(extractReviewedAt(`<!-- reviewed-at: ${ts} -->`)).toBe(ts);
+	});
+
+	it("extracts timestamp from a multi-line body", () => {
+		const ts = "2024-01-01T00:00:00.000Z";
+		const body = [
+			BOT_COMMENT_MARKER,
+			"<!-- reviewed-head-sha: " + "a".repeat(40) + " -->",
+			`<!-- reviewed-at: ${ts} -->`,
+			"",
+			"## Review",
+		].join("\n");
+		expect(extractReviewedAt(body)).toBe(ts);
+	});
+});
+
+// ── partitionComments ──────────────────────────────────────────────────────────
+
+function makeComment(
+	overrides: Partial<GitHubIssueComment> = {},
+): GitHubIssueComment {
+	return {
+		id: Math.floor(Math.random() * 1e9),
+		body: "A human comment",
+		user: { login: "contributor", type: "User" },
+		created_at: "2024-01-01T10:00:00Z",
+		...overrides,
+	};
+}
+
+function botComment(reviewedAt?: string): GitHubIssueComment {
+	const body = [
+		BOT_COMMENT_MARKER,
+		"<!-- reviewed-head-sha: " + "a".repeat(40) + " -->",
+		...(reviewedAt ? [`<!-- reviewed-at: ${reviewedAt} -->`] : []),
+		"",
+		"## Review",
+		"",
+		"✅ No issues found.",
+	].join("\n");
+	return makeComment({
+		body,
+		user: { login: "cloudflare-docs-bot", type: "Bot" },
+		created_at: reviewedAt ?? "2024-01-01T12:00:00Z",
+	});
+}
+
+describe("partitionComments", () => {
+	it("returns null botComment and empty human list for empty array", () => {
+		const { botComment: bc, humanCommentsAfterBot } = partitionComments([]);
+		expect(bc).toBeNull();
+		expect(humanCommentsAfterBot).toEqual([]);
+	});
+
+	it("returns all non-bot humans when no bot comment exists", () => {
+		const comments = [
+			makeComment({ created_at: "2024-01-01T09:00:00Z" }),
+			makeComment({ created_at: "2024-01-01T10:00:00Z" }),
+		];
+		const { botComment: bc, humanCommentsAfterBot } =
+			partitionComments(comments);
+		expect(bc).toBeNull();
+		expect(humanCommentsAfterBot).toHaveLength(2);
+	});
+
+	it("identifies the bot comment by the marker", () => {
+		const bot = botComment();
+		const { botComment: bc } = partitionComments([makeComment(), bot]);
+		expect(bc?.body).toContain(BOT_COMMENT_MARKER);
+	});
+
+	it("picks the LAST bot comment when multiple exist", () => {
+		const bot1 = botComment("2024-01-01T10:00:00Z");
+		const bot2 = botComment("2024-01-01T14:00:00Z");
+		const { botComment: bc } = partitionComments([bot1, makeComment(), bot2]);
+		expect(extractReviewedAt(bc?.body ?? null)).toBe("2024-01-01T14:00:00Z");
+	});
+
+	it("excludes comments before the bot's reviewed-at timestamp", () => {
+		const reviewedAt = "2024-01-01T12:00:00Z";
+		const bot = botComment(reviewedAt);
+		const before = makeComment({ created_at: "2024-01-01T11:00:00Z" });
+		const after = makeComment({ created_at: "2024-01-01T13:00:00Z" });
+		const { humanCommentsAfterBot } = partitionComments([before, bot, after]);
+		expect(humanCommentsAfterBot).toHaveLength(1);
+		expect(humanCommentsAfterBot[0].created_at).toBe("2024-01-01T13:00:00Z");
+	});
+
+	it("excludes Bot-type users from the human list", () => {
+		const bot = botComment("2024-01-01T12:00:00Z");
+		const automatedBot = makeComment({
+			body: "Dependabot says hi",
+			user: { login: "dependabot[bot]", type: "Bot" },
+			created_at: "2024-01-01T13:00:00Z",
+		});
+		const human = makeComment({ created_at: "2024-01-01T14:00:00Z" });
+		const { humanCommentsAfterBot } = partitionComments([
+			bot,
+			automatedBot,
+			human,
+		]);
+		expect(humanCommentsAfterBot).toHaveLength(1);
+		expect(humanCommentsAfterBot[0].user?.type).toBe("User");
+	});
+
+	it("falls back to bot comment created_at when reviewed-at is absent", () => {
+		// Bot comment without reviewed-at embedded
+		const bc = makeComment({
+			body: BOT_COMMENT_MARKER + "\n## Review\n\n✅ No issues found.",
+			user: { login: "bot", type: "Bot" },
+			created_at: "2024-01-01T12:00:00Z",
+		});
+		const before = makeComment({ created_at: "2024-01-01T11:00:00Z" });
+		const after = makeComment({ created_at: "2024-01-01T13:00:00Z" });
+		const { humanCommentsAfterBot } = partitionComments([before, bc, after]);
+		expect(humanCommentsAfterBot).toHaveLength(1);
+		expect(humanCommentsAfterBot[0].created_at).toBe("2024-01-01T13:00:00Z");
+	});
+});

--- a/.flue/lib/github-webhook.test.ts
+++ b/.flue/lib/github-webhook.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from "vitest";
+import {
+	getIssueOrPullRequestLabel,
+	getIssueOrPullRequestNumber,
+	getIssueOrPullRequestTitle,
+	getIssueOrPullRequestUrl,
+	truncateLogValue,
+} from "./github-webhook";
+
+// ── getIssueOrPullRequestNumber ────────────────────────────────────────────────
+
+describe("getIssueOrPullRequestNumber", () => {
+	it("extracts number from issues event", () => {
+		expect(
+			getIssueOrPullRequestNumber("issues", { issue: { number: 42 } }),
+		).toBe(42);
+	});
+
+	it("extracts number from issue_comment event", () => {
+		expect(
+			getIssueOrPullRequestNumber("issue_comment", { issue: { number: 7 } }),
+		).toBe(7);
+	});
+
+	it("extracts number from pull_request event", () => {
+		expect(
+			getIssueOrPullRequestNumber("pull_request", {
+				pull_request: { number: 99 },
+			}),
+		).toBe(99);
+	});
+
+	it("returns undefined for unknown event type", () => {
+		expect(getIssueOrPullRequestNumber("push", { number: 1 })).toBeUndefined();
+	});
+
+	it("returns undefined when payload is missing the nested object", () => {
+		expect(getIssueOrPullRequestNumber("issues", {})).toBeUndefined();
+	});
+});
+
+// ── getIssueOrPullRequestUrl ───────────────────────────────────────────────────
+
+describe("getIssueOrPullRequestUrl", () => {
+	it("extracts html_url from issues event", () => {
+		expect(
+			getIssueOrPullRequestUrl(
+				"issues",
+				{
+					issue: { html_url: "https://github.com/org/repo/issues/1" },
+				},
+				1,
+			),
+		).toBe("https://github.com/org/repo/issues/1");
+	});
+
+	it("falls back to constructed URL for issues when html_url absent", () => {
+		expect(getIssueOrPullRequestUrl("issues", {}, 5)).toBe(
+			"https://github.com/cloudflare/cloudflare-docs/issues/5",
+		);
+	});
+
+	it("extracts html_url from pull_request event", () => {
+		expect(
+			getIssueOrPullRequestUrl(
+				"pull_request",
+				{
+					pull_request: { html_url: "https://github.com/org/repo/pull/2" },
+				},
+				2,
+			),
+		).toBe("https://github.com/org/repo/pull/2");
+	});
+
+	it("falls back to constructed URL for PRs when html_url absent", () => {
+		expect(getIssueOrPullRequestUrl("pull_request", {}, 10)).toBe(
+			"https://github.com/cloudflare/cloudflare-docs/pull/10",
+		);
+	});
+
+	it("returns undefined for unknown event type", () => {
+		expect(getIssueOrPullRequestUrl("push", {}, 1)).toBeUndefined();
+	});
+});
+
+// ── getIssueOrPullRequestLabel ─────────────────────────────────────────────────
+
+describe("getIssueOrPullRequestLabel", () => {
+	it("returns 'PR' for pull_request", () => {
+		expect(getIssueOrPullRequestLabel("pull_request")).toBe("PR");
+	});
+
+	it("returns 'Issue' for issues", () => {
+		expect(getIssueOrPullRequestLabel("issues")).toBe("Issue");
+	});
+
+	it("returns 'PR' for issue_comment", () => {
+		expect(getIssueOrPullRequestLabel("issue_comment")).toBe("PR");
+	});
+
+	it("returns generic label for unknown event type", () => {
+		expect(getIssueOrPullRequestLabel("push")).toBe("GitHub webhook");
+	});
+});
+
+// ── getIssueOrPullRequestTitle ─────────────────────────────────────────────────
+
+describe("getIssueOrPullRequestTitle", () => {
+	it("extracts title from issues event", () => {
+		expect(
+			getIssueOrPullRequestTitle("issues", { issue: { title: "Bug report" } }),
+		).toBe("Bug report");
+	});
+
+	it("extracts title from issue_comment event", () => {
+		expect(
+			getIssueOrPullRequestTitle("issue_comment", {
+				issue: { title: "Some issue" },
+			}),
+		).toBe("Some issue");
+	});
+
+	it("extracts title from pull_request event", () => {
+		expect(
+			getIssueOrPullRequestTitle("pull_request", {
+				pull_request: { title: "[Workers] Add KV docs" },
+			}),
+		).toBe("[Workers] Add KV docs");
+	});
+
+	it("returns undefined for unknown event type", () => {
+		expect(getIssueOrPullRequestTitle("push", {})).toBeUndefined();
+	});
+});
+
+// ── truncateLogValue ───────────────────────────────────────────────────────────
+
+describe("truncateLogValue", () => {
+	it("returns short strings unchanged", () => {
+		expect(truncateLogValue("hello")).toBe("hello");
+	});
+
+	it("returns strings of exactly 100 chars unchanged", () => {
+		const s = "a".repeat(100);
+		expect(truncateLogValue(s)).toBe(s);
+	});
+
+	it("truncates strings longer than 100 chars with ellipsis", () => {
+		const s = "a".repeat(101);
+		const result = truncateLogValue(s);
+		expect(result).toHaveLength(100);
+		expect(result.endsWith("...")).toBe(true);
+	});
+
+	it("truncates to 97 chars + '...' for long strings", () => {
+		const s = "x".repeat(200);
+		expect(truncateLogValue(s)).toBe("x".repeat(97) + "...");
+	});
+});

--- a/.flue/lib/inproc-utils.test.ts
+++ b/.flue/lib/inproc-utils.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from "vitest";
+import { withConcurrency } from "./inproc-utils";
+
+describe("withConcurrency", () => {
+	it("returns empty array for no tasks", async () => {
+		expect(await withConcurrency([], 5)).toEqual([]);
+	});
+
+	it("runs a single task and returns its result", async () => {
+		const result = await withConcurrency([async () => 42], 1);
+		expect(result).toEqual([42]);
+	});
+
+	it("preserves input order regardless of completion order", async () => {
+		// Task 0 resolves last, task 2 resolves first
+		const delays = [30, 20, 10];
+		const tasks = delays.map(
+			(delay, i) => () =>
+				new Promise<number>((resolve) => setTimeout(() => resolve(i), delay)),
+		);
+		const result = await withConcurrency(tasks, 3);
+		expect(result).toEqual([0, 1, 2]);
+	});
+
+	it("runs all tasks with limit >= task count", async () => {
+		const called: number[] = [];
+		const tasks = Array.from({ length: 5 }, (_, i) => async () => {
+			called.push(i);
+			return i;
+		});
+		await withConcurrency(tasks, 10);
+		expect(called).toHaveLength(5);
+	});
+
+	it("respects the concurrency limit", async () => {
+		let active = 0;
+		let maxActive = 0;
+		const tasks = Array.from({ length: 10 }, () => async () => {
+			active++;
+			maxActive = Math.max(maxActive, active);
+			await new Promise((r) => setTimeout(r, 5));
+			active--;
+		});
+		await withConcurrency(tasks, 3);
+		expect(maxActive).toBeLessThanOrEqual(3);
+	});
+
+	it("clamps non-positive limit to 1", async () => {
+		let maxActive = 0;
+		let active = 0;
+		const tasks = Array.from({ length: 4 }, () => async () => {
+			active++;
+			maxActive = Math.max(maxActive, active);
+			await new Promise((r) => setTimeout(r, 5));
+			active--;
+		});
+		await withConcurrency(tasks, 0);
+		expect(maxActive).toBe(1);
+	});
+
+	it("clamps NaN limit to 1", async () => {
+		let maxActive = 0;
+		let active = 0;
+		const tasks = Array.from({ length: 4 }, () => async () => {
+			active++;
+			maxActive = Math.max(maxActive, active);
+			await new Promise((r) => setTimeout(r, 5));
+			active--;
+		});
+		await withConcurrency(tasks, NaN);
+		expect(maxActive).toBe(1);
+	});
+
+	it("returns correct results for limit of 1 (serial execution)", async () => {
+		const order: number[] = [];
+		const tasks = [3, 1, 2].map((v) => async () => {
+			order.push(v);
+			return v;
+		});
+		const result = await withConcurrency(tasks, 1);
+		expect(result).toEqual([3, 1, 2]);
+		expect(order).toEqual([3, 1, 2]);
+	});
+});

--- a/.flue/lib/inproc-utils.test.ts
+++ b/.flue/lib/inproc-utils.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { withConcurrency } from "./inproc-utils";
 
 describe("withConcurrency", () => {

--- a/.flue/package.json
+++ b/.flue/package.json
@@ -7,7 +7,8 @@
 	"scripts": {
 		"build": "flue build",
 		"dev": "flue dev",
-		"typecheck": "tsc --noEmit"
+		"typecheck": "tsc --noEmit",
+		"test": "vitest run"
 	},
 	"dependencies": {
 		"@cloudflare/codemode": "0.3.8",
@@ -22,6 +23,7 @@
 		"wrangler": "4.107.0"
 	},
 	"devDependencies": {
-		"typescript": "5.9.3"
+		"typescript": "5.9.3",
+		"vitest": "4.1.10"
 	}
 }

--- a/.flue/pnpm-lock.yaml
+++ b/.flue/pnpm-lock.yaml
@@ -42,6 +42,9 @@ importers:
       typescript:
         specifier: 5.9.3
         version: 5.9.3
+      vitest:
+        specifier: 4.1.10
+        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@26.1.0)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(yaml@2.9.0))
 
 packages:
 
@@ -1144,6 +1147,15 @@ packages:
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
@@ -1165,6 +1177,35 @@ packages:
   '@vercel/oidc@3.2.0':
     resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
     engines: {node: '>= 20'}
+
+  '@vitest/expect@4.1.10':
+    resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
+
+  '@vitest/mocker@4.1.10':
+    resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.10':
+    resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
+
+  '@vitest/runner@4.1.10':
+    resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
+
+  '@vitest/snapshot@4.1.10':
+    resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
+
+  '@vitest/spy@4.1.10':
+    resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
+
+  '@vitest/utils@4.1.10':
+    resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
 
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
@@ -1250,6 +1291,10 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   async-lock@1.4.1:
     resolution: {integrity: sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ==}
 
@@ -1321,6 +1366,10 @@ packages:
 
   caniuse-lite@1.0.30001802:
     resolution: {integrity: sha512-vmv8ub2xwTNmljSKf82mtCk5JH7hC+YgzLj3P5zotvA0tPQ9016tdNNOG8WRca1IxOnhSsivB+J0z5FeE5LOUw==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
@@ -1457,6 +1506,9 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
+  es-module-lexer@2.3.1:
+    resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
+
   es-object-atoms@1.1.2:
     resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
     engines: {node: '>= 0.4'}
@@ -1472,6 +1524,9 @@ packages:
 
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
   etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
@@ -1499,6 +1554,10 @@ packages:
   expand-template@2.0.3:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
     engines: {node: '>=6'}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
 
   express-rate-limit@8.5.2:
     resolution: {integrity: sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==}
@@ -1867,6 +1926,9 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
@@ -1984,6 +2046,10 @@ packages:
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
+
+  obug@2.1.4:
+    resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
+    engines: {node: '>=12.20.0'}
 
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
@@ -2231,6 +2297,9 @@ packages:
     resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   simple-concat@1.0.1:
     resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
 
@@ -2251,9 +2320,15 @@ packages:
   sql.js@1.14.1:
     resolution: {integrity: sha512-gcj8zBWU5cFsi9WUP+4bFNXAyF1iRpA3LLyS/DP5xlrNzGmPIizUeBggKa8DbDwdqaKwUcTEnChtd2grWo/x/A==}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
+
+  std-env@4.2.0:
+    resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
 
   string-width@7.2.0:
     resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
@@ -2288,9 +2363,20 @@ packages:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.2.4:
+    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   to-buffer@1.2.2:
     resolution: {integrity: sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==}
@@ -2429,6 +2515,47 @@ packages:
       yaml:
         optional: true
 
+  vitest@4.1.10:
+    resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.10
+      '@vitest/browser-preview': 4.1.10
+      '@vitest/browser-webdriverio': 4.1.10
+      '@vitest/coverage-istanbul': 4.1.10
+      '@vitest/coverage-v8': 4.1.10
+      '@vitest/ui': 4.1.10
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
@@ -2440,6 +2567,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   workerd@1.20260701.1:
@@ -3684,6 +3816,15 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.9': {}
+
   '@types/json-schema@7.0.15': {}
 
   '@types/node@26.1.0':
@@ -3699,6 +3840,47 @@ snapshots:
   '@vercel/detect-agent@1.2.3': {}
 
   '@vercel/oidc@3.2.0': {}
+
+  '@vitest/expect@4.1.10':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.10(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(yaml@2.9.0)
+
+  '@vitest/pretty-format@4.1.10':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.10':
+    dependencies:
+      '@vitest/utils': 4.1.10
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/utils': 4.1.10
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.10': {}
+
+  '@vitest/utils@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
 
   abort-controller@3.0.0:
     dependencies:
@@ -3767,6 +3949,8 @@ snapshots:
   anynum@1.0.1: {}
 
   argparse@2.0.1: {}
+
+  assertion-error@2.0.1: {}
 
   async-lock@1.4.1: {}
 
@@ -3852,6 +4036,8 @@ snapshots:
       get-intrinsic: 1.3.0
 
   caniuse-lite@1.0.30001802: {}
+
+  chai@6.2.2: {}
 
   chownr@1.1.4:
     optional: true
@@ -3953,6 +4139,8 @@ snapshots:
 
   es-errors@1.3.0: {}
 
+  es-module-lexer@2.3.1: {}
+
   es-object-atoms@1.1.2:
     dependencies:
       es-errors: 1.3.0
@@ -3990,6 +4178,10 @@ snapshots:
 
   escape-html@1.0.3: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
   etag@1.8.1: {}
 
   event-target-polyfill@0.0.4: {}
@@ -4006,6 +4198,8 @@ snapshots:
 
   expand-template@2.0.3:
     optional: true
+
+  expect-type@1.4.0: {}
 
   express-rate-limit@8.5.2(express@5.2.1):
     dependencies:
@@ -4399,6 +4593,10 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
   math-intrinsics@1.1.0: {}
 
   media-typer@1.1.0: {}
@@ -4496,6 +4694,8 @@ snapshots:
   object-assign@4.1.1: {}
 
   object-inspect@1.13.4: {}
+
+  obug@2.1.4: {}
 
   on-finished@2.4.1:
     dependencies:
@@ -4820,6 +5020,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   simple-concat@1.0.1: {}
 
   simple-get@4.0.1:
@@ -4836,7 +5038,11 @@ snapshots:
 
   sql.js@1.14.1: {}
 
+  stackback@0.0.2: {}
+
   statuses@2.0.2: {}
+
+  std-env@4.2.0: {}
 
   string-width@7.2.0:
     dependencies:
@@ -4882,10 +5088,16 @@ snapshots:
       readable-stream: 3.6.2
     optional: true
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.2.4: {}
+
   tinyglobby@0.2.17:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.5)
       picomatch: 4.0.5
+
+  tinyrainbow@3.1.0: {}
 
   to-buffer@1.2.2:
     dependencies:
@@ -4980,6 +5192,34 @@ snapshots:
       fsevents: 2.3.3
       yaml: 2.9.0
 
+  vitest@4.1.10(@opentelemetry/api@1.9.0)(@types/node@26.1.0)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.1
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.4
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+      '@types/node': 26.1.0
+    transitivePeerDependencies:
+      - msw
+
   web-streams-polyfill@3.3.3: {}
 
   which-typed-array@1.1.22:
@@ -4995,6 +5235,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   workerd@1.20260701.1:
     optionalDependencies:

--- a/.flue/vitest.config.ts
+++ b/.flue/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	// Treat .md skill files as static assets so the `with { type: "skill" }`
+	// import assertions in source files don't fail during test transforms.
+	assetsInclude: ["**/*.md"],
+	test: {
+		environment: "node",
+		include: ["**/*.test.ts"],
+	},
+});

--- a/.github/workflows/flue-ci.yml
+++ b/.github/workflows/flue-ci.yml
@@ -43,6 +43,10 @@ jobs:
         run: pnpm run typecheck
         working-directory: .flue
 
+      - name: Test
+        run: pnpm run test
+        working-directory: .flue
+
   build:
     name: Build
     needs: pre-build


### PR DESCRIPTION
### Summary

Adds 127 Vitest unit tests covering the deterministic, pure TypeScript functions in `.flue/` — the layer that doesn't require AI, GitHub API calls, R2, or Cloudflare Workers bindings to verify.

**What's tested:**

| File | Tests | What it covers |
|---|---|---|
| `lib/code-review-inproc.test.ts` | 29 | `parseAddedLines` (diff parsing, hunk math, file headers, edge cases), `selectCodeReviewFiles` (exclusions, sorting, capping), `mergeCodeReviewResults` (dedup by ID, summary counts) |
| `lib/code-review-render.test.ts` | 41 | `renderPendingComment`, `renderFailureComment`, `renderComment` (all severity combinations, fix-in-agent block, acknowledged findings, degraded sections), `renderReviewLimitComment`, `renderRebaseStatusUpdate` (all status values, existing body injection, timestamp refresh) |
| `lib/code-review-state.test.ts` | 16 | `extractReviewedHeadSha`, `extractReviewedAt`, `partitionComments` (bot detection, last-wins, timestamp partitioning, bot-type exclusion) |
| `lib/code-review-results.test.ts` | 11 | `assignCodeReviewFindingIds` and `assignFindingIds` (CR-/SG- prefix, stable IDs, line-number independence, evidence trimming) |
| `lib/inproc-utils.test.ts` | 8 | `withConcurrency` (ordering, concurrency limit, NaN/zero clamping, serial execution) |
| `lib/github-webhook.test.ts` | 22 | `getIssueOrPullRequestNumber/Url/Label/Title`, `truncateLogValue` |

Also adds `vitest` as a devDependency, a `vitest.config.ts` (with `assetsInclude: ['**/*.md']` to handle SKILL.md imports), and wires `pnpm run test` into the Pre Build job in `flue-ci.yml`.
