### PR TITLE
fix invalid R2 bucket names

### DIFF
--- a/src/content/docs/r2/examples/aws/aws-sdk-php.mdx
+++ b/src/content/docs/r2/examples/aws/aws-sdk-php.mdx
@@ -19,7 +19,7 @@ This example uses version 3 of the [aws-sdk-php](https://packagist.org/packages/
 <?php
 require 'vendor/aws/aws-autoloader.php';
 
-$bucket_name = "my_bucket";
+$bucket_name = "my-bucket";
 // Provide your Cloudflare account ID
 $account_id = "<ACCOUNT_ID>";
 // Retrieve your S3 API credentials for your R2 bucket via API tokens (see: https://developers.cloudflare.com/r2/api/tokens)

--- a/src/content/docs/r2/examples/aws/custom-header.mdx
+++ b/src/content/docs/r2/examples/aws/custom-header.mdx
@@ -36,7 +36,7 @@ def add_custom_header(params, **kwargs):
 
 event_system.register('before-call.s3.PutObject', add_custom_header)
 
-response = client.put_object(Bucket="my_bucket", Key="my_file", Body="file_contents")
+response = client.put_object(Bucket="my-bucket", Key="my_file", Body="file_contents")
 print(response)
 ```
 
@@ -71,7 +71,7 @@ client.middlewareStack.add(
 )
 
 const command = new PutObjectCommand({
-  Bucket: "my_bucket",
+  Bucket: "my-bucket",
   Key: "my_key",
   Body: "my_data"
 });
@@ -118,7 +118,7 @@ event_system.register('before-call.s3.PutObject', add_custom_headers)
 custom_headers = {'If-Match' : '"29d911f495d1ba7cb3a4d7d15e63236a"'}
 
 # Note that boto3 will throw an exception if the precondition failed. Catch this exception if necessary
-response = client.put_object(Bucket="my_bucket", Key="my_key", Body="file_contents", custom_headers=custom_headers)
+response = client.put_object(Bucket="my-bucket", Key="my_key", Body="file_contents", custom_headers=custom_headers)
 print(response)
 ```
 
@@ -144,7 +144,7 @@ const client = new S3Client({
 });
 
 const command = new PutObjectCommand({
-  Bucket: "my_bucket",
+  Bucket: "my-bucket",
   Key: "my_key",
   Body: "my_data"
 });


### PR DESCRIPTION
### Summary

Updates the R2 PHP, boto3, and JavaScript examples to use valid hyphenated bucket names instead of names containing unsupported underscores.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).