### PR TITLE
[Workers] Mention Flagship in automatic provisioning docs

### DIFF
--- a/src/content/docs/workers/wrangler/configuration.mdx
+++ b/src/content/docs/workers/wrangler/configuration.mdx
@@ -104,7 +104,7 @@ Further, there are a few keys that can _only_ appear at the top-level.
 
 Wrangler can automatically provision resources for you when you deploy your Worker without you having to create them ahead of time.
 
-This currently works for KV, R2, and D1 bindings.
+This currently works for KV, R2, D1, and Flagship bindings.
 
 To use this feature, add bindings to your configuration file _without_ adding resource IDs, or in the case of R2, a bucket name. Resources will be created with the name of your worker as the prefix.
 
@@ -1918,26 +1918,26 @@ A common example of using a redirected configuration is where a custom build too
 - First, the user writes code that uses Cloudflare Workers resources, configured via a user's Wrangler configuration file like the following:
 
   <WranglerConfig>
-
-  ```jsonc
-  {
-  	"$schema": "./node_modules/wrangler/config-schema.json",
-  	"name": "my-worker",
-  	"main": "src/index.ts",
-  	"vars": {
-  		"MY_VARIABLE": "production variable",
-  	},
-  	"env": {
-  		"staging": {
-  			"vars": {
-  				"MY_VARIABLE": "staging variable",
-  			},
-  		},
-  	},
-  }
-  ```
-
-  </WranglerConfig>
+  
+    ```jsonc
+    {
+    	"$schema": "./node_modules/wrangler/config-schema.json",
+    	"name": "my-worker",
+    	"main": "src/index.ts",
+    	"vars": {
+    		"MY_VARIABLE": "production variable",
+    	},
+    	"env": {
+    		"staging": {
+    			"vars": {
+    				"MY_VARIABLE": "staging variable",
+    			},
+    		},
+    	},
+    }
+    ```
+  
+    </WranglerConfig>
 
   This configuration points `main` at the user's code entry-point and defines the `MY_VARIABLE` variable in two different environments.
 
@@ -1951,13 +1951,13 @@ A common example of using a redirected configuration is where a custom build too
   It also creates a `.wrangler/deploy/config.json` file that redirects Wrangler to the new, generated deployment configuration file:
 
   <FileTree>
-		- dist/
-			- index.js
-			- wrangler.jsonc
-		- .wrangler/
-			- deploy/
-				- config.json
-  </FileTree>
+  		- dist/
+  			- index.js
+  			- wrangler.jsonc
+  		- .wrangler/
+  			- deploy/
+  				- config.json
+    </FileTree>
 
 The generated `dist/wrangler.jsonc` might contain:
 


### PR DESCRIPTION
### Summary

Wrangler supports automatic provisioning for Flagship bindings via [`cloudflare/workers-sdk#13352`](https://github.com/cloudflare/workers-sdk/pull/13352). This updates the automatic provisioning section in the Wrangler configuration docs to list Flagship alongside KV, R2, and D1.

Re-applies the content change from #31990, which was reverted in #32105 pending feature release. The feature has now shipped.

### Documentation checklist

- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
