### PR TITLE
[Developer Platform] Update limit request form links in docs

### DIFF
--- a/src/content/docs/hyperdrive/configuration/tune-connection-pool.mdx
+++ b/src/content/docs/hyperdrive/configuration/tune-connection-pool.mdx
@@ -75,7 +75,7 @@ The Hyperdrive connection pool limit is a "soft limit". This means that it is po
 :::
 
 :::note
-You can request adjustments to Hyperdrive's origin connection limits. To request an increase, submit a [Limit Increase Request](https://forms.gle/eX6pXvit1wBv77Yw5) and Cloudflare will contact you with next steps. Cloudflare also regularly monitors the Hyperdrive channel in [Cloudflare's Discord community](https://discord.cloudflare.com/) and can answer questions regarding limits and requests.
+You can request adjustments to Hyperdrive's origin connection limits. To request an increase, submit a [Limit Increase Request](https://dash.cloudflare.com/?to=/:account/limits-usage&request-limit-increase=true) and Cloudflare will contact you with next steps. Cloudflare also regularly monitors the Hyperdrive channel in [Cloudflare's Discord community](https://discord.cloudflare.com/) and can answer questions regarding limits and requests.
 :::
 
 ## Best practices

--- a/src/content/docs/hyperdrive/platform/limits.mdx
+++ b/src/content/docs/hyperdrive/platform/limits.mdx
@@ -62,4 +62,4 @@ Queries exceeding the maximum duration are terminated. Query responses larger th
 
 You can request adjustments to limits that conflict with your project goals by contacting Cloudflare. Not all limits can be increased.
 
-To request an increase, submit a [Limit Increase Request form](https://forms.gle/eX6pXvit1wBv77Yw5). You can also ask questions in the Hyperdrive channel on [Cloudflare's Discord community](https://discord.cloudflare.com/).
+To request an increase, submit a [Limit Increase Request form](https://dash.cloudflare.com/?to=/:account/limits-usage&request-limit-increase=true). You can also ask questions in the Hyperdrive channel on [Cloudflare's Discord community](https://discord.cloudflare.com/).

--- a/src/content/docs/pages/configuration/monorepos.mdx
+++ b/src/content/docs/pages/configuration/monorepos.mdx
@@ -42,4 +42,4 @@ While Pages does not provide specialized tooling for dependency management in mo
 ## Limitations
 
 - You must be using [Build System V2](/pages/configuration/build-image/#v2-build-system) or later in order for monorepo support to be enabled.
-- You can configure a maximum of 5 Pages projects per repository. If you need this limit raised, contact your Cloudflare account team or use the [Limit Increase Request Form](https://docs.google.com/forms/d/e/1FAIpQLSd_fwAVOboH9SlutMonzbhCxuuuOmiU1L_I5O2CFbXf_XXMRg/viewform).
+- You can configure a maximum of 5 Pages projects per repository. If you need this limit raised, contact your Cloudflare account team or use the [Limit Increase Request Form](https://dash.cloudflare.com/?to=/:account/limits-usage&request-limit-increase=true).

--- a/src/content/docs/r2/api/error-codes.mdx
+++ b/src/content/docs/r2/api/error-codes.mdx
@@ -52,7 +52,7 @@ For the **S3-compatible API**, errors are returned as XML in the response body:
 | 10005 | InvalidBucketName | 400 | Bucket name does not meet naming requirements. | Bucket names must be 3-63 chars, lowercase alphanumeric and hyphens, start/end with alphanumeric. |
 | 10006 | NoSuchBucket | 404 | The specified bucket does not exist. | Verify the bucket name is correct and the bucket exists in your account. |
 | 10008 | BucketNotEmpty | 409 | Cannot delete bucket that contains objects. | Delete all objects in the bucket before deleting the bucket. |
-| 10009 | TooManyBuckets | 400 | Account bucket limit exceeded (default: 1,000,000 buckets). | Request a limit increase via the [Limits Increase Request Form](https://forms.gle/eX6pXvit1wBv77Yw5). |
+| 10009 | TooManyBuckets | 400 | Account bucket limit exceeded (default: 1,000,000 buckets). | Request a limit increase via the [Limits Increase Request Form](https://dash.cloudflare.com/?to=/:account/limits-usage&request-limit-increase=true). |
 | 10073 | BucketConflict | 409 | Bucket name already exists. | Choose a different bucket name. Bucket names must be unique within your account. |
 
 ### Object errors

--- a/src/content/partials/workers/limits_increase.mdx
+++ b/src/content/partials/workers/limits_increase.mdx
@@ -1,12 +1,9 @@
 ---
 {}
-
 ---
 
 :::note[Need a higher limit?]
 
-
-To request an adjustment to a limit, complete the [Limit Increase Request Form](https://forms.gle/eX6pXvit1wBv77Yw5). If the limit can be increased, Cloudflare will contact you with next steps.
-
+Complete the [Limit Increase Request Form](https://dash.cloudflare.com/?to=/:account/limits-usage&request-limit-increase=true) or [Upgrade to Workers Paid](https://dash.cloudflare.com/?to=/:account/workers/plans).
 
 :::


### PR DESCRIPTION
### Summary

Replaces legacy Google limit-increase form links with an account-aware Dashboard deep link that opens the native request form. The shared Developer Platform limits partial updates Workers, KV, D1, Durable Objects, R2, Queues, Workflows, Pages, Workers for Platforms, Email Service, Agents, and Pipelines limits pages. Direct links are also updated for Hyperdrive, R2 errors, and Pages monorepos.

Depends on Dashboard MR [cloudflare/fe/stratus!40756](https://gitlab.cfdata.org/cloudflare/fe/stratus/-/merge_requests/40756).

### Testing preview

https://possibilities-marketing-plan-attorneys.trycloudflare.com

Use this temporary preview to test the full Developer Docs to Cloudflare dashboard limit-increase flow. The preview remains available while the local development server and tunnel are running.

### Documentation checklist

- [x] The change adheres to the documentation style guide.
- [x] No changelog is needed for this link migration.
- [x] No files changed location, so redirects are not needed.

### Validation

- `pnpm run check`
- Rendered all 16 affected pages locally and verified the Dashboard deep link.