### PR TITLE
[Audit Logs] Fix Resource History dashboard instruction to reference History tab

### DIFF
--- a/src/content/docs/fundamentals/account/account-security/audit-logs.mdx
+++ b/src/content/docs/fundamentals/account/account-security/audit-logs.mdx
@@ -139,7 +139,7 @@ For any audit log entry, Resource History retrieves every other audit log entry 
 
 1. Go to **Manage Account** > **Audit Logs**.
 2. Open any audit log entry.
-3. Select **Change History** to see the full history for the resource that entry describes.
+3. Select the **History** tab to see the full history for the resource that entry describes.
 4. In the history view, select any earlier entry to see a side-by-side diff of the fields that changed between it and the current entry.
 
 When Resource History cannot identify the underlying resource (for example, for certain system-initiated events), the dashboard shows an empty state indicating that change history is not available for that entry.


### PR DESCRIPTION
Small wording fix. The dashboard button in Audit Logs v2 Resource History is labeled **History** (a tab), not **Change History**.

## Change

- `src/content/docs/fundamentals/account/account-security/audit-logs.mdx` line 142: `Select **Change History**` → `Select the **History** tab`

## Context

Follow-up to #32078, which added the Resource History section. The original wording used `Change History`, but the actual UI element is a tab labeled `History`. Confirmed via screenshot from the Cloudflare dashboard.

One-line change, no other content affected.