### PR TITLE
fix: add missing space between 'LLM-friendly' and 'llms.txt directory' on 404 page

### DIFF
--- a/src/components/404.astro
+++ b/src/components/404.astro
@@ -15,7 +15,7 @@
 			id="404-search-link"
 			class="cursor-pointer border-none bg-transparent p-0 font-[inherit] text-blue-500 underline hover:no-underline dark:text-orange-500"
 			>search</button
-		> or try our LLM-friendly
+		> or try our LLM-friendly{" "}
 		<a
 			href="/llms.txt"
 			class="text-blue-500 underline hover:no-underline dark:text-orange-500"


### PR DESCRIPTION
## Summary

The 404 page had a JSX whitespace issue: a newline between `LLM-friendly` and the `<a>` link to `llms.txt directory` caused JSX to collapse the whitespace, rendering as `LLM-friendlyllms.txt directory`.

Added `{" "}` to preserve the space.

## Changes

- `src/components/404.astro`: Added explicit `{" "}` after `LLM-friendly` to prevent JSX whitespace collapse.

## Images

#### Before
<img width="653" height="345" alt="Screenshot 2026-07-27 at 12 55 56 PM" src="https://github.com/user-attachments/assets/fcf6f0fe-a933-460b-8d3d-627acfc79226" />

#### After
<img width="589" height="398" alt="Screenshot 2026-07-27 at 1 07 47 PM" src="https://github.com/user-attachments/assets/7327a09d-4342-4176-b3de-5061d2b191bc" />


