### PR TITLE
[Cache] Clarify DYNAMIC vs BYPASS cache statuses

### DIFF
--- a/src/content/docs/cache/concepts/cache-responses.mdx
+++ b/src/content/docs/cache/concepts/cache-responses.mdx
@@ -50,7 +50,17 @@ The resource was served from Cloudflare's cache but was expired. Cloudflare coul
 
 ## BYPASS
 
-The origin web server instructed Cloudflare to bypass cache via a `Cache-Control` header set to `no-cache`, `private`, or `max-age=0` even though Cloudflare originally preferred to cache the asset. BYPASS is returned when enabling [Origin Cache-Control](/cache/concepts/cache-control/). Cloudflare also sets BYPASS when your origin web server sends cookies in the response header. If the Request to your origin web server includes an `Authorization` header, in some cases the response will also be BYPASS. Refer to [Conditions](/cache/concepts/cache-control/#conditions) in the Origin Cache-Control behavior section for more details.
+Cloudflare considered the asset eligible for cache at request time — either because it matches the [default cached file extensions](/cache/concepts/default-cache-behavior/#default-cached-file-extensions), or because a [Cache Rule](/cache/how-to/cache-rules/) enabled caching for it — but the origin response was ultimately not cacheable.
+
+Common reasons the origin response is treated as not cacheable include:
+
+* The origin web server returned a `Cache-Control` header set to `no-cache`, `no-store`, `private`, or `max-age=0`. Origin `Cache-Control` directives are only honored when [Origin Cache-Control](/cache/concepts/cache-control/) is enabled. Refer to [Conditions](/cache/concepts/cache-control/#conditions) for the full behavior.
+* The origin web server returned a `Set-Cookie` header.
+* The request to the origin web server included an `Authorization` header (in some cases).
+
+:::note
+If you configured a [Cache Rule](/cache/how-to/cache-rules/) with **Eligible for cache** set to *Yes* (for example, on HTML content) and the origin response is not cacheable, the response is returned with `CF-Cache-Status: BYPASS` — not `DYNAMIC`. `DYNAMIC` is only returned when Cloudflare determines the asset is not eligible for cache at request time. Refer to [DYNAMIC](#dynamic) below for details.
+:::
 
 ## REVALIDATED
 
@@ -64,4 +74,11 @@ The resource was expired but served from Cloudflare's cache while the origin upd
 
 ## DYNAMIC
 
-Cloudflare does not consider the asset eligible to cache and your Cloudflare settings do not explicitly instruct Cloudflare to cache the asset. Instead, the asset was requested from the origin web server. Use [Cache Rules](/cache/how-to/cache-rules/) to implement custom caching options.
+Cloudflare determined at request time that the asset is not eligible for cache, so the request went to the origin web server without a cache lookup.
+
+This typically happens when:
+
+* The requested asset is not one of the [default cached file extensions](/cache/concepts/default-cache-behavior/#default-cached-file-extensions) (for example, HTML or JSON) and no rule instructs Cloudflare to cache it.
+* A [Cache Rule](/cache/how-to/cache-rules/) with the **Bypass cache** setting matches the request. The legacy `Cache Level: Bypass` option in [Configuration Rules](/rules/configuration-rules/) or [Page Rules](/rules/page-rules/) behaves the same way.
+
+Use [Cache Rules](/cache/how-to/cache-rules/) to change what content Cloudflare caches. Once the request is treated as eligible for cache, the `CF-Cache-Status` header will reflect the response-time cache decision (`HIT`, `MISS`, `EXPIRED`, `REVALIDATED`, `BYPASS`, and so on) — see [BYPASS](#bypass) for the case where the origin response is ultimately not cacheable.

--- a/src/content/docs/cache/concepts/cache-responses.mdx
+++ b/src/content/docs/cache/concepts/cache-responses.mdx
@@ -54,12 +54,12 @@ Cloudflare considered the asset eligible for cache at request time — either be
 
 Common reasons the origin response is treated as not cacheable include:
 
-* The origin web server returned a `Cache-Control` header set to `no-cache`, `no-store`, `private`, or `max-age=0`. Origin `Cache-Control` directives are only honored when [Origin Cache-Control](/cache/concepts/cache-control/) is enabled. Refer to [Conditions](/cache/concepts/cache-control/#conditions) for the full behavior.
+* The origin web server returned a `Cache-Control` header set to `no-cache`, `no-store`, or `private`. Origin `Cache-Control` directives are only honored when [Origin Cache-Control](/cache/concepts/cache-control/) is enabled, and specific directives may result in a different cache status (for example, `max-age=0` with Origin Cache Control enabled caches and revalidates). Refer to [Conditions](/cache/concepts/cache-control/#conditions) for the full behavior.
 * The origin web server returned a `Set-Cookie` header.
 * The request to the origin web server included an `Authorization` header (in some cases).
 
 :::note
-If you configured a [Cache Rule](/cache/how-to/cache-rules/) with **Eligible for cache** set to *Yes* (for example, on HTML content) and the origin response is not cacheable, the response is returned with `CF-Cache-Status: BYPASS` — not `DYNAMIC`. `DYNAMIC` is only returned when Cloudflare determines the asset is not eligible for cache at request time. Refer to [DYNAMIC](#dynamic) below for details.
+If you configured a [Cache Rule](/cache/how-to/cache-rules/) with **Eligible for cache** set to *Yes* (for example, on HTML content) and the origin returns a non-cacheable `Cache-Control` directive, the response is returned with `CF-Cache-Status: BYPASS` — not `DYNAMIC`. `DYNAMIC` is only returned when Cloudflare determines the asset is not eligible for cache at request time.
 :::
 
 ## REVALIDATED
@@ -81,4 +81,4 @@ This typically happens when:
 * The requested asset is not one of the [default cached file extensions](/cache/concepts/default-cache-behavior/#default-cached-file-extensions) (for example, HTML or JSON) and no rule instructs Cloudflare to cache it.
 * A [Cache Rule](/cache/how-to/cache-rules/) with the **Bypass cache** setting matches the request. The legacy `Cache Level: Bypass` option in [Configuration Rules](/rules/configuration-rules/) or [Page Rules](/rules/page-rules/) behaves the same way.
 
-Use [Cache Rules](/cache/how-to/cache-rules/) to change what content Cloudflare caches. Once the request is treated as eligible for cache, the `CF-Cache-Status` header will reflect the response-time cache decision (`HIT`, `MISS`, `EXPIRED`, `REVALIDATED`, `BYPASS`, and so on) — see [BYPASS](#bypass) for the case where the origin response is ultimately not cacheable.
+Use [Cache Rules](/cache/how-to/cache-rules/) to change what content Cloudflare caches. Once the request is treated as eligible for cache, the `CF-Cache-Status` header will reflect the response-time cache decision (`HIT`, `MISS`, `EXPIRED`, `REVALIDATED`, `BYPASS`, and so on) — refer to [BYPASS](#bypass) for the case where the origin response is ultimately not cacheable.


### PR DESCRIPTION
## What / Why

Customers regularly confuse `CF-Cache-Status: DYNAMIC` and `CF-Cache-Status: BYPASS` — they look similar (both go to origin), but they signal fundamentally different stages of Cloudflare's cache decision:

- **DYNAMIC** — asset is determined ineligible for cache **at request time** (before contacting the origin)
- **BYPASS** — asset **is** eligible at request time, but the origin response makes it uncacheable **at response time**

The current [cache responses page](/cache/concepts/cache-responses/) does not make this distinction, and both wordings miss the case that trips customers up most often: a Cache Rule with `cache: true` on default-ineligible content (for example, HTML) will return `BYPASS` rather than `DYNAMIC` when the origin sends `no-store`/`no-cache`/etc.

This PR rewrites both sections to:

1. State the request-time vs response-time framing explicitly
2. Enumerate the concrete causes of each status
3. Cross-link the two sections so customers reading either can find the other case

## Context
ESCALATION-5657