### PR TITLE
[Workers] Document unsupported node:crypto argon2 APIs

### DIFF
--- a/src/content/docs/workers/runtime-apis/nodejs/crypto.mdx
+++ b/src/content/docs/workers/runtime-apis/nodejs/crypto.mdx
@@ -16,6 +16,7 @@ All `node:crypto` APIs are fully supported in Workers with the following excepti
 
 - The functions [generateKeyPair](https://nodejs.org/api/crypto.html#cryptogeneratekeypairtype-options-callback) and [generateKeyPairSync](https://nodejs.org/api/crypto.html#cryptogeneratekeypairsynctype-options)
   do not support DSA or DH key pairs.
+- `argon2` and `argon2Sync` are not supported.
 - `ed448` and `x448` curves are not supported.
 - It is not possible to manually enable or disable [FIPS mode](https://nodejs.org/docs/latest/api/crypto.html#fips-mode).
 


### PR DESCRIPTION
### Summary

Updates the Workers `node:crypto` docs to note that `argon2` and `argon2Sync` are not supported. References DEE-3743.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
