### PR TITLE
moq: update docs for draft-14/16 support, provisioning API, and draft…

### DIFF
--- a/src/content/docs/moq/feature-matrix.mdx
+++ b/src/content/docs/moq/feature-matrix.mdx
@@ -1,12 +1,53 @@
 ---
 pcx_content_type: get-started
 title: MoQ Feature Matrix
+description: Supported and unsupported MoQ Transport messages for each draft version deployed by Cloudflare.
 sidebar:
   order: 18
 
 ---
 
-## Draft-14 Messages
+## Draft-16 messages
+
+### Supported
+
+| Message | Support | Relevant specification |
+| ------- | ------- | ---------------------- |
+| SUBSCRIBE | ✅ | [draft-ietf-moq-transport-16](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-16) |
+| UNSUBSCRIBE | ✅ | [draft-ietf-moq-transport-16](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-16) |
+| PUBLISH | ✅ | [draft-ietf-moq-transport-16](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-16) |
+| PUBLISH_OK | ✅ | [draft-ietf-moq-transport-16](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-16) |
+| SUBSCRIBE_NAMESPACE | ✅ | [draft-ietf-moq-transport-16](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-16) |
+| SUBSCRIBE_NAMESPACE_OK | ✅ | [draft-ietf-moq-transport-16](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-16) |
+| SUBSCRIBE_NAMESPACE_ERROR | ✅ | [draft-ietf-moq-transport-16](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-16) |
+| UNSUBSCRIBE_NAMESPACE | ✅ | [draft-ietf-moq-transport-16](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-16) |
+| SUBSCRIBE_OK | ✅ | [draft-ietf-moq-transport-16](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-16) |
+| SUBSCRIBE_ERROR | ✅ | [draft-ietf-moq-transport-16](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-16) |
+| TRACK_STATUS | ✅ | [draft-ietf-moq-transport-16](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-16) |
+| TRACK_STATUS_OK | ✅ | [draft-ietf-moq-transport-16](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-16) |
+| SETUP_MESSAGES (client and server) | ✅ | [draft-ietf-moq-transport-16](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-16) |
+
+### Partial
+
+| Message | Support | Notes | Relevant specification |
+| ------- | ------- | ----- | ---------------------- |
+| MAX_REQUEST_ID | Partial | Initial limit negotiated in SETUP and mid-session raises are applied. REQUESTS_BLOCKED does not trigger an automatic limit increase. | [draft-ietf-moq-transport-16](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-16) |
+| REQUESTS_BLOCKED | Partial | Received and logged. It does not trigger an automatic MAX_REQUEST_ID response. | [draft-ietf-moq-transport-16](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-16) |
+
+### Unsupported
+
+| Message | Support | Relevant specification |
+| ------- | ------- | ---------------------- |
+| GOAWAY | No | [draft-ietf-moq-transport-16](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-16) |
+| SUBSCRIBE_UPDATE | No | [draft-ietf-moq-transport-16](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-16) |
+| PUBLISH_ERROR | No | [draft-ietf-moq-transport-16](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-16) |
+| FETCH | No | [draft-ietf-moq-transport-16](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-16) |
+| FETCH_OK | No | [draft-ietf-moq-transport-16](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-16) |
+| FETCH_ERROR | No | [draft-ietf-moq-transport-16](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-16) |
+| FETCH_CANCEL | No | [draft-ietf-moq-transport-16](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-16) |
+| TRACK_STATUS_ERROR | No | [draft-ietf-moq-transport-16](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-16) |
+
+## Draft-14 messages
 
 ### Supported
 
@@ -45,39 +86,3 @@ sidebar:
 | SUBSCRIBE_NAMESPACE_OK | No | [draft-ietf-moq-transport-14](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-14) |
 | SUBSCRIBE_NAMESPACE_ERROR | No | [draft-ietf-moq-transport-14](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-14) |
 | UNSUBSCRIBE_NAMESPACE | No | [draft-ietf-moq-transport-14](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-14) |
-
-## Draft-07 Messages
-
-### Supported
-
-| Message | Support | Relevant specification |
-| ------- | ------- | ---------------------- |
-| ANNOUNCE_OK | ✅ | [draft-ietf-moq-transport-07](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-07) |
-| ANNOUNCE_ERROR | ✅ | [draft-ietf-moq-transport-07](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-07) |
-| ANNOUNCE_CANCEL | ✅ | [draft-ietf-moq-transport-07](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-07) |
-| SUBSCRIBE | ✅ | [draft-ietf-moq-transport-07](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-07) |
-| UNSUBSCRIBE | ✅ | [draft-ietf-moq-transport-07](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-07) |
-| TRACK_STATUS_REQUEST | ✅ | [draft-ietf-moq-transport-07](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-07) |
-| ANNOUNCE | ✅ | [draft-ietf-moq-transport-07](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-07) |
-| UNANNOUNCE | ✅ | [draft-ietf-moq-transport-07](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-07) |
-| SUBSCRIBE_OK | ✅ | [draft-ietf-moq-transport-07](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-07) |
-| SUBSCRIBE_ERROR | ✅ | [draft-ietf-moq-transport-07](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-07) |
-| SUBSCRIBE_DONE | ✅ | [draft-ietf-moq-transport-07](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-07) |
-| MAX_SUBSCRIBE_ID | ✅ | [draft-ietf-moq-transport-07](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-07) |
-| TRACK_STATUS | ✅ | [draft-ietf-moq-transport-07](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-07) |
-| SETUP_MESSAGES (client and server) | ✅ | [draft-ietf-moq-transport-07](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-07) |
-
-### Unsupported
-
-| Message | Support | Relevant specification |
-| ------- | ------- | ---------------------- |
-| SUBSCRIBE_UPDATE | No | [draft-ietf-moq-transport-07](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-07) |
-| GOAWAY | No | [draft-ietf-moq-transport-07](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-07) |
-| SUBSCRIBE_ANNOUNCES | No | [draft-ietf-moq-transport-07](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-07) |
-| SUBSCRIBE_ANNOUNCES_OK | No | [draft-ietf-moq-transport-07](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-07) |
-| SUBSCRIBE_ANNOUNCES_ERROR | No | [draft-ietf-moq-transport-07](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-07) |
-| UNSUBSCRIBE_ANNOUNCES | No | [draft-ietf-moq-transport-07](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-07) |
-| FETCH | No | [draft-ietf-moq-transport-07](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-07) |
-| FETCH_OK | No | [draft-ietf-moq-transport-07](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-07) |
-| FETCH_ERROR | No | [draft-ietf-moq-transport-07](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-07) |
-| FETCH_CANCEL | No | [draft-ietf-moq-transport-07](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-07) |

--- a/src/content/docs/moq/index.mdx
+++ b/src/content/docs/moq/index.mdx
@@ -16,44 +16,65 @@ MoQ (Media over QUIC) is a protocol for delivering live media content using QUIC
 
 MoQ is designed to be an Internet infrastructure level service that provides media delivery to applications, similar to how HTTP provides content delivery and WebRTC provides real-time communication.
 
-Cloudflare's implementation of MoQ currently supports a subset of the [draft-07 MoQ Transport specification](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-07).
+Cloudflare currently supports [draft-14](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-14) and [draft-16](https://www.ietf.org/archive/id/draft-ietf-moq-transport-16.html) of the MoQ Transport specification. For a full breakdown of supported messages per draft, refer to [MoQ Feature Matrix](/moq/feature-matrix/).
 
 For the most up-to-date documentation on the protocol, please visit the IETF working group documentation.
 
-## Frequently Asked Questions
+## Get started
 
-* What about Safari?
+Cloudflare MoQ relays are available through the [Cloudflare dashboard](https://dash.cloudflare.com/) and the [API](/api/resources/moq). They are free to use during the beta period.
 
-  Safari does not yet have fully functional WebTransport support. Apple never publicly commits to timelines for new features like this. However, Apple has indicated their [intent to support WebTransport](https://github.com/WebKit/standards-positions/issues/18#issuecomment-1495890122). An Apple employee is even a co-author of the [WebTransport over HTTP/3](https://datatracker.ietf.org/doc/draft-ietf-webtrans-http3/) draft. Since Safari 18.4 (2025-03-31), an early (not yet fully functional) implementation of the WebTransport API has been available for testing behind a developer-mode / advanced settings feature flag (including on iOS).
+### Provision a relay
 
-  Until Safari has a fully functional WebTransport implementation, some MoQ use cases may require a fallback to WebRTC, or, in some cases, WebSockets.
+Each relay provides an isolated scope — your namespaces, tracks, and objects are separated from those belonging to other relays. You control who can publish and who can subscribe by issuing tokens scoped to the operations each client needs.
 
-## Known Issues
+To create a relay via the API:
 
-* Extra Subgroup header field
+```sh
+curl -X POST \
+  "https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/moq/relays" \
+  -H "Authorization: Bearer $API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "My Relay"}'
+```
 
-  The current implementation includes a `subscribe_id` field in Subgroup Headers which [`draft-ietf-moq-transport-07`](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-07) omits. 
-  
-  In section 7.3.1, `draft-ietf-moq-transport-07` [specifies](https://www.ietf.org/archive/id/draft-ietf-moq-transport-07.html#section-7.3.1):
-  
-  ```txt
-  STREAM_HEADER_SUBGROUP Message {
-    Track Alias (i),
-    Group ID (i),
-    Subgroup ID (i),
-    Publisher Priority (8),
-  }
-  ```
-  
-  Whereas our implementation expects and produces:
-  ```txt
-  STREAM_HEADER_SUBGROUP Message {
-    Subscribe ID (i),
-    Track Alias (i),
-    Group ID (i),
-    Subgroup ID (i),
-    Publisher Priority (8),
-  }
-  ```
-  
-  This was erroroneously left over from a previous draft version and will be fixed in a future release. Thank you to [@yuki-uchida](https://github.com/yuki-uchida) for reporting.
+Cloudflare returns a relay ID and two default tokens: one that can publish and subscribe, and one that can only subscribe. Token secrets are shown once in the response and never stored.
+
+You can also create and manage relays in the Cloudflare dashboard under **Media** > **Realtime** > **MoQ Relay**.
+
+### Connect a publisher and subscriber (draft-16)
+
+Draft-16 requires authentication. Clients send a token in the URL path when opening a MoQ session. Using the open-source [moq-rs](https://github.com/cloudflare/moq-rs) tools:
+
+**Publisher:**
+```sh
+ffmpeg -stream_loop -1 -re -i input.mp4 \
+  -f mp4 -movflags empty_moov+frag_every_frame+separate_moof+omit_tfhd_offset - \
+  | moq-pub --name my-namespace \
+    "https://draft-16.cloudflare.mediaoverquic.com/<publish_subscribe_token>"
+```
+
+**Subscriber:**
+```sh
+moq-sub --name my-namespace \
+  "https://draft-16.cloudflare.mediaoverquic.com/<subscribe_token>" \
+  | ffplay -hide_banner -
+```
+
+:::note[Token security]
+Tokens sent in the URL path appear in server access logs. Issue separate tokens per client, set short expiration times, and rotate tokens when a client's access should end. You can create additional tokens and set expiration times using the [API](/api/resources/moq).
+
+The IETF MoQ working group is developing in-band authentication standards — [C4M](https://datatracker.ietf.org/doc/draft-ietf-moq-c4m/) and [Privacy Pass for MoQ](https://datatracker.ietf.org/doc/draft-ietf-moq-privacy-pass-auth/) — that will enable richer token schemes without URL exposure. Cloudflare plans to support these as they mature.
+:::
+
+### Connect a publisher and subscriber (draft-14)
+
+Draft-14 clients connect to:
+
+```txt
+https://draft-14.cloudflare.mediaoverquic.com/
+```
+
+### Test draft-18
+
+Cloudflare is working on draft-18 support ahead of a global deployment. To test against a draft-18 relay in the meantime, refer to [moq-interop-runner](https://github.com/englishm/moq-interop-runner).


### PR DESCRIPTION
…-18 preview

- Replace draft-07 references with draft-14 and draft-16
- Add Getting Started section covering relay provisioning via API/dashboard, publisher/subscriber connection examples for both drafts, and a pointer to moq-interop-runner for draft-18 early testing
- Remove the now-resolved Safari WebTransport FAQ entry
- feature-matrix: remove draft-07 section (relay no longer running), add draft-16 section including PUBLISH and SUBSCRIBE_NAMESPACE support
- Carry forward upstream additions to frontmatter (description, products)

### Summary

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
