### PR TITLE
chore: remove .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,0 @@
-# Migration from Hugo -> Starlight
-abb2df90da1a9d8544ec51f7638b10d007ba45b1


### PR DESCRIPTION
### Summary

Removes `.git-blame-ignore-revs`. It had exactly one entry (the Hugo→Starlight migration commit) and wasn't kept up to date across several later large mechanical commits (the Starlight→Nimbus migration, the `src/nimbus`→`src` promotion, and various rename/reformat-only commits) — a single stale entry wasn't providing enough value to justify maintaining the file going forward.

Confirmed no references to this file anywhere else in the repo (workflows, docs, scripts) before removing it.

### Documentation checklist

- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
