### PR TITLE
fix: require skip comments before fix commits in agent prompt

### DIFF
--- a/.flue/lib/code-review-render.ts
+++ b/.flue/lib/code-review-render.ts
@@ -370,7 +370,7 @@ function renderFixInAgentBlock(
 
 	return [
 		"<details>",
-		"<summary>Fix in your agent</summary>",
+		"<summary>👉 Fix in your agent 👈</summary>",
 		"",
 		fenced,
 		"",

--- a/.flue/lib/code-review-render.ts
+++ b/.flue/lib/code-review-render.ts
@@ -347,8 +347,12 @@ function renderFixInAgentBlock(
 		"- If you need clarification before deciding, ask those questions",
 		"- Then share your plan for which issues to tackle and in what order",
 		"",
-		"After triaging, fix all legitimate findings. For any you decide to skip,",
-		"post a comment on this PR with the finding ID and your reasoning.",
+		"After triaging, follow this order:",
+		"1. Post a comment on this PR for any findings you are skipping, with the finding ID and your reasoning.",
+		"2. Then commit the fixes for the legitimate findings.",
+		"",
+		"The comment must come before the commit — the bot reads PR comments when a new",
+		"push triggers a review, so skip comments posted after the push will be missed.",
 	].join("\n");
 
 	const sections = [


### PR DESCRIPTION
### Summary

The "Fix in your agent" prompt previously said "fix all legitimate findings; post a comment for any you skip" without specifying order. This caused agents to post skip comments *after* pushing fix commits — but a push immediately triggers a new review, which reads PR comments as part of reconciliation. Skip comments posted after the push are invisible to that review run.

Makes the ordering explicit: post skip comments first, then push fixes.