### PR TITLE
Wrangler check startup command docs update + changelog

### DIFF
--- a/src/content/changelog/workers/2026-07-31-wrangler-startup-profile-summary.mdx
+++ b/src/content/changelog/workers/2026-07-31-wrangler-startup-profile-summary.mdx
@@ -9,6 +9,8 @@ date: 2026-07-31
 
 `wrangler check startup` now reports your Worker's raw and compressed bundle sizes. It also summarizes local CPU activity during startup directly in your terminal.
 
+Large bundles and costly startup work can introduce cold-start latency, so use this command to find code and large dependencies that slow your Worker before it handles requests.
+
 The summary includes sampled, active, garbage collection, and idle time. Wrangler continues to save a `.cpuprofile` file for detailed flamegraph analysis in Chrome DevTools or VS Code.
 
 ```bash

--- a/src/content/changelog/workers/2026-07-31-wrangler-startup-profile-summary.mdx
+++ b/src/content/changelog/workers/2026-07-31-wrangler-startup-profile-summary.mdx
@@ -1,0 +1,41 @@
+---
+title: Inspect Worker startup performance with Wrangler
+description: Wrangler now reports bundle size and local CPU activity when profiling Worker startup.
+products:
+  - workers
+  - durable-objects
+date: 2026-07-31
+---
+
+`wrangler check startup` now reports your Worker's raw and compressed bundle sizes. It also summarizes local CPU activity during startup directly in your terminal.
+
+The summary includes sampled, active, garbage collection, and idle time. Wrangler continues to save a `.cpuprofile` file for detailed flamegraph analysis in Chrome DevTools or VS Code.
+
+```bash
+⛅️ wrangler 4.116.0
+───────────────────────────────────────────────
+├ Building your Worker
+│ Worker Built! 🎉
+│
+├ Analysing
+│ Startup phase analysed
+│
+│ Bundle: 7171.25 KiB / gzip: 2197.00 KiB
+│
+│ Local startup profile:
+│   Profile window: 70.3 ms
+│   Sampled time: 70.3 ms
+│   Active: 38.5 ms (including 3.7 ms garbage collection)
+│   Idle: 31.8 ms
+│   Samples: 36
+│
+│ CPU Profile has been written to worker-startup.cpuprofile. Load it into the Chrome DevTools profiler (or directly in VSCode) to view a flamegraph.
+│
+│ Note that the CPU Profile was measured on your Worker running locally on your machine, which has a different CPU than when your Worker runs on Cloudflare.
+│
+│ As such, CPU Profile can be used to understand where time is spent at startup, but the overall startup time in the profile should not be expected to exactly match what your Worker's startup time will be when deploying to Cloudflare.
+```
+
+The profile runs locally, so its duration will differ from startup time on Cloudflare. For authoritative startup time, deploy your Worker or upload a version.
+
+Available in Wrangler version 4.116.0 or later. For more information, refer to [`wrangler check startup`](/workers/wrangler/commands/workers/#startup).

--- a/src/content/docs/workers/wrangler/commands/workers.mdx
+++ b/src/content/docs/workers/wrangler/commands/workers.mdx
@@ -527,21 +527,42 @@ To generate types for only a specific environment, use the `--env` flag.
 
 ### `startup`
 
-Generate a CPU profile of your Worker's startup phase.
+Analyze your Worker's startup phase. Wrangler reports bundle size and a summary of local CPU activity. It also saves a detailed CPU profile.
 
-After you run `wrangler check startup`, you can import the profile into Chrome DevTools or open it directly in VSCode to view a flamegraph of your Worker's startup phase. Additionally, when a Worker deployment fails with a startup time error Wrangler will automatically generate a CPU profile for easy investigation.
+```sh
+wrangler check startup
+```
+
+```txt output
+Bundle: 42.31 KiB / gzip: 11.24 KiB
+
+Local startup profile:
+  Profile window: 25.2 ms
+  Sampled time: 24.8 ms
+  Active: 18.4 ms (including 1.2 ms garbage collection)
+  Idle: 6.4 ms
+  Samples: 25
+```
+
+The local startup profile includes the following metrics:
+
+| Metric | Description |
+| --- | --- |
+| Profile window | Elapsed time between the start and end of the profiling session. |
+| Sampled time | Total time represented by the captured CPU samples. |
+| Active | Sampled time that the Worker was not idle, including garbage collection. |
+| Idle | Sampled time that the Worker was idle. |
+| Samples | Number of CPU samples captured during the profiling session. |
+
+Import the generated `.cpuprofile` file into Chrome DevTools or open it directly in VS Code to view a flamegraph. When a Worker deployment fails with a startup time error, Wrangler also generates this profile automatically.
 
 :::note
 
 This command measures performance of your Worker locally, on your own machine — which has a different CPU than when your Worker runs on Cloudflare. This means results can vary widely.
 
-You should use the CPU profile that `wrangler check startup` generates in order to understand where time is spent at startup, but you should not expect the overall startup time in the profile to match exactly what your Worker's startup time will be when deploying to Cloudflare.
+Use the summary and CPU profile to understand where your Worker spends time during startup. Do not expect the local profile duration to match your Worker's startup time on Cloudflare.
 
 :::
-
-```sh
-wrangler check startup
-```
 
 - `--args` <Type text="string" /> <MetaInfo text="optional" />
   - To customise the way `wrangler check startup` builds your Worker for analysis, provide the exact arguments you use when deploying your Worker with `wrangler deploy`, or your Pages project with `wrangler pages functions build`. For instance, if you deploy your Worker with `wrangler deploy --no-bundle`, you should use `wrangler check startup --args="--no-bundle"` to profile the startup phase.


### PR DESCRIPTION
### Summary

The `wrangler check startup` command has existed for a while, but was never publicised - it's been in alpha since. It's very useful though for debugging slow-starting Workers (and Durable Objects, as the root Worker that exports it needs to load before the DO can load).

Rather than just a CPU profile, the command has been updated to extract key information into the terminal alongside the flamegraph. This key information includes start up time (how long the initial JS takes to load) plus bundle size.

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
