### PR TITLE
chore: Add CODEOWNERS for networking changelogs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -251,6 +251,11 @@ package.json @cloudflare/content-engineering
 /src/content/docs/cloudflare-wan/ @steve-cloudflare @jeffh-cloudflare @alpdot @cloudflare/cf1-reviewers @elithrar @cloudflare/product-owners
 /src/content/docs/multi-cloud-networking/ @steve-cloudflare @jeffh-cloudflare @cloudflare/cf1-reviewers @elithrar @cloudflare/product-owners
 /src/content/partials/networking-services/ @steve-cloudflare @jeffh-cloudflare @alpdot @cloudflare/product-owners
+/src/content/changelog/cloudflare-network-firewall/ @steve-cloudflare @jeffh-cloudflare @alpdot @cloudflare/pm-changelogs @cloudflare/product-owners
+/src/content/changelog/cloudflare-wan/ @steve-cloudflare @jeffh-cloudflare @alpdot @cloudflare/pm-changelogs @cloudflare/product-owners
+/src/content/changelog/magic-transit/ @steve-cloudflare @jeffh-cloudflare @alpdot @cloudflare/pm-changelogs @cloudflare/product-owners
+/src/content/changelog/multi-cloud-networking/ @steve-cloudflare @jeffh-cloudflare @alpdot @cloudflare/pm-changelogs @cloudflare/product-owners
+/src/content/changelog/network-interconnect/ @steve-cloudflare @jeffh-cloudflare @alpdot @cloudflare/pm-changelogs @cloudflare/product-owners
 
 # Migration guides
 


### PR DESCRIPTION
### Summary

Adds CODEOWNERS entries for Magic/Cloudflare networking product changelogs to ensure changes are routed to the correct reviewers. 

Specifically adds changelog directories for `cloudflare-network-firewall`, `cloudflare-wan`, `magic-transit`, `multi-cloud-networking`, and `network-interconnect`. These previously fell back to the root changelog owners.

Owners match the base set already used for the Magic products docs entries, plus the standard `@cloudflare/pm-changelogs` team.