### PR TITLE
clarify historical Worker code retrieval on Versions & deployments pa…

### DIFF
--- a/src/content/docs/workers/versions-and-deployments/index.mdx
+++ b/src/content/docs/workers/versions-and-deployments/index.mdx
@@ -41,7 +41,7 @@ You can decouple them so that uploading a version and deploying it are independe
 
 ### Via Wrangler
 
-Wrangler allows you to view the 100 most recent versions and deployments. These commands return metadata only, not the Worker cod itself. Refer to the [`versions list`](/workers/wrangler/commands/workers/#versions-list) and [`deployments list`](/workers/wrangler/commands/workers/#deployments-list) documentation for the commands.
+Wrangler allows you to view the 100 most recent versions and deployments. Refer to the [`versions list`](/workers/wrangler/commands/workers/#versions-list) and [`deployments list`](/workers/wrangler/commands/workers/#deployments-list) documentation for the commands.
 
 ### Via the Cloudflare dashboard
 

--- a/src/content/docs/workers/versions-and-deployments/index.mdx
+++ b/src/content/docs/workers/versions-and-deployments/index.mdx
@@ -41,7 +41,7 @@ You can decouple them so that uploading a version and deploying it are independe
 
 ### Via Wrangler
 
-Wrangler allows you to view the 100 most recent versions and deployments. Refer to the [`versions list`](/workers/wrangler/commands/workers/#versions-list) and [`deployments list`](/workers/wrangler/commands/workers/#deployments-list) documentation for the commands.
+Wrangler allows you to view the 100 most recent versions and deployments. These commands return metadata only, not the Worker cod itself. Refer to the [`versions list`](/workers/wrangler/commands/workers/#versions-list) and [`deployments list`](/workers/wrangler/commands/workers/#deployments-list) documentation for the commands.
 
 ### Via the Cloudflare dashboard
 
@@ -50,6 +50,17 @@ Wrangler allows you to view the 100 most recent versions and deployments. Refer 
    <DashButton url="/?to=/:account/workers-and-pages" />
 
 2. Select your Worker > **Deployments**.
+
+The Deployments tab shows the deployment history and IDs. It does not display the code of previous deployments.
+
+### Retrieve code from a previous deployment
+
+The Cloudflare dashboard and Wrangler do not provide a built-in way to download the code of a previous deployment. You can retrieve a specific deployment's code using the Cloudflare API:
+```bash
+curl -s -H "Authorization: Bearer <API_TOKEN>" \
+  "https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/workers/scripts/<WORKER_NAME>/content/v2?deployment=<DEPLOYMENT_ID>"
+```
+You can find the <DEPLOYMENT_ID> in the Deployments tab in the dashboard, or by running wrangler deployments list. The API token requires Workers Scripts: Read permission.
 
 ## Next steps
 


### PR DESCRIPTION
…ge.mdx

Users frequently need to audit or retrieve the code from a previous Worker deployment, for example during a security investigation. The current Versions & deployments page implies that the dashboard andWrangler provide full visibility into historical deployments, but neither exposes the actual code of a previous deployment.

This change:

- Clarifies that Wrangler's `deployments list` and `versions list` commands return metadata only .
- Clarifies that the dashboard Deployments tab shows deployment history and IDs, but not the code of previous deployments.
- Adds a "Retrieve code from a previous deployment" subsection with the Cloudflare API call that can be used to fetch a specific deployment's bundled code.


This helps customers understand the correct workflow  and avoids the assumption that historical code can be retrieved through Wrangler or the dashboard alone.

