### PR TITLE
[Gateway] Changelog: new header control options for HTTP policies

### DIFF
--- a/src/content/changelog/gateway/2026-07-17-http-request-header-manipulation.mdx
+++ b/src/content/changelog/gateway/2026-07-17-http-request-header-manipulation.mdx
@@ -1,0 +1,42 @@
+---
+title: New header control options for Gateway HTTP policies
+description: Add, overwrite, or delete HTTP request headers in Allow policies.
+products:
+  - gateway
+date: 2026-07-17
+---
+
+Cloudflare Gateway now supports advanced header control on [Allow policies](/cloudflare-one/traffic-policies/http-policies/#allow). Administrators can add, overwrite, or delete headers on matching requests using static values or dynamic variables.
+
+### Header operations
+
+Gateway HTTP policies using the Allow action support three operations in `rule_settings`:
+
+| Operation | API field        | Behavior                                                            |
+| --------- | ---------------- | ------------------------------------------------------------------- |
+| Add       | `add_headers`    | Appends a value to the header. Existing values are preserved.       |
+| Overwrite | `set_headers`    | Replaces the header value. Creates the header if it does not exist. |
+| Delete    | `delete_headers` | Removes the header from the request.                                |
+
+Gateway applies operations in order: delete, then overwrite, then add.
+
+### Dynamic variables
+
+Header values can include dynamic variables using the `@{...}` syntax. Gateway resolves variables at request time from identity, device, and network context.
+
+| Variable             | Description                                  |
+| -------------------- | -------------------------------------------- |
+| `@{identity.email}`  | User email from the identity provider        |
+| `@{identity.name}`   | User display name from the identity provider |
+| `@{identity.id}`     | Cloudflare identity UUID                     |
+| `@{identity.groups}` | Identity provider group memberships          |
+| `@{identity.SAML}`   | SAML attributes (if configured)              |
+| `@{identity.OIDC}`   | OIDC claims (if configured)                  |
+| `@{source.ip}`       | Source IP of the connection                  |
+| `@{destination.ip}`  | Destination IP of the request                |
+| `@{device.id}`       | Cloudflare One Client device UUID            |
+| `@{device.posture}`  | Device posture check results (JSON string)   |
+
+You can mix static text and dynamic variables in a single header value. For example, `user-@{identity.email}` resolves to `user-jdoe@example.com`.
+
+For more information, refer to [Custom headers](/cloudflare-one/traffic-policies/http-policies/tenant-control/).


### PR DESCRIPTION
Adds a changelog entry for the new HTTP request header control feature in Gateway Allow policies.

Covers the three header operations (add, overwrite, delete), the `@{...}` dynamic variable syntax with the full variable reference table, and links to the updated Custom headers docs page from PR #32090.

Related: #32090 (docs page update)