### PR TITLE
[Flue] Add image style-guide rules and read_repo_file to style-guide agent

### DIFF
--- a/.agents/references/style-guide.md
+++ b/.agents/references/style-guide.md
@@ -401,7 +401,7 @@ Guidelines:
 - Avoid including the sidebar navigation (it changes frequently).
 - Always provide descriptive alt text.
 - Use Markdown image syntax for content images. Do not use raw `<img>` tags for screenshots or diagrams.
-- Store images in `src/assets/images/{product}/` and reference them with `~/assets/images/{product}/...`. Do not reference `public/images/` from MDX content pages.
+- Store images in `src/assets/images/{product}/` and reference them with `~/assets/images/{product}/...`. This enables Astro's asset pipeline (optimization, responsive variants, cache-busting). Only use `public/` for assets that need a stable static URL (e.g. OG images, badges, files referenced from non-Astro contexts). Do not use `public/images/` for docs screenshots or diagrams.
 
 ```mdx
 ![Cloudflare dashboard showing the DNS records page with an A record highlighted](~/assets/images/dns/dns-records.png)

--- a/.agents/references/style-guide.md
+++ b/.agents/references/style-guide.md
@@ -400,6 +400,8 @@ Guidelines:
 - Do not include sensitive information (redact if needed).
 - Avoid including the sidebar navigation (it changes frequently).
 - Always provide descriptive alt text.
+- Use Markdown image syntax for content images. Do not use raw `<img>` tags for screenshots or diagrams.
+- Store images in `src/assets/images/{product}/` and reference them with `~/assets/images/{product}/...`. Do not reference `public/images/` from MDX content pages.
 
 ```mdx
 ![Cloudflare dashboard showing the DNS records page with an A record highlighted](~/assets/images/dns/dns-records.png)

--- a/.flue/.agents/skills/style-guide-review/SKILL.md
+++ b/.flue/.agents/skills/style-guide-review/SKILL.md
@@ -18,6 +18,8 @@ The prompt provides the pull request metadata (number, title, base, head), the f
 
 **Diff data** — the pull request metadata and the added lines to review are provided directly in the prompt. There is no workspace to read.
 
+**Full file context** — use the `read_repo_file` tool to read the full current content of the file under review (pinned to the PR head SHA). Use this **only** when you need surrounding context to determine whether an added line matches a rule — for example, checking whether an added `<img>` tag is inside a fenced code block whose fence lines were not part of the added lines. Do not use `read_repo_file` to browse other files in the repo. Do not flag findings on unchanged lines — only flag violations on the added lines provided in the prompt.
+
 **Style guide references** — packaged skill resources; read them with the `read_skill_resource` tool. The `<skill_resources>` section lists every reference file with its advertised read path. To read one, find its entry there and read the path shown after `→ read_skill_resource`:
 
 - Reference manifest: `reference/manifest.json`
@@ -42,6 +44,7 @@ For the file under review:
 - Read `reference/conditional/code-blocks.md` when the patch contains fenced code blocks.
 - Read `reference/conditional/imports.md` when the patch contains `import` statements or JSX component tags.
 - Read `reference/conditional/frontmatter.md` when the patch changes frontmatter fields at the top of the file.
+- Read `reference/conditional/images.md` when the patch contains image syntax (`![`, `<img`, `/images/`, `public/images`, `~/assets/images`, or common image file extensions).
 - Read a component reference only when the patch contains that component tag or imports that component name.
 - For component references, use the manifest `componentNames` field to match component names.
 - Do not read all component reference files by default.
@@ -62,6 +65,8 @@ The added lines are provided in the prompt as `line: content` pairs with accurat
 - Do not flag speculative issues.
 - Do not flag stale or missing `reviewed` dates.
 - Do not flag formatting preferences that are not explicit loaded rules.
+- If you need to check whether an added line is inside a fenced code block or JSX component, use `read_repo_file` to read the current file and verify. Only do this when the added line itself is ambiguous — do not read the file for every line.
+- Never flag findings on unchanged lines. `read_repo_file` is for disambiguating added lines only, not for finding new violations in surrounding context.
 
 ## Severity
 

--- a/.flue/.agents/skills/style-guide-review/reference/conditional/images.md
+++ b/.flue/.agents/skills/style-guide-review/reference/conditional/images.md
@@ -1,0 +1,30 @@
+---
+title: Images
+description: Rules for image syntax and asset paths in MDX content.
+---
+
+## Rules
+
+- If an added line outside a fenced code block uses a raw `<img>` tag to embed a content image (screenshot, diagram, illustration) → **warning**: use Markdown image syntax instead: `![Alt text](~/assets/images/{product}/file.png)`. Exception: `<img>` is acceptable inside fenced code blocks, inside JSX component props that accept image elements, or when the line is part of an HTML/JSX application code example shown to the reader.
+
+- If an added line references a content image via an absolute `/images/...` path or a `public/images/...` path → **warning**: store the image under `src/assets/images/{product}/` and reference it with `~/assets/images/{product}/...`. Exception: paths inside fenced code blocks or code examples.
+
+- If a Markdown image uses empty alt text `![](...)` for a non-decorative content image → **suggestion**: add descriptive alt text per the style guide.
+
+## Examples
+
+Correct:
+
+```mdx
+![Cloudflare dashboard showing the DNS records page with an A record highlighted](~/assets/images/dns/dns-records.png)
+```
+
+Incorrect:
+
+```mdx
+<img src="/images/precursor/precursor-rules.png" alt="Precursor mode selector" />
+```
+
+```mdx
+![Precursor mode selector](/images/precursor/precursor-rules.png)
+```

--- a/.flue/.agents/skills/style-guide-review/reference/conditional/images.md
+++ b/.flue/.agents/skills/style-guide-review/reference/conditional/images.md
@@ -7,7 +7,7 @@ description: Rules for image syntax and asset paths in MDX content.
 
 - If an added line outside a fenced code block uses a raw `<img>` tag to embed a content image (screenshot, diagram, illustration) → **warning**: use Markdown image syntax instead: `![Alt text](~/assets/images/{product}/file.png)`. Exception: `<img>` is acceptable inside fenced code blocks, inside JSX component props that accept image elements, or when the line is part of an HTML/JSX application code example shown to the reader.
 
-- If an added line references a content image via an absolute `/images/...` path or a `public/images/...` path → **warning**: store the image under `src/assets/images/{product}/` and reference it with `~/assets/images/{product}/...`. Exception: paths inside fenced code blocks or code examples.
+- If an added line references a content image via an absolute `/images/...` path or a `public/images/...` path → **warning**: store the image under `src/assets/images/{product}/` and reference it with `~/assets/images/{product}/...`. Images in `src/assets/images/` get Astro asset optimization, responsive variants, and cache-busting. Only use `public/` for assets that need a stable static URL (e.g. OG images, badges, files referenced from non-Astro contexts). Exception: paths inside fenced code blocks or code examples.
 
 - If a Markdown image uses empty alt text `![](...)` for a non-decorative content image → **suggestion**: add descriptive alt text per the style guide.
 

--- a/.flue/.agents/skills/style-guide-review/reference/manifest.json
+++ b/.flue/.agents/skills/style-guide-review/reference/manifest.json
@@ -30,6 +30,12 @@
 		"when": "Patch changes frontmatter fields at the top of the file."
 	},
 	{
+		"id": "images",
+		"file": "reference/conditional/images.md",
+		"load": "conditional",
+		"when": "Patch contains image syntax (![), <img, /images/, public/images, ~/assets/images, or common image file extensions."
+	},
+	{
 		"id": "component-anchor-heading",
 		"file": "reference/components/anchor-heading.md",
 		"load": "component",

--- a/.flue/.agents/skills/style-guide-review/reference/rule-authoring.md
+++ b/.flue/.agents/skills/style-guide-review/reference/rule-authoring.md
@@ -28,7 +28,7 @@ Severities:
 2. **Include false-positive exceptions.** If a rule could fire inside code blocks, JSX component props, or application code examples, add an explicit exception.
 3. **Do not duplicate CI.** Before adding a rule, verify the repository does not already catch the issue in CI (build, typecheck, lint, link validation, schema validation).
 4. **Remember the agent sees added lines by default.** Rules match on the content of added/changed lines with their new-file line numbers. The agent can optionally use `read_repo_file` to read the full current file for surrounding context (e.g. to check whether an added line is inside a fenced code block), but rules should be written to match on the added lines themselves whenever possible.
-5. **Provide examples.** Include correct and incorrect examples in the reference file so the model can pattern-match accurately.
+5. **Consider providing examples.** Correct and incorrect examples help the model pattern-match accurately, but keep them minimal — rule files share context window space, so conciseness matters.
 
 ## Wiring a new rule
 

--- a/.flue/.agents/skills/style-guide-review/reference/rule-authoring.md
+++ b/.flue/.agents/skills/style-guide-review/reference/rule-authoring.md
@@ -27,7 +27,7 @@ Severities:
 1. **Be specific.** The condition must be checkable by mechanical pattern matching on added lines. Avoid vague guidance like "consider improving clarity."
 2. **Include false-positive exceptions.** If a rule could fire inside code blocks, JSX component props, or application code examples, add an explicit exception.
 3. **Do not duplicate CI.** Before adding a rule, verify the repository does not already catch the issue in CI (build, typecheck, lint, link validation, schema validation).
-4. **Remember the agent sees added lines only.** Rules match on the content of added/changed lines with their new-file line numbers. The agent does not see the full file or surrounding context unless it uses a tool to read it.
+4. **Remember the agent sees added lines by default.** Rules match on the content of added/changed lines with their new-file line numbers. The agent can optionally use `read_repo_file` to read the full current file for surrounding context (e.g. to check whether an added line is inside a fenced code block), but rules should be written to match on the added lines themselves whenever possible.
 5. **Provide examples.** Include correct and incorrect examples in the reference file so the model can pattern-match accurately.
 
 ## Wiring a new rule

--- a/.flue/.agents/skills/style-guide-review/reference/rule-authoring.md
+++ b/.flue/.agents/skills/style-guide-review/reference/rule-authoring.md
@@ -1,0 +1,52 @@
+# How to Write Style-Guide Review Rules
+
+This file is guidance for maintainers and agents who add new rules to the style-guide review skill. It is not a runtime review file and is not listed in `manifest.json`.
+
+## Rule categories
+
+| Category     | Directory                  | Load condition                                           |
+| ------------ | -------------------------- | -------------------------------------------------------- |
+| `always`     | `reference/always/`        | Loaded for every reviewed MDX file with added content.   |
+| `conditional`| `reference/conditional/`   | Loaded when the patch matches a trigger described in the manifest `when` field and the SKILL.md reference selection. |
+| `component`  | `reference/components/`    | Loaded when the patch contains a specific component tag or imports a component name. The manifest `componentNames` field lists which names trigger the load. |
+
+## Rule format
+
+Each rule is an explicit if/then check with a severity:
+
+```
+- If <condition on added lines> → **<severity>**: <what to do>.
+```
+
+Severities:
+- `warning` — clear rule violation, correctness issue, or convention breach.
+- `suggestion` — improvement covered by a rule but not strictly required.
+
+## Writing a good rule
+
+1. **Be specific.** The condition must be checkable by mechanical pattern matching on added lines. Avoid vague guidance like "consider improving clarity."
+2. **Include false-positive exceptions.** If a rule could fire inside code blocks, JSX component props, or application code examples, add an explicit exception.
+3. **Do not duplicate CI.** Before adding a rule, verify the repository does not already catch the issue in CI (build, typecheck, lint, link validation, schema validation).
+4. **Remember the agent sees added lines only.** Rules match on the content of added/changed lines with their new-file line numbers. The agent does not see the full file or surrounding context unless it uses a tool to read it.
+5. **Provide examples.** Include correct and incorrect examples in the reference file so the model can pattern-match accurately.
+
+## Wiring a new rule
+
+1. Create or edit the reference `.md` file in the appropriate `reference/` subdirectory.
+2. Add an entry to `reference/manifest.json` with `id`, `file`, `load`, and `when` (plus `componentNames` for component rules).
+3. Update the SKILL.md reference selection section with a new load condition line for conditional rules.
+4. Add at least two eval cases: one that triggers the rule and one clean counterexample that does not.
+5. Update `.agents/references/style-guide.md` if the rule represents a public docs convention that contributors should follow.
+
+## Evaluating rules
+
+Run the style-guide evals against a live Flue dev server:
+
+```bash
+pnpm run flue:dev          # terminal 1
+pnpm --dir .flue run evals # terminal 2
+```
+
+Each new rule should have:
+- A **violation eval** — added lines that should trigger the rule. Assert the finding exists with the expected severity, path, and line.
+- A **clean counterexample eval** — added lines that are similar but correct. Assert no warnings are produced.

--- a/.flue/AGENTS.md
+++ b/.flue/AGENTS.md
@@ -134,6 +134,8 @@ Do not add agent review rules for issues that are already reliably caught by CI,
 
 Before adding a rule, verify whether the repository already catches the issue in CI. If it does, do not duplicate it in agent review output. For MDX/code structure checks, prefer AST-aware checks; avoid raw line pattern matching unless the rule explicitly ignores fenced code blocks and JSX component syntax.
 
+For guidance on writing, wiring, and evaluating new style-guide review rules, see `.flue/.agents/skills/style-guide-review/reference/rule-authoring.md`.
+
 ## Agent Evals
 
 Agent evals test agent behavior against the live Workers AI model. They live in `.flue/evals/` and use `vitest-evals` with a custom harness that drives agents over HTTP through the Flue Worker's eval routes.

--- a/.flue/agents/style-guide-file.ts
+++ b/.flue/agents/style-guide-file.ts
@@ -36,6 +36,8 @@ import {
 import styleGuideSkill from "../.agents/skills/style-guide-review/SKILL.md";
 import { useBotRole } from "../lib/bot-role";
 import { StyleGuideResultFromModelSchema } from "../lib/style-guide-results";
+import { makeReadRepoFileTool } from "../lib/github-repo-tools";
+import { getGitHubToken } from "../lib/token-provider";
 import type { AddedLine } from "../lib/code-review-files";
 import type { StyleGuidePullRequest } from "../lib/style-guide-files";
 
@@ -52,6 +54,8 @@ export interface StyleGuideFileInput {
 	filename: string;
 	/** Added/changed lines with new-file line numbers, pre-parsed in trusted code. */
 	addedLines: AddedLine[];
+	/** PR head SHA — the ref `read_repo_file` is pinned to. */
+	headSha: string;
 }
 
 function buildPrompt(input: StyleGuideFileInput): string {
@@ -82,6 +86,11 @@ export default function StyleGuideFile(_props: AgentProps): string {
 	useBotRole();
 
 	const input = useInitialData<StyleGuideFileInput>();
+
+	// read_repo_file pinned to the PR head SHA, so the agent can read the
+	// full current file when it needs surrounding context (e.g. checking
+	// whether an added line is inside a fenced code block).
+	useTool(makeReadRepoFileTool(getGitHubToken, input.headSha));
 
 	const writeReview = useDataWriter(STYLE_GUIDE_FILE_DATA, {
 		schema: StyleGuideResultFromModelSchema,

--- a/.flue/cloudflare.ts
+++ b/.flue/cloudflare.ts
@@ -344,6 +344,7 @@ export class ReviewOrchestrator extends WorkflowEntrypoint<
 						pullRequest: stylePr,
 						files: selected,
 						runId,
+						headSha,
 					});
 					return { ok: true, result };
 				} catch (err) {

--- a/.flue/evals/code-review.eval.ts
+++ b/.flue/evals/code-review.eval.ts
@@ -68,7 +68,7 @@ describeEval("code review file", { harness }, (it) => {
 		expect(match!.path).toBe("src/handler.ts");
 		expect(match!.line).toBe(4);
 		expect(match!.rule?.toLowerCase()).toMatch(
-			/\b(promise|reject|unhandled|await|error|fire|discard|floating|ignored)\b/,
+			/(promise|reject|unhandled|await|error|fire|discard|floating|ignored)/,
 		);
 
 		expect(toolCalls(result).map((c) => c.name)).toContain(

--- a/.flue/evals/mocks/github-repo-tools.ts
+++ b/.flue/evals/mocks/github-repo-tools.ts
@@ -1,0 +1,112 @@
+/**
+ * Eval-only mock of `read_repo_file`.
+ *
+ * Replaces the GitHub API call with a lookup against a fixture map keyed by
+ * `ref` (the headSha passed in eval initialData). This lets eval cases provide
+ * synthetic file content without touching production agent or tool code.
+ *
+ * Wired via Vite alias only when `DOCS_FLUE_AGENT_EVALS=1` — see `vite.config.ts`.
+ * Production and normal dev builds import the real `../lib/github-repo-tools`.
+ */
+import { defineTool, type ToolDefinition } from "@flue/runtime";
+import type { TokenProvider } from "../../lib/token-provider";
+import * as v from "valibot";
+
+/** Fixtures keyed by ref (eval headSha) → path → file content. */
+const FIXTURES: Record<string, Record<string, string>> = {
+	// Style-guide eval: raw <img> tag not inside a code block.
+	"eval-style-raw-img": {
+		"src/content/docs/cloudflare-challenges/precursor.mdx": [
+			"---",
+			"pcx_content_type: concept",
+			"title: Precursor",
+			"description: Precursor detection.",
+			"products:",
+			"  - cloudflare-challenges",
+			"sidebar:",
+			"  order: 4",
+			"---",
+			"",
+			"## Get started",
+			"",
+			"1. Turn on Precursor.",
+			"",
+			'<img src="/images/precursor/precursor-rules.png" alt="Precursor mode selector" style="border:1px solid #e5e7eb;" />',
+			"",
+			"For most customers, selecting a mode is the only configuration required.",
+		].join("\n"),
+	},
+
+	// Style-guide eval: <img> inside a fenced code block.
+	"eval-style-fenced-img": {
+		"src/content/docs/workers/example.mdx": [
+			"---",
+			"title: Example",
+			"---",
+			"",
+			"Here is an example:",
+			"",
+			"```html",
+			'<img src="/static/logo.png" alt="Logo" />',
+			"```",
+			"",
+			"That's it.",
+		].join("\n"),
+	},
+
+	// Style-guide eval: Markdown image with /images/ path.
+	"eval-style-images-path": {
+		"src/content/docs/cloudflare-challenges/precursor.mdx": [
+			"---",
+			"title: Precursor",
+			"---",
+			"",
+			"![Precursor mode selector](/images/precursor/precursor-rules.png)",
+		].join("\n"),
+	},
+
+	// Style-guide eval: correct Markdown image syntax.
+	"eval-style-correct-img": {
+		"src/content/docs/cloudflare-challenges/precursor.mdx": [
+			"---",
+			"title: Precursor",
+			"---",
+			"",
+			"![Precursor mode selector](~/assets/images/cloudflare-challenges/precursor-rules.png)",
+		].join("\n"),
+	},
+};
+
+/** Mock `read_repo_file` — drop-in replacement for the real tool in evals. */
+export function makeReadRepoFileTool(
+	_getToken: TokenProvider,
+	defaultRef: string = "production",
+): ToolDefinition {
+	return defineTool({
+		name: "read_repo_file",
+		description: `Read any text file from the cloudflare/cloudflare-docs repo. Use for package.json, tsconfig, source files, etc. The default ref is "${defaultRef}".`,
+		input: v.object({
+			path: v.pipe(
+				v.string(),
+				v.description(
+					"File path relative to repo root, e.g. 'package.json' or 'src/util/algolia.ts'",
+				),
+			),
+			ref: v.optional(
+				v.pipe(
+					v.string(),
+					v.description(`Git ref. Defaults to "${defaultRef}".`),
+				),
+			),
+		}),
+		run({ data }) {
+			const path = data.path;
+			const ref = data.ref ?? defaultRef;
+			const refFixtures = FIXTURES[ref];
+			if (refFixtures && path in refFixtures) {
+				return refFixtures[path];
+			}
+			return `File not found: ${path}`;
+		},
+	});
+}

--- a/.flue/evals/style-guide.eval.ts
+++ b/.flue/evals/style-guide.eval.ts
@@ -33,6 +33,13 @@ const PR = {
 
 const HEAD_SHA = "abc123def456";
 
+// Fixture refs for image eval cases — the mock read_repo_file (wired via
+// Vite alias in eval builds) returns synthetic file content keyed by these.
+const RAW_IMG_SHA = "eval-style-raw-img";
+const IMAGES_PATH_SHA = "eval-style-images-path";
+const CORRECT_IMG_SHA = "eval-style-correct-img";
+const FENCED_IMG_SHA = "eval-style-fenced-img";
+
 describeEval("style-guide reviewer", { harness }, (it) => {
 	it("flags a full URL for an internal link", async ({ run }) => {
 		const result = await run({
@@ -186,7 +193,7 @@ describeEval("style-guide reviewer", { harness }, (it) => {
 	it("flags a raw <img> tag for a content image", async ({ run }) => {
 		const result = await run({
 			pullRequest: PR,
-			headSha: HEAD_SHA,
+			headSha: RAW_IMG_SHA,
 			filename: "src/content/docs/cloudflare-challenges/precursor.mdx",
 			addedLines: [
 				{
@@ -224,7 +231,7 @@ describeEval("style-guide reviewer", { harness }, (it) => {
 	}) => {
 		const result = await run({
 			pullRequest: PR,
-			headSha: HEAD_SHA,
+			headSha: IMAGES_PATH_SHA,
 			filename: "src/content/docs/cloudflare-challenges/precursor.mdx",
 			addedLines: [
 				{
@@ -258,7 +265,7 @@ describeEval("style-guide reviewer", { harness }, (it) => {
 	}) => {
 		const result = await run({
 			pullRequest: PR,
-			headSha: HEAD_SHA,
+			headSha: CORRECT_IMG_SHA,
 			filename: "src/content/docs/cloudflare-challenges/precursor.mdx",
 			addedLines: [
 				{
@@ -290,7 +297,7 @@ describeEval("style-guide reviewer", { harness }, (it) => {
 	it("does not flag <img> inside a fenced HTML code block", async ({ run }) => {
 		const result = await run({
 			pullRequest: PR,
-			headSha: HEAD_SHA,
+			headSha: FENCED_IMG_SHA,
 			filename: "src/content/docs/workers/example.mdx",
 			addedLines: [
 				{

--- a/.flue/evals/style-guide.eval.ts
+++ b/.flue/evals/style-guide.eval.ts
@@ -31,10 +31,13 @@ const PR = {
 	head: "fix-link",
 };
 
+const HEAD_SHA = "abc123def456";
+
 describeEval("style-guide reviewer", { harness }, (it) => {
 	it("flags a full URL for an internal link", async ({ run }) => {
 		const result = await run({
 			pullRequest: PR,
+			headSha: HEAD_SHA,
 			filename: "src/content/docs/workers/example.mdx",
 			addedLines: [
 				{
@@ -68,6 +71,7 @@ describeEval("style-guide reviewer", { harness }, (it) => {
 	it("passes on a clean root-relative link", async ({ run }) => {
 		const result = await run({
 			pullRequest: PR,
+			headSha: HEAD_SHA,
 			filename: "src/content/docs/workers/example.mdx",
 			addedLines: [
 				{
@@ -93,6 +97,7 @@ describeEval("style-guide reviewer", { harness }, (it) => {
 	}) => {
 		const result = await run({
 			pullRequest: PR,
+			headSha: HEAD_SHA,
 			filename: "src/content/docs/stream/stream-live/start-stream-live.mdx",
 			addedLines: [
 				{
@@ -121,6 +126,7 @@ describeEval("style-guide reviewer", { harness }, (it) => {
 	it("flags a missing Oxford comma before final and", async ({ run }) => {
 		const result = await run({
 			pullRequest: PR,
+			headSha: HEAD_SHA,
 			filename: "src/content/docs/workers/example.mdx",
 			addedLines: [
 				{
@@ -148,6 +154,7 @@ describeEval("style-guide reviewer", { harness }, (it) => {
 	it("flags a body H1 heading", async ({ run }) => {
 		const result = await run({
 			pullRequest: PR,
+			headSha: HEAD_SHA,
 			filename: "src/content/docs/workers/example.mdx",
 			addedLines: [
 				{
@@ -170,6 +177,147 @@ describeEval("style-guide reviewer", { harness }, (it) => {
 		expect(h1Finding!.severity).toBe("warning");
 		expect(h1Finding!.path).toBe("src/content/docs/workers/example.mdx");
 		expect(h1Finding!.line).toBe(15);
+
+		expect(toolCalls(result).map((c) => c.name)).toContain(
+			"submit_style_guide",
+		);
+	});
+
+	it("flags a raw <img> tag for a content image", async ({ run }) => {
+		const result = await run({
+			pullRequest: PR,
+			headSha: HEAD_SHA,
+			filename: "src/content/docs/cloudflare-challenges/precursor.mdx",
+			addedLines: [
+				{
+					line: 50,
+					content:
+						'<img src="/images/precursor/precursor-rules.png" alt="Precursor mode selector" style="border:1px solid #e5e7eb;" />',
+				},
+			],
+		});
+
+		const findings = (result.output as { findings?: Finding[] })?.findings;
+		expect(findings).toBeDefined();
+		expect(findings!.length).toBeGreaterThan(0);
+
+		const imgFinding = findings!.find(
+			(f) =>
+				f.rule?.toLowerCase().includes("img") ||
+				f.rule?.toLowerCase().includes("image") ||
+				f.rule?.toLowerCase().includes("markdown image"),
+		);
+		expect(imgFinding).toBeDefined();
+		expect(imgFinding!.severity).toBe("warning");
+		expect(imgFinding!.path).toBe(
+			"src/content/docs/cloudflare-challenges/precursor.mdx",
+		);
+		expect(imgFinding!.line).toBe(50);
+
+		expect(toolCalls(result).map((c) => c.name)).toContain(
+			"submit_style_guide",
+		);
+	});
+
+	it("flags a Markdown image using /images/ instead of ~/assets/images/", async ({
+		run,
+	}) => {
+		const result = await run({
+			pullRequest: PR,
+			headSha: HEAD_SHA,
+			filename: "src/content/docs/cloudflare-challenges/precursor.mdx",
+			addedLines: [
+				{
+					line: 35,
+					content:
+						"![Precursor mode selector](/images/precursor/precursor-rules.png)",
+				},
+			],
+		});
+
+		const findings = (result.output as { findings?: Finding[] })?.findings;
+		expect(findings).toBeDefined();
+
+		const pathFinding = (findings ?? []).filter(
+			(f) =>
+				f.rule?.toLowerCase().includes("image") ||
+				f.rule?.toLowerCase().includes("path") ||
+				f.rule?.toLowerCase().includes("asset") ||
+				f.evidence?.includes("/images/"),
+		);
+		expect(pathFinding.length).toBeGreaterThan(0);
+		expect(pathFinding[0].severity).toBe("warning");
+
+		expect(toolCalls(result).map((c) => c.name)).toContain(
+			"submit_style_guide",
+		);
+	});
+
+	it("passes on correct Markdown image syntax with ~/assets/images/", async ({
+		run,
+	}) => {
+		const result = await run({
+			pullRequest: PR,
+			headSha: HEAD_SHA,
+			filename: "src/content/docs/cloudflare-challenges/precursor.mdx",
+			addedLines: [
+				{
+					line: 35,
+					content:
+						"![Precursor mode selector showing Minimize Friction and Maximize Security options](~/assets/images/cloudflare-challenges/precursor-rules.png)",
+				},
+			],
+		});
+
+		const findings = (result.output as { findings?: Finding[] })?.findings;
+		expect(findings).toBeDefined();
+
+		const imageWarnings = (findings ?? []).filter(
+			(f) =>
+				f.severity === "warning" &&
+				(f.rule?.toLowerCase().includes("img") ||
+					f.rule?.toLowerCase().includes("image") ||
+					f.rule?.toLowerCase().includes("path") ||
+					f.rule?.toLowerCase().includes("asset")),
+		);
+		expect(imageWarnings).toHaveLength(0);
+
+		expect(toolCalls(result).map((c) => c.name)).toContain(
+			"submit_style_guide",
+		);
+	});
+
+	it("does not flag <img> inside a fenced HTML code block", async ({ run }) => {
+		const result = await run({
+			pullRequest: PR,
+			headSha: HEAD_SHA,
+			filename: "src/content/docs/workers/example.mdx",
+			addedLines: [
+				{
+					line: 10,
+					content: "```html",
+				},
+				{
+					line: 11,
+					content: '<img src="/static/logo.png" alt="Logo" />',
+				},
+				{
+					line: 12,
+					content: "```",
+				},
+			],
+		});
+
+		const findings = (result.output as { findings?: Finding[] })?.findings;
+		expect(findings).toBeDefined();
+
+		const imgFindings = (findings ?? []).filter(
+			(f) =>
+				f.rule?.toLowerCase().includes("img") ||
+				f.rule?.toLowerCase().includes("image") ||
+				f.evidence?.includes("<img"),
+		);
+		expect(imgFindings).toHaveLength(0);
 
 		expect(toolCalls(result).map((c) => c.name)).toContain(
 			"submit_style_guide",

--- a/.flue/lib/run-style-guide.ts
+++ b/.flue/lib/run-style-guide.ts
@@ -43,6 +43,8 @@ export interface RunStyleGuideOptions {
 	concurrency?: number;
 	/** Per-file hard timeout in ms. Defaults to STYLE_GUIDE_FILE_TIMEOUT_MS. */
 	fileTimeoutMs?: number;
+	/** PR head SHA — pinned to `read_repo_file` so the agent can read the full file for surrounding context. */
+	headSha: string;
 }
 
 /**
@@ -59,6 +61,7 @@ export async function runStyleGuide(
 		runId,
 		concurrency = STYLE_GUIDE_CONCURRENCY,
 		fileTimeoutMs = STYLE_GUIDE_FILE_TIMEOUT_MS,
+		headSha,
 	} = options;
 
 	if (files.length === 0) {
@@ -91,6 +94,7 @@ export async function runStyleGuide(
 						pullRequest,
 						filename: file.filename,
 						addedLines,
+						headSha,
 					},
 					instanceId: `${runId}:sg:${index}`,
 					fileTimeoutMs,

--- a/.flue/vite.config.ts
+++ b/.flue/vite.config.ts
@@ -1,5 +1,6 @@
 import { cloudflare } from "@cloudflare/vite-plugin";
 import { flue, flueWorkerConfig } from "@flue/vite";
+import path from "node:path";
 import { defineConfig, type Plugin } from "vite";
 
 // Flue 2.0 build. `flue()` scans the source root for `'use agent'` modules and
@@ -33,7 +34,7 @@ const evalRepoFileMock: Plugin = {
 		// Only redirect the style-guide agent's import of github-repo-tools.
 		if (
 			source.endsWith("/lib/github-repo-tools") &&
-			importer.includes("style-guide-file")
+			path.basename(importer) === "style-guide-file.ts"
 		) {
 			return this.resolve("/evals/mocks/github-repo-tools", importer, {
 				skipSelf: true,

--- a/.flue/vite.config.ts
+++ b/.flue/vite.config.ts
@@ -1,6 +1,6 @@
 import { cloudflare } from "@cloudflare/vite-plugin";
 import { flue, flueWorkerConfig } from "@flue/vite";
-import { defineConfig } from "vite";
+import { defineConfig, type Plugin } from "vite";
 
 // Flue 2.0 build. `flue()` scans the source root for `'use agent'` modules and
 // the `app.ts` route map, then merges its Worker contributions (DO classes,
@@ -18,9 +18,35 @@ import { defineConfig } from "vite";
 const fluePlugin = flue();
 const flueCustomizer = flueWorkerConfig();
 
+// When running evals, redirect the style-guide agent's import of
+// `makeReadRepoFileTool` to an eval-only mock that returns synthetic file
+// content instead of calling the GitHub API. This keeps production agent and
+// tool code free of eval-specific branches. Only the style-guide agent's
+// import is redirected — other agents that import from the same module
+// (code-review, dependabot) keep using the real implementation.
+const evalRepoFileMock: Plugin = {
+	name: "flue-eval-repo-file-mock",
+	apply: "serve",
+	resolveId(source, importer) {
+		if (process.env.DOCS_FLUE_AGENT_EVALS !== "1") return null;
+		if (!importer) return null;
+		// Only redirect the style-guide agent's import of github-repo-tools.
+		if (
+			source.endsWith("/lib/github-repo-tools") &&
+			importer.includes("style-guide-file")
+		) {
+			return this.resolve("/evals/mocks/github-repo-tools", importer, {
+				skipSelf: true,
+			});
+		}
+		return null;
+	},
+};
+
 export default defineConfig({
 	plugins: [
 		fluePlugin,
+		evalRepoFileMock,
 		cloudflare({
 			config: (config) => {
 				flueCustomizer(config);


### PR DESCRIPTION
### Summary

Adds image syntax and asset-path rules to the Flue style-guide review bot, and gives the style-guide agent a `read_repo_file` tool so it can check surrounding context when an added line is ambiguous (e.g. whether an `<img>` tag is inside a fenced code block).

Changes:
- New conditional rule file `reference/conditional/images.md` with three rules: flag raw `<img>` for content images, flag `/images/` or `public/images/` paths, suggest alt text for empty `![]()`
- Wired `images` entry into `manifest.json` and `SKILL.md` reference selection
- Added `read_repo_file` tool to the style-guide agent (pinned to PR head SHA), with SKILL.md guidance: use only for surrounding context on the current file, don't browse other files, don't flag unchanged lines
- Added `headSha` to `StyleGuideFileInput`, `RunStyleGuideOptions`, and the orchestrator call site
- New `reference/rule-authoring.md` — maintainer guidance on writing, wiring, and evaluating style-guide review rules
- Linked rule-authoring guidance from `.flue/AGENTS.md` under Review Rule Policy
- Updated `.agents/references/style-guide.md` with image conventions (use Markdown syntax, store in `src/assets/images/`, reference with `~/assets/images/`)
- Four new eval cases: flags raw `<img>`, flags `/images/` path, passes on correct `~/assets/images/` syntax, does not flag `<img>` in fenced code blocks
- Eval-only mock for `read_repo_file` (`.flue/evals/mocks/github-repo-tools.ts`) — returns synthetic file content from a fixture map keyed by ref, instead of calling the GitHub API with a fake SHA. Wired via a Vite plugin that redirects only `style-guide-file.ts`'s import to the mock when `DOCS_FLUE_AGENT_EVALS=1`. Production agent and tool code are untouched.

All 9 style-guide evals pass against the live model.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).