### PR TITLE
[DNS] Fix ACNS dashboard navigation path

### DIFF
--- a/src/content/docs/dns/nameservers/custom-nameservers/account-custom-nameservers.mdx
+++ b/src/content/docs/dns/nameservers/custom-nameservers/account-custom-nameservers.mdx
@@ -109,9 +109,9 @@ Cloudflare will assign an IPv4 and an IPv6 address to each ACNS name, and these 
 <Tabs syncKey="dashPlusAPI">
 <TabItem label="Dashboard">
 
-1. In the Cloudflare dashboard, go to the **DNS Records** page.
+1. In the Cloudflare dashboard, go to the **DNS Settings** page.
 
-   <DashButton url="/?to=/:account/:zone/dns/records" />
+   <DashButton url="/?to=/:account/:zone/dns/settings" />
 
 2. For **Custom nameservers**, select **Configure**.
 3. Select **Use your account custom nameservers** and choose a nameserver set from the list.


### PR DESCRIPTION
### Summary

Fixes the dashboard navigation instructions for configuring Account Custom Nameservers (ACNS). The steps pointed to the **DNS Records** page, but the **Custom nameservers** configuration option lives under the **DNS Settings** page.

### Documentation checklist

- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
