### PR TITLE
[AI Gateway] Document credential precedence for BYOK and Unified Billing

### DIFF
--- a/src/content/docs/ai-gateway/configuration/bring-your-own-keys.mdx
+++ b/src/content/docs/ai-gateway/configuration/bring-your-own-keys.mdx
@@ -143,6 +143,10 @@ Each API key can be assigned an alias to identify it. When you add a key, you ca
 
 When making requests, AI Gateway uses the key with the `default` alias by default. To use a different key, include the `cf-aig-byok-alias` header with the alias of the key you want to use.
 
+:::note
+The `cf-aig-byok-alias` header applies to [direct provider-passthrough](/ai-gateway/usage/providers/) requests. On requests routed through [Unified Billing](/ai-gateway/features/unified-billing/) endpoints (for example, `env.AI.run()` or `/ai/v1/chat/completions`), only the `default` alias is consulted — if the `default` key is missing, the request falls through to Unified Billing. See [Credential precedence](/ai-gateway/features/unified-billing/#credential-precedence) for the full order.
+:::
+
 ### Example: Using a specific key alias
 
 If you have multiple OpenAI keys configured with different aliases (for example, `default`, `production`, and `testing`), you can specify which one to use:

--- a/src/content/docs/ai-gateway/features/unified-billing.mdx
+++ b/src/content/docs/ai-gateway/features/unified-billing.mdx
@@ -55,6 +55,20 @@ You can configure AI Gateway to automatically replenish your credits when they f
 
 When your balance falls below the set threshold, AI Gateway will automatically apply the auto top-up amount to your account.
 
+## Credential precedence
+
+When a request reaches AI Gateway, credentials are resolved in this order:
+
+1. **Provider key on the request** — if the request carries provider authentication (for example, an `Authorization` header), AI Gateway forwards it to the provider unchanged. BYOK and Unified Billing are not consulted.
+2. **BYOK (stored key)** — if no provider key is on the request and the gateway has a [stored key](/ai-gateway/configuration/bring-your-own-keys/) for the provider under the `default` alias, that key is used.
+3. **Unified Billing** — if neither of the above applies, the request is served with Cloudflare-managed credentials and billed against your Cloudflare credit balance.
+
+:::note
+On requests routed through Unified Billing endpoints (for example, `env.AI.run()` or `/ai/v1/chat/completions`), only the BYOK key stored under the `default` alias prevents fall-through to Unified Billing. Keys stored under other aliases are not consulted on this path — a request will fall through to Unified Billing even if you have a key stored under, for example, `production` or `testing`.
+
+The `cf-aig-byok-alias` header selects a non-default alias only on [direct provider-passthrough](/ai-gateway/usage/providers/) requests.
+:::
+
 ## Use Unified Billing
 
 Unified Billing works in two ways: through the AI binding or through the HTTP API. Both deduct credits from your account automatically without requiring provider API keys.


### PR DESCRIPTION
Documents the credential resolution order that AI Gateway applies to inference requests: request-supplied provider key, then BYOK, then Unified Billing.

Also clarifies a subtle behavior on the Unified Billing path: only the BYOK key stored under the `default` alias prevents fall-through to Unified Billing. Keys stored under other aliases are only consulted via `cf-aig-byok-alias` on direct provider-passthrough requests. A customer who stores their key under `production` (for example) and calls a Unified Billing endpoint will silently be billed via Unified Billing rather than their BYOK key — worth documenting.

- New "Credential precedence" section in `features/unified-billing.mdx`.
- Cross-reference note added to `configuration/bring-your-own-keys.mdx` next to the alias docs.

Sourced from the AIG worker in \`ai-gateway-infra\` (\`BaseProviderLibrary.loadSecrets\`, \`DynamicRoutesConnector\`, \`IProvider.prepareRequestBody\`). There is a TODO in the connector path to make the BYOK alias request-header driven; if/when that lands, the "only \`default\` prevents fall-through" caveat will need revisiting.