### PR TITLE
Fix Mastodon media hostname typo

### DIFF
--- a/src/content/docs/r2/tutorials/mastodon.mdx
+++ b/src/content/docs/r2/tutorials/mastodon.mdx
@@ -84,7 +84,7 @@ If you had the media files hosted locally, you will likely need to set up redire
 
 ### 3. Verify bucket and redirects
 
-Depending on your migration plan, you can verify if the bucket is accessible publicly and the redirects work correctly. To verify, open an existing uploaded media file with a path like `https://mastodon.example.com/cache/...` and replace the hostname from `mastodon.example.com` to `mastocon-files.example.com` and visit the new path. If the file opened correctly, proceed to the final step.
+Depending on your migration plan, you can verify if the bucket is accessible publicly and the redirects work correctly. To verify, open an existing uploaded media file with a path like `https://mastodon.example.com/cache/...` and replace the hostname from `mastodon.example.com` to `mastodon-files.example.com` and visit the new path. If the file opened correctly, proceed to the final step.
 
 ### 4. Finalize migration
 


### PR DESCRIPTION
## Summary

Fixing a typo in the Mastodon hostname

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).