### PR TITLE
fix: remove invalid :global() pseudo-class in agent-setup.css

### DIFF
--- a/src/styles/agent-setup.css
+++ b/src/styles/agent-setup.css
@@ -950,7 +950,7 @@
 	line-height: 1.6;
 }
 
-.agent-setup-troubleshooting-solution-body :global(code) {
+.agent-setup-troubleshooting-solution-body code {
 	background-color: var(--sl-color-bg-inline-code);
 	font-family: var(--sl-font-mono, monospace);
 	font-size: var(--sl-text-code-sm);


### PR DESCRIPTION
`.agent-setup-troubleshooting-solution-body :global(code)` uses Astro/Vue-style `:global()` scoping syntax inside a plain global stylesheet (`src/styles/agent-setup.css`), where it has no meaning — this file isn't a scoped Astro component `<style>` block. `lightningcss` (Vite's CSS minifier) correctly flags it: `'global' is not recognized as a valid pseudo-class`.