### PR TITLE
docs(reference-architecture): fix ASR acronym and link to the Whisper model

### DIFF
--- a/src/content/docs/reference-architecture/diagrams/ai/ai-video-caption.mdx
+++ b/src/content/docs/reference-architecture/diagrams/ai/ai-video-caption.mdx
@@ -25,7 +25,7 @@ The process begins with capturing the audio from the video source, which is then
 ![Figure 1: Automatic captioning on upload](~/assets/images/reference-architecture/ai-auto-caption-architecture-diagrams/ai-auto-caption-architecture-diagram.svg "Figure 1:  Automatic captioning on upload")
 
 1. **Client upload**: Send POST request with both video and audio to API endpoint.
-2. **Audio transcription**: Generate timestamped transcriptions by calling [Workers AI](/workers-ai/) [automatic speech recognition (ARS) model](/workers-ai/models/) with audio as input. Use [Workers](/workers/) to convert the output to a supported subtitled format.
+2. **Audio transcription**: Generate timestamped transcriptions by calling [Workers AI](/workers-ai/) [automatic speech recognition (ASR) model](/workers-ai/models/whisper-large-v3-turbo/) with audio as input. Use [Workers](/workers/) to convert the output to a supported subtitled format.
 3. **Store subtitles**: Store the subtitle file(s) on [R2](/r2/).
 4. **Store video**: Store the video files on [R2](/r2/).
 5. **Client request**: Send GET requests for video and subtitle(s) to origin. Use global [Cache](/cache/) to increase performance.
@@ -34,5 +34,5 @@ The process begins with capturing the audio from the video source, which is then
 ## Related resources
 
 - [Community project: automatic captioning demo](https://auto-caption.pages.dev/)
-- [Workers AI: Automatic speech recognition (ARS) model](/workers-ai/models/)
+- [Workers AI: Automatic speech recognition (ASR) model](/workers-ai/models/whisper-large-v3-turbo/)
 - [R2: Object storage for all your data](/r2/)


### PR DESCRIPTION
Addresses #32406, reported by @jeffsani.

Verified all links on the AI video caption diagram page currently resolve (each returns 200), so the "none resolve" part did not reproduce. The substantive problem is real though: the page misspells automatic speech recognition as "ARS" twice, so searching the Workers AI models page for that acronym finds nothing, which matches the report.

This fixes the acronym to ASR in both places and points the model links at the Whisper ASR model page directly (`/workers-ai/models/whisper-large-v3-turbo/`, verified live) instead of the generic models index, so the reference lands on actual speech-recognition content.
