### PR TITLE
ci: add R2 production snapshots

### DIFF
--- a/.github/workflows/upload-r2-snapshot.yml
+++ b/.github/workflows/upload-r2-snapshot.yml
@@ -1,0 +1,96 @@
+name: Upload R2 snapshot
+
+on:
+  workflow_run:
+    workflows: ["Publish"]
+    types: [completed]
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  upload:
+    name: Upload production snapshot to R2
+    if: >-
+      github.repository == 'cloudflare/cloudflare-docs' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == 'production'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Download published site
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: site-html
+          path: dist
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Upload snapshot
+        env:
+          R2_BUCKET: ${{ vars.R2_SNAPSHOT_BUCKET }}
+          R2_ACCOUNT_ID: ${{ vars.R2_SNAPSHOT_ACCOUNT_ID }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_SNAPSHOT_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SNAPSHOT_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: auto
+          PUBLISHED_SHA: ${{ github.event.workflow_run.head_sha }}
+          PUBLISH_RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          set -euo pipefail
+          : "${R2_BUCKET:?R2_SNAPSHOT_BUCKET repository variable is required}"
+          : "${R2_ACCOUNT_ID:?R2_SNAPSHOT_ACCOUNT_ID repository variable is required}"
+          : "${AWS_ACCESS_KEY_ID:?R2_SNAPSHOT_ACCESS_KEY_ID secret is required}"
+          : "${AWS_SECRET_ACCESS_KEY:?R2_SNAPSHOT_SECRET_ACCESS_KEY secret is required}"
+
+          endpoint="https://$R2_ACCOUNT_ID.r2.cloudflarestorage.com"
+          timestamp=$(date -u '+%Y-%m-%dT%H-%M-%SZ')
+          destination="s3://$R2_BUCKET/$timestamp"
+          manifest="$RUNNER_TEMP/manifest.json"
+          success="$RUNNER_TEMP/_SUCCESS"
+
+          if [ -z "$(find dist -type f -name '*.html' -print -quit)" ]; then
+            echo "No HTML files found in the site artifact" >&2
+            exit 1
+          fi
+
+          jq -n \
+            --arg timestamp "$timestamp" \
+            --arg sha "$PUBLISHED_SHA" \
+            --arg publish_run_id "$PUBLISH_RUN_ID" \
+            '{timestamp: $timestamp, commitSha: $sha, publishRunId: $publish_run_id}' \
+            > "$manifest"
+          touch "$success"
+
+          aws configure set default.s3.max_concurrent_requests 32
+
+          aws s3 cp . "$destination/source/" \
+            --recursive --exclude '.git/*' --exclude 'dist/*' \
+            --no-follow-symlinks --no-progress --endpoint-url "$endpoint"
+          aws s3 cp dist "$destination/dist/" \
+            --recursive --exclude '*' --include '*.html' --no-progress \
+            --endpoint-url "$endpoint"
+          aws s3 cp "$manifest" "$destination/manifest.json" \
+            --no-progress --endpoint-url "$endpoint"
+          aws s3 cp "$success" "$destination/_SUCCESS" \
+            --no-progress --endpoint-url "$endpoint"
+
+      - name: Notify Google Chat on failure
+        if: failure()
+        env:
+          WEBHOOK_URL: ${{ secrets.CED_TEAM_ALERTS_CHANNEL_WEBHOOK }}
+          ACTOR: ${{ github.event.workflow_run.actor.login }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+          PUBLISHED_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          MESSAGE="*R2 production snapshot* failed (site already deployed).\nActor: $ACTOR\nCommit: $PUBLISHED_SHA\n<https://github.com/$REPO/actions/runs/$RUN_ID|View run>"
+          JSON_PAYLOAD=$(jq -n --arg text "$MESSAGE" '{text: $text}')
+          curl -X POST "$WEBHOOK_URL" \
+            -H "Content-Type: application/json" \
+            -d "$JSON_PAYLOAD"

--- a/.github/workflows/upload-r2-snapshot.yml
+++ b/.github/workflows/upload-r2-snapshot.yml
@@ -50,7 +50,7 @@ jobs:
 
           endpoint="https://$R2_ACCOUNT_ID.r2.cloudflarestorage.com"
           timestamp=$(date -u '+%Y-%m-%dT%H-%M-%SZ')
-          destination="s3://$R2_BUCKET/$timestamp"
+          destination="s3://$R2_BUCKET/$timestamp-$PUBLISH_RUN_ID"
           manifest="$RUNNER_TEMP/manifest.json"
           checksums="$RUNNER_TEMP/MD5SUMS"
           success="$RUNNER_TEMP/_SUCCESS"

--- a/.github/workflows/upload-r2-snapshot.yml
+++ b/.github/workflows/upload-r2-snapshot.yml
@@ -34,19 +34,19 @@ jobs:
 
       - name: Upload snapshot
         env:
-          R2_BUCKET: ${{ vars.R2_SNAPSHOT_BUCKET }}
-          R2_ACCOUNT_ID: ${{ vars.R2_SNAPSHOT_ACCOUNT_ID }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.R2_SNAPSHOT_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SNAPSHOT_SECRET_ACCESS_KEY }}
+          R2_BUCKET: ${{ secrets.R2_SNAPSHOT_BUCKET }}
+          R2_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AI_SEARCH_R2_SNAPSHOT_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AI_SEARCH_R2_SNAPSHOT_SECRET_ACCESS_KEY_ID }}
           AWS_DEFAULT_REGION: auto
           PUBLISHED_SHA: ${{ github.event.workflow_run.head_sha }}
           PUBLISH_RUN_ID: ${{ github.event.workflow_run.id }}
         run: |
           set -euo pipefail
-          : "${R2_BUCKET:?R2_SNAPSHOT_BUCKET repository variable is required}"
-          : "${R2_ACCOUNT_ID:?R2_SNAPSHOT_ACCOUNT_ID repository variable is required}"
-          : "${AWS_ACCESS_KEY_ID:?R2_SNAPSHOT_ACCESS_KEY_ID secret is required}"
-          : "${AWS_SECRET_ACCESS_KEY:?R2_SNAPSHOT_SECRET_ACCESS_KEY secret is required}"
+          : "${R2_BUCKET:?R2_SNAPSHOT_BUCKET secret is required}"
+          : "${R2_ACCOUNT_ID:?CLOUDFLARE_ACCOUNT_ID secret is required}"
+          : "${AWS_ACCESS_KEY_ID:?AI_SEARCH_R2_SNAPSHOT_ACCESS_KEY_ID secret is required}"
+          : "${AWS_SECRET_ACCESS_KEY:?AI_SEARCH_R2_SNAPSHOT_SECRET_ACCESS_KEY_ID secret is required}"
 
           endpoint="https://$R2_ACCOUNT_ID.r2.cloudflarestorage.com"
           timestamp=$(date -u '+%Y-%m-%dT%H-%M-%SZ')

--- a/.github/workflows/upload-r2-snapshot.yml
+++ b/.github/workflows/upload-r2-snapshot.yml
@@ -52,6 +52,7 @@ jobs:
           timestamp=$(date -u '+%Y-%m-%dT%H-%M-%SZ')
           destination="s3://$R2_BUCKET/$timestamp"
           manifest="$RUNNER_TEMP/manifest.json"
+          checksums="$RUNNER_TEMP/MD5SUMS"
           success="$RUNNER_TEMP/_SUCCESS"
 
           if [ -z "$(find dist -type f -name '*.html' -print -quit)" ]; then
@@ -59,11 +60,19 @@ jobs:
             exit 1
           fi
 
+          find . \( -path './.git' -o -path './dist' \) -prune -o -type f -print0 \
+            | sort -z \
+            | xargs -0 md5sum \
+            | sed 's|  \./|  source/|' > "$checksums"
+          find dist -type f -name '*.html' -print0 \
+            | sort -z \
+            | xargs -0 md5sum >> "$checksums"
+
           jq -n \
             --arg timestamp "$timestamp" \
             --arg sha "$PUBLISHED_SHA" \
             --arg publish_run_id "$PUBLISH_RUN_ID" \
-            '{timestamp: $timestamp, commitSha: $sha, publishRunId: $publish_run_id}' \
+            '{timestamp: $timestamp, commitSha: $sha, publishRunId: $publish_run_id, checksumAlgorithm: "md5", checksumFile: "MD5SUMS"}' \
             > "$manifest"
           touch "$success"
 
@@ -75,6 +84,8 @@ jobs:
           aws s3 cp dist "$destination/dist/" \
             --recursive --exclude '*' --include '*.html' --no-progress \
             --endpoint-url "$endpoint"
+          aws s3 cp "$checksums" "$destination/MD5SUMS" \
+            --no-progress --endpoint-url "$endpoint"
           aws s3 cp "$manifest" "$destination/manifest.json" \
             --no-progress --endpoint-url "$endpoint"
           aws s3 cp "$success" "$destination/_SUCCESS" \


### PR DESCRIPTION
### Summary
Adds a post-deployment workflow that mirrors each successful production build to R2. It uploads the generated HTML from dist/ and the corresponding Git-tracked source files under a timestamped prefix. Each snapshot includes an `MD5SUMS` file for comparing individual files between snapshots.

### Documentation checklist
This is a different kind of change, does not affect any of the deployed pages, thus does not fit into the docs style, or changelog.

- [X] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [X] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [X] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file). (No files affected)

# IMPORTANT
Needs new secrets before merge, to be provided internally.

Repository secrets:
- CLOUDFLARE_ACCOUNT_ID
- R2_SNAPSHOT_BUCKET
- AI_SEARCH_R2_SNAPSHOT_ACCESS_KEY_ID
- AI_SEARCH_R2_SNAPSHOT_SECRET_ACCESS_KEY_ID
