### PR TITLE
[Cache] Link purge docs to API reference

### DIFF
--- a/src/content/docs/cache/how-to/purge-cache/index.mdx
+++ b/src/content/docs/cache/how-to/purge-cache/index.mdx
@@ -14,6 +14,8 @@ Cloudflare's Instant Purge ensures that updates to your content are reflected im
 
 <DirectoryListing />
 
+To purge cached content using the Cloudflare API, refer to [Purge Cached Content](/api/resources/cache/methods/purge/).
+
 :::note
 If versioning is active on your zone and multiple environments are configured, you can select the specific environment you want to purge. For more details, refer to the [Version Management](/version-management/) documentation.
 :::


### PR DESCRIPTION
## Summary

- Link the Purge cache overview to the Purge Cached Content API reference.

## Tests

- `pnpm exec prettier --check src/content/docs/cache/how-to/purge-cache/index.mdx`
- `git diff --check`
- `pnpm run check` (blocked by missing Worker globals in generated `skills/turnstile-spin` templates)
- `pnpm run build` (blocked by the Astro `cookie.parseCookie` dependency export)