### PR TITLE
fix: package manager copy buttons

### DIFF
--- a/src/nimbus/components/ui/package-managers/PackageManagers.astro
+++ b/src/nimbus/components/ui/package-managers/PackageManagers.astro
@@ -109,6 +109,7 @@ const uid = `pm-${crypto.randomUUID()}`;
 								class="border-border text-muted-foreground hover:text-foreground focus-visible:outline-ring m-0 flex shrink-0 cursor-pointer items-center justify-center border-0 border-l border-solid bg-transparent px-3 transition-colors focus-visible:outline-2 focus-visible:-outline-offset-2"
 							>
 								<Icon name="ph:copy" class="h-[18px] w-[18px]" />
+								<Icon name="ph:check" class="hidden h-[18px] w-[18px]" />
 							</button>
 						</div>
 					</div>
@@ -117,12 +118,6 @@ const uid = `pm-${crypto.randomUUID()}`;
 		}
 		<nb-pm-restore style="display:contents"></nb-pm-restore>
 	</LayerCard>
-	<template data-nb-pm-icon-copy
-		><Icon name="ph:copy" class="h-[18px] w-[18px]" is:inline /></template
-	>
-	<template data-nb-pm-icon-check
-		><Icon name="ph:check" class="h-[18px] w-[18px]" is:inline /></template
-	>
 </div>
 
 <script>

--- a/src/nimbus/components/ui/package-managers/package-managers.client.ts
+++ b/src/nimbus/components/ui/package-managers/package-managers.client.ts
@@ -5,18 +5,7 @@
 
 import { mount, initTabs } from "nimbus-docs/client";
 
-function cloneIcon(tpl: HTMLTemplateElement | null): Node {
-	return tpl ? tpl.content.cloneNode(true) : document.createTextNode("");
-}
-
 function initPackageManager(container: HTMLElement): () => void {
-	const copyTpl = container.querySelector<HTMLTemplateElement>(
-		"[data-nb-pm-icon-copy]",
-	);
-	const checkTpl = container.querySelector<HTMLTemplateElement>(
-		"[data-nb-pm-icon-check]",
-	);
-
 	const tabs = initTabs({
 		container,
 		tabSelector: "[data-nb-pm-tab]",
@@ -34,6 +23,13 @@ function initPackageManager(container: HTMLElement): () => void {
 	container
 		.querySelectorAll<HTMLButtonElement>("[data-nb-pm-copy]")
 		.forEach((btn) => {
+			// Toggle between the two icons instead of replacing the button's
+			// children. astro-icon renders the first `ph:copy`/`ph:check` on the
+			// page as a shared `<symbol>` and every other instance as a `<use>`
+			// reference to it; removing the button that hosts the definition would
+			// orphan every other copy icon on the page. Never remove the nodes.
+			const copyIcon = btn.querySelector<SVGElement>('[data-icon="ph:copy"]');
+			const checkIcon = btn.querySelector<SVGElement>('[data-icon="ph:check"]');
 			const handlerInfo: {
 				btn: HTMLButtonElement;
 				handler: () => void;
@@ -46,10 +42,12 @@ function initPackageManager(container: HTMLElement): () => void {
 					} catch {
 						return;
 					}
-					btn.replaceChildren(cloneIcon(checkTpl));
+					copyIcon?.classList.add("hidden");
+					checkIcon?.classList.remove("hidden");
 					if (handlerInfo.timer) window.clearTimeout(handlerInfo.timer);
 					handlerInfo.timer = window.setTimeout(() => {
-						btn.replaceChildren(cloneIcon(copyTpl));
+						checkIcon?.classList.add("hidden");
+						copyIcon?.classList.remove("hidden");
 					}, 1500);
 				},
 			};


### PR DESCRIPTION
### Summary

Clicking a package-manager copy button could make every other copy icon on the page vanish. This fixes it by toggling icons instead of replacing the button's contents.

Why

astro-icon renders the first ph:copy on a page as a shared <svg><symbol id="ai:ph:copy">…</symbol></svg> and every other instance as <use href="#ai:ph:copy">. That definition happens to live inside the first copy button.
The click handler swapped the icon with btn.replaceChildren(...). So clicking the button that hosts the definition deleted the <symbol>, orphaning all 12+ <use> references — every other copy icon disappeared, and didn't come back (the 1.5s "restore" was itself a <use> pointing at the now-missing symbol).
Repro: https://developers.cloudflare.com/workers/framework-guides/automatic-configuration/#deploy-with-automatic-configuration — click one copy button, watch the others go blank.

The fix

- PackageManagers.astro — each button now renders both icons (ph:copy + a hidden ph:check); dropped the two <template> icon blocks.
- package-managers.client.ts — the handler toggles the hidden class on the two icons instead of replaceChildren. Nodes are never removed, so the shared <symbol> always stays in the DOM. Removed the now-unused cloneIcon/template plumbing.
Doesn't rely on astro-icon's dedup internals: even a display:none <symbol> is a valid <use> target, and nothing gets detach

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
