### PR TITLE
[1.1.1.1] Add DoH JSON formatting changelog entry

### DIFF
--- a/src/content/changelog/1.1.1.1/2026-07-28-improved-record-display-format.mdx
+++ b/src/content/changelog/1.1.1.1/2026-07-28-improved-record-display-format.mdx
@@ -1,0 +1,55 @@
+---
+title: Improved DoH JSON formatting for additional record types
+description: The 1.1.1.1 DoH JSON API is rolling out human-readable presentation format for more record types, numeric DNSSEC algorithm identifiers, and minor formatting changes.
+date: 2026-07-28
+---
+
+Cloudflare is rolling out updated formatting for the `data` field in the 1.1.1.1 [DoH JSON API](/1.1.1.1/encryption/dns-over-https/make-api-requests/dns-json/) (`application/dns-json`). During the roll out responses may use either the old or new format.
+
+:::note
+These are breaking changes. The DoH JSON format has no formal RFC and its schema is not guaranteed to be stable. If you need a stable format, use the [DoH wireformat](/1.1.1.1/encryption/dns-over-https/make-api-requests/dns-wireformat/) instead.
+:::
+
+## Human-readable display for additional record types
+
+Several record types previously returned their `data` field in [RFC 3597](https://datatracker.ietf.org/doc/html/rfc3597) generic hex encoding (`\# <length> <hex>`). These now use standard presentation format:
+
+```txt
+CAA:        0 issue "letsencrypt.org"
+NAPTR:      100 10 "s" "SIP+D2U" "" _sip._udp.example.com.
+RP:         admin.example.com. txt.example.com.
+IPSECKEY:   10 1 2 192.0.2.1 AwEA...
+SVCB:       1 target.example.com. alpn=h2
+HTTPS:      1 . alpn=h3,h2 ipv4hint=192.0.2.1
+TLSA:       3 1 1 aabbccdd...
+SSHFP:      1 2 aabbccdd...
+OPENPGPKEY: AwEA...
+```
+
+## Numeric DNSSEC algorithm identifiers
+
+DNSSEC-related records now use numeric algorithm identifiers as defined in [RFC 4034](https://datatracker.ietf.org/doc/html/rfc4034) instead of mnemonic names. This affects `RRSIG`, `DS`, `CDS`, `DNSKEY`, and `CDNSKEY` records. For example, `RSASHA256` becomes `8`, `ECDSAP256SHA256` becomes `13`, and `ED25519` becomes `15`. DS digest types also change from mnemonic to numeric: `SHA-256` becomes `2`.
+
+```txt title="Before"
+RRSIG:  A RSASHA256 2 300 ...
+DS:     12345 RSASHA256 SHA-256 aabb...
+DNSKEY: 257 3 RSASHA256 AwEA...
+```
+
+```txt title="After"
+RRSIG:  A 8 2 300 ...
+DS:     12345 8 2 aabb...
+DNSKEY: 257 3 8 AwEA...
+```
+
+## Other formatting changes
+
+`HINFO` character-strings are now individually quoted to remove ambiguity when values contain spaces:
+
+```txt title="Before"
+"data": "Intel Xeon Linux"
+```
+
+```txt title="After"
+"data": "\"Intel Xeon\" \"Linux\""
+```


### PR DESCRIPTION
Add changelog entry for improved `data` field formatting in the DoH JSON API: human-readable presentation format for additional record types, numeric DNSSEC algorithm identifiers, and HINFO quoting changes.

Fix changelog `generateId` to preserve dots in folder names — the default github-slugger strips dots, turning `1.1.1.1` into `1111` which fails the `directory` collection lookup.