### PR TITLE
ci: include/exclude flue-ci.yml in workflow path filters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
       - production
     paths-ignore:
       - ".flue/**"
+      - ".github/workflows/flue-ci.yml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/flue-ci.yml
+++ b/.github/workflows/flue-ci.yml
@@ -6,6 +6,7 @@ on:
       - production
     paths:
       - ".flue/**"
+      - ".github/workflows/flue-ci.yml"
 
 permissions:
   contents: read


### PR DESCRIPTION
### Summary

Extends the path filters introduced in #32178 so that changes to `.github/workflows/flue-ci.yml` itself are routed correctly:

- **`flue-ci.yml`** — adds `.github/workflows/flue-ci.yml` to its own `paths` trigger, so editing the workflow file runs Flue CI instead of the full docs build.
- **`ci.yml`** — adds `.github/workflows/flue-ci.yml` to `paths-ignore`, so a PR touching only that file skips the docs build entirely.