### PR TITLE
Add Workers KV jurisdictions documentation

### DIFF
--- a/src/content/docs/kv/concepts/kv-namespaces.mdx
+++ b/src/content/docs/kv/concepts/kv-namespaces.mdx
@@ -21,7 +21,7 @@ KV namespace IDs are public and bound to your account.
 
 ## Jurisdictions
 
-Namespaces can optionally be restricted to a jurisdiction to store and process data only within a specific region. This feature is currently in private beta. Refer to [Data location](/kv/reference/data-location/) for more information.
+Namespaces can optionally be restricted to a jurisdiction to durably store data only within a specific region. This feature is currently in private beta. Refer to [Data location](/kv/reference/data-location/) for more information.
 
 ## Bind your KV namespace through Wrangler
 

--- a/src/content/docs/kv/concepts/kv-namespaces.mdx
+++ b/src/content/docs/kv/concepts/kv-namespaces.mdx
@@ -19,6 +19,10 @@ KV namespace IDs are public and bound to your account.
 
 :::
 
+## Jurisdictions
+
+Namespaces can optionally be restricted to a jurisdiction to store and process data only within a specific region. This feature is currently in private beta. Refer to [Data location](/kv/reference/data-location/) for more information.
+
 ## Bind your KV namespace through Wrangler
 
 To bind KV namespaces to your Worker, assign an array of the below object to the `kv_namespaces` key.

--- a/src/content/docs/kv/index.mdx
+++ b/src/content/docs/kv/index.mdx
@@ -172,6 +172,12 @@ Bindings allow your Workers to interact with resources on the Cloudflare develop
 
 </Feature>
 
+<Feature header="Jurisdictions" href="/kv/reference/data-location/">
+
+Restrict a KV namespace to store and process data only within a specific jurisdiction to help meet compliance requirements. Currently in private beta.
+
+</Feature>
+
 ---
 
 ## Related products

--- a/src/content/docs/kv/index.mdx
+++ b/src/content/docs/kv/index.mdx
@@ -174,7 +174,7 @@ Bindings allow your Workers to interact with resources on the Cloudflare develop
 
 <Feature header="Jurisdictions" href="/kv/reference/data-location/">
 
-Restrict a KV namespace to store and process data only within a specific jurisdiction to help meet compliance requirements. Currently in private beta.
+Restrict a KV namespace to durably store data only within a specific jurisdiction to help meet compliance requirements. Currently in private beta.
 
 </Feature>
 

--- a/src/content/docs/kv/reference/data-location.mdx
+++ b/src/content/docs/kv/reference/data-location.mdx
@@ -21,7 +21,7 @@ By default, data written to a Workers KV namespace is replicated globally across
 
 Jurisdictions are used to create Workers KV namespaces that only durably store data within a region, to help comply with data locality regulations such as the [GDPR](https://gdpr-info.eu/) or [FedRAMP](https://blog.cloudflare.com/cloudflare-achieves-fedramp-authorization/).
 
-Workers may still access a namespace constrained to a jurisdiction from anywhere in the world. The jurisdiction constraint only controls where the namespace's data is durably stored. Consider using [Regional Services](/data-localization/regional-services/) to control the regions from which Cloudflare responds to requests.
+Workers may still access a namespace constrained to a jurisdiction from anywhere in the world, and KV data can be cached outside the jurisdiction location on Cloudflare's network. The jurisdiction constraint only controls where the namespace's data is durably stored. Consider using [Regional Services](/data-localization/regional-services/) to control the regions from which Cloudflare responds to requests.
 
 :::note
 

--- a/src/content/docs/kv/reference/data-location.mdx
+++ b/src/content/docs/kv/reference/data-location.mdx
@@ -19,9 +19,9 @@ By default, data written to a Workers KV namespace is replicated globally across
 
 ## Restrict a namespace to a jurisdiction
 
-Jurisdictions are used to create Workers KV namespaces that only store and process data within a region, to help comply with data locality regulations such as the [GDPR](https://gdpr-info.eu/) or [FedRAMP](https://blog.cloudflare.com/cloudflare-achieves-fedramp-authorization/).
+Jurisdictions are used to create Workers KV namespaces that only durably store data within a region, to help comply with data locality regulations such as the [GDPR](https://gdpr-info.eu/) or [FedRAMP](https://blog.cloudflare.com/cloudflare-achieves-fedramp-authorization/).
 
-Workers may still access a namespace constrained to a jurisdiction from anywhere in the world. The jurisdiction constraint only controls where the namespace's data is stored and processed. Consider using [Regional Services](/data-localization/regional-services/) to control the regions from which Cloudflare responds to requests.
+Workers may still access a namespace constrained to a jurisdiction from anywhere in the world. The jurisdiction constraint only controls where the namespace's data is durably stored. Consider using [Regional Services](/data-localization/regional-services/) to control the regions from which Cloudflare responds to requests.
 
 :::note
 

--- a/src/content/docs/kv/reference/data-location.mdx
+++ b/src/content/docs/kv/reference/data-location.mdx
@@ -1,0 +1,42 @@
+---
+title: Data location
+pcx_content_type: concept
+sidebar:
+  order: 4
+---
+
+:::note
+
+Jurisdictions for Workers KV are currently in private beta. To enroll, contact your Cloudflare account team or [Cloudflare Support](/support/contacting-cloudflare-support/).
+
+:::
+
+Learn how the location of data stored in Workers KV is determined, including how you can restrict a namespace to a specific jurisdiction.
+
+## Automatic (default)
+
+By default, data written to a Workers KV namespace is replicated globally across Cloudflare's network with no jurisdictional restriction, allowing your data to be read with low latency from anywhere in the world.
+
+## Restrict a namespace to a jurisdiction
+
+Jurisdictions are used to create Workers KV namespaces that only store and process data within a region, to help comply with data locality regulations such as the [GDPR](https://gdpr-info.eu/) or [FedRAMP](https://blog.cloudflare.com/cloudflare-achieves-fedramp-authorization/).
+
+Workers may still access a namespace constrained to a jurisdiction from anywhere in the world. The jurisdiction constraint only controls where the namespace's data is stored and processed. Consider using [Regional Services](/data-localization/regional-services/) to control the regions from which Cloudflare responds to requests.
+
+:::note
+
+Jurisdictions can only be set when a namespace is created and cannot be added or changed afterwards.
+
+:::
+
+### Supported jurisdictions
+
+| Parameter | Location                       |
+| --------- | ------------------------------- |
+| eu        | The European Union              |
+| fedramp   | FedRAMP-compliant data centers  |
+| us        | The United States of America    |
+
+### Get access
+
+Workers KV jurisdictions are in private beta. If you are interested in restricting your namespaces to a supported jurisdiction, contact your Cloudflare account team or [Cloudflare Support](/support/contacting-cloudflare-support/) to request access.


### PR DESCRIPTION
### Summary

Adds a new reference page documenting Workers KV jurisdictions, which allow a KV namespace to be restricted to store and process data only within a specific region (EU, FedRAMP, US) to help meet compliance requirements. This feature is currently in private beta.

- New page: `/kv/reference/data-location/` covering automatic (default) data location, how to restrict a namespace to a jurisdiction, supported jurisdictions, and how to request access.
- Links added from the KV namespaces concept page and the KV product index page.

### Screenshots (optional)

N/A

### Documentation checklist

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [x] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).