### PR TITLE
[AI Gateway] Warn against x-api-key in Anthropic BYOK example

### DIFF
--- a/src/content/docs/ai-gateway/usage/providers/anthropic.mdx
+++ b/src/content/docs/ai-gateway/usage/providers/anthropic.mdx
@@ -6,7 +6,7 @@ products:
   - ai-gateway
 ---
 
-import { Render, Details, Tabs, TabItem } from "~/components";
+import { Render, Details, Tabs, TabItem, Aside } from "~/components";
 
 [Anthropic](https://www.anthropic.com/) helps build reliable, interpretable, and steerable AI systems.
 
@@ -124,6 +124,7 @@ import Anthropic from "@anthropic-ai/sdk";
 const baseURL = `https://gateway.ai.cloudflare.com/v1/{accountId}/{gatewayId}/anthropic`;
 
 const anthropic = new Anthropic({
+	apiKey: "placeholder", // Ignored by AI Gateway when using BYOK or Unified Billing, but the SDK requires a value.
 	baseURL,
 	defaultHeaders: {
 		Authorization: `Bearer {cf_api_token}`,
@@ -136,6 +137,10 @@ const message = await anthropic.messages.create({
 	max_tokens: 1024,
 });
 ```
+
+<Aside type="note">
+When using BYOK or Unified Billing, do not set `x-api-key` in `defaultHeaders`. AI Gateway supplies the Anthropic key for you, and adding your own `x-api-key` header will cause the request to fail. The `apiKey` value above is a placeholder to satisfy the Anthropic SDK, which requires either the `apiKey` option or the `ANTHROPIC_API_KEY` environment variable to be set.
+</Aside>
 </Details>
 
 <Render

--- a/src/content/docs/ai-gateway/usage/providers/anthropic.mdx
+++ b/src/content/docs/ai-gateway/usage/providers/anthropic.mdx
@@ -139,7 +139,7 @@ const message = await anthropic.messages.create({
 ```
 
 <Aside type="note">
-When using BYOK or Unified Billing, do not set `x-api-key` in `defaultHeaders`. AI Gateway supplies the Anthropic key for you, and adding your own `x-api-key` header will cause the request to fail. The `apiKey` value above is a placeholder to satisfy the Anthropic SDK, which requires either the `apiKey` option or the `ANTHROPIC_API_KEY` environment variable to be set.
+When using BYOK or Unified Billing, do not set `x-api-key` in `defaultHeaders`. AI Gateway supplies the Anthropic key for you, and adding your own `x-api-key` header will cause the request to fail. The `apiKey` value in the example is a placeholder to satisfy the Anthropic SDK, which requires either the `apiKey` option or the `ANTHROPIC_API_KEY` environment variable to be set.
 </Aside>
 </Details>
 


### PR DESCRIPTION
The BYOK/Unified Billing Anthropic SDK example on the Anthropic provider page didn't warn against manually setting `x-api-key` in `defaultHeaders`, and silently relied on `ANTHROPIC_API_KEY` being set in the environment for the SDK to construct.

When using BYOK or Unified Billing, adding `x-api-key: "unused"` (a natural instinct, and something coding agents will try) causes the request to fail rather than being ignored.

- Add `apiKey: "placeholder"` to the BYOK Anthropic SDK example so it doesn't depend on env vars.
- Add an Aside noting that `x-api-key` must not be set in `defaultHeaders` under BYOK/Unified Billing, and that `apiKey` is only a placeholder to satisfy the SDK.