### PR TITLE
[Agents] Document AI SDK v6 and v7 support

### DIFF
--- a/src/content/changelog/agents/2026-07-22-ai-sdk-v6-v7-support.mdx
+++ b/src/content/changelog/agents/2026-07-22-ai-sdk-v6-v7-support.mdx
@@ -1,0 +1,21 @@
+---
+title: Agents SDK packages support AI SDK v6 and v7
+description: Agents SDK packages now support AI SDK v6 and v7, so applications can update without a forced AI SDK migration.
+products:
+  - agents
+date: 2026-07-22
+---
+
+import { PackageManagers } from "~/components";
+
+The `agents`, `@cloudflare/ai-chat`, `@cloudflare/codemode`, and `@cloudflare/think` packages now support AI SDK v6 and v7. Existing applications can remain on v6 when updating these packages. Applications can also adopt v7 without changing the Cloudflare Agents APIs they use.
+
+The supported peer ranges are `ai@^6 || ^7` and `@ai-sdk/react@^3 || ^4`. Use matching major versions: pair AI SDK v6 with `@ai-sdk/react` v3, or pair AI SDK v7 with `@ai-sdk/react` v4.
+
+To install the latest packages with AI SDK v7:
+
+<PackageManagers pkg="agents@latest @cloudflare/ai-chat@latest @cloudflare/codemode@latest @cloudflare/think@latest ai@^7 @ai-sdk/react@^4" />
+
+Think normalizes streaming, tool completion events, and telemetry across both AI SDK versions. Existing v6 applications do not need to migrate these integrations before updating Think.
+
+For setup and usage details, refer to the [Think documentation](/agents/harnesses/think/).

--- a/src/content/changelog/agents/2026-07-23-ai-sdk-v6-v7-support.mdx
+++ b/src/content/changelog/agents/2026-07-23-ai-sdk-v6-v7-support.mdx
@@ -3,7 +3,7 @@ title: Agents SDK packages support AI SDK v6 and v7
 description: Agents SDK packages now support AI SDK v6 and v7, so applications can update without a forced AI SDK migration.
 products:
   - agents
-date: 2026-07-22
+date: 2026-07-23
 ---
 
 import { PackageManagers } from "~/components";

--- a/src/content/docs/agents/harnesses/think/index.mdx
+++ b/src/content/docs/agents/harnesses/think/index.mdx
@@ -15,6 +15,7 @@ products:
 import {
 	TypeScriptExample,
 	WranglerConfig,
+	PackageManagers,
 	LinkCard,
 	CardGrid,
 } from "~/components";
@@ -31,9 +32,9 @@ If this is your first agent, start with the [Getting started tutorial](/agents/h
 
 ### Install
 
-```sh
-npm install @cloudflare/think @cloudflare/ai-chat agents ai @cloudflare/shell zod workers-ai-provider
-```
+<PackageManagers pkg="@cloudflare/think @cloudflare/ai-chat agents ai @cloudflare/shell zod workers-ai-provider" />
+
+Think supports AI SDK v6 and v7. Use `ai@^6` with `@ai-sdk/react@^3`, or use `ai@^7` with `@ai-sdk/react@^4`. Keep the AI SDK packages on matching major versions throughout your project.
 
 ### Server
 


### PR DESCRIPTION
### Summary

This PR documents dual AI SDK v6 and v7 support across the Agents SDK packages. It adds compatible peer-major guidance to Think and an Agents changelog entry.

Related: https://github.com/cloudflare/agents/pull/1922

### Screenshots (optional)

<!-- TODO: add screenshots before requesting review -->

### Documentation checklist

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
