### PR TITLE
fix: Correct environment-dependent Mermaid sizing

### DIFF
--- a/src/scripts/mermaid.client.node.test.ts
+++ b/src/scripts/mermaid.client.node.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test, vi } from "vitest";
+
+import { fitSvgToContents } from "./mermaid.client";
+
+describe("fitSvgToContents", () => {
+	test("replaces Mermaid's stale HTML label dimensions with rendered bounds", () => {
+		const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+		svg.setAttribute("viewBox", "-75 -35 2084 2043");
+		svg.style.maxWidth = "2084px";
+		svg.getBBox = vi.fn(() => new DOMRect(8, 8, 1431, 160));
+
+		fitSvgToContents(svg);
+
+		expect(svg.getAttribute("viewBox")).toBe("0 0 1447 176");
+		expect(svg.style.maxWidth).toBe("1447px");
+	});
+
+	test("preserves a view box that already fits the rendered bounds", () => {
+		const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+		svg.setAttribute("viewBox", "0 0 120 70");
+		svg.style.maxWidth = "120px";
+		svg.getBBox = vi.fn(() => new DOMRect(10, 10, 100, 50));
+
+		fitSvgToContents(svg);
+
+		expect(svg.getAttribute("viewBox")).toBe("0 0 120 70");
+		expect(svg.style.maxWidth).toBe("120px");
+	});
+
+	test("leaves dimensions unchanged when bounds are unavailable", () => {
+		const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+		svg.setAttribute("viewBox", "0 0 100 50");
+		svg.getBBox = vi.fn(() => {
+			throw new Error("not rendered");
+		});
+
+		fitSvgToContents(svg);
+
+		expect(svg.getAttribute("viewBox")).toBe("0 0 100 50");
+	});
+});

--- a/src/scripts/mermaid.client.ts
+++ b/src/scripts/mermaid.client.ts
@@ -5,6 +5,7 @@
 
 let dialog: HTMLDialogElement | null = null;
 let themeObserver: MutationObserver | null = null;
+const diagramPadding = 8;
 // Per-<pre> guard: capture source text once, before mermaid replaces innerHTML.
 const captured = new WeakSet<HTMLPreElement>();
 
@@ -183,6 +184,47 @@ function wrapDiagram(diagram: HTMLPreElement, title: string | null) {
 	}
 }
 
+export function fitSvgToContents(svg: SVGSVGElement): void {
+	let bounds: DOMRect;
+	try {
+		bounds = svg.getBBox();
+	} catch {
+		return;
+	}
+
+	if (
+		![bounds.x, bounds.y, bounds.width, bounds.height].every(Number.isFinite) ||
+		bounds.width <= 0 ||
+		bounds.height <= 0
+	) {
+		return;
+	}
+
+	const width = bounds.width + diagramPadding * 2;
+	const height = bounds.height + diagramPadding * 2;
+	// Mermaid briefly uses an oversized foreignObject to measure HTML labels.
+	// Preserve valid padding, but replace a view box based on that stale geometry.
+	const viewBox = svg
+		.getAttribute("viewBox")
+		?.trim()
+		.split(/[\s,]+/)
+		.map(Number);
+	if (
+		viewBox?.length === 4 &&
+		viewBox.every(Number.isFinite) &&
+		viewBox[2] <= width * 2 &&
+		viewBox[3] <= height * 2
+	) {
+		return;
+	}
+
+	svg.setAttribute(
+		"viewBox",
+		`${bounds.x - diagramPadding} ${bounds.y - diagramPadding} ${width} ${height}`,
+	);
+	svg.style.maxWidth = `${width}px`;
+}
+
 async function render() {
 	const diagrams = document.querySelectorAll<HTMLPreElement>("pre.mermaid");
 	if (diagrams.length === 0) return;
@@ -277,6 +319,7 @@ async function render() {
 			const title = titleElement?.textContent?.trim() || null;
 
 			wrapDiagram(diagram, title);
+			if (svgElement) fitSvgToContents(svgElement);
 			diagram.setAttribute("data-processed", "true");
 		} catch (e) {
 			showRenderError(diagram);

--- a/src/styles/markdown-pipeline.css
+++ b/src/styles/markdown-pipeline.css
@@ -280,7 +280,7 @@ pre.mermaid[data-processed] svg {
 	max-width: 100%;
 	height: auto;
 	display: block;
-	margin: 0;
+	margin: 0 auto;
 	padding: 0;
 	vertical-align: top;
 }


### PR DESCRIPTION
### Summary

Corrects an environment-dependent Mermaid rendering issue that is not reproducible on every machine.

On affected browser and OS combinations, Mermaid can retain the temporary `2000 × 2000` dimensions used to measure HTML labels. The resulting oversized SVG view box makes diagrams appear tiny, especially in the expanded view. This was reproduced with a clean browser profile, ruling out cache and extensions.

This change refits only disproportionately large view boxes after rendering, centers diagrams, and adds regression coverage.

### Screenshots (optional)

<!-- TODO: add before and after screenshots from an affected environment -->

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
