### PR TITLE
[Access] Document eager redirect cookie setting

### DIFF
--- a/src/content/changelog/access/2026-08-03-eager-redirect-cookie-setting.mdx
+++ b/src/content/changelog/access/2026-08-03-eager-redirect-cookie-setting.mdx
@@ -1,0 +1,17 @@
+---
+title: Control authorization cookies for multi-domain Access applications
+description: Access administrators can control whether self-hosted applications preemptively set authorization cookies across their public hostnames.
+date: 2026-08-03
+products:
+  - access
+---
+
+Cloudflare Access administrators can now control whether a self-hosted application preemptively sets authorization cookies across its public hostnames.
+
+Previously, Access automatically used eager redirects for applications with five or fewer hostnames. Applications with more than five hostnames received cookies as users visited each hostname. Administrators can now choose either behavior, regardless of the number of hostnames.
+
+The new **Eager redirect cookie** setting is turned on by default for new applications. After a user signs in, Access redirects the browser through each hostname and sets a `CF_Authorization` cookie. This supports applications that need to make requests across hostnames before the user visits each one.
+
+For applications with many hostnames, the redirect chain can cause sign-in loops in some browsers. Turn off the setting to issue the cookie only when a user visits each hostname.
+
+To configure the setting, refer to [Authorization cookie](/cloudflare-one/access-controls/applications/http-apps/authorization-cookie/#eager-redirect-cookie).

--- a/src/content/docs/cloudflare-one/access-controls/applications/http-apps/authorization-cookie/index.mdx
+++ b/src/content/docs/cloudflare-one/access-controls/applications/http-apps/authorization-cookie/index.mdx
@@ -149,7 +149,9 @@ The Cookie Path Attribute adds the application's path URL to the `CF_Authorizati
 
 When turned on, the Eager redirect cookie setting preemptively sets a `CF_Authorization` cookie for every concrete domain in a multi-domain application. Access redirects the browser through each domain after the user first authenticates. This setting is turned on by default for new applications.
 
-Some browsers can have trouble with the redirect chain across many domains. Turn off this setting if users encounter sign-in loops. Access will instead set the cookie when a user visits each domain.
+:::caution
+Browser behavior can become unreliable when the redirect chain exceeds 10 redirects. If your application has more than 10 domains, turn off this setting or thoroughly test the authentication flow before you deploy it. When turned off, Access sets the cookie as a user visits each domain.
+:::
 
 ## Allow third-party cookies in the browser
 

--- a/src/content/docs/cloudflare-one/access-controls/applications/http-apps/authorization-cookie/index.mdx
+++ b/src/content/docs/cloudflare-one/access-controls/applications/http-apps/authorization-cookie/index.mdx
@@ -22,16 +22,19 @@ The `CF_Authorization` cookie contains the user's identity in the form of a [JSO
 Access generates two separate `CF_Authorization` tokens depending on the domain:
 
 - **Global session token**: Generated when a user logs in to Access. This token is stored as a cookie at your <GlossaryTooltip term="team domain">team domain</GlossaryTooltip> (for example, `https://<your-team-name>.cloudflareaccess.com`) and prevents a user from needing to log in to each application.
-
 - [**Application token**](/cloudflare-one/access-controls/applications/http-apps/authorization-cookie/application-token/): Generated for each application that a user reaches. This token is stored as a cookie on the protected domain (for example, `https://jira.site.com`) and may be used to [validate requests](/cloudflare-one/access-controls/applications/http-apps/authorization-cookie/validating-json) on your origin.
 
 ### Multi-domain applications
 
 Cloudflare Access allows you to protect and manage multiple domains in a single [self-hosted application](/cloudflare-one/access-controls/applications/http-apps/self-hosted-public-app/). After a user has successfully authenticated to one domain, Access will automatically issue a `CF_Authorization` cookie when they go to another domain in the same Access application. This means that users only need to authenticate once to a multi-domain application.
 
-For Access applications with five or fewer domains, Access preemptively sets the cookie for all domains through a series of redirects when the user first authenticates. This allows single-page applications (SPAs) to retrieve data from other subdomains without requiring the user to visit each subdomain individually. Wildcarded subdomains (for example, `*.example.com`) cannot receive preemptive cookies because Access does not know which concrete subdomain to redirect to. Wildcarded paths are supported.
+Access can preemptively set the cookie for every domain through a series of redirects when the user first authenticates. This allows single-page applications (SPAs) to retrieve data from other subdomains before the user visits each subdomain. Wildcarded subdomains (for example, `*.example.com`) cannot receive preemptive cookies because Access does not know which concrete subdomain to redirect to. Wildcarded paths are supported.
 
-For Access applications with more than five domains, Access does not preemptively set cookies. Instead, cookies are issued as the user visits each domain. This avoids the latency that would result from redirecting through a large number of domains during authentication.
+Use the [Eager redirect cookie](#eager-redirect-cookie) setting to control this behavior.
+
+:::note
+Access previously chose the cookie behavior based on the number of domains. It preemptively set cookies for applications with five or fewer domains and issued cookies as users visited each domain for applications with more than five domains. Applications without a saved setting retain this behavior. Administrators can override it by turning the Eager redirect cookie setting on or off.
+:::
 
 ## Access cookies
 
@@ -69,8 +72,8 @@ The following Access cookies are essential to Access functionality. Cookies that
 
 ### CF_Device
 
-| Details                                                                                                                                                    | Expiration | HttpOnly | SameSite | Required? |
-| ---------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- | -------- | -------- | --------- |
+| Details                                                                                                                                                                                                                                                                                                                                           | Expiration | HttpOnly | SameSite | Required? |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- | -------- | -------- | --------- |
 | Cookie set on the `cloudflareaccess.com` [team domain](/cloudflare-one/faq/getting-started-faq/#what-is-a-team-domainteam-name), used to prevent abuse of [one-time PIN](/cloudflare-one/integrations/identity-providers/one-time-pin/) and [multi-factor authentication](/cloudflare-one/access-controls/access-settings/independent-mfa/) flows | 30 days    | Yes      | Strict   | Required  |
 
 ## Cookie settings
@@ -81,17 +84,14 @@ Cloudflare Access provides optional security settings that can be added to the b
 - [HttpOnly flag](#httponly)
 - [Binding cookie](#binding-cookie)
 - [Cookie path](#cookie-path-attribute)
+- [Eager redirect cookie](#eager-redirect-cookie)
 
 To enable these settings:
 
 1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Access controls** > **Applications**.
-
 2. Locate the application you would like to configure and select **Configure**.
-
 3. Select **Advanced settings** and scroll down to **Cookie settings**.
-
 4. Configure the desired cookie settings.
-
 5. Select **Save**.
 
 ### SameSite Attribute
@@ -144,6 +144,12 @@ Do not enable Binding Cookie if:
 ### Cookie Path Attribute
 
 The Cookie Path Attribute adds the application's path URL to the `CF_Authorization` cookie. When enabled, a user who logs in to `example.com/path1` must re-authenticate to access `example.com/path2`. When disabled, the `CF_Authorization` cookie is only scoped to the domain and subdomain.
+
+### Eager redirect cookie
+
+When turned on, the Eager redirect cookie setting preemptively sets a `CF_Authorization` cookie for every concrete domain in a multi-domain application. Access redirects the browser through each domain after the user first authenticates. This setting is turned on by default for new applications.
+
+Some browsers can have trouble with the redirect chain across many domains. Turn off this setting if users encounter sign-in loops. Access will instead set the cookie when a user visits each domain.
 
 ## Allow third-party cookies in the browser
 


### PR DESCRIPTION
### Summary

Documents the customer-controlled Eager redirect cookie setting for multi-domain Access applications, including the previous automatic five-hostname cutoff. Adds an Access changelog entry for the new setting.

### Documentation checklist

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) - how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
