### PR TITLE
[AI Gateway] Mark Evaluations as deprecated

### DIFF
--- a/src/content/docs/ai-gateway/evaluations/index.mdx
+++ b/src/content/docs/ai-gateway/evaluations/index.mdx
@@ -12,6 +12,12 @@ products:
   - ai-gateway
 ---
 
+import { Aside } from "~/components";
+
+<Aside type="caution" title="Deprecated">
+	Evaluations are deprecated and no longer supported for new accounts.
+</Aside>
+
 Understanding your application's performance is essential for optimization. Developers often have different priorities, and finding the optimal solution involves balancing key factors such as cost, latency, and accuracy. Some prioritize low-latency responses, while others focus on accuracy or cost-efficiency.
 
 AI Gateway's Evaluations provide the data needed to make informed decisions on how to optimize your AI application. Whether it is adjusting the model, provider, or prompt, this feature delivers insights into key metrics around performance, speed, and cost. It empowers developers to better understand their application's behavior, ensuring improved accuracy, reliability, and customer satisfaction.

--- a/src/content/docs/ai-gateway/evaluations/set-up-evaluations.mdx
+++ b/src/content/docs/ai-gateway/evaluations/set-up-evaluations.mdx
@@ -9,6 +9,12 @@ products:
   - ai-gateway
 ---
 
+import { Aside } from "~/components";
+
+<Aside type="caution" title="Deprecated">
+	Evaluations are deprecated and no longer supported for new accounts.
+</Aside>
+
 This guide walks you through the process of setting up an evaluation in AI Gateway. These steps are done in the [Cloudflare dashboard](https://dash.cloudflare.com/).
 
 ## 1. Select or create a dataset


### PR DESCRIPTION
Adds a deprecation banner to the AI Gateway Evaluations landing page and the Set up Evaluations guide, flagging that the feature is deprecated and no longer supported for new accounts.