### PR TITLE
[R2] Fix jurisdiction binding configuration

### DIFF
--- a/src/content/docs/r2/reference/data-location.mdx
+++ b/src/content/docs/r2/reference/data-location.mdx
@@ -94,13 +94,9 @@ To access R2 buckets that belong to a jurisdiction from [Workers](/workers/), yo
 {
 	"r2_buckets": [
 		{
-			"bindings": [
-				{
-					"binding": "MY_BUCKET",
-					"bucket_name": "<YOUR_BUCKET_NAME>",
-					"jurisdiction": "<JURISDICTION>"
-				}
-			]
+			"binding": "MY_BUCKET",
+			"bucket_name": "<YOUR_BUCKET_NAME>",
+			"jurisdiction": "<JURISDICTION>"
 		}
 	]
 }


### PR DESCRIPTION
### Summary

Fixes the invalid Wrangler configuration in the R2 jurisdiction documentation.

The example nested a `bindings` array inside `r2_buckets`, which Wrangler does not support. This change places `binding`, `bucket_name`, and `jurisdiction` directly on the R2 bucket entry.

Validated with formatting checks, Astro checks, and a full build.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).