### PR TITLE
chore: enable Nimbus internal-link validation in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,6 +165,12 @@ jobs:
           pnpm run build 2>&1 | tee build.log
           echo "succeeded=true" >> "$GITHUB_OUTPUT"
 
+      # Needs .nimbus/routes.json, materialized by the Build step above —
+      # only a full `astro build` regenerates it (`astro dev`/`astro sync`
+      # don't), so this can't run as its own job without re-building.
+      - name: Nimbus link validation
+        run: pnpm run lint:nimbus
+
       - name: Upload build artifact
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,7 +168,7 @@ jobs:
       # Needs .nimbus/routes.json, materialized by the Build step above —
       # only a full `astro build` regenerates it (`astro dev`/`astro sync`
       # don't), so this can't run as its own job without re-building.
-      - name: Nimbus link validation
+      - name: Nimbus lint
         run: pnpm run lint:nimbus
 
       - name: Upload build artifact

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,6 +177,12 @@ jobs:
           name: dist
           path: dist
 
+      - name: Upload nimbus config
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        with:
+          name: nimbus-config
+          path: .nimbus/
+
       - name: Upload build log
         if: always()
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
@@ -315,6 +321,16 @@ jobs:
         with:
           name: dist
           path: dist
+
+      - name: Download nimbus config
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: nimbus-config
+          path: .nimbus
+
+      - name: Nimbus lint (preview test)
+        continue-on-error: true
+        run: pnpm run lint:nimbus
 
       - name: Deploy to Cloudflare Workers
         id: deploy

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -53,8 +53,29 @@ async function getExternalLinkPaths(dir: string): Promise<Set<string>> {
 	return paths;
 }
 
+// Every public/ file as an exact root-relative path, for internal-link's
+// `ignore` — exact matches so a product with both a public/ asset folder
+// and real doc pages under the same prefix (workers-ai, ssl, ...) can't
+// have its real pages masked by an overly broad ignore.
+async function getPublicAssetPaths(dir: string): Promise<string[]> {
+	const paths: string[] = [];
+	const entries = await readdir(dir, { withFileTypes: true });
+
+	for (const entry of entries) {
+		const full = join(dir, entry.name);
+		if (entry.isDirectory()) {
+			paths.push(...(await getPublicAssetPaths(full)));
+		} else {
+			paths.push(`/${full.slice("public/".length)}`);
+		}
+	}
+
+	return paths;
+}
+
 const sidebarItems = await autogenSections();
 const externalLinkPaths = await getExternalLinkPaths("src/content/docs");
+const publicAssetPaths = await getPublicAssetPaths("public");
 const serializeSitemapLastmod = createSitemapLastmodSerializer();
 
 // Mirrors production's sitemap `filter` (root astro.config.ts).
@@ -257,6 +278,9 @@ const integrations = [
 						"/style-guide/index.md",
 						"/agent-setup/",
 						"/videos/**",
+						// RSS/index.xml endpoints aren't real Astro page routes.
+						"**/index.xml",
+						...publicAssetPaths,
 					],
 				},
 			],

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -231,21 +231,11 @@ const integrations = [
 				"error",
 				{ aliases: { "~/assets/": "src/assets/" } },
 			],
-			// `ignore` mirrors the exclude list from the pre-Nimbus
-			// `starlight-links-validator` config (see git history,
-			// astro.config.ts before #32203), translated to picomatch glob
-			// syntax. Two categories:
-			//   - Carried over from that list: /api, /changelog, llms.txt
-			//     endpoints, {props.*} placeholders, dynamic example/reference
-			//     pages, retired workers-ai models, agent-setup, videos, etc.
-			//   - Added during this migration: public/-served static assets
-			//     (PDFs, notebooks, certs, etc.) that aren't real Astro page
-			//     routes, so they're invisible to the route truth this rule
-			//     checks against.
 			"nimbus/internal-link": [
 				"error",
 				{
 					ignore: [
+						"/api/",
 						"/api/**",
 						"/changelog/**",
 						"/http/resources/**",
@@ -254,35 +244,29 @@ const integrations = [
 						"**/llms.txt",
 						"**/index.md",
 						"{props.*}",
-						"/glossary",
-						"/directory",
-						"/rules/snippets/examples",
-						"/rules/transform/examples",
+						"/",
+						"/glossary/",
+						"/directory/",
+						"/rules/snippets/examples/?operation=*",
+						"/rules/transform/examples/?operation=*",
 						"/ruleset-engine/rules-language/fields/reference/**",
-						"/workers/examples",
+						"/workers/examples/?languages=*",
 						"/workers/llms-full.txt",
 						"/workers-ai/models/**",
 						"/markdown.zip",
 						"/style-guide/index.md",
-						"/agent-setup",
+						"/agent-setup/",
 						"/videos/**",
-						// public/-served static assets — not real Astro routes.
-						"/cloudflare-one/static/**",
-						"/email-security/static/**",
-						"/network-interconnect/static/**",
-						"/realtime/static/**",
-						"/reference-architecture/static/**",
-						"/ssl/static/**",
-						"/waiting-room/static/**",
-						"/workers-ai/static/**",
-						"/workers-ai-notebooks/**",
-						"/sandbox/guides/2026-deprecation/SKILL.md",
-						// RSS/index.xml-style endpoints — dynamic routes, same
-						// blind spot as the llms.txt endpoints above.
-						"**/index.xml",
 					],
 				},
 			],
+		},
+		// `compatibility-flags` entries use a `name` field, not `title` — not
+		// a docs page, so `frontmatter-shape`'s docs schema doesn't apply.
+		collections: {
+			"compatibility-flags": {
+				rules: { "nimbus/frontmatter-shape": "off" },
+			},
 		},
 	}),
 ];

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -231,7 +231,58 @@ const integrations = [
 				"error",
 				{ aliases: { "~/assets/": "src/assets/" } },
 			],
-			"nimbus/internal-link": "error",
+			// `ignore` mirrors the exclude list from the pre-Nimbus
+			// `starlight-links-validator` config (see git history,
+			// astro.config.ts before #32203), translated to picomatch glob
+			// syntax. Two categories:
+			//   - Carried over from that list: /api, /changelog, llms.txt
+			//     endpoints, {props.*} placeholders, dynamic example/reference
+			//     pages, retired workers-ai models, agent-setup, videos, etc.
+			//   - Added during this migration: public/-served static assets
+			//     (PDFs, notebooks, certs, etc.) that aren't real Astro page
+			//     routes, so they're invisible to the route truth this rule
+			//     checks against.
+			"nimbus/internal-link": [
+				"error",
+				{
+					ignore: [
+						"/api/**",
+						"/changelog/**",
+						"/http/resources/**",
+						"/llms.txt",
+						"/llms-full.txt",
+						"**/llms.txt",
+						"**/index.md",
+						"{props.*}",
+						"/glossary",
+						"/directory",
+						"/rules/snippets/examples",
+						"/rules/transform/examples",
+						"/ruleset-engine/rules-language/fields/reference/**",
+						"/workers/examples",
+						"/workers/llms-full.txt",
+						"/workers-ai/models/**",
+						"/markdown.zip",
+						"/style-guide/index.md",
+						"/agent-setup",
+						"/videos/**",
+						// public/-served static assets — not real Astro routes.
+						"/cloudflare-one/static/**",
+						"/email-security/static/**",
+						"/network-interconnect/static/**",
+						"/realtime/static/**",
+						"/reference-architecture/static/**",
+						"/ssl/static/**",
+						"/waiting-room/static/**",
+						"/workers-ai/static/**",
+						"/workers-ai-notebooks/**",
+						"/sandbox/guides/2026-deprecation/SKILL.md",
+						// RSS/index.xml-style endpoints — dynamic routes, same
+						// blind spot as the llms.txt endpoints above.
+						"**/index.xml",
+					],
+				},
+			],
 		},
 	}),
 ];

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
 		"@astrojs/rss": "4.0.18",
 		"@astrojs/sitemap": "3.7.3",
 		"@base-ui/react": "1.5.0",
-		"@cloudflare/nimbus-docs": "https://pkg.pr.new/@cloudflare/nimbus-docs@34",
+		"@cloudflare/nimbus-docs": "^0.8.2",
 		"@cloudflare/vitest-pool-workers": "0.16.15",
 		"@cloudflare/workers-types": "4.20260615.1",
 		"@docsearch/css": "3.9.0",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
 		"flue:clear-r2-pr-data:local": "tsx .flue/bin/clear-r2-pr-data.ts --local",
 		"flue:reset:local": "rm -rf .flue/.wrangler/state .flue/.wrangler/tmp .flue/dist/cloudflare_docs_flue/.wrangler/state && echo 'Cleared local flue dev state (Durable Objects + R2). Stop the dev server before running this.'",
 		"lint": "eslint",
+		"lint:nimbus": "nimbus-docs lint",
 		"prepare": "husky"
 	},
 	"devDependencies": {
@@ -49,7 +50,7 @@
 		"@astrojs/rss": "4.0.18",
 		"@astrojs/sitemap": "3.7.3",
 		"@base-ui/react": "1.5.0",
-		"@cloudflare/nimbus-docs": "0.7.1",
+		"@cloudflare/nimbus-docs": "https://pkg.pr.new/@cloudflare/nimbus-docs@34",
 		"@cloudflare/vitest-pool-workers": "0.16.15",
 		"@cloudflare/workers-types": "4.20260615.1",
 		"@docsearch/css": "3.9.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,8 +39,8 @@ importers:
         specifier: 1.5.0
         version: 1.5.0(@types/react@19.0.7)(date-fns@4.4.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@cloudflare/nimbus-docs':
-        specifier: 0.7.1
-        version: 0.7.1(astro@7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@25.9.3)(jiti@2.7.0)(rollup@4.62.2)(tsx@4.22.4)(yaml@2.9.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        specifier: https://pkg.pr.new/@cloudflare/nimbus-docs@34
+        version: https://pkg.pr.new/@cloudflare/nimbus-docs@34(astro@7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@25.9.3)(jiti@2.7.0)(rollup@4.62.2)(tsx@4.22.4)(yaml@2.9.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@cloudflare/vitest-pool-workers':
         specifier: 0.16.15
         version: 0.16.15(@cloudflare/workers-types@4.20260615.1)(@vitest/runner@4.1.9)(@vitest/snapshot@4.1.9)(vitest@4.1.9(@types/node@25.9.3)(happy-dom@20.10.3)(vite@8.1.5(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))
@@ -776,8 +776,9 @@ packages:
     resolution: {integrity: sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==}
     engines: {node: '>=22.0.0'}
 
-  '@cloudflare/nimbus-docs@0.7.1':
-    resolution: {integrity: sha512-SkjnlaTY1qeE4W28SbRg9mOYTEbczIrfVd0+IseIKDT7RvoR7TjzAQForR4PfIZVeCwoiqkIWqS10KeJ28Q+UQ==}
+  '@cloudflare/nimbus-docs@https://pkg.pr.new/@cloudflare/nimbus-docs@34':
+    resolution: {integrity: sha512-6dQQvOTLxss9nI3KbFSvccnmXhhdlWern28975ouFVeh6CKUuxKNDu/Dr1xdDdQ4UoFMfYp/Dd2mnerushvWcg==, tarball: https://pkg.pr.new/@cloudflare/nimbus-docs@34}
+    version: 0.7.0
     engines: {node: '>=22.12.0'}
     hasBin: true
     peerDependencies:
@@ -6876,7 +6877,7 @@ snapshots:
 
   '@cloudflare/kv-asset-handler@0.5.0': {}
 
-  '@cloudflare/nimbus-docs@0.7.1(astro@7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@25.9.3)(jiti@2.7.0)(rollup@4.62.2)(tsx@4.22.4)(yaml@2.9.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+  '@cloudflare/nimbus-docs@https://pkg.pr.new/@cloudflare/nimbus-docs@34(astro@7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@25.9.3)(jiti@2.7.0)(rollup@4.62.2)(tsx@4.22.4)(yaml@2.9.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@astrojs/markdown-satteri': 0.3.4
       '@astrojs/mdx': 7.0.3(@astrojs/markdown-satteri@0.3.4)(astro@7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@25.9.3)(jiti@2.7.0)(rollup@4.62.2)(tsx@4.22.4)(yaml@2.9.0))
@@ -6889,6 +6890,7 @@ snapshots:
       clsx: 2.1.1
       github-slugger: 2.0.0
       mri: 1.2.0
+      picomatch: 4.0.5
       remark-lint-emphasis-marker: 4.0.1
       remark-lint-fenced-code-flag: 4.2.0
       remark-lint-heading-increment: 4.0.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,8 +39,8 @@ importers:
         specifier: 1.5.0
         version: 1.5.0(@types/react@19.0.7)(date-fns@4.4.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@cloudflare/nimbus-docs':
-        specifier: https://pkg.pr.new/@cloudflare/nimbus-docs@34
-        version: https://pkg.pr.new/@cloudflare/nimbus-docs@34(astro@7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@25.9.3)(jiti@2.7.0)(rollup@4.62.2)(tsx@4.22.4)(yaml@2.9.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        specifier: ^0.8.2
+        version: 0.8.2(astro@7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@25.9.3)(jiti@2.7.0)(rollup@4.62.2)(tsx@4.22.4)(yaml@2.9.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@cloudflare/vitest-pool-workers':
         specifier: 0.16.15
         version: 0.16.15(@cloudflare/workers-types@4.20260615.1)(@vitest/runner@4.1.9)(@vitest/snapshot@4.1.9)(vitest@4.1.9(@types/node@25.9.3)(happy-dom@20.10.3)(vite@8.1.5(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))
@@ -776,9 +776,8 @@ packages:
     resolution: {integrity: sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==}
     engines: {node: '>=22.0.0'}
 
-  '@cloudflare/nimbus-docs@https://pkg.pr.new/@cloudflare/nimbus-docs@34':
-    resolution: {integrity: sha512-6dQQvOTLxss9nI3KbFSvccnmXhhdlWern28975ouFVeh6CKUuxKNDu/Dr1xdDdQ4UoFMfYp/Dd2mnerushvWcg==, tarball: https://pkg.pr.new/@cloudflare/nimbus-docs@34}
-    version: 0.7.0
+  '@cloudflare/nimbus-docs@0.8.2':
+    resolution: {integrity: sha512-SLrU2xeXIHQYxhZAivpQWqEHk+egwPAuCPffdEMI4qUANAccP9jV6MPdP4s57xwXaD3TP2URSMI28fGH9kkywg==}
     engines: {node: '>=22.12.0'}
     hasBin: true
     peerDependencies:
@@ -3855,6 +3854,10 @@ packages:
     resolution: {integrity: sha512-7nF7C9fIPFEMHgEMEfgIlO9wDdZ8CyHw27rWciFZfHvHDReIiPhsYuzPRXsfvBCqFy1l8RRyyWV7QLM+ZhUJsQ==}
     engines: {node: '>=20.20.0'}
 
+  giget@3.3.0:
+    resolution: {integrity: sha512-gzi2D96p+AMfDcmJHGDj3KJ9NRiwvlFAU5yfa3ROwWZmFUjX4P43x3BcyRaOMMLto1vUo7C+86+MFhYTl6Ryiw==}
+    hasBin: true
+
   github-slugger@2.0.0:
     resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
 
@@ -6877,7 +6880,7 @@ snapshots:
 
   '@cloudflare/kv-asset-handler@0.5.0': {}
 
-  '@cloudflare/nimbus-docs@https://pkg.pr.new/@cloudflare/nimbus-docs@34(astro@7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@25.9.3)(jiti@2.7.0)(rollup@4.62.2)(tsx@4.22.4)(yaml@2.9.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+  '@cloudflare/nimbus-docs@0.8.2(astro@7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@25.9.3)(jiti@2.7.0)(rollup@4.62.2)(tsx@4.22.4)(yaml@2.9.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@astrojs/markdown-satteri': 0.3.4
       '@astrojs/mdx': 7.0.3(@astrojs/markdown-satteri@0.3.4)(astro@7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@25.9.3)(jiti@2.7.0)(rollup@4.62.2)(tsx@4.22.4)(yaml@2.9.0))
@@ -6888,6 +6891,7 @@ snapshots:
       '@vercel/detect-agent': 1.2.3
       astro: 7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@25.9.3)(jiti@2.7.0)(rollup@4.62.2)(tsx@4.22.4)(yaml@2.9.0)
       clsx: 2.1.1
+      giget: 3.3.0
       github-slugger: 2.0.0
       mri: 1.2.0
       picomatch: 4.0.5
@@ -10110,6 +10114,8 @@ snapshots:
   get-tsconfig@5.0.0-beta.4:
     dependencies:
       resolve-pkg-maps: 1.0.0
+
+  giget@3.3.0: {}
 
   github-slugger@2.0.0: {}
 

--- a/src/content/changelog/access/2025-09-22-browser-based-rdp-ga.mdx
+++ b/src/content/changelog/access/2025-09-22-browser-based-rdp-ga.mdx
@@ -8,7 +8,7 @@ products:
 
 [Browser-based RDP](/cloudflare-one/networks/connectors/cloudflare-tunnel/use-cases/rdp/rdp-browser/) with [Cloudflare Access](/cloudflare-one/access-controls/policies/) is now generally available for all Cloudflare customers. It enables secure, remote Windows server access without VPNs or RDP clients.
 
-Since we announced our [open beta](/changelog/access/#2025-06-30), we've made a few improvements:
+Since we announced our [open beta](/changelog/post/2025-07-01-browser-based-rdp-open-beta/), we've made a few improvements:
 
 - Support for targets with IPv6.
 - Support for [Magic WAN](/cloudflare-wan/) and [WARP Connector](/cloudflare-one/networks/connectors/cloudflare-mesh/) as on-ramps.

--- a/src/content/changelog/cloudflare-one-client/2024-06-16-cloudflare-one.mdx
+++ b/src/content/changelog/cloudflare-one-client/2024-06-16-cloudflare-one.mdx
@@ -45,6 +45,6 @@ If you are looking for older product updates, refer to the following locations.
 - [Magic WAN](/cloudflare-wan/changelog/)
 - [Network Interconnect](/network-interconnect/changelog/)
 - [Risk score](/cloudflare-one/changelog/risk-score/)
-- [Cloudflare One Client](/changelog/cloudflare-one-client/)
+- [Cloudflare One Client](/changelog/product/cloudflare-one-client/)
 
 </Details>

--- a/src/content/docs/cloudflare-one/team-and-resources/devices/cloudflare-one-client/download/lts-releases.mdx
+++ b/src/content/docs/cloudflare-one/team-and-resources/devices/cloudflare-one-client/download/lts-releases.mdx
@@ -16,7 +16,7 @@ Long-Term Support (LTS) releases are stable releases that are guaranteed to cont
 <Render file="warp/support-lifecycle" product="cloudflare-one" />
 
 :::note
-No LTS releases are currently available, as Cloudflare is still rolling out our new LTS release process. When a stable release is declared an LTS release, it will be listed on this page and announced in the [Cloudflare One Client changelog](/cloudflare-one/changelog/cloudflare-one-client/).
+No LTS releases are currently available, as Cloudflare is still rolling out our new LTS release process. When a stable release is declared an LTS release, it will be listed on this page and announced in the [Cloudflare One Client changelog](/changelog/product/cloudflare-one-client/).
 :::
 
 ## Windows

--- a/src/content/docs/cloudflare-one/team-and-resources/devices/cloudflare-one-client/download/support-lifecycle.mdx
+++ b/src/content/docs/cloudflare-one/team-and-resources/devices/cloudflare-one-client/download/support-lifecycle.mdx
@@ -39,7 +39,7 @@ Cloudflare will provide a minimum 90-day notice prior to removing major features
 
 ### Release schedule
 
-Cloudflare does not operate on a fixed release schedule; all releases for the Cloudflare One Client are incremental. When a new Cloudflare One Client version is released, Cloudflare will publish release notes on the [Downloads page](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/download/) and in the [changelog](/changelog/cloudflare-one-client/).
+Cloudflare does not operate on a fixed release schedule; all releases for the Cloudflare One Client are incremental. When a new Cloudflare One Client version is released, Cloudflare will publish release notes on the [Downloads page](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/download/) and in the [changelog](/changelog/product/cloudflare-one-client/).
 
 ## Supported operating systems
 

--- a/src/content/docs/cloudflare-one/team-and-resources/devices/cloudflare-one-client/download/update.mdx
+++ b/src/content/docs/cloudflare-one/team-and-resources/devices/cloudflare-one-client/download/update.mdx
@@ -25,7 +25,7 @@ If you run into issues that require troubleshooting or support tickets, one of t
 <Render file="warp/support-lifecycle" product="cloudflare-one" />
 
 :::tip
-To get notified of new releases, subscribe to the [Cloudflare One Client changelog](/changelog/cloudflare-one-client/).
+To get notified of new releases, subscribe to the [Cloudflare One Client changelog](/changelog/product/cloudflare-one-client/).
 :::
 
 ## How to update the Cloudflare One Client

--- a/src/content/docs/learning-paths/sase-overview-course/series/connect-secure-from-any-network-to-anywhere-4.mdx
+++ b/src/content/docs/learning-paths/sase-overview-course/series/connect-secure-from-any-network-to-anywhere-4.mdx
@@ -3,8 +3,6 @@ pcx_content_type: navigation
 title: Connect and secure from any network to anywhere
 sidebar:
   order: 5
-prev: true
-next: true
 tableOfContents: false
 description: Connect networks securely with Cloudflare SASE.
 products:

--- a/src/content/docs/learning-paths/sase-overview-course/series/protect-users-from-internet-risks-5.mdx
+++ b/src/content/docs/learning-paths/sase-overview-course/series/protect-users-from-internet-risks-5.mdx
@@ -3,7 +3,6 @@ pcx_content_type: navigation
 title: Protect your users from Internet risks
 sidebar:
   order: 6
-prev: true
 next: false
 tableOfContents: false
 description: Filter Internet traffic to protect users.

--- a/src/content/docs/learning-paths/sase-overview-course/series/secure-remote-access-to-critical-infrastructure-3.mdx
+++ b/src/content/docs/learning-paths/sase-overview-course/series/secure-remote-access-to-critical-infrastructure-3.mdx
@@ -3,8 +3,6 @@ pcx_content_type: navigation
 title: Secure remote access to your critical infrastructure
 sidebar:
   order: 4
-prev: true
-next: true
 tableOfContents: false
 description: Secure remote access to critical infrastructure.
 products:

--- a/src/content/docs/learning-paths/sase-overview-course/series/stop-hosting-own-vpn-service-2.mdx
+++ b/src/content/docs/learning-paths/sase-overview-course/series/stop-hosting-own-vpn-service-2.mdx
@@ -3,8 +3,6 @@ pcx_content_type: navigation
 title: Stop hosting your own VPN service
 sidebar:
   order: 3
-prev: true
-next: true
 tableOfContents: false
 description: Replace self-hosted VPNs with ZTNA.
 products:

--- a/src/content/docs/reference-architecture/diagrams/ai/ai-asset-creation.mdx
+++ b/src/content/docs/reference-architecture/diagrams/ai/ai-asset-creation.mdx
@@ -39,4 +39,4 @@ Example uses of such compositions of AI models can be employed to generation vis
 - [Community project: content-based asset creation demo](https://auto-asset.pages.dev/)
 - [Workers AI: Text generation models](/workers-ai/models/)
 - [Workers AI: Text-to-image models](/workers-ai/models/)
-- [Workers AI: llamaguard-7b-awq](/workers-ai/models/llamaguard-7b-awq/)
+- [Workers AI: llama-guard-3-8b](/workers-ai/models/llama-guard-3-8b/)

--- a/src/content/docs/workers-ai/features/json-mode.mdx
+++ b/src/content/docs/workers-ai/features/json-mode.mdx
@@ -121,7 +121,6 @@ This is the list of models that now support JSON Mode:
 - [@cf/meta/llama-3.1-8b-instruct](/workers-ai/models/llama-3.1-8b-instruct/)
 - [@cf/meta/llama-3.2-11b-vision-instruct](/workers-ai/models/llama-3.2-11b-vision-instruct/)
 - [@hf/nousresearch/hermes-2-pro-mistral-7b](/workers-ai/models/hermes-2-pro-mistral-7b/)
-- [@hf/thebloke/deepseek-coder-6.7b-instruct-awq](/workers-ai/models/deepseek-coder-6.7b-instruct-awq/)
 - [@cf/deepseek-ai/deepseek-r1-distill-qwen-32b](/workers-ai/models/deepseek-r1-distill-qwen-32b/)
 
 We will continue extending this list to keep up with new, and requested models.

--- a/src/content/docs/workers-ai/guides/tutorials/image-generation-playground/image-generator-flux-newmodels.mdx
+++ b/src/content/docs/workers-ai/guides/tutorials/image-generation-playground/image-generator-flux-newmodels.mdx
@@ -10,8 +10,6 @@ tags:
   - AI
   - TypeScript
 
-prev: true
-next: true
 description: >-
   In part 2, Kristian expands upon the existing environment built in part 1, by showing you how to integrate new AI models and introduce new parameters that allow you to customize how images are generated.
 ---

--- a/src/content/docs/workers-ai/guides/tutorials/image-generation-playground/image-generator-flux.mdx
+++ b/src/content/docs/workers-ai/guides/tutorials/image-generation-playground/image-generator-flux.mdx
@@ -11,7 +11,6 @@ tags:
   - AI
   - TypeScript
 
-next: true
 description: >-
   The new flux models on Workers AI are our most powerful text-to-image AI models yet. Using Workers AI, you can get access to the best models in the industry without having to worry about inference, ops, or deployment.
 ---

--- a/src/content/docs/workers-ai/guides/tutorials/image-generation-playground/image-generator-store-and-catalog.mdx
+++ b/src/content/docs/workers-ai/guides/tutorials/image-generation-playground/image-generator-store-and-catalog.mdx
@@ -9,7 +9,6 @@ products: [workers]
 tags:
   - AI
   - TypeScript
-prev: true
 description: >-
   In the final part of the AI Image Playground series, Kristian teaches how to utilize Cloudflare's R2 object storage.
 ---

--- a/src/content/docs/workers-ai/platform/limits.mdx
+++ b/src/content/docs/workers-ai/platform/limits.mdx
@@ -52,12 +52,7 @@ Rate limits are default per task type, with some per-model limits defined as fol
 ### [Text Generation](/workers-ai/models/)
 
 - 300 requests per minute
-- [@hf/thebloke/mistral-7b-instruct-v0.1-awq](/workers-ai/models/mistral-7b-instruct-v0.1-awq/) is 400 requests per minute
 - [@cf/microsoft/phi-2](/workers-ai/models/phi-2/) is 720 requests per minute
-- [@cf/qwen/qwen1.5-0.5b-chat](/workers-ai/models/qwen1.5-0.5b-chat/) is 1500 requests per minute
-- [@cf/qwen/qwen1.5-1.8b-chat](/workers-ai/models/qwen1.5-1.8b-chat/) is 720 requests per minute
-- [@cf/qwen/qwen1.5-14b-chat-awq](/workers-ai/models/qwen1.5-14b-chat-awq/) is 150 requests per minute
-- [@cf/tinyllama/tinyllama-1.1b-chat-v1.0](/workers-ai/models/tinyllama-1.1b-chat-v1.0/) is 720 requests per minute
 
 ### [Text-to-Image](/workers-ai/models/)
 


### PR DESCRIPTION
### Summary

Wires up `nimbus/internal-link` — currently `"error"` in config but never actually enforced, since it's an authoring-tier rule that only runs via `nimbus-docs lint`, which nothing in CI called.

- Adds an `ignore` list, translated from the pre-Nimbus `starlight-links-validator` `exclude` config (git history, before #32203) into picomatch glob syntax — needs [cloudflare/nimbus#34](https://github.com/cloudflare/nimbus/pull/34), which adds real glob support (the old hand-rolled matcher couldn't express `**/llms.txt`-style leading wildcards the old exclude list depended on).
- Adds a CI step (`pnpm run lint:nimbus`) in the `build` job, right after `Build` — needs `.nimbus/routes.json`, only materialized by a full `astro build`.
- Fixes real broken links the rule surfaced once wired up:
  - `/changelog/access/#2025-06-30` → wrong shape; real route is `/changelog/post/2025-07-01-browser-based-rdp-open-beta/`
  - `/changelog/cloudflare-one-client/` (×4 files) → missing `/product/` segment; real route is `/changelog/product/cloudflare-one-client/`
  - Stale references to retired `workers-ai` models (removed from the model catalog, pages now 404) — dropped the dead entries, swapped one for its current equivalent (`llama-guard-3-8b`)

**Temporary:** `@cloudflare/nimbus-docs` is pinned to the `pkg.pr.new` preview build for [cloudflare/nimbus#34](https://github.com/cloudflare/nimbus/pull/34) (`https://pkg.pr.new/@cloudflare/nimbus-docs@34`), not a real release. Needs to be swapped to a published version once that PR merges and ships — **do not merge this as-is** until then.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
