### PR TITLE
[Support] Clarify Error 522 timeout wording

### DIFF
--- a/src/content/docs/support/troubleshooting/http-status-codes/cloudflare-5xx-errors/error-522.mdx
+++ b/src/content/docs/support/troubleshooting/http-status-codes/cloudflare-5xx-errors/error-522.mdx
@@ -15,8 +15,8 @@ Error `522` occurs when Cloudflare times out contacting the origin web server.
 
 Two different timeouts cause HTTP error `522` depending on when they occur between Cloudflare and the origin web server:
 
-- Before a connection is established, the origin web server does not return a SYN+ACK to Cloudflare within 19 seconds of Cloudflare sending a SYN (the SYN retry backoff scheme is 1,1,1,1,1,2,4,8).
-- After a connection is established, the origin web server does not acknowledge (ACK) Cloudflare's resource request within 90 seconds.
+- Before a TCP connection is established, Cloudflare does not receive a SYN+ACK within 19 seconds after sending a SYN. The SYN retry backoff intervals are 1, 1, 1, 1, 1, 2, 4, and 8 seconds.
+- After the TCP connection is established, Cloudflare does not receive an acknowledgment (ACK) of its resource request within 90 seconds.
 
 ### Resolution
 


### PR DESCRIPTION
### Summary

Updates the Error 522 timeout wording so it describes what Cloudflare does not receive instead of asserting that the origin failed to send the expected SYN+ACK or acknowledgment.

The previous wording could implicitly attribute the timeout to the origin. An origin can perform the expected protocol actions while the signals fail to reach Cloudflare's origin connection because of transit loss or internal packet handling. This change keeps the description bounded to Cloudflare's observation and does not alter the documented timeout durations or categories.

Scope note: This PR does not validate or redefine the existing 19-second and 90-second timeout semantics. That requires separate implementation-owner review.

Updates https://developers.cloudflare.com/support/troubleshooting/http-status-codes/cloudflare-5xx-errors/error-522/

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).