### PR TITLE
[Workers AI] Use paid plan model flag

### DIFF
--- a/src/components/models/ModelDetailPage.astro
+++ b/src/components/models/ModelDetailPage.astro
@@ -141,7 +141,9 @@ if (model.name.includes("@cf/openai/gpt-oss")) {
 const author = authorData[model.author];
 const authorName = model.authorName;
 
-const requiresWorkersPaid = model.properties.require_workers_paid === "true";
+const requiresWorkersPaid =
+	model.properties.require_workers_paid === true ||
+	model.properties.require_workers_paid === "true";
 
 // `hasSchema`: input must have at least one key.
 const hasSchema = Object.keys(model.schema.input).length > 0;

--- a/src/components/models/ModelDetailPage.astro
+++ b/src/components/models/ModelDetailPage.astro
@@ -141,13 +141,7 @@ if (model.name.includes("@cf/openai/gpt-oss")) {
 const author = authorData[model.author];
 const authorName = model.authorName;
 
-// Models that require the Workers Paid plan (not available on Workers Free).
-const workersPaidOnlyModels = [
-	"@cf/moonshotai/kimi-k2.6",
-	"@cf/moonshotai/kimi-k2.7-code",
-	"@cf/zai-org/glm-5.2",
-];
-const isWorkersPaidOnly = workersPaidOnlyModels.includes(model.name);
+const requiresWorkersPaid = model.properties.require_workers_paid === "true";
 
 // `hasSchema`: input must have at least one key.
 const hasSchema = Object.keys(model.schema.input).length > 0;
@@ -340,7 +334,7 @@ const headings: MarkdownHeading[] = [
 	}
 
 	{
-		isWorkersPaidOnly && (
+		requiresWorkersPaid && (
 			<Render file="workers-paid-only-note" product="workers-ai" />
 		)
 	}

--- a/src/content/workers-ai-models/glm-5.2.json
+++ b/src/content/workers-ai-models/glm-5.2.json
@@ -2,6 +2,10 @@
     "name": "@cf/zai-org/glm-5.2",
     "properties": [
         {
+            "property_id": "require_workers_paid",
+            "value": "true"
+        },
+        {
             "property_id": "context_window",
             "value": "262144"
         },

--- a/src/content/workers-ai-models/kimi-k2.6.json
+++ b/src/content/workers-ai-models/kimi-k2.6.json
@@ -12,6 +12,10 @@
     "tags": [],
     "properties": [
         {
+            "property_id": "require_workers_paid",
+            "value": "true"
+        },
+        {
             "property_id": "context_window",
             "value": "262144"
         },

--- a/src/content/workers-ai-models/kimi-k2.7-code.json
+++ b/src/content/workers-ai-models/kimi-k2.7-code.json
@@ -2,6 +2,10 @@
     "name": "@cf/moonshotai/kimi-k2.7-code",
     "properties": [
         {
+            "property_id": "require_workers_paid",
+            "value": "true"
+        },
+        {
             "property_id": "context_window",
             "value": "262144"
         },


### PR DESCRIPTION
### Summary

Uses the Workers AI model API's `require_workers_paid` property to determine whether a model page displays the existing Workers Paid caution note. This replaces the hardcoded model-name list and syncs the property into the GLM-5.2, Kimi K2.6, and Kimi K2.7 Code model records.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
