### PR TITLE
[Flagship] Add Flagship to homepage Compute section

### DIFF
--- a/src/components/landing/BuildFromScratch.astro
+++ b/src/components/landing/BuildFromScratch.astro
@@ -28,6 +28,7 @@ const primitives = [
 			{ label: "Containers", href: "/containers/" },
 			{ label: "Durable Objects", href: "/durable-objects/" },
 			{ label: "Queues", href: "/queues/" },
+			{ label: "Flagship", href: "/flagship/" },
 		],
 	},
 	{


### PR DESCRIPTION
### Summary

Adds Flagship to the Compute tab on the homepage to surface it alongside the other compute products.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
