### PR TITLE
[Spectrum] Correct IPv4 hostname quota scope to per-account

### DIFF
--- a/src/content/docs/data-localization/regional-services/spectrum-applications.mdx
+++ b/src/content/docs/data-localization/regional-services/spectrum-applications.mdx
@@ -43,14 +43,11 @@ You create a Spectrum HTTP/S application for each hostname you want to regionali
 
    <Details header="Spectrum hostname limits and workarounds">
 
-   By default, a zone is limited to **10 unique Spectrum hostnames** (each backed by a dedicated IPv4 address). If you need to regionalize more hostnames than this, you can:
+   By default, an account is limited to **10 unique Spectrum hostnames** using Cloudflare-managed IPv4 addresses, across all zones on the account. Each hostname is backed by a dedicated IPv4 address, and this quota is applied at the account level — not per zone.
 
-   - **Use [BYOIP](/spectrum/about/byoip/)** — bring your own IP space so Spectrum applications are not constrained by the default shared-IPv4 allocation.
-   - **Use IPv6-only Spectrum applications** — IPv6 addresses are not subject to the same scarcity as IPv4, so IPv6-only applications do not count against the IPv4 hostname limit.
-   - **CNAME multiple subdomains to a single Spectrum application** — point several DNS-only (gray-clouded) `CNAME` records at one Spectrum app hostname. This works only when those hostnames share the same origin (one origin per application).
-   - **Use [Cloudflare for SaaS](/cloudflare-for-platforms/cloudflare-for-saas/)** — configure the Spectrum application as the target (fallback origin) for Custom Hostnames.
+   If you need to regionalize more hostnames than this, refer to the workarounds in [Spectrum limitations: IPv4 hostname quota](/spectrum/reference/limitations/#ipv4-hostname-quota) (BYOIP, IPv6-only applications, CNAMEing subdomains to a single application, or Cloudflare for SaaS).
 
-   These are Spectrum-wide limits, not specific to Regional Services. Contact your account team if you expect to exceed them.
+   This quota is a Spectrum-wide limit, not specific to Regional Services. Contact your account team if you expect to exceed it.
 
    </Details>
 

--- a/src/content/docs/spectrum/reference/limitations.mdx
+++ b/src/content/docs/spectrum/reference/limitations.mdx
@@ -1,13 +1,28 @@
 ---
 pcx_content_type: reference
 title: Limitations
-description: Protocol-specific limitations for Spectrum applications.
+description: Limitations that apply to Spectrum applications.
 products:
   - spectrum
 weight: 0
 ---
 
-The following limitations apply to different protocols supported by Spectrum.
+The following limitations apply to Spectrum applications.
+
+## IPv4 hostname quota
+
+By default, an account is limited to **10 unique Spectrum hostnames** using Cloudflare-managed IPv4 addresses, across all zones on the account. Each hostname is backed by a dedicated IPv4 address, and this quota is applied at the account level — not per zone.
+
+IPv6-only Spectrum applications do not count against this quota.
+
+If you need more than 10 IPv4-backed Spectrum hostnames, you can:
+
+- **Use [BYOIP](/spectrum/about/byoip/)** — bring your own IP space so Spectrum applications are not constrained by the default shared-IPv4 allocation.
+- **Use IPv6-only Spectrum applications** — IPv6 addresses are not subject to the same scarcity as IPv4.
+- **CNAME multiple subdomains to a single Spectrum application** — point several DNS-only (gray-clouded) `CNAME` records at one Spectrum application hostname. This works only when those hostnames share the same origin (one origin per application).
+- **Use [Cloudflare for SaaS](/cloudflare-for-platforms/cloudflare-for-saas/)** — configure the Spectrum application as the target (fallback origin) for Custom Hostnames.
+
+Contact your account team if you expect to exceed the quota.
 
 ## HTTPS
 


### PR DESCRIPTION
### Summary

Fixes an incorrect definition of the Spectrum IPv4 hostname limit. The limit is 10 unique Spectrum hostnames **per account** (across all zones), not per zone.

- Adds a canonical `IPv4 hostname quota` section to the Spectrum Limitations page as the single source of truth, covering the quota and the four workarounds (BYOIP, IPv6-only apps, CNAMEing subdomains, Cloudflare for SaaS).
- Corrects the wording on the Data Localization → Regional Services → Spectrum applications page ("a zone is limited to" → "an account is limited to") and links to the new canonical section instead of duplicating the workaround list.

Note: `spectrum/reference/error-codes.mdx` (error 12005) was intentionally left unchanged. Its current "The zone has allocated..." wording accurately describes the current per-zone enforcement behavior, even though customers purchase quota at the account level.

### Documentation checklist

- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
