### PR TITLE
docs(realtime): document Datachannels canReply (return-to-publisher)

### DIFF
--- a/public/realtime/static/realtime-api-2024-05-21.yaml
+++ b/public/realtime/static/realtime-api-2024-05-21.yaml
@@ -687,6 +687,14 @@ paths:
                       waitForAck: true
                       sessionId: "2a45361d5fd7cc14eface0587c276c94"
                       dataChannelName: 1a037563-c35c-4bf6-a9ee-2b474cbb9a51
+              remote_datachannels_can_reply:
+                description: Consume a remote data channel and admit reverse traffic to the publisher
+                value:
+                  datachannels:
+                    - location: remote
+                      canReply: true
+                      sessionId: "2a45361d5fd7cc14eface0587c276c94"
+                      dataChannelName: 1a037563-c35c-4bf6-a9ee-2b474cbb9a51
       security:
         - secret: []
       parameters:
@@ -727,6 +735,69 @@ paths:
                       - sessionId: 2a45361d5fd7cc14eface0587c276c94
                         location: remote
                         dataChannelName: 1a037563-c35c-4bf6-a9ee-2b474cbb9a51
+                        id: 4
+  /apps/{appId}/sessions/{sessionId}/datachannels/update:
+    put:
+      tags:
+        - Update data channel(s)
+      summary: Update flags on already pulled remote data channel(s), such as granting or revoking canReply
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DataChannelsRequest"
+            examples:
+              grant_can_reply:
+                description: Grant return-to-publisher admission on a pulled remote data channel
+                value:
+                  datachannels:
+                    - location: remote
+                      canReply: true
+                      sessionId: "2a45361d5fd7cc14eface0587c276c94"
+                      dataChannelName: 1a037563-c35c-4bf6-a9ee-2b474cbb9a51
+              revoke_can_reply:
+                description: Revoke return-to-publisher admission
+                value:
+                  datachannels:
+                    - location: remote
+                      canReply: false
+                      sessionId: "2a45361d5fd7cc14eface0587c276c94"
+                      dataChannelName: 1a037563-c35c-4bf6-a9ee-2b474cbb9a51
+      security:
+        - secret: []
+      parameters:
+        - in: path
+          name: appId
+          schema:
+            type: string
+          required: true
+          description: WebRTC application ID
+        - in: path
+          name: sessionId
+          schema:
+            type: string
+          required: true
+          description: Current PeerConnection session ID (the subscriber session that pulled the channel)
+      responses:
+        "200":
+          description: OK
+          headers:
+            vary:
+              schema:
+                type: string
+                example: Origin
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DataChannelsResponse"
+              examples:
+                grant_can_reply:
+                  value:
+                    datachannels:
+                      - sessionId: 2a45361d5fd7cc14eface0587c276c94
+                        location: remote
+                        dataChannelName: 1a037563-c35c-4bf6-a9ee-2b474cbb9a51
+                        canReply: true
                         id: 4
   /apps/{appId}/sessions/{sessionId}/datachannels/close:
     put:
@@ -1173,6 +1244,16 @@ components:
             The acknowledgment is consumed by the SFU and is not forwarded. It must arrive within
             15 seconds of creating the remote DataChannel; otherwise the SFU tears down the gated
             channel. Ignored for local DataChannels.
+        canReply:
+          type: boolean
+          default: false
+          description: >
+            For remote DataChannels only. When true, this subscriber may send reverse traffic on
+            the DataChannel to the publisher. Reverse messages are delivered only to the publisher
+            and are not fanned out to other subscribers. At most one subscriber may hold canReply
+            for a given publisher DataChannel at a time; granting canReply to another subscriber
+            replaces the previous selection. Set on datachannels/new at pull time, or grant and
+            revoke later with datachannels/update. Ignored for local DataChannels.
         id:
           type: number
           description: Data channel id

--- a/src/content/docs/realtime/sfu/datachannels.mdx
+++ b/src/content/docs/realtime/sfu/datachannels.mdx
@@ -22,7 +22,7 @@ DataChannels on Cloudflare Realtime can scale up to many subscribers per publish
 
 ### How to use DataChannels
 
-1. Create  two Realtime sessions, one for the publisher and one for the subscribers.
+1. Create two Realtime sessions, one for the publisher and one for the subscribers.
 2. Create a DataChannel by calling /datachannels/new with the location set to "local" and the dataChannelName set to the name of the DataChannel.
 3. Create a DataChannel by calling /datachannels/new with the location set to "remote" and the sessionId set to the sessionId of the publisher.
 4. Use the DataChannel to send data from the publisher to the subscribers.
@@ -33,7 +33,7 @@ By default, a subscriber starts receiving messages as soon as it pulls a remote 
 
 - Set `waitForAck: true` when you create a remote DataChannel with the [HTTPS API](/realtime/sfu/https-api/). While the gate is closed, the SFU does not forward any messages to that subscriber on that DataChannel.
 - After the subscriber's DataChannel opens, have the subscriber send any message on it (for example, the string `"ack"`). The first message opens the gate, and the SFU starts forwarding messages to that subscriber.
-- The acknowledgment is consumed by the SFU. It is not forwarded to the publisher or to other subscribers, so the channel stays [unidirectional](#unidirectional-datachannels).
+- The acknowledgment is consumed by the SFU. It is not forwarded to the publisher or to other subscribers. Without [`canReply`](#return-to-publisher-canreply), the channel stays publisher-to-subscriber only.
 - The acknowledgment must reach the SFU within 15 seconds of creating the remote DataChannel. If it does not, the SFU tears down the gated channel and forwards no messages; create the remote DataChannel again to retry.
 - `waitForAck` applies only to `location: "remote"` DataChannels and defaults to `false`, so existing behavior is unchanged.
 
@@ -41,49 +41,146 @@ Create a remote DataChannel with the gate enabled by calling `POST /apps/{appId}
 
 ```json
 {
-  "dataChannels": [
-    {
-      "location": "remote",
-      "sessionId": "<publisherSessionId>",
-      "dataChannelName": "my-channel",
-      "waitForAck": true
-    }
-  ]
+	"dataChannels": [
+		{
+			"location": "remote",
+			"sessionId": "<publisherSessionId>",
+			"dataChannelName": "my-channel",
+			"waitForAck": true
+		}
+	]
 }
 ```
 
 Then, on the subscriber, send the acknowledgment once the DataChannel is open:
 
 ```ts
-const resp = await fetch(`${API_BASE}/sessions/${subscriberId}/datachannels/new`, {
-  method: "POST",
-  headers,
-  body: JSON.stringify({
-    dataChannels: [
-      {
-        location: "remote",
-        sessionId: publisherId,
-        dataChannelName: "my-channel",
-        waitForAck: true,
-      },
-    ],
-  }),
-}).then((r) => r.json());
+const resp = await fetch(
+	`${API_BASE}/sessions/${subscriberId}/datachannels/new`,
+	{
+		method: "POST",
+		headers,
+		body: JSON.stringify({
+			dataChannels: [
+				{
+					location: "remote",
+					sessionId: publisherId,
+					dataChannelName: "my-channel",
+					waitForAck: true,
+				},
+			],
+		}),
+	},
+).then((r) => r.json());
 
 const dc = pc.createDataChannel("my-channel-subscribed", {
-  negotiated: true,
-  id: resp.dataChannels[0].id,
+	negotiated: true,
+	id: resp.dataChannels[0].id,
 });
 
 await waitForOpen(dc);
 dc.send("ack"); // The first frame opens the gate; later frames are your application data.
 ```
 
-### Unidirectional DataChannels
+### Default direction (publisher to subscribers)
 
-Cloudflare Realtime SFU DataChannels are one way only. This means that you can only send data from the publisher to the subscribers. Subscribers cannot send data back to the publisher. While regular MediaStream WebRTC DataChannels are bidirectional, this introduces a problem for Cloudflare Realtime because the SFU does not know which session to send the data back to. This is especially problematic for scenarios where you have multiple subscribers and you want to send data from the publisher to all subscribers at scale, such as distributing game score updates to all players in a multiplayer game.
+By default, Cloudflare Realtime SFU DataChannels are one-way. The publisher sends, and every subscriber that pulled the channel receives. Subscribers cannot send data back to the publisher unless you opt in with [`canReply`](#return-to-publisher-canreply).
 
-To send data in a bidirectional way, you can use two DataChannels, one for sending data from the publisher to the subscribers and one for sending data the opposite direction.
+### Return to publisher (canReply)
+
+`canReply` lets one subscriber send messages back to the publisher on the same remote DataChannel it pulled. Forward traffic (publisher to subscribers) does not change. The SFU admits reverse traffic only from the subscriber that holds `canReply`, and delivers those messages only to the publisher, not to other subscribers.
+
+```mermaid
+graph LR
+    P[Publisher] -->|forward| SFU[Cloudflare Realtime SFU]
+    SFU -->|forward| S1[Subscriber with canReply]
+    SFU -->|forward| S2[Other subscribers]
+    S1 -->|reverse| SFU
+    SFU -->|reverse| P
+```
+
+`canReply` follows these rules:
+
+- Set `canReply: true` when the subscriber creates a remote DataChannel with `POST .../datachannels/new`. You can also grant or revoke it later with `PUT .../datachannels/update` on that subscriber session.
+- `canReply` applies only to `location: "remote"` DataChannels and defaults to `false`, so existing pull behavior does not change.
+- At most one subscriber may hold `canReply` for a given publisher DataChannel at a time. Granting `canReply` to another subscriber replaces the previous holder. To revoke, set `canReply: false` on the subscriber that currently holds it.
+- The SFU does not forward messages from a non-admitted subscriber to the publisher.
+- The SFU does not fan out reverse messages to other subscribers.
+
+#### Grant at pull time
+
+Create the remote DataChannel on the subscriber session with `canReply: true`:
+
+```json
+{
+	"dataChannels": [
+		{
+			"location": "remote",
+			"sessionId": "<publisherSessionId>",
+			"dataChannelName": "my-channel",
+			"canReply": true
+		}
+	]
+}
+```
+
+Example flow:
+
+1. Publisher creates a local DataChannel named `my-channel`.
+2. Subscriber pulls it with `canReply: true` and opens the negotiated channel in the browser.
+3. Publisher sends on the channel; the subscriber receives (forward path).
+4. Subscriber sends on the same channel; the publisher receives (reverse path).
+
+#### Grant or revoke with update
+
+To change admission without recreating the pull, call `PUT /apps/{appId}/sessions/{subscriberSessionId}/datachannels/update`:
+
+```json
+{
+	"dataChannels": [
+		{
+			"location": "remote",
+			"sessionId": "<publisherSessionId>",
+			"dataChannelName": "my-channel",
+			"canReply": true
+		}
+	]
+}
+```
+
+Use the same body with `"canReply": false` to revoke. The following table lists common patterns:
+
+| Goal                                      | Action                                                                                                                  |
+| ----------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| Pull without reverse, then allow reverse  | Create remote without `canReply` (or `canReply: false`). Confirm reverse is blocked. Call update with `canReply: true`. |
+| Move reverse rights to another subscriber | On the new subscriber, call update with `canReply: true`. The previous holder loses reverse admission.                  |
+| Stop reverse traffic                      | On the current holder, call update with `canReply: false`.                                                              |
+
+```ts
+// Subscriber already pulled "my-channel" without canReply.
+// Grant reverse admission later:
+await fetch(`${API_BASE}/sessions/${subscriberId}/datachannels/update`, {
+	method: "PUT",
+	headers,
+	body: JSON.stringify({
+		dataChannels: [
+			{
+				location: "remote",
+				sessionId: publisherId,
+				dataChannelName: "my-channel",
+				canReply: true,
+			},
+		],
+	}),
+});
+
+// Same negotiated DataChannel instance; subscriber can now send and the publisher receives.
+dc.send(JSON.stringify({ type: "reply", body: "pong" }));
+```
+
+#### Combine canReply and waitForAck
+
+You can set both `canReply` and `waitForAck` on the same remote DataChannel. `waitForAck` still gates forward delivery to that subscriber until it sends its first message. That first message is consumed as the acknowledgment and is not forwarded. After the gate opens, further subscriber messages on an admitted `canReply` channel become reverse traffic to the publisher.
 
 ## Example
 

--- a/src/content/docs/realtime/sfu/https-api.mdx
+++ b/src/content/docs/realtime/sfu/https-api.mdx
@@ -16,10 +16,20 @@ Cloudflare Realtime simplifies the management of peer connections and media trac
   - `POST /apps/{appId}/sessions/new`
 - **Add a New Track**: Adds a media track (audio or video) to an existing session.
   - `POST /apps/{appId}/sessions/{sessionId}/tracks/new`
+- **Update Tracks**: Changes tracks by reusing existing transceivers.
+  - `PUT /apps/{appId}/sessions/{sessionId}/tracks/update`
 - **Renegotiate a Session**: Updates the session's negotiation state to accommodate new tracks or changes in the existing ones.
   - `PUT /apps/{appId}/sessions/{sessionId}/renegotiate`
 - **Close a Track**: Removes a specified track from the session.
   - `PUT /apps/{appId}/sessions/{sessionId}/tracks/close`
+- **Establish a DataChannel Transport**: Pulls the `server-events` channel to establish DataChannel transport. Call this before you add DataChannels.
+  - `POST /apps/{appId}/sessions/{sessionId}/datachannels/establish`
+- **Add DataChannels**: Publishes a local DataChannel or pulls a remote one (optional `waitForAck`, `canReply`).
+  - `POST /apps/{appId}/sessions/{sessionId}/datachannels/new`
+- **Update DataChannels**: Grants or revokes flags on an already pulled remote DataChannel (for example `canReply`).
+  - `PUT /apps/{appId}/sessions/{sessionId}/datachannels/update`
+- **Close DataChannels**: Removes a specified DataChannel from the session.
+  - `PUT /apps/{appId}/sessions/{sessionId}/datachannels/close`
 - **Retrieve Session Information**: Fetches detailed information about a specific session.
   - `GET /apps/{appId}/sessions/{sessionId}`
 

--- a/src/content/docs/realtime/sfu/limits.mdx
+++ b/src/content/docs/realtime/sfu/limits.mdx
@@ -23,6 +23,8 @@ Understanding the limits and timeouts of Cloudflare Realtime is crucial for opti
 
 * **Tracks per Session**: There's no upper limit to the number of tracks a session can contain, the practical limit is governed by your connection's bandwidth to and from Cloudflare.
 
+* **DataChannel canReply exclusivity**: At most one subscriber may hold `canReply` for a given publisher DataChannel at a time. Granting `canReply` to another subscriber replaces the previous selection. The publisher receives reverse traffic only, and it is not fanned out to other subscribers. For more information, refer to [Return to publisher (canReply)](/realtime/sfu/datachannels/#return-to-publisher-canreply).
+
 ## Inactivity Timeout
 
 * **Track Timeout**: Tracks will automatically timeout and be garbage collected after 30 seconds of inactivity, where inactivity is defined as no media packets being received by Cloudflare. This mechanism ensures efficient use of resources and session cleanliness across all Sessions that use a track.

--- a/src/content/release-notes/realtime.yaml
+++ b/src/content/release-notes/realtime.yaml
@@ -3,6 +3,16 @@ link: "/realtime/changelog/"
 productName: Realtime
 productLink: "/realtime/"
 entries:
+  - publish_date: "2026-07-23"
+    title: DataChannels return-to-publisher (canReply)
+    description: |-
+      DataChannels now support opt-in reverse traffic from one subscriber back to the publisher on the same channel. When a subscriber pulls a remote DataChannel with `canReply: true` (or is granted it later via `datachannels/update`), the SFU admits that subscriber's messages to the publisher only.
+
+      - Opt-in per subscriber; defaults to `false`, so existing publisher-to-subscriber fan-out is unchanged.
+      - Reverse traffic is not fanned out to other subscribers.
+      - Exclusive: at most one subscriber holds `canReply` per publisher DataChannel; a new grant replaces the previous holder.
+      - Grant or revoke without re-pulling via `PUT .../datachannels/update`.
+      - Docs: [DataChannels](/realtime/sfu/datachannels/), [Limits, timeouts and quotas](/realtime/sfu/limits/)
   - publish_date: "2026-06-10"
     title: DataChannels subscriber acknowledgment gate (waitForAck)
     description: |-


### PR DESCRIPTION
### Summary
Add opt-in reverse traffic from one subscriber back to publisher on the same remote DataChannel. It is allowed to configure this setting during the pull or call /datachannels/update to grant the permission.

### Documentation checklist
- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
