### PR TITLE
[Flagship] Add Flagship to homepage Compute section

### DIFF
--- a/src/nimbus/components/landing/BuildFromScratch.astro
+++ b/src/nimbus/components/landing/BuildFromScratch.astro
@@ -27,6 +27,7 @@ const primitives = [
 			{ label: "Containers", href: "/containers/" },
 			{ label: "Durable Objects", href: "/durable-objects/" },
 			{ label: "Queues", href: "/queues/" },
+			{ label: "Flagship", href: "/flagship/" },
 		],
 	},
 	{

--- a/src/nimbus/components/landing/sidebar-data.ts
+++ b/src/nimbus/components/landing/sidebar-data.ts
@@ -78,6 +78,7 @@ export const sidebarSections: SidebarSection[] = [
 					link("Durable Objects", "/durable-objects/"),
 					link("Queues", "/queues/"),
 					link("Workflows", "/workflows/"),
+					link("Flagship", "/flagship/"),
 					link("Browser Run", "/browser-run/"),
 					link("Workers VPC", "/workers-vpc/"),
 					link("Cloudflare for Platforms", "/cloudflare-for-platforms/"),


### PR DESCRIPTION
### Summary

Adds Flagship to the Compute section on the homepage, including the sidebar nav and the Compute tab tags in the Build section.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
