### PR TITLE
[SSL, Cloudflare One] Clarify AOP incompatibility with Cloudflare Tunnel

### DIFF
--- a/src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/index.mdx
+++ b/src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/index.mdx
@@ -39,6 +39,10 @@ Cloudflare Tunnel uses an outbound-only connection model to enable bidirectional
 
 Once the connection is established, traffic flows in both directions over the tunnel between your origin and Cloudflare. Most firewalls allow outbound traffic by default. `cloudflared` takes advantage of this standard by connecting out to the Cloudflare network from the server you installed `cloudflared` on. You can then configure your firewall to allow only these outbound connections and block all inbound traffic, effectively blocking access to your origin from anything other than Cloudflare. This setup ensures that all traffic to your origin is securely routed through the tunnel.
 
+:::note[Authenticated Origin Pulls does not apply]
+Because Cloudflare Tunnel does not use an inbound listener on your origin, [Authenticated Origin Pulls](/ssl/origin-configuration/authenticated-origin-pull/) has no effect on hostnames routed through Cloudflare Tunnel. Origin traffic is already authenticated using your tunnel's connector credentials.
+:::
+
 ## Next steps
 
 - Create a tunnel using the [Cloudflare dashboard](/cloudflare-one/networks/connectors/cloudflare-tunnel/get-started/create-remote-tunnel/) or [API](/cloudflare-one/networks/connectors/cloudflare-tunnel/get-started/create-remote-tunnel-api/).

--- a/src/content/docs/ssl/origin-configuration/authenticated-origin-pull/index.mdx
+++ b/src/content/docs/ssl/origin-configuration/authenticated-origin-pull/index.mdx
@@ -21,6 +21,10 @@ Authenticated Origin Pulls does not apply when your [SSL/TLS encryption mode](/s
 
 Without AOP, anyone who discovers your origin server's IP address can send requests directly, bypassing Cloudflare and all its protections. When you combine AOP with the [Cloudflare Web Application Firewall (WAF)](/waf/), your origin only accepts requests that have passed through Cloudflare, which means every request is evaluated by the WAF before reaching your server.
 
+:::note[Not compatible with Cloudflare Tunnel]
+AOP is not compatible with origins connected through [Cloudflare Tunnel](/cloudflare-one/networks/connectors/cloudflare-tunnel/). Tunnel uses outbound-only connections from your origin, so there is no inbound listener for Cloudflare to present a client certificate to. If your origin is reachable through Cloudflare Tunnel, origin traffic is already authenticated using the tunnel's connector credentials, and AOP settings have no effect on that hostname.
+:::
+
 ## Availability
 
 <FeatureTable id="ssl.authenticated_origin_pulls" />
@@ -53,4 +57,3 @@ Zone-level and per-hostname AOP support ML-DSA (FIPS 204) post-quantum client ce
 ## Related topics
 
 - [SSL/TLS Encryption Modes](/ssl/origin-configuration/ssl-modes/)
-- [Cloudflare Tunnel](/cloudflare-one/networks/connectors/cloudflare-tunnel/)


### PR DESCRIPTION
### Summary

Clarifies that Authenticated Origin Pullsis not compatible with origins connected through Cloudflare Tunnel.

AOP requires the origin to run an inbound HTTPS listener so Cloudflare can present a client TLS certificate. Cloudflare Tunnel uses outbound-only connections from the origin, so there is no inbound listener for AOP to negotiate against and AOP settings have no effect on Tunnel-routed hostnames.

Changes:
- Removed the unqualified Cloudflare Tunnel link from the AOP Related topics section.
- Added an incompatibility note to the AOP page.
- Added a reciprocal note to the Cloudflare Tunnel overview page.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).