### PR TITLE
DNS-13199: document Advanced Nameservers API rollout

### DIFF
--- a/src/content/changelog/dns/2026-10-26-foundation-dns-nameserver-type.mdx
+++ b/src/content/changelog/dns/2026-10-26-foundation-dns-nameserver-type.mdx
@@ -1,0 +1,31 @@
+---
+title: Advanced Nameservers use a nameserver type
+pcx_content_type: changelog
+description: DNS settings now use the Advanced Nameservers type instead of the Foundation DNS setting.
+date: 2026-10-26
+---
+
+Starting today, the [DNS settings endpoints](/api/resources/dns/subresources/settings/) gradually begin to represent Advanced Nameservers with `nameservers.type: "cloudflare.advanced"`. The rollout is expected to take seven days. Previously, the API used the `"foundation_dns": true` setting for this configuration.
+
+Before the rollout reaches an account, the endpoints continue to return `nameservers.type: "cloudflare.standard"` for Advanced Nameservers. The endpoints accept `nameservers.type: "cloudflare.advanced"` in `PATCH` requests for entitled accounts throughout the rollout. The zone settings JSON for [`/zones/{zone_id}/dns_settings`](/api/resources/dns/subresources/settings/subresources/zone/) is:
+
+```json
+{
+  "nameservers": {
+    "type": "cloudflare.advanced"
+  },
+  "foundation_dns": true
+}
+```
+
+Cloudflare will make an equivalent change to [`/accounts/{account_id}/dns_settings`](/api/resources/dns/subresources/settings/subresources/account/) at the same time.
+
+The `foundation_dns` boolean remains available as a deprecated compatibility alias in zone and account-default settings. Use `nameservers.type: "cloudflare.advanced"` for new writes.
+
+You can continue to read and write `foundation_dns` during this transition. If a `PATCH` request includes both values, they must match. The API rejects conflicting values.
+
+Update clients that treat `nameservers.type` as a closed enum to recognize the `"cloudflare.advanced"` value.
+
+This API update does not change your Foundation DNS subscription or whether Advanced Nameservers are enabled on your zones. It does not require a zone migration.
+
+In a future API change, Cloudflare will remove the `foundation_dns` parameter from the API endpoint. After migrating to `nameservers.type`, remove handling for the boolean from your client.

--- a/src/content/changelog/dns/2026-11-23-remove-foundation-dns-boolean.mdx
+++ b/src/content/changelog/dns/2026-11-23-remove-foundation-dns-boolean.mdx
@@ -1,0 +1,24 @@
+---
+title: DNS settings endpoints remove deprecated Foundation DNS boolean
+pcx_content_type: changelog
+description: Advanced Nameservers now use only the cloudflare.advanced nameserver type in DNS settings.
+date: 2026-11-23
+---
+
+Starting today, the [DNS settings endpoints](/api/resources/dns/subresources/settings/) no longer return or accept the deprecated `foundation_dns` boolean for zone settings or account defaults. The rollout is expected to take seven days. Use `nameservers.type: "cloudflare.advanced"` to configure Advanced Nameservers.
+
+Update clients that still read or write `foundation_dns`. Remove handling for the boolean and use the nameserver type instead. The zone settings JSON for [`/zones/{zone_id}/dns_settings`](/api/resources/dns/subresources/settings/subresources/zone/) is:
+
+```json
+{
+  "nameservers": {
+    "type": "cloudflare.advanced"
+  }
+}
+```
+
+Cloudflare will make an equivalent change to [`/accounts/{account_id}/dns_settings`](/api/resources/dns/subresources/settings/subresources/account/) at the same time.
+
+`PATCH` requests that include `foundation_dns` will be rejected.
+
+This API update does not change your Foundation DNS subscription or whether Advanced Nameservers are enabled on your zones. It does not require a zone migration.

--- a/src/content/docs/dns/foundation-dns/setup.mdx
+++ b/src/content/docs/dns/foundation-dns/setup.mdx
@@ -97,7 +97,9 @@ To enable advanced nameservers on an existing zone:
    	path="/zones/{zone_id}/dns_settings"
    	method="PATCH"
    	json={{
-   		foundation_dns: true,
+		nameservers: {
+			type: "cloudflare.advanced",
+		},
    	}}
    />
 

--- a/src/content/release-notes/api-deprecations.yaml
+++ b/src/content/release-notes/api-deprecations.yaml
@@ -39,6 +39,25 @@ entries:
       - `PUT /accounts/{account_id}` — Update account (already enforced)
 
       After the enforcement date, integrations that create accounts with names longer than 65 characters must truncate or shorten the name before sending the request to ensure uninterrupted service.
+  - publish_date: "2026-07-27"
+    title: "Foundation DNS boolean setting"
+    description: |-
+      Deprecation date: July 27, 2026
+
+      End of life date: November 23, 2026
+
+      The `foundation_dns` boolean is deprecated in the [DNS settings endpoints](/api/resources/dns/subresources/settings/) for zone settings and account defaults. Use `nameservers.type: "cloudflare.advanced"` to configure Advanced Nameservers instead.
+
+      Affected endpoints:
+
+      - [`/zones/{zone_id}/dns_settings`](/api/resources/dns/subresources/settings/subresources/zone/)
+      - [`/accounts/{account_id}/dns_settings`](/api/resources/dns/subresources/settings/subresources/account/)
+
+      Beginning October 26, 2026, the DNS settings API will gradually represent Advanced Nameservers with `nameservers.type: "cloudflare.advanced"`. This rollout is expected to take seven days. Before the rollout reaches an account, the API will continue to return `nameservers.type: "cloudflare.standard"` for Advanced Nameservers. The API will accept `nameservers.type: "cloudflare.advanced"` in `PATCH` requests for entitled accounts throughout the rollout.
+
+      The `foundation_dns` boolean remains available as a compatibility alias during this transition. You can continue to read and write it. If a `PATCH` request includes both values, they must match. The API will reject conflicting values.
+
+      Beginning November 23, 2026, the DNS settings API will no longer return or accept `foundation_dns`. This rollout is expected to take seven days. `PATCH` requests that include `foundation_dns` will be rejected. Update clients that treat `nameservers.type` as a closed enum to recognize the `"cloudflare.advanced"` value, and update clients that read or write `foundation_dns` before the end-of-life date. This API change does not change your Foundation DNS subscription or whether Advanced Nameservers are enabled on your zones. It does not require a zone migration.
 
   - publish_date: "2026-07-21"
     title: "Account Roles API"


### PR DESCRIPTION
### Summary

Document the nameserver type transition and removal of the deprecated foundation_dns API field.

### Screenshots (optional)

None

### Documentation checklist

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
