### PR TITLE
[Sandbox] Update Devin Outposts documentation links

### DIFF
--- a/src/content/docs/sandbox/tutorials/devin-outposts.mdx
+++ b/src/content/docs/sandbox/tutorials/devin-outposts.mdx
@@ -11,7 +11,7 @@ products:
 
 import { PackageManagers, Steps } from "~/components";
 
-Run [Devin agents](https://docs.devin.ai/cloud/outposts/overview) on Cloudflare. Each Devin session runs in its own isolated sandbox backed by Cloudflare Containers.
+Run [Devin agents](https://docs.devin.ai/onboard-devin/outposts) on Cloudflare. Each Devin session runs in its own isolated sandbox backed by Cloudflare Containers.
 
 ## Prerequisites
 
@@ -30,10 +30,10 @@ You need:
    https://my-org.devinenterprise.com/org/my-org/settings/enterprise-environment?tab=outposts
    ```
 
-2. Create or select an outpost. Copy its outpost ID for `DEVIN_OUTPOST_ID` aswell as its token for `DEVIN_API_TOKEN`.
+2. Create or select an outpost. Copy its outpost ID for `DEVIN_OUTPOST_ID` and its token for `DEVIN_API_TOKEN`.
 </Steps>
 
-For more information about outposts, refer to the [Devin Outposts overview](https://docs.devin.ai/cloud/outposts/overview).
+For more information about outposts, refer to the [Devin Outposts overview](https://docs.devin.ai/onboard-devin/outposts).
 
 ## Deploy with one click
 
@@ -137,7 +137,7 @@ Checkpoints provide suspend-and-resume persistence, not continuous backups. An a
 
 ## Related resources
 
-- [Devin Outposts overview](https://docs.devin.ai/cloud/outposts/overview)
+- [Devin Outposts overview](https://docs.devin.ai/onboard-devin/outposts)
 - [Devin Outpost deployment template](https://github.com/cloudflare/sandbox-sdk/tree/main/devin)
 - [Cloudflare Containers](/containers/)
 - [R2](/r2/)


### PR DESCRIPTION
### Summary

Updates the Devin Outposts tutorial to use the new Devin documentation URL. Also fixes a small typo in the credential setup steps.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
