### PR TITLE
Hyperdrive Dynamic Workers docs with placeholder helper

### DIFF
--- a/src/assets/images/hyperdrive/configuration/hyperdrive-dynamic-workers.svg
+++ b/src/assets/images/hyperdrive/configuration/hyperdrive-dynamic-workers.svg
@@ -1,0 +1,67 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 480" font-family="ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif" role="img" aria-label="A loader Worker creates two invocations of Dynamic Worker A and one invocation of Dynamic Worker B. The Dynamic Worker A invocations connect to the same tenant database through the same Hyperdrive pool.">
+	<defs>
+		<marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+			<path d="M0 0 L10 5 L0 10 z" fill="#595959" />
+		</marker>
+	</defs>
+
+	<!-- Loader Worker branches to Dynamic Worker invocations -->
+	<g stroke="#595959" stroke-width="1.5" fill="none">
+		<line x1="400" y1="87" x2="400" y2="120" />
+		<line x1="160" y1="120" x2="640" y2="120" />
+		<line x1="160" y1="120" x2="160" y2="151" marker-end="url(#arrow)" />
+		<line x1="400" y1="120" x2="400" y2="151" marker-end="url(#arrow)" />
+		<line x1="640" y1="120" x2="640" y2="151" marker-end="url(#arrow)" />
+
+		<!-- Two Dynamic Worker A invocations reuse Hyperdrive pool A -->
+		<line x1="160" y1="207" x2="235" y2="271" marker-end="url(#arrow)" />
+		<line x1="400" y1="207" x2="325" y2="271" marker-end="url(#arrow)" />
+		<line x1="640" y1="207" x2="640" y2="271" marker-end="url(#arrow)" />
+
+		<!-- Each Hyperdrive pool reaches its tenant database -->
+		<line x1="280" y1="327" x2="280" y2="391" marker-end="url(#arrow)" />
+		<line x1="640" y1="327" x2="640" y2="391" marker-end="url(#arrow)" />
+	</g>
+
+	<!-- Loader Worker -->
+	<g>
+		<rect x="320" y="33" width="160" height="54" rx="8" fill="#fbe8d3" stroke="#f6821f" stroke-width="1.5" />
+		<text x="400" y="65" text-anchor="middle" font-size="15" font-weight="600" fill="#1d1d1d">Loader Worker</text>
+	</g>
+
+	<!-- Dynamic Workers -->
+	<g fill="#fbe8d3" stroke="#f6821f" stroke-width="1.5">
+		<rect x="80" y="153" width="160" height="54" rx="8" />
+		<rect x="320" y="153" width="160" height="54" rx="8" />
+		<rect x="560" y="153" width="160" height="54" rx="8" />
+	</g>
+	<g text-anchor="middle" font-size="14" fill="#1d1d1d">
+		<text x="160" y="179">Dynamic Worker A</text>
+		<text x="160" y="195" font-size="12">Invocation 1</text>
+		<text x="400" y="179">Dynamic Worker A</text>
+		<text x="400" y="195" font-size="12">Invocation 2</text>
+		<text x="640" y="179">Dynamic Worker B</text>
+		<text x="640" y="195" font-size="12">Invocation 1</text>
+	</g>
+
+	<!-- Hyperdrive pools -->
+	<g fill="#c5ebf5" stroke="#0055dc" stroke-width="1.5">
+		<rect x="140" y="273" width="280" height="54" rx="8" />
+		<rect x="560" y="273" width="160" height="54" rx="8" />
+	</g>
+	<g text-anchor="middle" font-size="14" fill="#1d1d1d">
+		<text x="280" y="298">Hyperdrive pool A</text>
+		<text x="280" y="314" font-size="12">reused</text>
+		<text x="640" y="305">Hyperdrive pool B</text>
+	</g>
+
+	<!-- Tenant databases -->
+	<g fill="#ededed" stroke="#595959" stroke-width="1.5">
+		<rect x="140" y="393" width="280" height="54" rx="8" />
+		<rect x="560" y="393" width="160" height="54" rx="8" />
+	</g>
+	<g text-anchor="middle" font-size="14" fill="#1d1d1d">
+		<text x="280" y="425">Tenant database A</text>
+		<text x="640" y="425">Tenant database B</text>
+	</g>
+</svg>

--- a/src/content/docs/hyperdrive/concepts/dynamic-hyperdrive.mdx
+++ b/src/content/docs/hyperdrive/concepts/dynamic-hyperdrive.mdx
@@ -1,0 +1,206 @@
+---
+pcx_content_type: concept
+title: Hyperdrive with Dynamic Workers
+description: Connect Dynamic Workers to external databases via Hyperdrive.
+sidebar:
+  order: 5
+products:
+  - hyperdrive
+---
+
+import { TypeScriptExample, WranglerConfig } from "~/components";
+
+## Overview
+
+Hyperdrive lets you connect to external databases from [Dynamic Workers](/dynamic-workers/).
+
+In this model, a [loader Worker](/dynamic-workers/getting-started/#configure-worker-loader) creates each Dynamic Worker and controls its outbound network access by providing the database connection details for that Dynamic Worker. Each Dynamic Worker can then connect to the provided database through Hyperdrive.
+
+When a Dynamic Worker connects to a database, Cloudflare creates a Hyperdrive configuration for that database at runtime using the database connection details. Hyperdrive reuses that per-database configuration for connection pooling and query caching across Dynamic Worker requests that connect to the same database.
+
+This means you do not need to pre-provision a separate Hyperdrive configuration for every database that your Dynamic Workers use. Instead, Dynamic Workers can connect to specific databases provided by the loader Worker, while Hyperdrive manages the configuration at runtime, pooling, and caching for each database.
+
+![A loader Worker creates each Dynamic Worker, and each Dynamic Worker connects to its tenant database through Hyperdrive.](~/assets/images/hyperdrive/configuration/hyperdrive-dynamic-workers.svg)
+
+## How it works
+
+Hyperdrive with Dynamic Workers uses Dynamic Workers [egress control model](/dynamic-workers/usage/egress-control/#intercept-outbound-requests). The `globalOutbound` option lets the loader Worker define a `WorkerEntrypoint` (`OutboundInterceptor`) to intercept outbound `connect()` calls from Dynamic Workers and to handle database connections with Hyperdrive.
+
+At request time:
+
+1. Loader Worker retrieves database connection details for the target tenant.
+2. Loader Worker creates the Dynamic Worker and passes the database connection details to the Dynamic Worker as `env.CONNECTION_STRING`.
+3. Dynamic Worker code attempts to connect to the database.
+4. `OutboundInterceptor` intercepts the outbound connection and checks the host and port against the tenant's placeholder connection string.
+5. `OutboundInterceptor` decides whether to route the connection through Hyperdrive.
+6. Hyperdrive pools and caches queries for that database.
+
+## Example configuration
+
+<WranglerConfig>
+```toml
+name = "my-dynamic-worker"
+main = "src/index.ts"
+compatibility_date = "2024-01-15"
+
+[[hyperdrive]]
+binding = "HYPERDRIVE"
+id = "YOUR_HYPERDRIVE_ID"
+```
+</WranglerConfig>
+
+## Placeholder connection string
+
+The placeholder connection string used by Dynamic Worker code must be a valid connection string that your database driver can parse and use. Database drivers still parse the connection string and send its username, password, database name, hostname, port, and TLS settings over the returned socket.
+
+Use a separate placeholder host and port for each database. The `OutboundInterceptor` compares the intercepted outbound connection host against the value it received via `props` to decide which connections to route through Hyperdrive.
+
+:::caution
+
+Do not use the real database hostname in the placeholder connection string, which exposes database credentials to Dynamic Workers. The placeholder host should be a hostname that your `OutboundInterceptor` recognizes. Keep `globalOutbound` restrictive so unmatched outbound connections are denied.
+
+:::
+
+For PostgreSQL drivers, the placeholder must be a valid PostgreSQL connection string. Use a helper like this to generate a syntactically valid but fake value:
+
+```ts
+function makePgPlaceholderConnectionString() {
+  const user = `placeholder_${crypto.randomUUID().replace(/-/g, "").slice(0, 12)}`;
+  const password = `placeholder_${crypto.randomUUID().replace(/-/g, "").slice(0, 16)}`;
+  const host = `db-${crypto.randomUUID().replace(/-/g, "").slice(0, 8)}.example.internal`;
+  const database = `placeholder_db`;
+
+  return `postgresql://${encodeURIComponent(user)}:${encodeURIComponent(password)}@${host}:5432/${database}?sslmode=require`;
+}
+```
+
+Example output:
+
+```txt
+postgresql://placeholder_1f3a9b8c7d2e:placeholder_9a2c4f6d1b3e8f70@db-7c1d2e3f.example.internal:5432/placeholder_db?sslmode=require
+```
+
+### 1. Get database details for each Dynamic Worker
+
+The loader Worker needs database connection information for each Dynamic Worker in a configuration store, such as Workers KV or your own control plane. Examples below use Workers KV.
+
+If each Dynamic Worker is a tenant that connects to a separate tenant database, a tenant record with the database details should include:
+
+```json
+{
+	"id": "tenant_A",
+	"connectionString": "...", // actual database credentials used by OutboundInterceptor
+	"placeholderConnectionString": "...", // connection string used by Dynamic Worker
+	"databaseRegion": "aws:us-east-1"
+}
+```
+
+<TypeScriptExample filename="loader-worker.ts">
+
+```ts
+export default {
+	async fetch(request, env, ctx): Promise<Response> {
+		// Lookup per-tenant database details in configuration store like Workers KV
+		const tenant = await env.KV.get<Tenant>("tenant_A", { type: "json" });
+
+		if (tenant === null) {
+			return new Response("Tenant not found", { status: 404 });
+		}
+	},
+};
+
+type Tenant = {
+	placeholderConnectionString: string;
+	connectionString: string;
+	databaseRegion: string;
+};
+```
+
+</TypeScriptExample>
+
+### 2. Load Dynamic Worker
+
+The loader Worker creates Dynamic Workers with `env.LOADER.load()` or `env.LOADER.get()`.
+
+The loader Worker passes `placeholderConnectionString` to the Dynamic Worker as `env.CONNECTION_STRING`, allowing the Dynamic Worker to connect to only that database.
+
+Your loader Worker defines an `OutboundInterceptor` class and passes it as [`globalOutbound`](/dynamic-workers/api-reference/#globaloutbound) when it creates the Dynamic Worker. This routes outbound `connect()` calls from the Dynamic Worker through `OutboundInterceptor`. The full tenant record with actual database credentials is passed to `OutboundInterceptor` via `props`, so that Hyperdrive can connect to the database.
+
+<TypeScriptExample filename="loader-worker.ts">
+
+```ts
+const worker = env.LOADER.load({
+	compatibilityDate: "2024-01-15",
+	compatibilityFlags: ["nodejs_compat"],
+	mainModule: "src/index.js",
+	modules: { "src/index.js": code },
+	env: {
+		CONNECTION_STRING: tenant.placeholderConnectionString,
+	},
+	globalOutbound: ctx.exports.OutboundInterceptor({
+		props: { tenant },
+	}),
+});
+```
+
+</TypeScriptExample>
+
+### 3. Dynamic Worker queries database
+
+The Dynamic Worker uses your preferred database client, such as [`pg`](https://www.npmjs.com/package/pg), with `env.CONNECTION_STRING` provided by the loader Worker.
+
+<TypeScriptExample filename="dynamic-worker.ts">
+
+```ts
+import { Client } from "pg";
+
+export default {
+	async fetch(request, env): Promise<Response> {
+		const client = new Client({
+			connectionString: env.CONNECTION_STRING,
+		});
+
+		await client.connect();
+		const result = await client.query("SELECT * FROM pg_tables");
+
+		return Response.json({ success: true, result: result.rows });
+	},
+};
+```
+
+</TypeScriptExample>
+
+### 4. OutboundInterceptor connects to database via Hyperdrive API
+
+`OutboundInterceptor` intercepts outbound connections made by the Dynamic Worker code and receives the host and port of the outbound connection. It compares the outbound connection host against the host parsed from the tenant's placeholder connection string to ensure that the Dynamic Worker accessed a database the loader Worker has allowed.
+
+If they match, `OutboundInterceptor` calls `this.env.HYPERDRIVE.get()` and returns `hyperdrive.connect()` to connect to the database using Hyperdrive's connection pool.
+
+`HYPERDRIVE.get()` returns a Hyperdrive configuration at runtime for the database target. `hyperdrive.connect()` does not require a host value because `HYPERDRIVE.get()` provided the database host through the actual database connection string.
+
+With a regular, pre-provisioned Hyperdrive configuration, Hyperdrive probes Cloudflare locations to decide where to run your database connection pool for low-latency queries. With Hyperdrive and Dynamic Workers, Hyperdrive creates the Hyperdrive configuration at runtime and uses `targetRegion` you provide to place the pool near the database.
+
+<TypeScriptExample filename="outbound-interceptor.ts">
+
+```ts
+import { WorkerEntrypoint } from "cloudflare:workers";
+
+export class OutboundInterceptor extends WorkerEntrypoint {
+	async connect(host) {
+		const placeholderHost = new URL(
+			this.ctx.props.tenant.placeholderConnectionString,
+		).host;
+
+		if (host === placeholderHost) {
+			const hyperdrive = this.env.HYPERDRIVE.get({
+				connectionString: this.ctx.props.tenant.connectionString,
+				targetRegion: this.ctx.props.tenant.databaseRegion,
+			});
+
+			return hyperdrive.connect();
+		}
+	}
+}
+```
+
+</TypeScriptExample>


### PR DESCRIPTION
Summary:
- Adds the Dynamic Hyperdrive concept page for per-tenant database connections.
- Includes a docs-only helper that generates a syntactically valid fake PostgreSQL placeholder connection string.
- Carries over the review fixes from PR 31837: SVG diagram, corrected labels, fixed env usage, fixed host comparison, and a real compatibility date.
- Adds discoverability cross-links back to the Dynamic Workers and Cloudflare for Platforms docs so readers can find the pattern from the main landing pages.

Notes:
- This branch is a clean replacement for PR 31837 to avoid stale branch / CI issues.
- Hyperdrive binding id remains unchanged by design.