### PR TITLE
[Docs] Prevent preview deployments from being indexed

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,6 +14,26 @@ export default defineConfig({
 				test: {
 					name: "Workers",
 					include: ["**/*.worker.test.ts"],
+					exclude: ["**/*.preview.worker.test.ts"],
+					deps: {
+						optimizer: {
+							ssr: {
+								enabled: true,
+								include: ["node-html-parser", "yaml"],
+							},
+						},
+					},
+				},
+			}),
+			defineConfig({
+				plugins: [
+					cloudflareTest({
+						wrangler: { configPath: "./wrangler.preview.test.json" },
+					}),
+				],
+				test: {
+					name: "Workers (Preview)",
+					include: ["**/*.preview.worker.test.ts"],
 					deps: {
 						optimizer: {
 							ssr: {

--- a/worker/index.preview.ts
+++ b/worker/index.preview.ts
@@ -3,6 +3,12 @@
 //
 // It is deployed via CI with:
 //   pnpm exec wrangler deploy --config wrangler.preview.json ...
+//
+// Anti-indexing measures (preview-only, not in production worker):
+//   - /robots.txt returns Disallow: / with no AI content signals
+//   - X-Robots-Tag header on every response
+//   - <meta name="robots"> injected into HTML responses via HTMLRewriter
+//   - Sitemap endpoints return 404
 import { WorkerEntrypoint } from "cloudflare:workers";
 import { generateRedirectsEvaluator } from "redirects-in-workers";
 import redirectsFileContents from "../dist/__redirects";
@@ -48,6 +54,46 @@ const API_CATALOG = JSON.stringify({
 	],
 });
 
+// --- Preview anti-indexing ---
+
+const ROBOTS_POLICY = "noindex, nofollow, noarchive, nosnippet, noimageindex";
+
+const PREVIEW_ROBOTS_TXT = [
+	"User-agent: *",
+	"Disallow: /",
+	"Content-Signal: ai-train=no, search=no, ai-input=no",
+].join("\n");
+
+function withRobotsHeaders(response: Response): Response {
+	const headers = new Headers(response.headers);
+	headers.set("X-Robots-Tag", ROBOTS_POLICY);
+	return new Response(response.body, {
+		status: response.status,
+		statusText: response.statusText,
+		headers,
+	});
+}
+
+function injectRobotsMeta(response: Response): Response {
+	const contentType = response.headers.get("Content-Type") ?? "";
+	if (!contentType.includes("text/html")) return response;
+	return new HTMLRewriter()
+		.on("head", {
+			element(element) {
+				element.append(`<meta name="robots" content="${ROBOTS_POLICY}" />`, {
+					html: true,
+				});
+			},
+		})
+		.transform(response);
+}
+
+function hardenResponse(response: Response): Response {
+	return injectRobotsMeta(withRobotsHeaders(response));
+}
+
+// --- End preview anti-indexing ---
+
 /**
  * When a redirect response is returned for an index.md request, rewrite the
  * Location header so the agent stays in Markdown land instead of landing on
@@ -86,8 +132,33 @@ function rewriteRedirectForMarkdown(
 
 export default class extends WorkerEntrypoint<Env> {
 	override async fetch(request: Request) {
+		const response = await this.handleRequest(request);
+		return hardenResponse(response);
+	}
+
+	private async handleRequest(request: Request): Promise<Response> {
 		const url = new URL(request.url);
 		const { pathname } = url;
+
+		// Preview-only robots.txt — disallows all crawling and AI content signals
+		if (pathname === "/robots.txt") {
+			return new Response(PREVIEW_ROBOTS_TXT, {
+				headers: {
+					"Content-Type": "text/plain; charset=utf-8",
+					"Cache-Control": "no-store",
+				},
+			});
+		}
+
+		// Block sitemap endpoints on previews
+		if (/^\/sitemap.*\.xml$/.test(pathname)) {
+			return new Response("Not found", {
+				status: 404,
+				headers: {
+					"Content-Type": "text/plain; charset=utf-8",
+				},
+			});
+		}
 
 		if (pathname === "/.well-known/api-catalog") {
 			return new Response(API_CATALOG, {

--- a/worker/index.preview.worker.test.ts
+++ b/worker/index.preview.worker.test.ts
@@ -1,0 +1,135 @@
+import { SELF } from "cloudflare:test";
+import { describe, it, expect } from "vitest";
+import { parse } from "node-html-parser";
+
+const ROBOTS_POLICY = "noindex, nofollow, noarchive, nosnippet, noimageindex";
+
+describe("Preview anti-indexing", () => {
+	describe("robots.txt", () => {
+		it("returns Disallow: / with no AI content signals", async () => {
+			const response = await SELF.fetch(
+				new Request("http://fakehost/robots.txt"),
+			);
+			expect(response.status).toBe(200);
+			expect(response.headers.get("X-Robots-Tag")).toBe(ROBOTS_POLICY);
+
+			const text = await response.text();
+			expect(text).toContain("User-agent: *");
+			expect(text).toContain("Disallow: /");
+			expect(text).toContain("ai-train=no");
+			expect(text).toContain("search=no");
+			expect(text).toContain("ai-input=no");
+		});
+
+		it("does not contain the production sitemap line", async () => {
+			const response = await SELF.fetch(
+				new Request("http://fakehost/robots.txt"),
+			);
+			const text = await response.text();
+			expect(text).not.toContain("Sitemap:");
+			expect(text).not.toContain("Allow: /");
+		});
+	});
+
+	describe("X-Robots-Tag header", () => {
+		it("is present on HTML pages", async () => {
+			const response = await SELF.fetch(
+				new Request("http://fakehost/workers/"),
+			);
+			expect(response.status).toBe(200);
+			expect(response.headers.get("X-Robots-Tag")).toBe(ROBOTS_POLICY);
+		});
+
+		it("is present on 404 pages", async () => {
+			const response = await SELF.fetch(
+				new Request("http://fakehost/non-existent"),
+			);
+			expect(response.status).toBe(404);
+			expect(response.headers.get("X-Robots-Tag")).toBe(ROBOTS_POLICY);
+		});
+
+		it("is present on redirect responses", async () => {
+			const response = await SELF.fetch(new Request("http://fakehost/docs/"), {
+				redirect: "manual",
+			});
+			expect(response.status).toBe(301);
+			expect(response.headers.get("X-Robots-Tag")).toBe(ROBOTS_POLICY);
+		});
+
+		it("is present on JSON endpoints", async () => {
+			const response = await SELF.fetch(
+				new Request(
+					"http://fakehost/workers/platform/compatibility-flags.json",
+				),
+			);
+			expect(response.status).toBe(200);
+			expect(response.headers.get("X-Robots-Tag")).toBe(ROBOTS_POLICY);
+		});
+
+		it("is present on RSS endpoints", async () => {
+			const response = await SELF.fetch(
+				new Request("http://fakehost/changelog/rss/index.xml"),
+			);
+			expect(response.status).toBe(200);
+			expect(response.headers.get("X-Robots-Tag")).toBe(ROBOTS_POLICY);
+		});
+
+		it("is present on llms.txt", async () => {
+			const response = await SELF.fetch(
+				new Request("http://fakehost/llms.txt"),
+			);
+			expect(response.status).toBe(200);
+			expect(response.headers.get("X-Robots-Tag")).toBe(ROBOTS_POLICY);
+		});
+	});
+
+	describe("HTML meta robots tag", () => {
+		it("is injected into HTML pages", async () => {
+			const response = await SELF.fetch(
+				new Request("http://fakehost/workers/"),
+			);
+			expect(response.status).toBe(200);
+
+			const html = await response.text();
+			const dom = parse(html);
+
+			const meta = dom.querySelector("meta[name='robots']");
+			expect(meta).toBeDefined();
+			expect(meta?.attributes.content).toBe(ROBOTS_POLICY);
+		});
+
+		it("is injected into 404 HTML pages", async () => {
+			const response = await SELF.fetch(
+				new Request("http://fakehost/non-existent"),
+			);
+			expect(response.status).toBe(404);
+
+			const html = await response.text();
+			const dom = parse(html);
+
+			const metas = dom.querySelectorAll("meta[name='robots']");
+			const hasFullPolicy = metas.some(
+				(m) => m.attributes.content === ROBOTS_POLICY,
+			);
+			expect(hasFullPolicy).toBe(true);
+		});
+	});
+
+	describe("sitemap blocking", () => {
+		it("returns 404 for /sitemap-index.xml", async () => {
+			const response = await SELF.fetch(
+				new Request("http://fakehost/sitemap-index.xml"),
+			);
+			expect(response.status).toBe(404);
+			expect(response.headers.get("X-Robots-Tag")).toBe(ROBOTS_POLICY);
+		});
+
+		it("returns 404 for /sitemap-0.xml", async () => {
+			const response = await SELF.fetch(
+				new Request("http://fakehost/sitemap-0.xml"),
+			);
+			expect(response.status).toBe(404);
+			expect(response.headers.get("X-Robots-Tag")).toBe(ROBOTS_POLICY);
+		});
+	});
+});

--- a/worker/index.preview.worker.test.ts
+++ b/worker/index.preview.worker.test.ts
@@ -94,7 +94,7 @@ describe("Preview anti-indexing", () => {
 			const dom = parse(html);
 
 			const meta = dom.querySelector("meta[name='robots']");
-			expect(meta).toBeDefined();
+			expect(meta).not.toBeNull();
 			expect(meta?.attributes.content).toBe(ROBOTS_POLICY);
 		});
 

--- a/wrangler.preview.test.json
+++ b/wrangler.preview.test.json
@@ -1,0 +1,18 @@
+{
+	"$schema": "./node_modules/wrangler/config-schema.json",
+	"name": "cloudflare-docs-preview-test",
+	"account_id": "b54f07a6c269ecca2fa60f1ae4920c99",
+	"compatibility_date": "2025-06-02",
+	"compatibility_flags": ["nodejs_compat"],
+	"main": "./worker/index.preview.ts",
+	"rules": [
+		{ "type": "Text", "globs": ["**/__redirects"], "fallthrough": true }
+	],
+	"assets": {
+		"directory": "./dist",
+		"binding": "ASSETS",
+		"not_found_handling": "404-page",
+		"run_worker_first": true
+	},
+	"r2_buckets": [{ "binding": "MIDDLECACHE", "bucket_name": "middlecache" }]
+}


### PR DESCRIPTION
## Summary

Add anti-indexing measures to the preview Worker (`worker/index.preview.ts`) so that all preview deployments — both existing GitHub Workers for Platforms previews and new GitLab Workers Preview URLs — are blocked from search engines and AI crawlers. Production (`worker/index.ts`) is unaffected.

## Changes

**`worker/index.preview.ts`** — anti-indexing measures:
- Override `/robots.txt` with `Disallow: /` and `Content-Signal: ai-train=no, search=no, ai-input=no` (no sitemap line)
- Add `X-Robots-Tag: noindex, nofollow, noarchive, nosnippet, noimageindex` to every response
- Inject `<meta name="robots">` with the same policy into HTML responses via `HTMLRewriter`
- Return 404 for `/sitemap-index.xml` and `/sitemap-*.xml`

**Test infrastructure:**
- `wrangler.preview.test.json` — test config for preview Worker with R2 binding
- `vitest.config.ts` — add "Workers (Preview)" project
- `worker/index.preview.worker.test.ts` — 12 tests covering robots.txt, X-Robots-Tag, HTML meta injection, and sitemap blocking

## Checklist

- [x] `pnpm run check` — type-check passes
- [x] `pnpm run format:core:check` — formatting passes
- [x] `pnpm run test:postbuild` — existing Workers tests pass (16/16)
- [x] `pnpm exec vitest --project "Workers (Preview)"` — new preview tests pass (12/12)
- [x] No changes to `worker/index.ts` (production Worker)
- [x] No production env var needed — production uses `index.ts`, previews use `index.preview.ts`