### PR TITLE
Capitalize "Organization" for clarity

### DIFF
--- a/src/content/docs/cloudflare-one/integrations/identity-providers/idp-federation.mdx
+++ b/src/content/docs/cloudflare-one/integrations/identity-providers/idp-federation.mdx
@@ -28,7 +28,7 @@ When a user in a recipient account authenticates, the request is routed through 
 ## Prerequisites
 
 - You must have permission to edit the source IdP in the source account.
-- You must be a member of a [Cloudflare Organization](/fundamentals/organizations).
+- You must be a member of a [Cloudflare Organization](/fundamentals/organizations/).
 - The source account must belong to a Cloudflare Organization.
 
 ## Share an IdP

--- a/src/content/docs/cloudflare-one/integrations/identity-providers/idp-federation.mdx
+++ b/src/content/docs/cloudflare-one/integrations/identity-providers/idp-federation.mdx
@@ -28,8 +28,8 @@ When a user in a recipient account authenticates, the request is routed through 
 ## Prerequisites
 
 - You must have permission to edit the source IdP in the source account.
-- You must be a member of a Cloudflare organization.
-- The source account must belong to a Cloudflare organization.
+- You must be a member of a [Cloudflare Organization](/fundamentals/organizations).
+- The source account must belong to a Cloudflare Organization.
 
 ## Share an IdP
 
@@ -70,12 +70,12 @@ The response includes the grant `id`, which you will use in the next step. To li
 
 #### 2. Share the grant
 
-You can share the grant with specific accounts or with your entire Cloudflare organization. In the `recipients` array, target each recipient with one of the following fields:
+You can share the grant with specific accounts or with your entire Cloudflare Organization. In the `recipients` array, target each recipient with one of the following fields:
 
 - `recipient_account_id`: Shares the IdP with a single account. Repeat the field for each account you want to add.
-- `organization_id`: Shares the IdP with every account in your Cloudflare organization.
+- `organization_id`: Shares the IdP with every account in your Cloudflare Organization.
 
-Specify only one of these fields per recipient. If you provide neither, the grant is shared with your entire organization by default.
+Specify only one of these fields per recipient. If you provide neither, the grant is shared with your entire Organization by default.
 
 To share the grant with one or more specific accounts:
 
@@ -97,7 +97,7 @@ To share the grant with one or more specific accounts:
 	}}
 />
 
-To share the grant with every account in your organization, replace the `recipients` array with your organization ID:
+To share the grant with every account in your Organization, replace the `recipients` array with your Organization ID:
 
 <CURL
 	url="https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/shares"
@@ -117,7 +117,7 @@ To share the grant with every account in your organization, replace the `recipie
 	}}
 />
 
-Each recipient account is automatically provisioned with a read-only IdP connection that points to the bridge. When you share with an organization, every account in the organization receives the connection.
+Each recipient account is automatically provisioned with a read-only IdP connection that points to the bridge. When you share with an Organization, every account in the Organization receives the connection.
 
 </TabItem></Tabs>
 


### PR DESCRIPTION
Clarifies that we're talking about Cloudflare Organizations, not just the concept of a company in abstract.

### Summary

<!-- Add context such as the type of documentation being updated or added -->
We had a team-member express confusion about whether we're talking generically about an abstract organization, or the Cloudflare feature called "Organizations". I went through and capitalized + cross referenced in the spots where I thought it made sense to be more specific. 

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
