### PR TITLE
Add SDK team as owners of API Deprecations page

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -56,7 +56,7 @@ package.json @cloudflare/content-engineering
 /src/content/docs/terraform/ @jhutchings1 @cloudflare/product-owners
 /src/content/docs/version-management/ @jhutchings1 @cloudflare/product-owners
 /src/content/partials/version-management/ @jhutchings1 @cloudflare/product-owners
-src/content/release-notes/api-deprecations.yaml @jhutchings1 @cloudflare/sdk
+/src/content/release-notes/api-deprecations.yaml @jhutchings1 @cloudflare/sdk
 
 # Billing
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -56,6 +56,7 @@ package.json @cloudflare/content-engineering
 /src/content/docs/terraform/ @jhutchings1 @cloudflare/product-owners
 /src/content/docs/version-management/ @jhutchings1 @cloudflare/product-owners
 /src/content/partials/version-management/ @jhutchings1 @cloudflare/product-owners
+src/content/release-notes/api-deprecations.yaml @jhutchings1 @cloudflare/sdk
 
 # Billing
 


### PR DESCRIPTION
### Summary

<!-- Add context such as the type of documentation being updated or added -->
The API team should be involved in the review of all upcoming deprecation notices as part of our role in governing the API. This adds the existing @cloudflare/sdk team as a codeowner for that file. 

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
