### PR TITLE
[Cloudflare One] Note ServiceNow OAuth Scope Restriction = Broadly sc…

### DIFF
--- a/src/content/partials/cloudflare-one/casb/servicenow-integration.mdx
+++ b/src/content/partials/cloudflare-one/casb/servicenow-integration.mdx
@@ -5,7 +5,7 @@ params:
   - slugifiedName
 ---
 
-import { Render } from "~/components";
+import { Aside, Render } from "~/components";
 
 <Render
 	file="casb/integration-description"
@@ -20,6 +20,10 @@ import { Render } from "~/components";
 
 - `admin` access to a {props.environmentName}
 - Ability to [create an OAuth API endpoint for external clients](https://docs.servicenow.com/csh?topicname=t_CreateEndpointforExternalClients)
+
+<Aside type="note">
+	If a **Scope Restriction** field appears, set it to **Broadly scoped**.
+</Aside>
 
 ## Integration permissions
 


### PR DESCRIPTION
### Summary

- Adds a note to the ServiceNow CASB integration prerequisites instructing users
  to set the OAuth endpoint's **Scope Restriction** field to **Broadly scoped**
  when it appears.
- Applies to both the ServiceNow and ServiceNow (FedRAMP) integration pages via
  the shared partial.

### Screenshots
<img width="807" height="938" alt="image" src="https://github.com/user-attachments/assets/31d58f40-0893-4a41-8940-452da6337dc3" />


### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [x] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
