### PR TITLE
chore: add semantic Outdated PR Check contexts alongside legacy context

### DIFF
--- a/.github/workflows/outdated-pr-check.yml
+++ b/.github/workflows/outdated-pr-check.yml
@@ -1,6 +1,6 @@
 name: Outdated PR Check
 
-# **What it does**: Posts an Outdated PR Check commit status when a PR is opened or updated.
+# **What it does**: Posts Outdated PR Check commit statuses when a PR is opened or updated.
 #                   Fails if the branch is more than 24 hours out of date with production.
 # **Why we have it**: Gives contributors immediate feedback when their branch has drifted.
 #                     The daily refresh job (outdated-pr-refresh.yml) catches PRs that go
@@ -86,11 +86,23 @@ jobs:
             fi
           fi
 
+          # Post the legacy context (required by current branch protection).
           gh api \
             --method POST \
             -H "Accept: application/vnd.github+json" \
             "/repos/${REPO}/statuses/${PR_SHA}" \
             -f state="$STATE" \
             -f context="Outdated PR Check" \
+            -f description="$DESCRIPTION" \
+            || echo "Failed to post status — skipping"
+
+          # Post the new semantic context (additive — will become required after branch
+          # protection is updated and the legacy context is removed in a follow-up PR).
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/${REPO}/statuses/${PR_SHA}" \
+            -f state="$STATE" \
+            -f context="Outdated PR Check / On Commit" \
             -f description="$DESCRIPTION" \
             || echo "Failed to post status — skipping"

--- a/.github/workflows/outdated-pr-refresh.yml
+++ b/.github/workflows/outdated-pr-refresh.yml
@@ -1,6 +1,6 @@
 name: Refresh PR Outdated Checks
 
-# **What it does**: Posts a Outdated PR Check commit status for every open PR once a day
+# **What it does**: Posts Outdated PR Check commit statuses for every open PR once a day
 #                   (~4am CT), including fork PRs. Catches PRs that go stale when production
 #                   advances without any PR activity.
 # **Why we have it**: The per-commit check (outdated-pr-check.yml) only runs when a PR is
@@ -86,12 +86,24 @@ jobs:
               fi
             fi
 
+            # Post the legacy context (required by current branch protection).
             gh api \
               --method POST \
               -H "Accept: application/vnd.github+json" \
               "/repos/${REPO}/statuses/${PR_SHA}" \
               -f state="$STATE" \
               -f context="Outdated PR Check" \
+              -f description="$DESCRIPTION" \
+              || { echo "  Failed to post status for PR #${PR_NUMBER} — continuing"; true; }
+
+            # Post the new semantic context (additive — will become required after branch
+            # protection is updated and the legacy context is removed in a follow-up PR).
+            gh api \
+              --method POST \
+              -H "Accept: application/vnd.github+json" \
+              "/repos/${REPO}/statuses/${PR_SHA}" \
+              -f state="$STATE" \
+              -f context="Outdated PR Check / Scheduled" \
               -f description="$DESCRIPTION" \
               || { echo "  Failed to post status for PR #${PR_NUMBER} — continuing"; true; }
 


### PR DESCRIPTION
### Summary

Adds distinct semantic commit status contexts alongside the existing `Outdated PR Check` context so they are distinguishable in the GitHub PR checks UI, without breaking current branch protection.

Previously both workflows posted the same status context (`Outdated PR Check`), which caused confusion when the on-commit check passed but the scheduled daily check later posted a failure on the same SHA — both appeared under the same name with contradictory states.

| Workflow | Contexts posted |
| --- | --- |
| `outdated-pr-check.yml` (on commit) | `Outdated PR Check` (legacy) + `Outdated PR Check / On Commit` (new) |
| `outdated-pr-refresh.yml` (scheduled) | `Outdated PR Check` (legacy) + `Outdated PR Check / Scheduled` (new) |

Both file names and workflow display names are unchanged — the only change is an additional `gh api` status post in each workflow for the new semantic context.

### Transition plan

1. **Merge this PR** — both workflows now post two contexts per SHA. Branch protection still requires `Outdated PR Check`, so no gap.
2. **Run the scheduled workflow once** via `workflow_dispatch` so GitHub has seen `Outdated PR Check / Scheduled` on at least one commit.
3. **Update branch protection** to require the new context name(s) instead of `Outdated PR Check`.
4. **Follow-up PR** — remove the legacy `Outdated PR Check` context posts once branch protection no longer references them.
