### PR TITLE
[R2] Document expired presigned URL behavior

### DIFF
--- a/src/content/docs/r2/api/error-codes.mdx
+++ b/src/content/docs/r2/api/error-codes.mdx
@@ -41,7 +41,7 @@ For the **S3-compatible API**, errors are returned as XML in the response body:
 |------------|------|-------------|---------|-----------------|
 | 10002 | Unauthorized | 401 | Missing or invalid authentication credentials. | Verify your [API token](/r2/api/tokens/) or access key credentials are correct and have not expired. |
 | 10003 | AccessDenied | 403 | Insufficient permissions for the requested operation. | Check that your [API token](/r2/api/tokens/) has the required permissions for the bucket and operation. |
-| 10018 | ExpiredRequest | `403` | Presigned URL or request signature has expired. | Regenerate the [presigned URL](/r2/api/s3/presigned-urls/) or signature. |
+| 10018 | ExpiredRequest | 403 | Presigned URL or request signature has expired. | Regenerate the [presigned URL](/r2/api/s3/presigned-urls/) or signature. |
 | 10035 | SignatureDoesNotMatch | 403 | Request signature does not match calculated signature. | Verify your secret key and signing algorithm. Check for URL encoding issues. |
 | 10042 | NotEntitled | 403 | Account not entitled to this feature. | Ensure your account has an [R2 subscription](/r2/pricing/). |
 

--- a/src/content/docs/r2/api/error-codes.mdx
+++ b/src/content/docs/r2/api/error-codes.mdx
@@ -41,7 +41,7 @@ For the **S3-compatible API**, errors are returned as XML in the response body:
 |------------|------|-------------|---------|-----------------|
 | 10002 | Unauthorized | 401 | Missing or invalid authentication credentials. | Verify your [API token](/r2/api/tokens/) or access key credentials are correct and have not expired. |
 | 10003 | AccessDenied | 403 | Insufficient permissions for the requested operation. | Check that your [API token](/r2/api/tokens/) has the required permissions for the bucket and operation. |
-| 10018 | ExpiredRequest | 403 | Presigned URL or request signature has expired. | Regenerate the [presigned URL](/r2/api/s3/presigned-urls/) or signature. |
+| 10018 | ExpiredRequest | `403` | Presigned URL or request signature has expired. | Regenerate the [presigned URL](/r2/api/s3/presigned-urls/) or signature. |
 | 10035 | SignatureDoesNotMatch | 403 | Request signature does not match calculated signature. | Verify your secret key and signing algorithm. Check for URL encoding issues. |
 | 10042 | NotEntitled | 403 | Account not entitled to this feature. | Ensure your account has an [R2 subscription](/r2/pricing/). |
 

--- a/src/content/docs/r2/api/error-codes.mdx
+++ b/src/content/docs/r2/api/error-codes.mdx
@@ -41,7 +41,7 @@ For the **S3-compatible API**, errors are returned as XML in the response body:
 |------------|------|-------------|---------|-----------------|
 | 10002 | Unauthorized | 401 | Missing or invalid authentication credentials. | Verify your [API token](/r2/api/tokens/) or access key credentials are correct and have not expired. |
 | 10003 | AccessDenied | 403 | Insufficient permissions for the requested operation. | Check that your [API token](/r2/api/tokens/) has the required permissions for the bucket and operation. |
-| 10018 | ExpiredRequest | 400 | Presigned URL or request signature has expired. | Regenerate the [presigned URL](/r2/api/s3/presigned-urls/) or signature. |
+| 10018 | ExpiredRequest | 403 | Presigned URL or request signature has expired. | Regenerate the [presigned URL](/r2/api/s3/presigned-urls/) or signature. |
 | 10035 | SignatureDoesNotMatch | 403 | Request signature does not match calculated signature. | Verify your secret key and signing algorithm. Check for URL encoding issues. |
 | 10042 | NotEntitled | 403 | Account not entitled to this feature. | Ensure your account has an [R2 subscription](/r2/pricing/). |
 

--- a/src/content/docs/r2/buckets/cors.mdx
+++ b/src/content/docs/r2/buckets/cors.mdx
@@ -40,6 +40,8 @@ Next, [add a CORS policy](#add-cors-policies-from-the-dashboard) to your bucket 
 
 When a browser makes a request to a presigned URL on a different origin, the browser enforces CORS. Without a CORS policy, browser-based uploads and downloads using presigned URLs will fail, even though the presigned URL itself is valid.
 
+Expired presigned URLs return a `403` `ExpiredRequest` response. R2 does not include CORS response headers on expired presigned URL responses, so browser JavaScript cannot read the error body. Refresh presigned URLs before they expire, or route requests through your application server if the browser needs to handle expiration errors directly.
+
 To enable browser-based access with presigned URLs:
 
 1. [Add a CORS policy](#add-cors-policies-from-the-dashboard) to your bucket that allows requests from your application's origin.


### PR DESCRIPTION
## Summary

Updates the R2 error code and CORS docs to clarify expired presigned URL behavior. References DEE-3746.
