### PR TITLE
[Changelog] Add billing-enabled entries for Pipelines, R2 Data Catalog, R2 SQL

### DIFF
--- a/src/content/changelog/pipelines/2026-08-03-pipelines-billing-enabled.mdx
+++ b/src/content/changelog/pipelines/2026-08-03-pipelines-billing-enabled.mdx
@@ -1,0 +1,27 @@
+---
+title: Billing is now enabled for Pipelines
+description: Cloudflare Pipelines usage is now billed on non-enterprise accounts. Pipelines usage beyond the included free tier will appear on your next invoice.
+products:
+  - pipelines
+date: 2026-08-03
+---
+
+Billing is now enabled for [Cloudflare Pipelines](/pipelines/) on non-enterprise accounts. Pipelines usage beyond the included free tier will appear on your next invoice.
+
+Pipelines charges based on two usage dimensions. Ingress into a Pipeline stream remains free regardless of volume:
+
+- **SQL transforms**: $0.04 / GB for stateless transforms (filter, reshape, unnest, cast, compute).
+- **Sinks (egress)**: $0.03 / GB for JSON output, $0.06 / GB for Parquet or Iceberg output.
+
+Workers Paid plans include 50 GB / month for both SQL transforms and sinks. Standard [R2 storage and operations](/r2/pricing/) charges apply for data written to R2 buckets, and [R2 Data Catalog](/r2/data-catalog/platform/pricing/) charges apply when writing to Iceberg tables.
+
+For example, a pipeline that ingests 500 GB of event data per month, uses a SQL transform to filter and reshape it, and writes 300 GB to an R2 Data Catalog Iceberg table would be billed as follows:
+
+| Dimension       | Usage  | Included  | Billable | Cost       |
+| --------------- | ------ | --------- | -------- | ---------- |
+| Streams         | 500 GB | Unlimited | 0 GB     | $0.00      |
+| SQL transforms  | 500 GB | 50 GB     | 450 GB   | $18.00     |
+| Sinks (Iceberg) | 300 GB | 50 GB     | 250 GB   | $15.00     |
+| **Total**       |        |           |          | **$33.00** |
+
+For full pricing details and billing examples, refer to [Pipelines pricing](/pipelines/platform/pricing/).

--- a/src/content/changelog/r2-sql/2026-05-11-r2-sql-pricing-announced.mdx
+++ b/src/content/changelog/r2-sql/2026-05-11-r2-sql-pricing-announced.mdx
@@ -12,6 +12,6 @@ Billing is not yet enabled. We will provide at least 30 days notice before we st
 
 Data scanned is measured on compressed bytes read from R2 object storage. This matches what you see in your R2 bucket — if a Parquet file is 100 MB on disk, scanning that file bills for 100 MB. Each query has a minimum billing increment of 10 MB.
 
-Free plans include 1 GB / month and Paid plans include 10 GB / month. Standard [R2 storage and operations](/r2/pricing/) and [R2 Data Catalog](/r2/data-catalog/platform/pricing/) charges apply separately.
+All plans include 10 GB of data scanned per month. Standard [R2 storage and operations](/r2/pricing/) and [R2 Data Catalog](/r2/data-catalog/platform/pricing/) charges apply separately.
 
 For full pricing details and billing examples, refer to [R2 SQL pricing](/r2-sql/platform/pricing/).

--- a/src/content/changelog/r2-sql/2026-08-03-r2-sql-billing-enabled.mdx
+++ b/src/content/changelog/r2-sql/2026-08-03-r2-sql-billing-enabled.mdx
@@ -1,0 +1,25 @@
+---
+title: Billing is now enabled for R2 SQL
+description: R2 SQL usage is now billed on non-enterprise accounts. R2 SQL usage beyond the included free tier will appear on your next invoice.
+products:
+  - r2-sql
+date: 2026-08-03
+---
+
+Billing is now enabled for [R2 SQL](/r2-sql/) on non-enterprise accounts. R2 SQL usage beyond the included free tier will appear on your next invoice.
+
+R2 SQL charges based on a single dimension:
+
+- **Data scanned**: $0.0025 / GB ($2.50 / TB) of compressed data read from R2 to execute your query.
+
+All plans include 10 GB of data scanned per month. Each query is billed for a minimum of 10 MB of data scanned. R2 SQL pricing is additive to standard [R2 storage and operations](/r2/pricing/) and [R2 Data Catalog](/r2/data-catalog/platform/pricing/) charges. R2 does not charge for egress, so there is no additional data transfer cost.
+
+For example, a user who stores 500 GB of Parquet data in R2 Data Catalog and runs queries that scan a total of 50 GB of compressed data during the month would be billed as follows:
+
+| Dimension             | Usage        | Included    | Billable     | Cost      |
+| --------------------- | ------------ | ----------- | ------------ | --------- |
+| R2 storage            | 500 GB-month | 10 GB-month | 490 GB-month | $7.35     |
+| R2 SQL (data scanned) | 50 GB        | 10 GB       | 40 GB        | $0.10     |
+| **Total**             |              |             |              | **$7.45** |
+
+For full pricing details and billing examples, refer to [R2 SQL pricing](/r2-sql/platform/pricing/).

--- a/src/content/changelog/r2/2026-08-03-r2-data-catalog-billing-enabled.mdx
+++ b/src/content/changelog/r2/2026-08-03-r2-data-catalog-billing-enabled.mdx
@@ -1,0 +1,29 @@
+---
+title: Billing is now enabled for R2 Data Catalog
+description: R2 Data Catalog usage is now billed on non-enterprise accounts. R2 Data Catalog usage beyond the included free tier will appear on your next invoice.
+products:
+  - r2
+date: 2026-08-03
+---
+
+Billing is now enabled for [R2 Data Catalog](/r2/data-catalog/) on non-enterprise accounts. R2 Data Catalog usage beyond the included free tier will appear on your next invoice.
+
+R2 Data Catalog charges based on two dimensions, in addition to standard [R2 storage and operations](/r2/pricing/):
+
+- **Catalog operations**: $9.00 / million operations for metadata requests such as creating tables, reading table metadata, and updating table properties.
+- **Compaction**: $0.005 / GB processed and $2.00 / million objects processed. These charges only apply when [automatic compaction](/r2/data-catalog/table-maintenance/) is turned on for a table.
+
+Each dimension includes a monthly free tier: 1 million catalog operations, 10 GB of compaction data processed, and 1 million compaction objects processed.
+
+For example, a single Iceberg table with 50 GB of data, 500,000 catalog operations per month, and compaction turned on that processes 20 GB across 200,000 files would be billed as follows:
+
+| Dimension                   | Usage   | Included  | Billable | Cost      |
+| --------------------------- | ------- | --------- | -------- | --------- |
+| Catalog operations          | 500,000 | 1,000,000 | 0        | $0.00     |
+| Compaction (data processed) | 20 GB   | 10 GB     | 10 GB    | $0.05     |
+| Compaction (objects)        | 200,000 | 1,000,000 | 0        | $0.00     |
+| **Total (Data Catalog)**    |         |           |          | **$0.05** |
+
+Standard R2 storage charges ($0.015 / GB-month) apply separately for the 50 GB of data stored.
+
+For full pricing details and billing examples, refer to [R2 Data Catalog pricing](/r2/data-catalog/platform/pricing/).


### PR DESCRIPTION
- Add changelog entry announcing billing is now enabled for Pipelines on non-enterprise accounts, with rates and a billing example from the Pipelines pricing page
- Add changelog entry announcing billing is now enabled for R2 Data Catalog on non-enterprise accounts, with rates and a billing example from the R2 Data Catalog pricing page
- Add changelog entry announcing billing is now enabled for R2 SQL on non-enterprise accounts, with rates and a billing example from the R2 SQL pricing page
- Update the older R2 SQL "pricing announced" changelog to reflect the single 10 GB/month included tier (no separate Free/Paid split)

Note - email notifications were sent 30+ days, 15 days, and 1 day prior to all super-admins of every account that has used a data platform product. 
