### PR TITLE
[cloudflare-challenges] Fix precursor-rules image overlap caused by negative margin-top

### DIFF
--- a/src/content/docs/cloudflare-challenges/precursor.mdx
+++ b/src/content/docs/cloudflare-challenges/precursor.mdx
@@ -50,7 +50,7 @@ Enable Precursor for your zone:
 <img
 	src="/images/precursor/precursor-rules.png"
 	alt="Precursor mode selector showing Minimize Friction and Maximize Security options"
-	style="border:1px solid #e5e7eb;border-radius:6px;display:block;margin-top:-32px;"
+	style="border:1px solid #e5e7eb;border-radius:6px;display:block;margin-top:1rem;"
 />
 
 For most customers, selecting a mode is the only configuration required.


### PR DESCRIPTION
[cloudflare-challenges] Fix precursor-rules image overlap caused by negative margin-top

### Summary

What
The precursor-rules.png image in the "Get started" section has a margin-top:-32px inline style. This negative margin pulls the image 32 px above its natural position, causing it to overlap the last line of the "Maximize Security (recommended)" bullet point above it.

Fix
Change margin-top:-32px → margin-top:1rem on the precursor-rules.png <img> element in src/content/docs/cloudflare-challenges/precursor.mdx.

File changed
src/content/docs/cloudflare-challenges/precursor.mdx

### Screenshots (optional)

<img width="1021" height="568" alt="Screenshot 2026-07-31 at 15 47 34" src="https://github.com/user-attachments/assets/09bf10ba-6922-424f-b2b7-598fd07c5ab8" />

### Documentation checklist

<!-- Remove items that do not apply -->


- [x ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
