### PR TITLE
chore: Clarify copied agent setup prompt text

### DIFF
--- a/src/components/agents.ts
+++ b/src/components/agents.ts
@@ -1,7 +1,7 @@
 // AI coding agents shown on the landing page, plus the prompt they copy.
 
 export const AGENT_SETUP_PROMPT =
-	"Fetch https://developers.cloudflare.com/agent-setup/prompt.md";
+	"Fetch and execute the appropriate instructions to set me up for Cloudflare from https://developers.cloudflare.com/agent-setup/prompt.md";
 
 // Each id maps to /icons/agents/{id}/{light,dark}.svg.
 export const AGENTS = [


### PR DESCRIPTION
### Summary

Updates the prompt string that the agent-setup landing page copies to the clipboard. The old text (`Fetch <url>`) only told the agent to fetch the URL; the new text instructs it to fetch and execute the setup instructions, which is clearer about the intended action across different coding agents.
