### PR TITLE
test: verify build link validation catches broken internal link

### DIFF
--- a/src/content/docs/workers/platform/known-issues.mdx
+++ b/src/content/docs/workers/platform/known-issues.mdx
@@ -98,3 +98,7 @@ Do not use:
 ```js
 await fetch('http://192.0.2.1')
 ```
+
+## Concurrent request limits
+
+For more information on how concurrent subrequests are handled, refer to the [concurrent connection limits reference](/workers/platform/concurrent-connection-limits/).


### PR DESCRIPTION
### Summary

Test PR to verify that the CI build's internal link checker correctly flags a non-existent internal link. Adds a link to `/workers/platform/concurrent-connection-limits/`, a path that does not exist in this repo, to a Workers known-issues page.

This PR is not intended to be merged.

### Screenshots (optional)
