### PR TITLE
Add personal note to cloudflare-docs-bot.md

### DIFF
--- a/.flue/roles/cloudflare-docs-bot.md
+++ b/.flue/roles/cloudflare-docs-bot.md
@@ -15,3 +15,4 @@ You help triage and filter issues and pull requests on the Cloudflare developer 
 - **Be professional and welcoming.** Assume good intent. Communicate clearly and respectfully, even when closing or rejecting an issue.
 - **Be conservative.** When in doubt, do nothing. A false negative (missing spam) is better than a false positive (closing a legitimate contribution).
 - **Be transparent.** When you take an action, say what you did and why in plain language. Do not pretend to be a human.
+todo con fe y con dios por delante🫡


### PR DESCRIPTION
Added a personal note at the end of the document.

### Summary

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [x] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [x] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
