### PR TITLE
handle missing R2 download objects

### DIFF
--- a/src/content/docs/r2/objects/download-objects.mdx
+++ b/src/content/docs/r2/objects/download-objects.mdx
@@ -29,6 +29,9 @@ Use R2 [bindings](/workers/runtime-apis/bindings/) in Workers to download object
 export default {
 	async fetch(request: Request, env: Env, ctx: ExecutionContext) {
 		const object = await env.MY_BUCKET.get("image.png");
+		if (object === null) {
+			return new Response("Object not found", { status: 404 });
+		}
 		return new Response(object.body);
 	},
 } satisfies ExportedHandler<Env>;


### PR DESCRIPTION
### Summary

Updates the R2 Workers API download example to return a `404` response when `R2Bucket.get()` returns `null`, preventing access to `object.body` on a missing object.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).