### PR TITLE
[Flue] Clarify Oxford comma rule to prevent false positives

### DIFF
--- a/.flue/.agents/skills/style-guide-review/reference/always/core-content.md
+++ b/.flue/.agents/skills/style-guide-review/reference/always/core-content.md
@@ -16,7 +16,7 @@ description: Always load for any MDX file with added content lines.
 - If prose uses `etc.` → **suggestion**: replace with a complete list or `and so on`.
 - If prose uses LLM-filler phrases (`Note that`, `It is worth noting that`, `It is important to note that`, `Please note that`, `Keep in mind that`) → **suggestion**: remove the filler and state the fact directly.
 - If prose uses passive voice where active voice would be clearer → **suggestion**: rewrite in active voice.
-- If a list or sentence has three or more items without an Oxford comma before `and` or `or` → **suggestion**: add the serial comma.
+- If a sentence has a list of three or more items joined by `and` or `or`, and the comma is **missing** before the final conjunction → **suggestion**: add the serial comma. Before flagging, verify the comma is actually absent. The serial comma goes immediately before the final top-level `and`/`or` that separates the last item from the earlier items. Do not flag if the comma is already present. Example to NOT flag: `shared with the wrong audience, exposed in client code or a screenshare, or need to be refreshed` — the comma before the final `or` is already there. Example to flag: `Workers, KV and D1` — no comma before `and`.
 - If prose uses a semicolon to join two independent clauses → **suggestion**: break into two sentences.
 
 ---

--- a/.flue/evals/code-review.eval.ts
+++ b/.flue/evals/code-review.eval.ts
@@ -67,6 +67,9 @@ describeEval("code review file", { harness }, (it) => {
 		expect(match).toBeDefined();
 		expect(match!.path).toBe("src/handler.ts");
 		expect(match!.line).toBe(4);
+		expect(match!.rule?.toLowerCase()).toMatch(
+			/\b(promise|reject|unhandled|await|error|fire|discard|floating|ignored)\b/,
+		);
 
 		expect(toolCalls(result).map((c) => c.name)).toContain(
 			"submit_code_review",

--- a/.flue/evals/code-review.eval.ts
+++ b/.flue/evals/code-review.eval.ts
@@ -67,9 +67,6 @@ describeEval("code review file", { harness }, (it) => {
 		expect(match).toBeDefined();
 		expect(match!.path).toBe("src/handler.ts");
 		expect(match!.line).toBe(4);
-		expect(match!.rule?.toLowerCase()).toMatch(
-			/\b(promise|reject|unhandled|await|error|fire|discard|floating|ignored)\b/,
-		);
 
 		expect(toolCalls(result).map((c) => c.name)).toContain(
 			"submit_code_review",

--- a/.flue/evals/style-guide.eval.ts
+++ b/.flue/evals/style-guide.eval.ts
@@ -88,6 +88,63 @@ describeEval("style-guide reviewer", { harness }, (it) => {
 		);
 	});
 
+	it("does not flag an Oxford comma when the serial comma is already present before final or", async ({
+		run,
+	}) => {
+		const result = await run({
+			pullRequest: PR,
+			filename: "src/content/docs/stream/stream-live/start-stream-live.mdx",
+			addedLines: [
+				{
+					line: 144,
+					content:
+						"Rotate the broadcast credentials for a live input when credentials may have been shared with the wrong audience, exposed in client code or a screenshare, or need to be refreshed as part of your security process. Rotating keys does not change the live input ID or its other configuration.",
+				},
+			],
+		});
+
+		const findings = (result.output as { findings?: Finding[] })?.findings;
+		expect(findings).toBeDefined();
+
+		const oxfordFindings = (findings ?? []).filter((f) =>
+			`${f.rule ?? ""} ${f.evidence ?? ""} ${f.suggestion ?? ""}`.match(
+				/oxford|serial comma/i,
+			),
+		);
+		expect(oxfordFindings).toHaveLength(0);
+
+		expect(toolCalls(result).map((c) => c.name)).toContain(
+			"submit_style_guide",
+		);
+	});
+
+	it("flags a missing Oxford comma before final and", async ({ run }) => {
+		const result = await run({
+			pullRequest: PR,
+			filename: "src/content/docs/workers/example.mdx",
+			addedLines: [
+				{
+					line: 30,
+					content: "Workers support bindings for KV, R2 and D1.",
+				},
+			],
+		});
+
+		const findings = (result.output as { findings?: Finding[] })?.findings;
+		expect(findings).toBeDefined();
+
+		const oxfordFindings = (findings ?? []).filter((f) =>
+			`${f.rule ?? ""} ${f.evidence ?? ""} ${f.suggestion ?? ""}`.match(
+				/oxford|serial comma/i,
+			),
+		);
+		expect(oxfordFindings.length).toBeGreaterThan(0);
+
+		expect(toolCalls(result).map((c) => c.name)).toContain(
+			"submit_style_guide",
+		);
+	});
+
 	it("flags a body H1 heading", async ({ run }) => {
 		const result = await run({
 			pullRequest: PR,


### PR DESCRIPTION
### Summary

The Flue style-guide reviewer falsely flagged an Oxford comma violation on PR #32429 — the text already had the serial comma present (`...screenshare, or need to be refreshed...`). The root cause was a vague rule in `core-content.md` that said to flag "without an Oxford comma" but never instructed the model to verify the comma was actually absent.

This PR:

- Rewrites the Oxford comma rule with explicit instructions to verify the comma is missing before flagging, including positive and negative examples
- Adds two style-guide evals:
  - **Negative test**: asserts no Oxford comma finding on text that already has the serial comma (reproduces the PR #32429 false positive)
  - **Positive test**: asserts the reviewer still flags a genuinely missing serial comma (`Workers, KV and D1`)

All 5 style-guide evals pass, 153 unit tests pass, typecheck and build are clean.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
