### PR TITLE
fix Wrangler object upload link

### DIFF
--- a/src/content/docs/r2/objects/upload-objects.mdx
+++ b/src/content/docs/r2/objects/upload-objects.mdx
@@ -819,7 +819,7 @@ Wrangler supports uploading files up to 315 MB and only allows one object at a t
 
 :::
 
-Use [Wrangler](/workers/wrangler/install-and-update/) to upload objects. Run the [`r2 object put` command](/workers/wrangler/commands/#r2-object-put):
+Use [Wrangler](/workers/wrangler/install-and-update/) to upload objects. Run the [`r2 object put` command](/workers/wrangler/commands/r2/#r2-object-put):
 
 ```sh
 wrangler r2 object put test-bucket/image.png --file=image.png


### PR DESCRIPTION
## Summary
Fix the Wrangler r2 object put link on the R2 object upload page.

## Documentation checklist
- The change adheres to the documentation style guide (https://developers.cloudflare.com/style-guide/).