### PR TITLE
Fix mismatched parseCookie function for extract-cookie-value example

### DIFF
--- a/src/content/docs/workers/examples/extract-cookie-value.mdx
+++ b/src/content/docs/workers/examples/extract-cookie-value.mdx
@@ -29,12 +29,12 @@ import { TabItem, Tabs } from "~/components";
 <Tabs syncKey="workersExamples"> <TabItem label="JavaScript" icon="seti:javascript">
 
 ```js
-import { parse } from "cookie";
+import { parseCookie } from "cookie";
 export default {
 	async fetch(request) {
 		// The name of the cookie
 		const COOKIE_NAME = "__uid";
-		const cookie = parse(request.headers.get("Cookie") || "");
+		const cookie = parseCookie(request.headers.get("Cookie") || "");
 		if (cookie[COOKIE_NAME] != null) {
 			// Respond with the cookie value
 			return new Response(cookie[COOKIE_NAME]);
@@ -47,12 +47,12 @@ export default {
 </TabItem> <TabItem label="TypeScript" icon="seti:typescript">
 
 ```ts
-import { parse } from "cookie";
+import { parseCookie } from "cookie";
 export default {
 	async fetch(request): Promise<Response> {
 		// The name of the cookie
 		const COOKIE_NAME = "__uid";
-		const cookie = parse(request.headers.get("Cookie") || "");
+		const cookie = parseCookie(request.headers.get("Cookie") || "");
 		if (cookie[COOKIE_NAME] != null) {
 			// Respond with the cookie value
 			return new Response(cookie[COOKIE_NAME]);


### PR DESCRIPTION
### Summary
In the example for extracting cookies in Workers, there was incorrect code in the Javascript and Typescript examples, where 
a function called "parse", instead of cookie.parseCookie() was used. I fixed both examples, adding ~16 characters total
