### PR TITLE
Fix Data Catalog setup steps

### DIFF
--- a/src/content/docs/r2/data-catalog/get-started.mdx
+++ b/src/content/docs/r2/data-catalog/get-started.mdx
@@ -69,10 +69,9 @@ This guide will instruct you through:
 
    <DashButton url="/?to=/:account/data-catalog/overview" />
 2. Select **Create catalog**.
-3. Enter the bucket name `r2-data-catalog-tutorial`. Since this bucket does not exist yet, the wizard will create it for you. Optionally choose a location hint.
 3. Enter the bucket name `r2-data-catalog-tutorial`. The wizard creates the bucket automatically if it does not already exist. Optionally choose a location hint.
-5. Review the configuration and select **Create catalog**.
-6. Once created, the catalog detail page displays your **Catalog URI** and **Warehouse name**. Note these values for later.
+4. Review the configuration and select **Create catalog**.
+5. Once created, the catalog detail page displays your **Catalog URI** and **Warehouse name**. Note these values for later.
 </Steps>
 </TabItem>
 </Tabs>


### PR DESCRIPTION
### Summary

Fix the R2 Data Catalog getting-started dashboard instructions, which repeated step 3 and skipped step 4.

- Remove the duplicate bucket configuration instruction.
- Renumber the remaining steps so the flow is sequential.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
Saved to /tmp/output.md; preview at /tmp/preview.html was not opened.