### PR TITLE
chore: remove explicit Node.js heap size override from build command

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 		"preinstall": "pnpx only-allow pnpm",
 		"astro": "astro",
 		"prebuild": "tsx bin/fetch-skills.ts",
-		"build": "export NODE_OPTIONS='--max-old-space-size=8192' || set NODE_OPTIONS=\"--max-old-space-size=8192\" && astro build",
+		"build": "astro build",
 		"typegen:worker": "wrangler types ./worker/worker-configuration.d.ts",
 		"check": "pnpm run check:astro && pnpm run check:worker",
 		"check:astro": "astro check",


### PR DESCRIPTION
### Summary

Removes the explicit `--max-old-space-size=8192` V8 heap override from the build command. Node.js v12+ (we run v24) auto-scales the V8 heap based on available system memory, making this cap unnecessary and potentially counterproductive.
