### PR TITLE
chore: tail-end Starlight->Nimbus migration cleanup

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -41,7 +41,7 @@ package.json @cloudflare/content-engineering
 /src/components/agent-setup @cloudflare/product-owners @cloudflare/ai-agents @cloudflare/dev-plat-leads
 /src/content/agent-setup @cloudflare/product-owners @cloudflare/ai-agents @cloudflare/dev-plat-leads
 /src/content/docs/agent-setup @cloudflare/product-owners @cloudflare/ai-agents @cloudflare/dev-plat-leads
-/src/nimbus/pages/agent-setup @cloudflare/product-owners @cloudflare/ai-agents @cloudflare/dev-plat-leads
+/src/pages/agent-setup @cloudflare/product-owners @cloudflare/ai-agents @cloudflare/dev-plat-leads
 
 # AI Crawl Control
 /src/content/docs/ai-crawl-control/ @cloudflare/product-owners @jinhee-c-lee @wafonso

--- a/src/content/docs/style-guide/components/badges.mdx
+++ b/src/content/docs/style-guide/components/badges.mdx
@@ -9,11 +9,9 @@ products:
 
 import { Badge } from "~/components";
 
-Badges are a built-in component provided by [Starlight](https://starlight.astro.build/components/badges/). Use them to indicate a product is in beta, for example.
+Badges are a built-in component provided by [Nimbus](https://nimbus-docs.com/components/badge/). Use them to indicate a product is in beta, for example.
 
 ## Component
-
-To adopt this styling in a React component, apply the `sl-badge` class to a `span` element.
 
 ```mdx
 import { Badge } from "~/components";

--- a/src/content/docs/style-guide/components/cards.mdx
+++ b/src/content/docs/style-guide/components/cards.mdx
@@ -9,7 +9,7 @@ products:
 
 import { Render } from "~/components";
 
-Cards are a built-in component provided by [Starlight](https://starlight.astro.build/components/cards/).
+Cards are a built-in component provided by [Nimbus](https://nimbus-docs.com/components/card/).
 
 ## Cards
 

--- a/src/content/docs/style-guide/components/directory-listing.mdx
+++ b/src/content/docs/style-guide/components/directory-listing.mdx
@@ -52,7 +52,7 @@ The folder path to list contents from. If not provided, defaults to the current 
 **type:** `boolean`
 **default:** `false`
 
-When enabled, displays the listing as a 3-column grid of button-style cards (sorted alphabetically) instead of a bullet list. The cards match the style of Starlight's `LinkCard` component.
+When enabled, displays the listing as a 3-column grid of button-style cards (sorted alphabetically) instead of a bullet list. The cards match the style of our [`LinkCard`](/style-guide/components/link-cards/) component.
 
 ### `descriptions`
 

--- a/src/content/docs/style-guide/components/file-tree.mdx
+++ b/src/content/docs/style-guide/components/file-tree.mdx
@@ -7,7 +7,7 @@ products:
   - style-guide
 ---
 
-File tree is a built-in component provided by [Starlight](https://starlight.astro.build/components/file-tree/).
+File tree is a built-in component provided by [Nimbus](https://nimbus-docs.com/components/file-tree/).
 
 ```mdx
 import { FileTree } from "~/components"

--- a/src/content/docs/style-guide/components/icons.mdx
+++ b/src/content/docs/style-guide/components/icons.mdx
@@ -32,7 +32,7 @@ import { Card, LinkCard } from "~/components";
 <LinkCard title="Example" href="/workers/" icon="ph:rocket-launch" />
 ```
 
-Content authored before the Nimbus migration may still use Starlight-style icon names (for example `icon="seti:shell"`). These are automatically mapped to an equivalent iconify icon at build time; new content should use iconify names directly.
+Content authored before the Nimbus migration may still use Starlight-style icon names (for example `icon="seti:shell"`). These are automatically mapped to an equivalent iconify icon at build time. New content should use iconify names directly.
 
 ## Icon library
 

--- a/src/content/docs/style-guide/components/icons.mdx
+++ b/src/content/docs/style-guide/components/icons.mdx
@@ -21,19 +21,18 @@ import { AstroIcon } from "~/components";
 <AstroIcon name="workers" class="text-5xl text-orange-400" />
 ```
 
-## Starlight
+## Card and LinkCard
 
-The Starlight icon set is available to use in `Tab`, `Card` and other Starlight components.
+Components like `Card` and `LinkCard` accept a plain `icon` string prop — any [iconify](https://icon-sets.iconify.design/) icon name.
 
 ```mdx
-import { StarlightIcon } from "~/components";
+import { Card, LinkCard } from "~/components";
 
-<StarlightIcon
-	name="seti:shell"
-	color="var(--sl-color-text-accent)"
-	size="3rem"
-/>
+<Card title="Example" icon="ph:rocket-launch" />
+<LinkCard title="Example" href="/workers/" icon="ph:rocket-launch" />
 ```
+
+Content authored before the Nimbus migration may still use Starlight-style icon names (for example `icon="seti:shell"`). These are automatically mapped to an equivalent iconify icon at build time; new content should use iconify names directly.
 
 ## Icon library
 

--- a/src/content/docs/style-guide/components/package-managers.mdx
+++ b/src/content/docs/style-guide/components/package-managers.mdx
@@ -7,7 +7,7 @@ products:
   - style-guide
 ---
 
-This component is provided by the [`starlight-package-managers` package.](https://github.com/HiDeoo/starlight-package-managers)
+This component is provided by [Nimbus](https://nimbus-docs.com/components/package-managers/).
 
 ```mdx
 import { PackageManagers } from "~/components"

--- a/src/content/docs/style-guide/components/rss-button.mdx
+++ b/src/content/docs/style-guide/components/rss-button.mdx
@@ -27,11 +27,11 @@ The text to display in the button.
 
 ### `icon`
 
-**type:** [`StarlightIcon`](https://starlight.astro.build/reference/icons/#all-icons)
+**type:** `string`
 
 **default:** `"rss"`
 
-The icon to display next to the text. Uses Starlight's icon component.
+The icon to display next to the text. Renders via [astro-icon](https://www.astroicon.dev/); accepts any iconify icon name (for example, `ph:rss-simple`). The default `"rss"` maps to `ph:rss-simple`.
 
 ### `changelog` or `href`
 

--- a/src/content/docs/style-guide/documentation-content-strategy/content-types/overview.mdx
+++ b/src/content/docs/style-guide/documentation-content-strategy/content-types/overview.mdx
@@ -54,7 +54,7 @@ For more details, refer to [`pcx_content_type`](/style-guide/frontmatter/custom-
 
 **Related products**: Links to documentation for products used or configured together with current product. For product icons, refer to this [icon library](https://cfdata.lol/icons/).
 
-**More resources**: External links to related resources, such as plans, pricing. Do not duplicate the information from the footer. Also, if the product is free to use or there are not any useful links, feel free to skip this section. Review [available icons on Starlight](https://starlight.astro.build/reference/icons/#all-icons).
+**More resources**: External links to related resources, such as plans, pricing. Do not duplicate the information from the footer. Also, if the product is free to use or there are not any useful links, feel free to skip this section. Review [available icons](/style-guide/components/icons/).
 
 **Visual**: Graphic or image that enhances the landing page. It should be something relatively static that will not require much (if any) updating in the future.
 

--- a/src/content/docs/style-guide/frontmatter/custom-properties.mdx
+++ b/src/content/docs/style-guide/frontmatter/custom-properties.mdx
@@ -13,7 +13,7 @@ import BaseSchemaProperties from "~/components/BaseSchemaProperties.astro";
 We have added specific custom [frontmatter](/style-guide/frontmatter/) properties to meet specific needs.
 
 :::note
-The `description` field is a Starlight built-in, not a custom property, but it is required for all pages with a `pcx_content_type`. For writing guidance, refer to [Writing a description](/style-guide/frontmatter/#writing-a-description).
+The `description` field is a Nimbus built-in, not a custom property, but it is required for all pages with a `pcx_content_type`. For writing guidance, refer to [Writing a description](/style-guide/frontmatter/#writing-a-description).
 :::
 
 ## Properties

--- a/src/content/docs/style-guide/frontmatter/index.mdx
+++ b/src/content/docs/style-guide/frontmatter/index.mdx
@@ -72,4 +72,4 @@ description: Set up your first Cloudflare Worker by installing Wrangler, writing
 
 For optional fields such as `sidebar`, `tags`, `products`, `difficulty`, and `reviewed`, refer to [Custom properties](/style-guide/frontmatter/custom-properties/).
 
-For more information on the available fields, please refer to [Nimbus's documentation](https://nimbus-docs.com/writing/frontmatter/).
+For more information on the available fields, refer to [Nimbus's documentation](https://nimbus-docs.com/writing/frontmatter/).

--- a/src/content/docs/style-guide/frontmatter/index.mdx
+++ b/src/content/docs/style-guide/frontmatter/index.mdx
@@ -23,7 +23,7 @@ sidebar:
 ---
 ```
 
-For more information on the available fields, refer to [Starlight's documentation](https://starlight.astro.build/reference/frontmatter/).
+For more information on the available fields, refer to [Nimbus's documentation](https://nimbus-docs.com/writing/frontmatter/).
 
 ## Required fields
 
@@ -72,4 +72,4 @@ description: Set up your first Cloudflare Worker by installing Wrangler, writing
 
 For optional fields such as `sidebar`, `tags`, `products`, `difficulty`, and `reviewed`, refer to [Custom properties](/style-guide/frontmatter/custom-properties/).
 
-For more information on the available fields, please refer to [Starlight's documentation](https://starlight.astro.build/reference/frontmatter/).
+For more information on the available fields, please refer to [Nimbus's documentation](https://nimbus-docs.com/writing/frontmatter/).

--- a/src/content/docs/style-guide/how-we-docs/ai-consumability.mdx
+++ b/src/content/docs/style-guide/how-we-docs/ai-consumability.mdx
@@ -49,7 +49,7 @@ The references to the panels `id`, usually handled by JavaScript, are visible bu
 To solve this, we use [Markdown for Agents](/fundamentals/reference/markdown-for-agents/), which converts HTML to Markdown at the Cloudflare network layer. It handles:
 
 - Removing non-content tags (`script`, `style`, `link`, etc.)
-- Transforming custom elements like `starlight-tabs` into standard unordered lists
+- Transforming interactive components like `Tabs` into standard unordered lists
 - Adapting code block HTML into clean Markdown fenced code blocks
 
 Taking the `Tabs` example from the previous section, Markdown for Agents will give us a normal unordered list with the content properly associated with a given list item:

--- a/src/content/docs/style-guide/how-we-docs/links.mdx
+++ b/src/content/docs/style-guide/how-we-docs/links.mdx
@@ -43,18 +43,7 @@ Of these three [link types](#link-types), only **Internal** links:
 - Universally lead to a bad customer experience (a `404` page).
 - Are easily auditable within the current context.
 
-For these reasons, we choose to make a build **fail** based on broken internal links. For our implementation, we rely on the [Starlight link validator plugin](https://github.com/HiDeoo/starlight-links-validator).
-
-<GitHubCode
-	repo="cloudflare/cloudflare-docs"
-	file="astro.config.ts"
-	commit="aaacc3c3c2a7517ee307ddfc56962cbea9847202"
-	lang="ts"
-	lines="129-153"
-	code={{ title: "astro.config.ts" }}
-/>
-
-Whether or not we run the link validation depends an environmental variable that we set in our [CI build process](https://github.com/cloudflare/cloudflare-docs/blob/production/.github/workflows/ci.yml#L52).
+For these reasons, we choose to make a build **fail** based on broken internal links. For our implementation, we rely on [Nimbus](https://nimbus-docs.com/)'s `nimbus/internal-link` [lint rule](https://nimbus-docs.com/writing/linting/), configured in [`astro-config.ts`](https://github.com/cloudflare/cloudflare-docs/blob/production/src/astro-config.ts).
 
 We also make two intentional decisions about this link auditing:
 

--- a/src/content/docs/style-guide/how-we-docs/metadata.mdx
+++ b/src/content/docs/style-guide/how-we-docs/metadata.mdx
@@ -134,7 +134,7 @@ For more on how we make content available to AI systems, refer to [AI consumabil
 
 It's difficult to avoid errors with this kind of metadata, specifically because we are relying on freeform text entry in the frontmatter of individual files.
 
-We utilize [Zod schemas](https://zod.dev/) heavily in our Astro site, which are defined in [`src/nimbus/schemas/`](https://github.com/cloudflare/cloudflare-docs/tree/production/src/nimbus/schemas).
+We utilize [Zod schemas](https://zod.dev/) heavily in our Astro site, which are defined in [`src/schemas/`](https://github.com/cloudflare/cloudflare-docs/tree/production/src/schemas).
 
 These allow us to provide [Intellisense guidance](https://docs.astro.build/en/reference/experimental-flags/content-intellisense/) for contributors using IDEs for local development.
 

--- a/src/content/docs/style-guide/how-we-docs/our-site.mdx
+++ b/src/content/docs/style-guide/how-we-docs/our-site.mdx
@@ -24,9 +24,9 @@ If you have open-source docs, you can be part of the free [DocSearch program](ht
 
 ## Site framework
 
-We use [Starlight](https://starlight.astro.build/) for our docs, which is a free, custom documentation theme supported by [Astro](https://astro.build/).
+We use [Nimbus](https://nimbus-docs.com/) for our docs, a documentation framework built on [Astro](https://astro.build/).
 
-Astro's [component overrides](https://starlight.astro.build/guides/overriding-components/) and [plugins](https://starlight.astro.build/resources/plugins/) system were a big part of us [choosing this framework](https://blog.cloudflare.com/open-source-all-the-way-down-upgrading-our-developer-documentation/) and have exponentially increased our [site's capabilities](/style-guide/components/) (without much extra work).
+Nimbus's component [registry](https://nimbus-docs.com/registry/) and [linting](https://nimbus-docs.com/writing/linting/) system have exponentially increased our [site's capabilities](/style-guide/components/) (without much extra work).
 
 
 ## Builds


### PR DESCRIPTION
### Summary

Tail-end cleanup pass identified after the Starlight→Nimbus migration ([#32229](https://github.com/cloudflare/cloudflare-docs/pull/32229)) and the `src/nimbus` → `src` promotion ([#32249](https://github.com/cloudflare/cloudflare-docs/pull/32249)). Scoped to dead paths and stale style-guide content that still describes the site's old architecture. (The `astro-config.ts` I/O optimization and `.git-blame-ignore-revs` removal that were originally bundled here have been split into their own PRs: [#32252](https://github.com/cloudflare/cloudflare-docs/pull/32252) and [#32253](https://github.com/cloudflare/cloudflare-docs/pull/32253).)

**Dead paths**
- `.github/CODEOWNERS` — `/src/nimbus/pages/agent-setup` no longer exists post-promotion; that team currently has zero CODEOWNERS coverage on the real `/src/pages/agent-setup` directory. Fixed.
- `style-guide/how-we-docs/metadata.mdx` — dead GitHub link to `src/nimbus/schemas` (now `src/schemas`).

**Style-guide content batch (11 pages)**

These pages describe our own component library and framework to authors — several still claimed the site runs on Starlight, or referenced removed community packages (`starlight-package-managers`, `starlight-links-validator`) instead of their Nimbus/local equivalents. Two are genuine functional breaks, not just wording:

- `icons.mdx` had a copy-pasteable example importing `StarlightIcon` from `~/components` — that export doesn't exist. Replaced with the real `Card`/`LinkCard` `icon` string-prop API.
- `badges.mdx` instructed readers to apply an `sl-badge` CSS class to restyle a `span` — that class doesn't exist on the ported `Badge` component anymore (styling is computed inline via Tailwind). Removed the now-broken instruction.
- `ai-consumability.mdx` claimed Cloudflare's Markdown-for-Agents network layer transforms a `starlight-tabs` custom element — Nimbus's `Tabs` component doesn't render that element at all anymore (verified: it's a plain `<div data-nb-tabs>`). Generalized the wording rather than asserting something about an external system I can't verify from this repo — **worth a cross-team check on whether that transform pipeline still handles Nimbus's actual Tabs markup for AI-agent consumption.**
- The rest (`cards.mdx`, `file-tree.mdx`, `package-managers.mdx`, `rss-button.mdx`, `frontmatter/index.mdx`, `frontmatter/custom-properties.mdx`, `directory-listing.mdx`, `content-types/overview.mdx`, `our-site.mdx`, `links.mdx`) — swapped stale Starlight attributions/links for the real Nimbus equivalents (nimbus-docs.com has its own public docs site).

### Verification

- `pnpm run check` / `lint` / `format:check` / `test` all clean
- Full `pnpm run build` succeeds locally (8709 pages)
- `pnpm run test:postbuild` passes

### Documentation checklist

- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
