### PR TITLE
label R2 multipart example as TypeScript

### DIFF
--- a/src/content/docs/r2/api/workers/workers-multipart-usage.mdx
+++ b/src/content/docs/r2/api/workers/workers-multipart-usage.mdx
@@ -28,10 +28,10 @@ The following example Worker includes any new information about the state of the
 
 import { Tabs, TabItem } from "~/components";
 
-Add the following code to your project's `index.js` file and replace `MY_BUCKET` with your bucket's name:
+Add the following code to your project's `index.ts` file and replace `MY_BUCKET` with your bucket's name:
 
-<Tabs syncKey="workersExamples"> <TabItem label="JavaScript" icon="seti:javascript">
-```js
+<Tabs syncKey="workersExamples"> <TabItem label="TypeScript" icon="seti:typescript">
+```ts
 interface Env {
   MY_BUCKET: R2Bucket;
 }


### PR DESCRIPTION
### Summary

Correct the R2 multipart Worker example to identify it as TypeScript.

The sample already uses TypeScript interfaces, type annotations, and the `satisfies` operator. This change updates the referenced filename to `index.ts` and labels the code block as TypeScript.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).