### PR TITLE
[Agents] Update MCP SDK dependency versions

### DIFF
--- a/src/content/docs/agents/model-context-protocol/apis/handler-api.mdx
+++ b/src/content/docs/agents/model-context-protocol/apis/handler-api.mdx
@@ -25,13 +25,13 @@ The Agents SDK provides two server handler paths:
 
 For a stateless server:
 
-<PackageManagers pkg="agents @modelcontextprotocol/server@2.0.0-beta.5 zod" />
+<PackageManagers pkg="agents @modelcontextprotocol/server@2.0.0 zod" />
 
 For an explicit legacy server:
 
-<PackageManagers pkg="agents @modelcontextprotocol/sdk@1.29.0 zod" />
+<PackageManagers pkg="agents @modelcontextprotocol/sdk@1.30.0 zod" />
 
-Use the exact MCP versions required by your installed Agents release while the v2 SDK remains in beta.
+Use the exact MCP versions required by your installed Agents release.
 
 ## `createMcpHandler`
 

--- a/src/content/docs/agents/model-context-protocol/guides/migrate-to-mcp-sdk-v2.mdx
+++ b/src/content/docs/agents/model-context-protocol/guides/migrate-to-mcp-sdk-v2.mdx
@@ -33,21 +33,21 @@ Agents SDK v0.20.0 deprecates these APIs:
 
 ## Install the MCP packages
 
-Install only the MCP package generations that your application imports. Keep the v2 beta version exact.
+Install only the MCP package generations that your application imports. Keep the v2 version exact.
 
 For a stateless server:
 
-<PackageManagers pkg="agents @modelcontextprotocol/server@2.0.0-beta.5 zod" />
+<PackageManagers pkg="agents @modelcontextprotocol/server@2.0.0 zod" />
 
 For a temporary legacy lane:
 
-<PackageManagers pkg="agents @modelcontextprotocol/sdk@1.29.0 zod" />
+<PackageManagers pkg="agents @modelcontextprotocol/sdk@1.30.0 zod" />
 
 For an Agent that connects to MCP servers:
 
-<PackageManagers pkg="agents @modelcontextprotocol/client@2.0.0-beta.5" />
+<PackageManagers pkg="agents @modelcontextprotocol/client@2.0.0" />
 
-Follow peer dependency instructions from your package manager. The exact v2 pin will change with later Agents releases while the MCP SDK remains in beta.
+Follow peer dependency instructions from your package manager. Update the exact MCP versions with the Agents release that supports them.
 
 ## Decide whether a temporary legacy lane is required
 
@@ -345,7 +345,7 @@ Custom transports, proxies, and gateways must preserve the draft request headers
 - `Mcp-Name` for tool, prompt, and resource operations
 - Declared `Mcp-Param-*` tool headers
 
-The exact beta used by Agents is a draft snapshot. Beta.5 makes `clientInfo` optional and places server identity in result `_meta`. Use high-level SDK APIs and update MCP packages with the Agents release that supports each snapshot. Raw stateless results must include `resultType`.
+The exact SDK version used by Agents implements the MCP 2026-07-28 revision. It makes `clientInfo` optional and places server identity in result `_meta`. Use high-level SDK APIs and update MCP packages with the Agents release that supports each protocol revision. Raw stateless results must include `resultType`.
 
 The draft deprecates Roots, Sampling, Logging, the old HTTP+SSE transport, and Dynamic Client Registration. The types remain available during the deprecation window for legacy compatibility. The published experimental task methods become the `io.modelcontextprotocol/tasks` extension. Agents SDK v0.20.0 does not add that extension.
 


### PR DESCRIPTION
### Summary

Updates the Agents MCP handler reference and SDK v2 migration guide to use stable `@modelcontextprotocol/client@2.0.0`, `@modelcontextprotocol/server@2.0.0`, and legacy `@modelcontextprotocol/sdk@1.30.0`. Removes beta-specific guidance that no longer applies.

Companion to https://github.com/cloudflare/agents/pull/1987.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
