### PR TITLE
[Logs] Update Logpush dataset field definitions (2026-07-31)

### DIFF
--- a/src/content/changelog/logs/2026-07-31-log-fields-updated.mdx
+++ b/src/content/changelog/logs/2026-07-31-log-fields-updated.mdx
@@ -1,0 +1,13 @@
+---
+title: Updated fields in Gateway HTTP Logpush dataset in Cloudflare Logs
+description: Fields have been updated in the Gateway HTTP Logpush dataset in Cloudflare Logs.
+date: 2026-07-31
+---
+
+Cloudflare has updated [Logpush datasets](/logs/logpush/logpush-job/datasets/):
+
+### Updated fields in existing datasets
+
+- **Gateway HTTP** (added): `ExperimentalFeatures` and `PackageInfo`.
+
+For the complete field definitions for each dataset, refer to [Logpush datasets](/logs/logpush/logpush-job/datasets/).

--- a/src/content/docs/logs/logpush/logpush-job/datasets/account/gateway_http.md
+++ b/src/content/docs/logs/logpush/logpush-job/datasets/account/gateway_http.md
@@ -165,6 +165,12 @@ Type: `string`
 
 Email used to authenticate the client.
 
+## ExperimentalFeatures
+
+Type: `object`
+
+List of experimental features, which will be either permanently added to the schema or marked for deprecation. In that case, they will be removed 3 months after the notice.
+
 ## FileInfo
 
 Type: `object`
@@ -206,6 +212,12 @@ Version name for the HTTP request.
 Type: `bool`
 
 If the requested was isolated with Cloudflare Browser Isolation or not.
+
+## PackageInfo
+
+Type: `object`
+
+Information about the software package detected in the HTTP request, including its ecosystem, namespace, name, version, and package URL (PURL).
 
 ## PolicyID
 


### PR DESCRIPTION
## Summary

Automated sync of Logpush dataset field definitions from [data/entities](https://gitlab.cfdata.org/cloudflare/data/entities).

### Updated fields in existing datasets

- **Gateway HTTP** (added): `ExperimentalFeatures` and `PackageInfo`.

### Files changed
- `src/content/docs/logs/logpush/logpush-job/datasets/account/` — dataset pages
- `src/content/changelog/logs/2026-07-31-log-fields-updated.mdx` — changelog

### Documentation checklist
- [x] Changelog entry added
- [x] Content generated by code generator (DO NOT EDIT manually)
