### PR TITLE
[Email Service, Workers] Document email handler testing

### DIFF
--- a/src/content/docs/email-service/local-development/routing.mdx
+++ b/src/content/docs/email-service/local-development/routing.mdx
@@ -70,10 +70,13 @@ Start your development server:
 npx wrangler dev
 ```
 
-Send a test email using the local endpoint. The request body must be a raw email message in [RFC 5322](https://datatracker.ietf.org/doc/html/rfc5322) format, and the message must include a `Message-ID` header:
+Send a test email using the local endpoint. The request body must be a raw email message in [RFC 5322](https://datatracker.ietf.org/doc/html/rfc5322) format, and the message must include a `Message-ID` header.
+
+By default, the endpoint returns the email handler outcome as text. Pass `format=json` to return the structured handler result:
 
 ```bash
 curl --request POST 'http://localhost:8787/cdn-cgi/handler/email' \
+  --url-query 'format=json' \
   --url-query 'from=sender@example.com' \
   --url-query 'to=recipient@example.com' \
   --data-raw 'Received: from smtp.example.com (127.0.0.1)
@@ -91,7 +94,32 @@ Message-ID: <6114391943504294873000@ZSH-GHOSTTY>
 Hi there'
 ```
 
-This will output the parsed email structure in the console:
+The endpoint returns the handler outcome, rejection reason, forwarded messages and replies:
+
+```json
+{
+	"outcome": "ok",
+	"forwards": [
+		{
+			"messageId": "<generated-message-id>@example.com",
+			"recipient": "general@example.com",
+			"headers": []
+		}
+	],
+	"replies": [],
+	"events": [
+		{
+			"type": "forward",
+			"timestamp": "<ISO 8601 timestamp>",
+			"messageId": "<generated-message-id>@example.com"
+		}
+	]
+}
+```
+
+The response includes `rejectReason` when the handler calls `message.setReject()`. The `outcome` is `"exception"` when the handler throws.
+
+This will also output the parsed email structure in the console:
 
 ```json
 {

--- a/src/content/docs/workers/testing/test-harness/interact-with-workers.mdx
+++ b/src/content/docs/workers/testing/test-harness/interact-with-workers.mdx
@@ -48,9 +48,24 @@ You can then use this Worker handle to send requests directly or dispatch other 
 const apiWorker = server.getWorker("api-worker");
 const response = await apiWorker.fetch("http://api.example.com/v1/users/123");
 
+// Dispatch a scheduled event to the Worker
 await apiWorker.scheduled({
 	cron: "0 0 * * *",
 	scheduledTime: new Date(),
+});
+
+// Dispatch an email event to the Worker
+await server.getWorker().email({
+	from: "sender@example.com",
+	to: "inbox@example.com",
+	raw: [
+		"From: Sender <sender@example.com>",
+		"To: Inbox <inbox@example.com>",
+		"Message-ID: <test@example.com>",
+		"Subject: Test email",
+		"",
+		"Hello from the test harness",
+	].join("\r\n"),
 });
 ```
 

--- a/src/content/docs/workers/wrangler/api.mdx
+++ b/src/content/docs/workers/wrangler/api.mdx
@@ -31,7 +31,7 @@ Wrangler offers APIs to programmatically interact with your Cloudflare Workers.
 
 ## `createTestHarness`
 
-`createTestHarness()` starts one or more Workers for integration tests from any Node.js test runner. It runs production build output from Wrangler configuration files, Vite-generated configuration files, or inline Wrangler configuration objects. The API wraps Miniflare and provides methods for dispatching requests and scheduled events.
+`createTestHarness()` starts one or more Workers for integration tests from any Node.js test runner. It runs production build output from Wrangler configuration files, Vite-generated configuration files, or inline Wrangler configuration objects. The API wraps Miniflare and provides methods for dispatching requests and triggering event handlers.
 
 For setup guidance and examples, refer to [Integration test harness](/workers/testing/test-harness/).
 
@@ -138,6 +138,8 @@ const server = createTestHarness({
   - Dispatches a fetch event directly to this Worker.
 - `scheduled(options)` <Type text={'Promise<{ outcome: "ok" | "canceled" | "exception"; noRetry: boolean }>'} />
   - Dispatches a scheduled event directly to this Worker.
+- `email(options)` <Type text="Promise<FetcherEmailResult>" />
+  - Dispatches an email event directly to this Worker.
 - `getEnv()` <Type text="Promise<Env>" />
   - Returns the full environment object configured for this Worker, including variables, secrets, and bindings.
 - `getExport()` <Type text={"Promise<Service<Module['default']>>"} />


### PR DESCRIPTION
### Summary

Documents the email handler testing support added in https://github.com/cloudflare/workers-sdk/pull/14685 so users can dispatch email events through `createTestHarness()` and inspect structured results. It also documents the matching `format=json` output for the local `/cdn-cgi/handler/email` endpoint.

### Documentation checklist

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
