### PR TITLE
[Workers] Align React + Vite Deploy button with CLI scaffold

### DIFF
--- a/src/content/docs/workers/framework-guides/web-apps/react.mdx
+++ b/src/content/docs/workers/framework-guides/web-apps/react.mdx
@@ -29,9 +29,9 @@ import {
 />
 ---
 
-**Or just deploy** - create a full-stack app using React, Hono API and Vite, with CI/CD and previews all set up for you.
+**Or just deploy** - create a full-stack app using React, a Workers API and Vite, with CI/CD and previews all set up for you.
 
-[![Deploy to Workers](https://deploy.workers.cloudflare.com/button)](https://dash.cloudflare.com/?to=/:account/workers-and-pages/create/deploy-to-workers&repository=https://github.com/cloudflare/templates/tree/main/vite-react-template)
+[![Deploy to Workers](https://deploy.workers.cloudflare.com/button)](https://dash.cloudflare.com/?to=/:account/workers-and-pages/create/deploy-to-workers&repository=https://github.com/cloudflare/templates/tree/main/react-starter-template)
 
 ## What is React?
 

--- a/src/content/docs/workers/framework-guides/web-apps/react.mdx
+++ b/src/content/docs/workers/framework-guides/web-apps/react.mdx
@@ -29,7 +29,7 @@ import {
 />
 ---
 
-**Or just deploy** - create a full-stack app using React, a Workers API and Vite, with CI/CD and previews all set up for you.
+**Or just deploy** - create a full-stack app using React, a Workers API, and Vite, with CI/CD and previews all set up for you.
 
 [![Deploy to Workers](https://deploy.workers.cloudflare.com/button)](https://dash.cloudflare.com/?to=/:account/workers-and-pages/create/deploy-to-workers&repository=https://github.com/cloudflare/templates/tree/main/react-starter-template)
 


### PR DESCRIPTION
## Summary

Fixes the React + Vite guide so CLI and Deploy describe the same stack (React SPA + Workers API + Vite plugin), instead of advertising Hono on the Deploy path while `--framework=react` does not include it.

**Changes**
- Deploy blurb: "Workers API" (not "Hono API")
- Deploy button → `cloudflare/templates/react-starter-template` (matches `--framework=react`)

Closes #32368

## Preview
<img width="1146" height="625" alt="React + Vite guide hero — CLI + Deploy" src="https://github.com/user-attachments/assets/811215ed-81eb-4d00-84da-40d382171878" />


## Status / blockers

Ready for merging

| Path | Stack |
|------|--------|
| CLI `--framework=react` | React + Worker `fetch` API + Vite plugin |
| Deploy → `react-starter-template` | Same ([templates#1086](https://github.com/cloudflare/templates/pull/1086)) |
| Hono guide / `vite-react-template` | React + Hono (unchanged) |

## Test plan

- [ ] Local/docs preview: React guide hero shows CLI + Deploy with Workers API copy (no Hono)
- [ ] Deploy button URL targets `.../templates/tree/main/react-starter-template`
- [ ] After `react-starter-template` is on `main`: Deploy flow scaffolds the same layout as CLI (`src/` + `worker/index.ts`, no `hono` dep)
- [ ] Hono guide still uses `vite-react-template`