### PR TITLE
fix: add concurrency group to publish workflow to prevent out-of-order deploys

### DIFF
--- a/.github/workflows/publish-production.yml
+++ b/.github/workflows/publish-production.yml
@@ -9,6 +9,9 @@ jobs:
     if: github.repository == 'cloudflare/cloudflare-docs'
     name: Production
     runs-on: ubuntu-22.04
+    concurrency:
+      group: publish-production
+      cancel-in-progress: false
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
### Summary

Adds a `concurrency` group to the production publish workflow to prevent out-of-order deploys. Previously, if two PRs merged in quick succession and the first build ran slower than the second, the first deploy could finish after the second and overwrite the newer code. With `cancel-in-progress: false`, concurrent runs queue instead of running in parallel — only one deploy executes at a time.

### Documentation checklist

- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
