### PR TITLE
[Cloudflare One] Remove unsupported Tor Network (T1) from Gateway continent selectors

### DIFF
--- a/src/content/docs/cloudflare-one/traffic-policies/dns-policies/index.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/dns-policies/index.mdx
@@ -421,7 +421,6 @@ Use this selector to filter based on the continent that the query resolves to. G
 - NA - North America
 - OC - Oceania
 - SA - South America
-- T1 - Tor network
 
 | UI name                           | API example                     | Evaluation phase     |
 | --------------------------------- | ------------------------------- | -------------------- |

--- a/src/content/partials/cloudflare-one/gateway/selectors/destination-continent.mdx
+++ b/src/content/partials/cloudflare-one/gateway/selectors/destination-continent.mdx
@@ -15,7 +15,6 @@ The continent where the request is destined. Geolocation is determined from the 
 | North America | `NA` |
 | Oceania       | `OC` |
 | South America | `SA` |
-| Tor network   | `T1` |
 
 | UI name                              | API example                                    |
 | ------------------------------------ | ---------------------------------------------- |

--- a/src/content/partials/cloudflare-one/gateway/selectors/source-continent-dns.mdx
+++ b/src/content/partials/cloudflare-one/gateway/selectors/source-continent-dns.mdx
@@ -15,7 +15,6 @@ Geolocation is determined from the device's public IP address (typically assigne
 | North America | `NA` |
 | Oceania       | `OC` |
 | South America | `SA` |
-| Tor network   | `T1` |
 
 | UI name                         | API example                                               | Evaluation phase      |
 | ------------------------------- | --------------------------------------------------------- | --------------------- |

--- a/src/content/partials/cloudflare-one/gateway/selectors/source-continent-http.mdx
+++ b/src/content/partials/cloudflare-one/gateway/selectors/source-continent-http.mdx
@@ -15,7 +15,6 @@ Geolocation is determined from the device's public IP address (typically assigne
 | North America | `NA` |
 | Oceania       | `OC` |
 | South America | `SA` |
-| Tor network   | `T1` |
 
 | UI name                         | API example                                               |
 | ------------------------------- | --------------------------------------------------------- |

--- a/src/content/partials/cloudflare-one/gateway/selectors/source-continent.mdx
+++ b/src/content/partials/cloudflare-one/gateway/selectors/source-continent.mdx
@@ -15,7 +15,6 @@ Geolocation is determined from the device's public IP address (typically assigne
 | North America | `NA` |
 | Oceania       | `OC` |
 | South America | `SA` |
-| Tor network   | `T1` |
 
 | UI name                         | API example                                               | Evaluation phase      |
 | ------------------------------- | --------------------------------------------------------- | --------------------- |


### PR DESCRIPTION
Removes "Tor Network" (T1) from all Gateway continent selector documentation. T1 is not a supported continent value in Gateway policies.

**Files changed:**
- `source-continent.mdx` - source continent selector partial
- `source-continent-dns.mdx` - DNS source continent selector partial
- `source-continent-http.mdx` - HTTP source continent selector partial
- `destination-continent.mdx` - destination continent selector partial
- `dns-policies/index.mdx` - inline Resolved Continent list on DNS policies page

Pure removal, no additions.