### PR TITLE
Update hubspot.mdx - changing link to public facing option

### DIFF
--- a/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/saas-customers/provider-guides/hubspot.mdx
+++ b/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/saas-customers/provider-guides/hubspot.mdx
@@ -39,7 +39,7 @@ O2O is enabled per hostname, so to enable O2O for a specific hostname within you
 
 :::note
 
-For questions about your HubSpot setup, refer to [HubSpot's reverse proxy support guide](https://developers.hubspot.com/docs/cms/developer-reference/reverse-proxy-support).
+For questions about your HubSpot setup, refer to [HubSpot's reverse proxy support guide](https://developers.hubspot.com/docs/cms/best-practices/testing-staging-performance/reverse-proxies/overview).
 
 :::
 


### PR DESCRIPTION
### Summary

As-is, the referenced help link is behind a HubSpot login. While not necessarily incorrect, HubSpot has a public-facing guide as well.

### Documentation checklist

- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).