### PR TITLE
Update WARPRelease.astro

### DIFF
--- a/src/components/cf/WARPRelease.astro
+++ b/src/components/cf/WARPRelease.astro
@@ -46,6 +46,7 @@ const sortedPlatforms = Object.entries(release.linuxPlatforms ?? {}).sort(
 				<span>
 					<strong>Version: </strong>
 					{release.platformName}
+					{" "}
 					{release.version}
 				</span>
 				<span>


### PR DESCRIPTION
### Summary

Adding a missing space under each download option after version, between the operating system and the actual version. 

Before: 

Version: Windows2026.6.880.0
Date: 2026-07-21
Size: 59 MB

After:

Version: Windows 2026.6.880.0
Date: 2026-07-21
Size: 59 MB

### Screenshots (optional)

<img width="1094" height="916" alt="Screenshot 2026-07-27 at 8 28 38 AM" src="https://github.com/user-attachments/assets/00b86203-eae8-4adb-b4b4-19490a4db677" />


### Documentation checklist

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
