### PR TITLE
[Workers] Update Node.js 24 build image documentation

### DIFF
--- a/src/content/changelog/workers/2026-07-30-workers-builds-nodejs-24.mdx
+++ b/src/content/changelog/workers/2026-07-30-workers-builds-nodejs-24.mdx
@@ -1,0 +1,11 @@
+---
+title: Node.js 24 is now the default for Workers Builds
+description: Workers Builds now uses Node.js 24.18.0 by default while retaining support for explicit Node.js version overrides.
+products:
+  - workers
+date: 2026-07-30
+---
+
+Workers Builds now uses Node.js 24.18.0 by default. The build image preinstalls Node.js 22.23.2 and 24.18.0.
+
+You can continue to override the default with the `NODE_VERSION` environment variable, an `.nvmrc` file, or a `.node-version` file. For more information, refer to [Override default versions](/workers/ci-cd/builds/build-image/#overriding-default-versions).

--- a/src/content/docs/workers/ci-cd/builds/build-image.mdx
+++ b/src/content/docs/workers/ci-cd/builds/build-image.mdx
@@ -23,9 +23,11 @@ The default versions will be updated regularly to the latest minor version. No m
 | Tool        | Default version | Environment variable | File                         |
 | ----------- | --------------- | -------------------- | ---------------------------- |
 | **Go**      | 1.24.3          | `GO_VERSION`         |                              |
-| **Node.js** | 22.16.0         | `NODE_VERSION`       | .nvmrc, .node-version        |
+| **Node.js** | 24.18.0         | `NODE_VERSION`       | .nvmrc, .node-version        |
 | **Python**  | 3.13.3          | `PYTHON_VERSION`     | .python-version, runtime.txt |
 | **Ruby**    | 3.4.4           | `RUBY_VERSION`       | .ruby-version                |
+
+The build image preinstalls Node.js 22.23.2 and 24.18.0.
 
 ### Tools and languages
 


### PR DESCRIPTION
### Summary

**tl;dr – Document Node.js 24.18.0 as the default runtime for Workers Builds.**

The build image preinstalls Node.js 22.23.2 and 24.18.0, with 24.18.0 selected by default.

Projects can continue to override the default with `NODE_VERSION`, `.nvmrc`, or `.node-version`. A changelog entry announces the major default-version change.

---

References: [Workers Builds build image](https://developers.cloudflare.com/workers/ci-cd/builds/build-image/)

### Documentation checklist

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
