### PR TITLE
[Agents] Add Algorand to x402 supported networks and SDKs

### DIFF
--- a/src/content/docs/agents/tools/payments/x402/index.mdx
+++ b/src/content/docs/agents/tools/payments/x402/index.mdx
@@ -45,12 +45,12 @@ The facilitator does not hold funds. It verifies and broadcasts the client's pre
 
 x402 uses payment **schemes** to define how a payment is constructed and settled on a given network.
 
-| Scheme                                                                                    | Networks                                 | Description                                                                                                                       |
-| ----------------------------------------------------------------------------------------- | ---------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| [`exact`](https://github.com/x402-foundation/x402/blob/main/specs/schemes/exact/scheme_exact.md) | EVM, Solana, Aptos, Stellar, Hedera, Sui | Transfers a fixed token amount — typically [ERC-20](https://eips.ethereum.org/EIPS/eip-20) USDC on EVM — to the merchant address. |
-| [`upto`](https://github.com/x402-foundation/x402/blob/main/specs/schemes/upto/scheme_upto.md)    | EVM                                      | Authorizes a maximum amount; the actual charge is determined at settlement time based on resource consumption.                    |
+| Scheme                                                                                           | Networks                                           | Description                                                                                                                       |
+| ------------------------------------------------------------------------------------------------ | -------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| [`exact`](https://github.com/x402-foundation/x402/blob/main/specs/schemes/exact/scheme_exact.md) | EVM, Solana, Aptos, Stellar, Hedera, Sui, Algorand | Transfers a fixed token amount — typically [ERC-20](https://eips.ethereum.org/EIPS/eip-20) USDC on EVM — to the merchant address. |
+| [`upto`](https://github.com/x402-foundation/x402/blob/main/specs/schemes/upto/scheme_upto.md)    | EVM                                                | Authorizes a maximum amount; the actual charge is determined at settlement time based on resource consumption.                    |
 
-Supported networks include Base, Ethereum, Polygon, Optimism, Arbitrum, Avalanche, Solana, Aptos, Stellar, and Sui. Use `base-sepolia` for testing with free test USDC from the [Circle Faucet](https://faucet.circle.com/).
+Supported networks include Base, Ethereum, Polygon, Optimism, Arbitrum, Avalanche, Solana, Aptos, Stellar, Sui, and Algorand. Use `base-sepolia` for testing with free test USDC from the [Circle Faucet](https://faucet.circle.com/).
 
 ## Charge for resources
 
@@ -89,6 +89,7 @@ Supported networks include Base, Ethereum, Polygon, Optimism, Arbitrum, Avalanch
 | `x402-hono`   | `npm install x402-hono`   | Hono middleware for Worker servers            |
 | `@x402/fetch` | `npm install @x402/fetch` | Fetch wrapper with automatic payment handling |
 | `@x402/evm`   | `npm install @x402/evm`   | EVM payment scheme support                    |
+| `@x402/avm`   | `npm install @x402/avm`   | Algorand payment scheme support               |
 | `agents/x402` | Included in `agents`      | MCP client with x402 payment support          |
 
 ## Related


### PR DESCRIPTION
### Summary

Adds Algorand in three places on `src/content/docs/agents/tools/payments/x402/index.mdx` so the overview page reflects current upstream x402 Foundation network and SDK support. Purely additive documentation update; no existing content was removed or rephrased.

**Changes**

1. **Payment schemes and networks table (`exact` row)** — appended `Algorand` to the Networks cell.
2. **"Supported networks include..." sentence** — appended `and Algorand` to the end of the list.
3. **SDKs table** — new row for `@x402/avm` inserted between `@x402/evm` and `agents/x402`.

**Evidence**

- **`@x402/avm` on npm (v2.19.0, published under the `@x402` scope by x402 Foundation maintainers):** https://www.npmjs.com/package/@x402/avm
  > "AVM (Algorand Virtual Machine) implementation of the x402 payment protocol using the **Exact** payment scheme with ASA (Algorand Standard Asset) transfers."
- **Upstream spec** confirming Algorand is part of the `exact` scheme family: [`specs/schemes/exact/scheme_exact_algo.md`](https://github.com/x402-foundation/x402/blob/main/specs/schemes/exact/scheme_exact_algo.md)
- **x402 Foundation "Networks & Token Support" docs** listing Algorand (AVM) alongside EVM, Solana, TON, Stellar, Aptos, Hedera, Keeta, NEAR, Concordium, and XRPL: https://docs.x402.org/core-concepts/network-and-token-support

**Validation**

- `pnpm run check:astro` → 0 errors, 0 warnings.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).