### PR TITLE
[Turnstile] Clarify client-side data processing

### DIFF
--- a/src/content/docs/turnstile/index.mdx
+++ b/src/content/docs/turnstile/index.mdx
@@ -49,6 +49,8 @@ Turnstile adapts the challenge outcome to the individual visitor or browser. Fir
 
 These challenges include proof-of-work (computational puzzles), proof-of-space, probing for web APIs, and various other challenges for detecting browser-quirks and human behavior. As a result, we can fine-tune the difficulty of the challenge to the specific request and avoid showing a visual or interactive puzzle to a user.
 
+Turnstile performs client-side security challenges on behalf of the website operator to distinguish human visitors from automated traffic. To do so, Turnstile processes only the data strictly necessary to provide this security function. Turnstile does not access, store, or transmit user communications, form entries, or other page inputs.
+
 :::note
 For detailed information on Turnstile's data privacy practices, refer to the [Turnstile Privacy Addendum](https://www.cloudflare.com/turnstile-privacy-policy/).
 :::


### PR DESCRIPTION
### Summary

Clarifies the data Turnstile processes when performing client-side security challenges and the page inputs it does not access, store, or transmit.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
