### PR TITLE
[Realtime] Fix broken use cases link on overview page

### DIFF
--- a/src/content/docs/realtime/index.mdx
+++ b/src/content/docs/realtime/index.mdx
@@ -86,7 +86,7 @@ Cloudflare Stream lets you or your end users upload, store, encode, and deliver 
 
 <LinkTitleCard
 	title="Use cases"
-	href="/realtime/realtimekit/introduction#use-cases"
+	href="/realtime/realtimekit/#build-with-realtimekit"
 	icon="document"
 >
 	Learn how you can build and deploy ambitious Realtime applications to


### PR DESCRIPTION
### Summary

The "Use cases" card on the Cloudflare Realtime overview page (`/realtime/`) linked to
`/realtime/realtimekit/introduction#use-cases`, a page that doesn't exist. This caused a 404 when clicked.

Updated the link to `/realtime/realtimekit/#build-with-realtimekit`, which points to the existing 
"Build with RealtimeKit" section on the RealtimeKit overview page.

Fixes #32328
