### PR TITLE
[Hyperdrive] Remove MySQL beta label

### DIFF
--- a/src/content/docs/hyperdrive/examples/connect-to-mysql/index.mdx
+++ b/src/content/docs/hyperdrive/examples/connect-to-mysql/index.mdx
@@ -5,8 +5,6 @@ description: Use Hyperdrive to connect to MySQL and MySQL-compatible databases f
 hideChildren: false
 sidebar:
   order: 2
-  badge:
-    text: Beta
   group:
     hideIndex: false
 reviewed: 2025-04-25


### PR DESCRIPTION
### Summary

Removes the Beta sidebar badge from the Hyperdrive "Connect to MySQL" example. This should be approved on 8/5/2026 and will include this label update.

- Removes the Beta badge from the example navigation because MySQL is no longer labeled Beta.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
