### PR TITLE
docs(tunnel): Palo Alto NGFW App-ID 9128+ requires allowing quic-base

### DIFF
--- a/src/content/docs/tunnel/troubleshooting.mdx
+++ b/src/content/docs/tunnel/troubleshooting.mdx
@@ -157,7 +157,7 @@ Cloudflare recently became aware of a change in Palo Alto Networks Next Generati
 
 Palo Alto Networks Next Generation Firewall (NGFW) detects both Cloudflare Tunnel (`cloudflared`) and the Cloudflare One Client (WARP with Zero Trust) as `cloudflare-warp`, regardless of the App-ID database version. There is currently no separate App-ID for `cloudflared`.
 
-This section focuses on Cloudflare Tunnel (`cloudflared`) connecting to Cloudflare over QUIC (UDP port `7844`). If the Cloudflare One Client is impacted, refer to the [WARP ingress IPs and ports](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/deployment/firewall/#warp-ingress-ip).
+This issue is likely to impact the Cloudflare One Client and WARP client, because Palo Alto Networks NGFW identifies their traffic as `cloudflare-warp`. This section focuses on Cloudflare Tunnel (`cloudflared`) connecting to Cloudflare over QUIC (UDP port `7844`). For WARP client connectivity requirements, refer to [WARP ingress IPs and ports](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/deployment/firewall/#warp-ingress-ip).
 
 Starting with App-ID database version 9128 (released on July 27, 2026), NGFW changed the requirements for permitting this traffic. App-ID database version 9128 and later requires you to explicitly allow the `quic-base` application in addition to the previously required App-IDs and their dependencies.
 

--- a/src/content/docs/tunnel/troubleshooting.mdx
+++ b/src/content/docs/tunnel/troubleshooting.mdx
@@ -151,7 +151,7 @@ Replace `198.41.200.43` with the IP shown in your [error message](#dialcontext-e
 	}}
 />
 
-## Cloudflare Tunnel (cloudflared) fails to connect through Palo Alto Networks Next-Generation Firewall (NGFW)
+## Cloudflare Tunnel fails to connect through Palo Alto Networks Next-Generation Firewall
 
 Cloudflare recently became aware of a change in Palo Alto Networks Next Generation Firewall (NGFW) App-ID database version 9128 that affects the requirements for permitting Cloudflare Tunnel and Cloudflare One Client traffic.
 

--- a/src/content/docs/tunnel/troubleshooting.mdx
+++ b/src/content/docs/tunnel/troubleshooting.mdx
@@ -151,6 +151,56 @@ Replace `198.41.200.43` with the IP shown in your [error message](#dialcontext-e
 	}}
 />
 
+## Cloudflare Tunnel (WARP/Cloudflare One Client/WARP) Fail to Connect through Palo Alto Networks Next-Generation Firewall (NGFW)
+
+Cloudflare recently became aware of a change in Palo Alto Networks Next Generation Firewall (NGFW) App-ID database version 9128 that affects the requirements for permitting Cloudflare Tunnel and Cloudflare One Client traffic.
+
+Palo Alto Networks Next Generation Firewall (NGFW) detects both Cloudflare Tunnel (`cloudflared`) and the Cloudflare One Client (WARP with Zero Trust) as `cloudflare-warp`, regardless of the App-ID database version. There is currently no separate App-ID for `cloudflared`.
+
+Starting with App-ID database version 9128 (released on 27/07/2026), NGFW changed the requirements for permitting this traffic. App-ID database version 9128 and later requires you to explicitly allow the `quic-base` application in addition to the previously required App-IDs and their dependencies.
+
+To restore connectivity, either revert the App-ID database or explicitly allow the required applications and UDP port.
+
+### Option 1: Revert the App-ID database
+
+Revert to App-ID database version 9127 and disable automatic App-ID updates until Palo Alto Networks provides a permanent resolution.
+
+### Option 2: Configure an explicit firewall policy
+
+#### Create a custom service for UDP port 7844
+
+1. In PAN-OS, go to **Objects** > **Services**.
+2. Create a service with the following settings:
+
+   | Setting | Value |
+   | --- | --- |
+   | Name | `cloudflared_7844_udp` |
+   | Description | Optional |
+   | Protocol | UDP |
+   | Destination Port | `7844` |
+   | Source Port | Leave blank |
+   | Session Timeout | Inherit from application |
+
+3. Select **OK**.
+
+#### Create or update a firewall rule
+
+1. Go to **Policies**.
+2. Create or modify a **universal** or **interzone** firewall rule.
+3. Configure the **Source** and **Destination** criteria to match the relevant traffic flows in your environment:
+   - **Source**: Select the appropriate Source Zone and/or Source Address.
+   - **Destination**: Select the appropriate Destination Zone and/or Destination Address.
+4. Under **Application**, add all of the following applications:
+   - `cloudflare-warp`
+   - `ike`
+   - `ipsec-esp-udp`
+   - `quic-base`
+   - `ssl`
+5. Under **Service/URL Category**, add the custom service `cloudflared_7844_udp`.
+6. Set the rule **Action** to **Accept**.
+7. Enable logging according to your organization's security policy.
+8. Commit the policy change, then verify that Cloudflare Tunnel and Cloudflare One Client traffic can establish and maintain connections through the firewall.
+
 ## How do I contact support?
 
 <Render

--- a/src/content/docs/tunnel/troubleshooting.mdx
+++ b/src/content/docs/tunnel/troubleshooting.mdx
@@ -157,7 +157,9 @@ Cloudflare recently became aware of a change in Palo Alto Networks Next Generati
 
 Palo Alto Networks Next Generation Firewall (NGFW) detects both Cloudflare Tunnel (`cloudflared`) and the Cloudflare One Client (WARP with Zero Trust) as `cloudflare-warp`, regardless of the App-ID database version. There is currently no separate App-ID for `cloudflared`.
 
-This issue is likely to impact the Cloudflare One Client and WARP client, because Palo Alto Networks NGFW identifies their traffic as `cloudflare-warp`. This section focuses on Cloudflare Tunnel (`cloudflared`) connecting to Cloudflare over QUIC (UDP port `7844`). For WARP client connectivity requirements, refer to [WARP ingress IPs and ports](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/deployment/firewall/#warp-ingress-ip).
+This issue is likely to impact the Cloudflare One Client and WARP client, because Palo Alto Networks NGFW identifies their traffic as `cloudflare-warp`.
+
+This section focuses on Cloudflare Tunnel (`cloudflared`) connecting to Cloudflare over QUIC (UDP port `7844`).
 
 Starting with App-ID database version 9128 (released on July 27, 2026), NGFW changed the requirements for permitting this traffic. App-ID database version 9128 and later requires you to explicitly allow the `quic-base` application in addition to the previously required App-IDs and their dependencies.
 

--- a/src/content/docs/tunnel/troubleshooting.mdx
+++ b/src/content/docs/tunnel/troubleshooting.mdx
@@ -151,7 +151,7 @@ Replace `198.41.200.43` with the IP shown in your [error message](#dialcontext-e
 	}}
 />
 
-## Cloudflare Tunnel (WARP/Cloudflare One Client/WARP) Fail to Connect through Palo Alto Networks Next-Generation Firewall (NGFW)
+## Cloudflare Tunnel (cloudflared) fails to connect through Palo Alto Networks Next-Generation Firewall (NGFW)
 
 Cloudflare recently became aware of a change in Palo Alto Networks Next Generation Firewall (NGFW) App-ID database version 9128 that affects the requirements for permitting Cloudflare Tunnel and Cloudflare One Client traffic.
 
@@ -198,7 +198,7 @@ If you revert the App-ID database, treat this as a temporary mitigation and coor
    - `cloudflare-warp`
    - `quic-base`
 5. Under **Service/URL Category**, add the custom service `cloudflared_7844_udp`.
-6. Set the rule **Action** to **Accept**.
+6. Set the rule **Action** to **Allow**.
 7. Enable logging according to your organization's security policy.
 8. Commit the policy change, then verify that Cloudflare Tunnel can establish and maintain connections through the firewall.
 

--- a/src/content/docs/tunnel/troubleshooting.mdx
+++ b/src/content/docs/tunnel/troubleshooting.mdx
@@ -157,13 +157,17 @@ Cloudflare recently became aware of a change in Palo Alto Networks Next Generati
 
 Palo Alto Networks Next Generation Firewall (NGFW) detects both Cloudflare Tunnel (`cloudflared`) and the Cloudflare One Client (WARP with Zero Trust) as `cloudflare-warp`, regardless of the App-ID database version. There is currently no separate App-ID for `cloudflared`.
 
-Starting with App-ID database version 9128 (released on 27/07/2026), NGFW changed the requirements for permitting this traffic. App-ID database version 9128 and later requires you to explicitly allow the `quic-base` application in addition to the previously required App-IDs and their dependencies.
+This section focuses on Cloudflare Tunnel (`cloudflared`) connecting to Cloudflare over QUIC (UDP port `7844`). If the Cloudflare One Client is impacted, refer to the [WARP ingress IPs and ports](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/deployment/firewall/#warp-ingress-ip).
+
+Starting with App-ID database version 9128 (released on July 27, 2026), NGFW changed the requirements for permitting this traffic. App-ID database version 9128 and later requires you to explicitly allow the `quic-base` application in addition to the previously required App-IDs and their dependencies.
 
 To restore connectivity, either revert the App-ID database or explicitly allow the required applications and UDP port.
 
 ### Option 1: Revert the App-ID database
 
 Revert to App-ID database version 9127 and disable automatic App-ID updates until Palo Alto Networks provides a permanent resolution.
+
+If you revert the App-ID database, treat this as a temporary mitigation and coordinate with your security team. Re-enable automatic updates once Palo Alto Networks provides a permanent resolution.
 
 ### Option 2: Configure an explicit firewall policy
 
@@ -172,14 +176,14 @@ Revert to App-ID database version 9127 and disable automatic App-ID updates unti
 1. In PAN-OS, go to **Objects** > **Services**.
 2. Create a service with the following settings:
 
-   | Setting | Value |
-   | --- | --- |
-   | Name | `cloudflared_7844_udp` |
-   | Description | Optional |
-   | Protocol | UDP |
-   | Destination Port | `7844` |
-   | Source Port | Leave blank |
-   | Session Timeout | Inherit from application |
+   | Setting          | Value                    |
+   | ---------------- | ------------------------ |
+   | Name             | `cloudflared_7844_udp`   |
+   | Description      | Optional                 |
+   | Protocol         | UDP                      |
+   | Destination Port | `7844`                   |
+   | Source Port      | Leave blank              |
+   | Session Timeout  | Inherit from application |
 
 3. Select **OK**.
 
@@ -192,14 +196,11 @@ Revert to App-ID database version 9127 and disable automatic App-ID updates unti
    - **Destination**: Select the appropriate Destination Zone and/or Destination Address.
 4. Under **Application**, add all of the following applications:
    - `cloudflare-warp`
-   - `ike`
-   - `ipsec-esp-udp`
    - `quic-base`
-   - `ssl`
 5. Under **Service/URL Category**, add the custom service `cloudflared_7844_udp`.
 6. Set the rule **Action** to **Accept**.
 7. Enable logging according to your organization's security policy.
-8. Commit the policy change, then verify that Cloudflare Tunnel and Cloudflare One Client traffic can establish and maintain connections through the firewall.
+8. Commit the policy change, then verify that Cloudflare Tunnel can establish and maintain connections through the firewall.
 
 ## How do I contact support?
 


### PR DESCRIPTION
Adds a troubleshooting section to `/tunnel/troubleshooting/` for Palo Alto Networks NGFW App-ID database version 9128+.

- Documents that Palo Alto classifies Cloudflare Tunnel (`cloudflared`) traffic as `cloudflare-warp` and may require explicitly allowing `quic-base`.
- Provides two mitigation options: revert to content version 9127 (with caution) or create an explicit policy for UDP/7844.
- Links to WARP firewall requirements for Cloudflare One Client.

Context: INCIDENT-9349
