### PR TITLE
[Web Assets][API Shield] Update operation management docs

### DIFF
--- a/src/content/docs/api-shield/management-and-monitoring/endpoint-management/index.mdx
+++ b/src/content/docs/api-shield/management-and-monitoring/endpoint-management/index.mdx
@@ -1,6 +1,6 @@
 ---
 pcx_content_type: concept
-description: Save, organize, and monitor API endpoints in API Shield.
+description: Promote, learn, and monitor API endpoints with API Shield and Web Assets.
 products:
   - api-shield
 title: Endpoint Management
@@ -14,22 +14,17 @@ import {
 	Steps,
 	Tabs,
 	TabItem,
-	Render,
 	DashButton,
 } from "~/components";
 
 <Plan type="all" />
 
-Monitor the health of your <GlossaryTooltip term="API endpoint">API endpoints</GlossaryTooltip> by saving, updating, and monitoring performance metrics using API Shield’s Endpoint Management.
+Web Assets provides a unified inventory for managing <GlossaryTooltip term="API endpoint">API endpoints</GlossaryTooltip>. In Web Assets, an **operation** represents an endpoint by its HTTP method, hostname pattern, and path pattern.
 
-**Add endpoints** allows customers to save endpoints directly from [API Discovery](/api-shield/security/api-discovery/) or manually by method, path, and host.
-
-This will add the specified endpoints to your list of managed endpoints. You can view your list of saved endpoints in the **Endpoint Management** page.
-
-Cloudflare will start collecting [performance data](/api-shield/management-and-monitoring/#endpoint-analysis) on your endpoint when you save an endpoint.
+Promote an API endpoint to move its operation into the `full` state. Promotion starts collecting data for profile learning and [performance analysis](#endpoint-analysis).
 
 :::note
-When an endpoint is using [Cloudflare Workers](/workers/), the metrics data will not be populated.
+When an endpoint uses [Cloudflare Workers](/workers/), some metrics are not populated.
 :::
 
 ## Access
@@ -40,32 +35,28 @@ When an endpoint is using [Cloudflare Workers](/workers/), the metrics data will
       1. In the Cloudflare dashboard, go to the **Web Assets** page.
 
           <DashButton url="/?to=/:account/:zone/security/web-assets" />
-      2. Go to the **Endpoints** tab.
-      3. Select **Add endpoints**.
-      4. Add your endpoints [manually](#add-endpoints-manually), from [Schema validation](#add-endpoints-from-schema-validation), or from [API Discovery](#add-endpoints-from-api-discovery).
+      2. Go to the **Operations** tab.
     </Steps>
   </TabItem>
   <TabItem label="Old dashboard">
     <Steps>
       1. Log in to the [Cloudflare dashboard](https://dash.cloudflare.com/login), and select your account and domain.
-      2. Select **Security** > **API Shield**.
-      3. Add your endpoints [manually](#add-endpoints-manually), from [Schema validation](#add-endpoints-from-schema-validation), or from [API Discovery](#add-endpoints-from-api-discovery).
+      2. Go to **Security** > **API Shield** > **Endpoint Management**.
     </Steps>
   </TabItem>
 </Tabs>
 
 ### Add endpoints from API Discovery
 
-There are two ways to add API endpoints from Discovery.
+The **Learn profile** action is available to API Shield customers using unified operation discovery and other customers with access to profile learning.
 
-#### Add from the Endpoints tab
+In the new dashboard, this workflow promotes an existing discovered operation. In the old dashboard, it adds a discovered endpoint to Endpoint Management.
 
 <Tabs syncKey="dashNewNav">
   <TabItem label="New dashboard" icon="rocket">
     <Steps>
-      1. From **Endpoints**, go to **Add endpoints** > **Select from Discovery** tab.
-      2. Select the discovered endpoints you would like to add.
-      3. Select **Add endpoints**.
+      1. From **Web Assets** > **Operations**, open the row actions for a candidate or shadow operation.
+      2. Select **Learn profile**.
     </Steps>
   </TabItem>
   <TabItem label="Old dashboard">
@@ -77,32 +68,17 @@ There are two ways to add API endpoints from Discovery.
   </TabItem>
 </Tabs>
 
-#### Add from the Discovery tab
+Cloudflare promotes the operation to the `full` state. The row action then changes to **Profile learned**. For more information, refer to [Promote an operation](/security/web-assets/manage-operations/#promote-an-operation).
 
-<Tabs syncKey="dashNewNav">
-  <TabItem label="New dashboard" icon="rocket">
-    <Steps>
-      1. From **Web assets**, go to the **Discovery** tab.
-      2. Select the discovered endpoints you would like to add.
-      3. Select **Save selected endpoints**.
-    </Steps>
-  </TabItem>
-  <TabItem label="Old dashboard">
-    <Steps>
-      1. From Endpoint Management, select the **Discovery** tab.
-      2. Select the discovered endpoints you would like to add.
-      3. Select **Save selected endpoints**.
-    </Steps>
-  </TabItem>
-</Tabs>
+You do not need to promote every discovered operation. Candidate operations can provide context for matching, edge security detections, and [Sequence Analytics](/api-shield/security/sequence-analytics/) without promotion. Persisted API profiles and [risk findings](/api-shield/management-and-monitoring/endpoint-labels/#risk-labels) require operations in the `full` state.
 
 ### Add endpoints from Schema validation
 
 <Tabs syncKey="dashNewNav">
   <TabItem label="New dashboard" icon="rocket">
     <Steps>
-      1. From **Web assets**, go to the **Endpoints** tab.
-      2. Select **Add endpoints** > **Upload Schema**.
+      1. From **Web Assets** > **Operations**, select **Add operation**.
+      2. Select **Upload schema**.
       3. Upload a schema file.
       4. Select **Add schema and endpoints**.
     </Steps>
@@ -116,10 +92,10 @@ There are two ways to add API endpoints from Discovery.
   </TabItem>
 </Tabs>
 
-API Shield will look for duplicate endpoints that have the same host, method, and path. Duplicate endpoints will not be saved to endpoint management.
+API Shield looks for duplicate operations with the same hostname, method, and path. Duplicate operations are not added.
 
 :::note
-If you deselect **Save new endpoints to endpoint management**, the endpoints will not be added.
+In the old dashboard, endpoints are not added if you deselect **Save new endpoints to endpoint management**.
 :::
 
 ### Add endpoints manually
@@ -127,10 +103,10 @@ If you deselect **Save new endpoints to endpoint management**, the endpoints wil
 <Tabs syncKey="dashNewNav">
   <TabItem label="New dashboard" icon="rocket">
     <Steps>
-      1. From **Web assets**, go to the **Endpoints** tab.
-      2. Select **Add endpoints** > **Manually add**.
-      3. Choose the method from the dropdown menu and add the path and hostname for the endpoint.
-      4. Select **Add endpoints**.
+      1. From **Web Assets** > **Operations**, select **Add operation**.
+      2. Select **Manually add**.
+      3. Select the method and enter the hostname pattern and path pattern.
+      4. Select **Add operation**.
     </Steps>
   </TabItem>
   <TabItem label="Old dashboard">
@@ -142,11 +118,7 @@ If you deselect **Save new endpoints to endpoint management**, the endpoints wil
   </TabItem>
 </Tabs>
 
-:::note
-By selecting multiple checkboxes, you can add several endpoints from Discovery at once instead of individually.
-:::
-
-When adding an endpoint manually, you can specify variable fields in the path or host by enclosing them in braces, `/api/user/{var1}/details` or `{hostVar1}.example.com`.
+When adding an operation manually, you can specify variable fields in the path or hostname. Enclose variables in braces, such as `/api/user/{var1}/details` or `{hostVar1}.example.com`.
 
 Cloudflare supports hostname variables in the following formats:
 
@@ -170,6 +142,25 @@ foo-{hostVar1}.example.com
 
 For more information on how Cloudflare uses variables in API Shield, refer to the examples from [API Discovery](/api-shield/security/api-discovery/).
 
+### Edit operations
+
+In the new dashboard, you can edit the identity of an operation.
+
+<Steps>
+
+1. From **Web Assets** > **Operations**, open the row actions for the operation.
+2. Select **Edit operation**.
+3. Update the HTTP method, hostname pattern, or path pattern.
+4. Select **Save**.
+
+</Steps>
+
+Editing a candidate or shadow operation promotes it to the `full` state with the edited values.
+
+:::caution[Editing this operation will change its ID]
+Cloudflare computes operation IDs from the HTTP method, hostname, and path. Cloudflare relearns labels, schemas, and rate limiting recommendations for an operation with a new ID.
+:::
+
 ### Delete endpoints manually
 
 You can delete endpoints one at a time or in bulk.
@@ -177,9 +168,8 @@ You can delete endpoints one at a time or in bulk.
 <Tabs syncKey="dashNewNav">
   <TabItem label="New dashboard" icon="rocket">
     <Steps>
-      1. From **Web assets**, go to the **Endpoints** tab.
-      2. Select the checkboxes for the endpoints that you want to delete.
-      3. Select **Delete endpoints**.
+      1. From **Web Assets** > **Operations**, select the operations that you want to delete.
+      2. Select **Delete operations**.
     </Steps>
   </TabItem>
   <TabItem label="Old dashboard">
@@ -191,44 +181,44 @@ You can delete endpoints one at a time or in bulk.
 </Tabs>
 
 :::caution
-When you delete an endpoint from Endpoint Management, Cloudflare immediately stops tracking all associated performance and analytics data. The endpoint's previous historical metrics are permanently removed and cannot be restored. If you later save this endpoint again, metric tracking will resume, starting from the point the endpoint is re-saved.
+When you delete a full operation, Cloudflare stops tracking its associated performance and analytics data. Its previous historical metrics cannot be restored. If the operation returns to the `full` state, metric tracking restarts from that point.
 :::
 
-## Endpoint Analysis
+## Endpoint analysis
 
-For each saved endpoint, customers can view:
+For each operation in the `full` state, you can view:
 
-- **Request count**: The total number of requests to the endpoint over time.
+- **Request count**: The total number of requests to the operation over time.
 - **Rate limiting recommendation**: per 10 minutes. This is guided by the request count.
 - **Latency**: The average origin response time in milliseconds (ms). This metric shows how long it takes from the moment a visitor makes a request to the moment the visitor gets a response back from the origin.
 - **Error rate** vs. overall traffic: grouped by 4xx, 5xx, and their sum.
 - **Response size**: The average size of the response (in bytes) returned to the request.
-- **Labels**: The current [labels](/api-shield/management-and-monitoring/endpoint-labels/) assigned to the endpoint.
-- **[Authentication status](/api-shield/security/authentication-posture/)**: The breakdown of which [session identifiers](/api-shield/get-started/#session-identifiers) were seen on successful requests to this endpoint.
-- **Sequences**: The number of [Sequence Analytics](/api-shield/security/sequence-analytics/) sequences the endpoint was found in.
+- **Labels**: The current [labels](/api-shield/management-and-monitoring/endpoint-labels/) assigned to the operation.
+- **[Authentication status](/api-shield/security/authentication-posture/)**: The session identifiers observed on successful requests to this operation.
+- **Sequences**: The number of [Sequence Analytics](/api-shield/security/sequence-analytics/) sequences containing the operation.
 
 :::note
 
-Customers viewing analytics have the ability to toggle detailed metrics view between the last 24 hours and 7 days.
+You can view detailed metrics from the last 24 hours or seven days.
 :::
 
 ## Using the Cloudflare API
 
-You can interact with Endpoint Management through the Cloudflare API. Refer to [Endpoint Management’s API documentation](/api/resources/api_gateway/subresources/discovery/subresources/operations/methods/list/) for more information.
+You can manage operations through the Cloudflare API. For more information, refer to the [operations API documentation](/api/resources/api_gateway/subresources/discovery/subresources/operations/methods/list/).
 
 ## Sensitive Data Detection
 
 Sensitive data comprises various personally identifiable information and financial data. Cloudflare created this ruleset to address common data loss threats, and the WAF can search for this data in HTTP response bodies from your origin.
 
-API Shield will alert users to the presence of sensitive data in the response body of API endpoints listed in Endpoint Management if the zone is also subscribed to the [Sensitive Data Detection managed ruleset](/waf/managed-rules/reference/sensitive-data-detection/).
+API Shield alerts you to sensitive data in responses from full operations. Your zone must also have the [Sensitive Data Detection managed ruleset](/waf/managed-rules/reference/sensitive-data-detection/).
 
 Sensitive Data Detection is available to Enterprise customers on our Advanced application security plan.
 
-Once Sensitive Data Detection is enabled for your zone, API Shield queries firewall events from the WAF for the last seven days and places a notification icon on the Endpoint Management table row if there are any matched sensitive responses for your endpoint.
+After you turn on Sensitive Data Detection, API Shield queries WAF events from the last seven days. Web Assets marks operations that have matched sensitive responses.
 
-API Shield displays the types of sensitive data found if you expand the Endpoint Management table row to view further details. Select **Explore Events** to view the matched events in Security Events.
+Open the operation details to review the detected sensitive data types. Select **Explore Events** to view matched events in Security Events.
 
-After Sensitive Data Detection is enabled for your zone, you can [browse the Sensitive Data Detection ruleset](https://dash.cloudflare.com/?to=/:account/:zone/security/data/ruleset/e22d83c647c64a3eae91b71b499d988e/rules). The link will not work if Sensitive Data Detection is not enabled.
+After you turn on Sensitive Data Detection for your zone, you can [browse the Sensitive Data Detection ruleset](https://dash.cloudflare.com/?to=/:account/:zone/security/data/ruleset/e22d83c647c64a3eae91b71b499d988e/rules). The link will not work if Sensitive Data Detection is not turned on.
 
 ## Limitations
 

--- a/src/content/docs/api-shield/management-and-monitoring/endpoint-management/schema-learning.mdx
+++ b/src/content/docs/api-shield/management-and-monitoring/endpoint-management/schema-learning.mdx
@@ -10,7 +10,9 @@ sidebar:
 
 import { Steps, Tabs, TabItem, DashButton } from "~/components";
 
-Schema learning observes live API traffic to automatically discover the parameters, headers, and body formats your endpoints accept. For all endpoints saved to Endpoint Management, you can export the learned schema in OpenAPI `v3.0.0` format by hostname.
+Schema learning observes live API traffic for operations in the `full` state. It discovers the parameters, headers, and body formats that your API endpoints accept. You can export learned schemas in OpenAPI `v3.0.0` format by hostname.
+
+For API Shield customers using unified operation discovery, select **Learn profile** from a discovered operation's row actions. This promotes the operation to the `full` state and starts collecting data for schema learning. The action then changes to **Profile learned**. For more information, refer to [Promote an operation](/security/web-assets/manage-operations/#promote-an-operation).
 
 To protect your API with a learned schema, refer to [Schema validation](/api-shield/security/schema-validation/#add-validation-by-applying-a-learned-schema-to-an-entire-hostname).
 
@@ -22,9 +24,9 @@ To protect your API with a learned schema, refer to [Schema validation](/api-shi
       1. In the Cloudflare dashboard, go to the **Web Assets** page.
 
           <DashButton url="/?to=/:account/:zone/security/web-assets" />
-      2. Go to the **Endpoints** tab.
+      2. Go to the **Operations** tab.
       3. Select **Export schema** and choose a hostname to export.
-      4. Select whether to include learned parameters and rate limit recommendations
+      4. Select whether to include learned parameters and rate limit recommendations.
       5. Select **Export schema** and choose a location to save the file.
     </Steps>
   </TabItem>
@@ -32,9 +34,9 @@ To protect your API with a learned schema, refer to [Schema validation](/api-shi
     <Steps>
       1. Log in to the [Cloudflare dashboard](https://dash.cloudflare.com/), and select your account and domain.
       2. Select **Security** > **API Shield** > **Endpoint Management**.
-      4. Select **Export schema** and choose a hostname to export.
-      5. Select whether to include [learned parameters](/api-shield/management-and-monitoring/#learned-schemas-will-always-include) and [rate limit recommendations](/api-shield/security/volumetric-abuse-detection/)
-      6. Select **Export schema** and choose a location to save the file.
+      3. Select **Export schema** and choose a hostname to export.
+      4. Select whether to include [learned parameters](#learned-schema-contents) and [rate limit recommendations](/api-shield/security/volumetric-abuse-detection/).
+      5. Select **Export schema** and choose a location to save the file.
     </Steps>
   </TabItem>
 </Tabs>
@@ -43,12 +45,14 @@ To protect your API with a learned schema, refer to [Schema validation](/api-shi
 The schema is saved as a JSON file in OpenAPI `v3.0.0` format.
 :::
 
-Learned schemas will always include:
+## Learned schema contents
+
+Learned schemas always include:
 
 - The listed hostname in the servers section
-- All endpoints by host, method, and path
+- All full operations by hostname, method, and path
 
-For endpoints that receive sufficient traffic, learned schemas will also include:
+For operations that receive sufficient traffic, learned schemas will also include:
 
 - Detected path variables and formats
 - Detected query parameters and formats
@@ -60,8 +64,8 @@ Learned schemas can optionally include:
 
 ## Limitations
 
-Endpoints must be added for at least 24 hours before schema learning begins. Schema learning is a continuous process that inspects the last 72 hours of traffic to an endpoint.
+An operation must remain in the `full` state for at least 24 hours before schema learning begins. Schema learning continuously inspects the last 72 hours of traffic to the operation.
 
 Schema learning only learns from requests with `2xx` response codes.
 
-Schema learning works best with high volumes of traffic. You may see less confident learned schemas for endpoints with less than 10,000 requests in the last 72 hours.
+Schema learning works best with high traffic volumes. Learned schemas may have lower confidence for operations with fewer than 10,000 requests in the last 72 hours.

--- a/src/content/docs/security/web-assets/get-started.mdx
+++ b/src/content/docs/security/web-assets/get-started.mdx
@@ -22,7 +22,7 @@ Discovered operations can be used for matching and downstream security detection
 
 Add an operation when traffic you want to protect does not appear, or when you want to define the operation structure yourself.
 
-Refine an operation when the current grouping does not match how the traffic should be grouped or protected. For example, you may want a separate operation for a login flow, password reset flow, or payment flow.
+Promote a discovered API endpoint to move its operation into the `full` state and learn its traffic profile. Refine an operation when its method, hostname pattern, or path pattern does not match how the traffic should be grouped or protected.
 
 For more information, refer to [Manage operations](/security/web-assets/manage-operations/).
 
@@ -46,7 +46,7 @@ Certain metrics, such as latency, may not populate when a request is handled by 
 
 ## Use learned schemas
 
-Schema learning observes live API traffic to discover the parameters, headers, and body formats your operations accept. You can export learned schemas in OpenAPI `v3.0.0` format.
+Schema learning observes live API traffic for operations in the `full` state. It discovers the parameters, headers, and body formats that your operations accept. You can export learned schemas in OpenAPI `v3.0.0` format.
 
 If you already maintain OpenAPI schemas, you can upload them to create operations and use them with API Shield [Schema Validation](/api-shield/security/schema-validation/).
 

--- a/src/content/docs/security/web-assets/index.mdx
+++ b/src/content/docs/security/web-assets/index.mdx
@@ -52,6 +52,12 @@ Operations can come from several sources:
 
 These sources contribute to the same operation inventory. You do not need to review every discovered operation before security detections can use operation context.
 
+## Operation states and profile learning
+
+Operations can be in the `candidate`, `shadow`, or `full` state. Promoting a candidate or shadow operation moves it to the `full` state and starts collecting data for profile learning. For more information, refer to [Promote an operation](/security/web-assets/manage-operations/#promote-an-operation).
+
+For API endpoints, configure protections such as [Schema Validation](/api-shield/security/schema-validation/) separately.
+
 ## Describe operations context
 
 [Labels](/security/web-assets/label-operations/) describe what an operation does, such as a login flow, sign-up flow, AI-powered operation, or another use case.

--- a/src/content/docs/security/web-assets/manage-operations.mdx
+++ b/src/content/docs/security/web-assets/manage-operations.mdx
@@ -3,7 +3,7 @@ title: Manage operations
 pcx_content_type: how-to
 sidebar:
   order: 2
-description: Add, review, refine, and delete HTTP request operations in Web Assets.
+description: Add, promote, review, refine, and delete HTTP request operations in Web Assets.
 products:
   - security
 ---
@@ -16,11 +16,11 @@ Each operation has one of the following states:
 
 | State       | Meaning                                                                                                                                                           |
 | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `full`      | An operation that you saved, added manually, or created from a schema. Full operations are used for matching, logging, detections, and rules.                     |
+| `full`      | An operation that you promoted, added manually, or created from a schema. Full operations are used for matching, logging, detections, and rules.                  |
 | `candidate` | An operation that Cloudflare discovered from traffic. Candidate operations are used for matching, logging, detections, and rules before you manually review them. |
 | `shadow`    | An operation that exists in Web Assets but is not used for matching, logging, detections, or rules.                                                               |
 
-You do not need to move every discovered operation into the `full` state. Candidate operations provide operation context automatically, while full operations give you more control over important traffic.
+You do not need to promote every discovered operation to the `full` state. Candidate operations provide operation context automatically, while full operations support additional learning and protections.
 
 ## Discovery requirements
 
@@ -47,9 +47,39 @@ Discovery can group them into one operation:
 GET api.example.com/profile/{var1}
 ```
 
-Discovered operations are used for matching before you manually refine them. This provides operation context for discovered traffic without requiring you to save every discovery first.
+Discovered operations are used for matching before you manually refine them. This provides operation context for discovered traffic without requiring you to promote every discovery first.
 
 Discovery-backed matching is subject to plan availability and system limits. Cloudflare currently sends up to 3,000 operations per zone to the edge for matching. Operations in the `full` state are prioritized first, followed by operations in the `candidate` state.
+
+## Promote an operation
+
+Promote a candidate or shadow operation to move it into the `full` state and start profile learning.
+
+The **Learn profile** action is available to API Shield customers using unified operation discovery and other customers with access to profile learning.
+
+After promotion, Cloudflare learns the expected request structure from observed traffic. For API endpoints, API Shield also collects data to learn and report additional context:
+
+- Request structures through [schema learning](/api-shield/management-and-monitoring/endpoint-management/schema-learning/)
+- Normal request volume through [rate limit recommendations](/api-shield/security/volumetric-abuse-detection/)
+- Authentication usage through [Authentication Posture](/api-shield/security/authentication-posture/)
+- Persisted security findings through [API endpoint risk labels](/api-shield/management-and-monitoring/endpoint-labels/#risk-labels)
+
+Each feature has separate data and timing requirements. For example, [schema learning](/api-shield/management-and-monitoring/endpoint-management/schema-learning/#limitations) requires an operation to remain full for at least 24 hours.
+
+Full operations can also use protections that require a known API endpoint, including [Schema Validation](/api-shield/security/schema-validation/), [fallthrough rules](/api-shield/security/schema-validation/#add-validation-by-adding-a-fallthrough-rule), and [sequence mitigation](/api-shield/security/sequence-mitigation/).
+
+<Steps>
+
+1. In the Cloudflare dashboard, go to the **Web Assets** page with the **Operations** tab highlighted.
+
+   <DashButton url="/?to=/:account/:zone/security/web-assets" />
+
+2. Open the row actions for a candidate or shadow operation.
+3. Select **Learn profile**.
+
+</Steps>
+
+After promotion, the row action changes to **Profile learned**.
 
 ## Traffic matching behavior
 
@@ -126,6 +156,25 @@ For example, you may want separate operations for login and password reset traff
 
 Review overlapping operations before making changes. Cloudflare matches a request to one operation. A broad operation can change how similar requests are grouped, while a narrow operation can isolate one flow from related traffic.
 
+<Steps>
+
+1. In the Cloudflare dashboard, go to the **Web Assets** page with the **Operations** tab highlighted.
+
+   <DashButton url="/?to=/:account/:zone/security/web-assets" />
+
+2. Open the row actions for the operation.
+3. Select **Edit operation**.
+4. Update the HTTP method, hostname pattern, or path pattern.
+5. Select **Save**.
+
+</Steps>
+
+Editing a candidate or shadow operation promotes it to the `full` state with the edited values.
+
+:::caution[Editing this operation will change its ID]
+Cloudflare computes operation IDs from the HTTP method, hostname, and path. Cloudflare relearns labels, schemas, and rate limiting recommendations for an operation with a new ID.
+:::
+
 ## Delete operations
 
 You can delete operations one at a time or in bulk.
@@ -142,7 +191,7 @@ You can delete operations one at a time or in bulk.
 </Steps>
 
 :::note
-When you delete an operation, future traffic towards this opetaion will not be matched at the edge, thus not generating analytics data for review. If Cloudflare later discovers similar traffic, the traffic may appear again as a discovered operation.
+After you delete an operation, Cloudflare no longer matches future traffic to that operation. If Cloudflare later discovers similar traffic, the traffic may appear again as a discovered operation.
 :::
 
 ## Use the Cloudflare API


### PR DESCRIPTION
### Summary

- Update Web Assets and API Shield documentation for unified operation management.
- Document promotion to the `full` state and profile learning for web and API traffic.
- Add operation editing behavior, including the warning shown when an edit changes the operation ID.

### Validation

- `pnpm run check`
- `pnpm run build`
