### PR TITLE
Add use_in_app_webview MDM parameter for Android/ChromeOS

### DIFF
--- a/src/content/docs/cloudflare-one/team-and-resources/devices/cloudflare-one-client/deployment/mdm-deployment/parameters.mdx
+++ b/src/content/docs/cloudflare-one/team-and-resources/devices/cloudflare-one-client/deployment/mdm-deployment/parameters.mdx
@@ -468,6 +468,21 @@ Assigns a unique identifier to the device for the [device UUID posture check](/c
 
 **Value:** UUID for the device (for example, `496c6124-db89-4735-bc4e-7f759109a6f1`).
 
+### `use_in_app_webview`
+
+:::note
+Only valid for Android and ChromeOS.
+:::
+
+Uses an in-app WebView for Zero Trust authentication instead of the default system browser. This setting is required when Always-on VPN with Lockdown mode is enabled.
+
+**Value Type:** `boolean`
+
+**Value:**
+
+- `false` — (default) Uses the default system browser for Zero Trust authentication.
+- `true` — Uses an in-app WebView for Zero Trust authentication.
+
 ### `warp_tunnel_protocol`
 
 Configures the protocol used to route IP traffic from the device to Cloudflare Gateway. For more information, refer to [Device tunnel protocol](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/settings/#device-tunnel-protocol).


### PR DESCRIPTION
### Summary

Adds documentation for the `use_in_app_webview` MDM parameter, which configures the Cloudflare One Client to use an in-app WebView for Zero Trust authentication instead of the default system browser.

### Screenshots (optional)

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
