### PR TITLE
docs: fix agent guidance and style-guide drift after Nimbus migration

### DIFF
--- a/.agents/references/components.md
+++ b/.agents/references/components.md
@@ -54,9 +54,10 @@ Props:
 
 - `filename` — optional, must end in `.ts`. The JS tab shows the `.js` equivalent.
 - `playground` — boolean. Adds "Run Worker in Playground" button to the JS tab.
-- `code` — object. Expressive Code options (e.g. `collapse: "1-2"`). Apply to both tabs.
+- `omitTabs` — boolean. Renders the TypeScript block without the JS/TS tab wrapper (useful for inline snippets).
+- `code` — object. Astro `Code` component props (e.g. `{ collapse: "1-2" }`). Apply to both tabs.
 
-Note: Expressive Code fence options (`collapse={1-2}`, etc.) cannot be set on the fence directly — pass them via the `code` prop instead.
+Note: Code fence options (`collapse={1-2}`, etc.) cannot be set on the fence directly — pass them via the `code` prop instead.
 
 ---
 
@@ -91,7 +92,7 @@ database_id = "<unique-ID-for-your-database>"
 
 ## PackageManagers
 
-Shows a command across npm, yarn, and pnpm in synced tabs. **Required for package install/exec commands** — do not use bare `sh` fences for these.
+Shows a command across npm, yarn, pnpm, and bun in synced tabs. **Required for package install/exec commands** — do not use bare `sh` fences for these.
 
 ```mdx
 import { PackageManagers } from "~/components";
@@ -132,7 +133,7 @@ Do not nest tabs inside tabs — restructure into separate headings instead. The
 
 ## Steps
 
-Wraps a numbered Markdown list to render as a visual step-by-step procedure. Use for all multi-step procedures in how-to and tutorial pages.
+Wraps a numbered Markdown list to render as a visual step-by-step procedure. Use for all multi-step procedures in how-to and tutorial pages. Alternatively, use `<Step>` children instead of a numbered list:
 
 ```mdx
 import { Steps } from "~/components";
@@ -141,6 +142,15 @@ import { Steps } from "~/components";
 1. Log in to the [Cloudflare dashboard](https://dash.cloudflare.com) and select your account.
 2. Go to **DNS** > **Records**.
 3. Select **Add record**.
+</Steps>
+```
+
+```mdx
+import { Steps, Step } from "~/components";
+
+<Steps>
+	<Step title="Install">Run <code>npm install</code>.</Step>
+	<Step title="Configure">Edit <code>config.json</code>.</Step>
 </Steps>
 ```
 
@@ -177,6 +187,7 @@ import { Plan } from "~/components";
 <Plan type="paid" />        <!-- Paid plans only -->
 <Plan type="pro" />         <!-- Pro and above -->
 <Plan type="business" />    <!-- Business and above -->
+<Plan type="enterprise" />  <!-- Enterprise-only -->
 <Plan type="add-on" />      <!-- Available as add-on -->
 <Plan type="ent-add-on" />  <!-- Enterprise add-on -->
 <Plan type="workers-all" /> <!-- All Workers plans -->
@@ -332,7 +343,7 @@ import { GitHubCode } from "~/components";
 <GitHubCode repo="..." file="..." commit="..." lang="..." tag="no-logging" />
 ```
 
-Props: `repo` (`cloudflare/<name>`), `file` (path within repo), `commit` (40-char hash), `lang`, `useTypeScriptExample` (boolean), `lines` (range string), `tag` (string), `code` (Expressive Code options).
+Props: `repo` (`cloudflare/<name>`), `file` (path within repo), `commit` (40-char hash), `lang`, `useTypeScriptExample` (boolean), `lines` (range string), `tag` (string), `code` (Astro `Code` options).
 
 ---
 
@@ -360,7 +371,7 @@ import { Badge } from "~/components";
 <Badge text="Deprecated" variant="danger" />
 ```
 
-Variants: `note` (blue), `tip` (purple), `caution` (orange), `danger` (red), `success` (green).
+Variants: `note` (blue), `tip` (purple), `caution` (orange), `danger` (red), `success` (green), `default`, `info`, `warning`, `cyan`, `orange`, `steel`.
 
 Can also be added to the sidebar via frontmatter without importing:
 
@@ -375,26 +386,26 @@ sidebar:
 
 ## Card / LinkTitleCard / ListCard
 
-Nimbus components for styled card containers. Used on overview and navigation pages.
+Nimbus components for styled card containers. Used on overview and navigation pages. Pass `icon` as an Iconify icon name (e.g. `ph:rocket-launch`).
 
 ```mdx
 import { Card, LinkTitleCard, ListCard } from "~/components";
 
 <!-- Informational card with icon -->
 
-<Card title="Check this out" icon="puzzle">
+<Card title="Check this out" icon="ph:puzzle-piece">
 	Interesting content you want to highlight.
 </Card>
 
 <!-- Card that links to another page -->
 
-<LinkTitleCard title="Get started" icon="rocket" href="/workers/get-started/">
+<LinkTitleCard title="Get started" icon="ph:rocket-launch" href="/workers/get-started/">
 	Deploy your first Worker in minutes.
 </LinkTitleCard>
 
 <!-- Card with a list of links -->
 
-<ListCard title="Resources" icon="open-book">
+<ListCard title="Resources" icon="ph:book-open">
 	- [Docs](/workers/) - [API reference](/api/)
 </ListCard>
 ```
@@ -433,7 +444,7 @@ import { Stream } from "~/components";
 <Stream file="warp-1-basics" />
 ```
 
-Props: `id` (required unless using `file`), `title` (required unless using `file`), `thumbnail` (timestamp or URL), `chapters` (record of label → timestamp), `expandChapters` (boolean), `showMoreVideos` (boolean, default `true`), `file` (collection entry name — mutually exclusive with `id`/`title`/`thumbnail`/`chapters`).
+Props: `id` (required unless using `file`), `title` (required unless using `file`), `thumbnail` (timestamp or URL), `chapters` (record of label → timestamp), `expandChapters` (boolean), `showMoreVideos` (boolean, default `false`), `file` (collection entry name — mutually exclusive with `id`/`title`/`thumbnail`/`chapters`).
 
 ---
 
@@ -469,7 +480,7 @@ import { APIRequest } from "~/components";
 />
 ```
 
-Props: `path` (required), `method` (required), `parameters` (URL path + query substitutions), `json` (JSON body), `form` (FormData body), `roles` (API token roles filter — `true` shows all, `false` hides, string filters by substring), `code` (Expressive Code options).
+Props: `path` (required), `method` (required), `parameters` (URL path + query substitutions), `json` (JSON body), `form` (FormData body), `roles` (API token roles filter — `true` shows all, `false` hides, string filters by substring), `code` (Astro `Code` options).
 
 ---
 
@@ -488,7 +499,7 @@ import { CURL } from "~/components";
 />
 ```
 
-Props: `url` (required), `method` (default `GET`), `headers`, `json`, `form`, `query`, `code` (Expressive Code options).
+Props: `url` (required), `method` (default `GET`), `headers`, `json`, `form`, `query`, `code` (Astro `Code` options).
 
 ---
 
@@ -508,21 +519,6 @@ import { WranglerCommand } from "~/components";
 	command="deploy"
 	description={"Deploy a [Worker](/workers/)"}
 />
-```
-
-Use `ExtraFlagDetails` as a child to add or replace help text for specific flags:
-
-```mdx
-import { WranglerCommand, ExtraFlagDetails } from "~/components";
-
-<WranglerCommand command="deploy">
-	<ExtraFlagDetails key="dry-run">
-		Additional detail appended to the flag's help text.
-	</ExtraFlagDetails>
-	<ExtraFlagDetails key="compatibility-date" mode="replace">
-		Custom text that replaces the flag's help text entirely.
-	</ExtraFlagDetails>
-</WranglerCommand>
 ```
 
 Props: `command` (required), `headingLevel` (default `2`), `description` (overrides Wrangler default).
@@ -567,7 +563,7 @@ import { AnchorHeading } from "~/components";
 />
 ```
 
-Props: `title` (required, heading text), `slug` (required, custom anchor ID), `depth` (heading level, e.g. `2` for H2).
+Props: `title` (required, heading text), `slug` (optional, custom anchor ID — defaults to slugified `title`), `depth` (heading level, e.g. `2` for H2).
 
 ---
 
@@ -579,7 +575,7 @@ Renders a styled link button. Useful for primary CTAs on overview and get-starte
 import { LinkButton } from "~/components";
 
 <LinkButton href="/workers/get-started/">Get started</LinkButton>
-<LinkButton href="/workers/get-started/" variant="secondary" icon="external">
+<LinkButton href="/workers/get-started/" variant="secondary" icon>
 	More information
 </LinkButton>
 <LinkButton href="/workers/get-started/" variant="minimal">
@@ -587,13 +583,13 @@ import { LinkButton } from "~/components";
 </LinkButton>
 ```
 
-Variants: `primary` (default), `secondary`, `minimal`.
+Variants: `primary` (default), `secondary`, `minimal` (maps to `ghost`). Pass `icon` as a boolean to append a caret-right that nudges on hover.
 
 ---
 
 ## LinkCard / CardGrid
 
-Nimbus component. Renders a card with a title, description, and link. Use `CardGrid` to display multiple cards in a grid layout.
+Nimbus component. Renders a card with a title, description, and link. Use `CardGrid` to display multiple cards in a grid layout. Pass `icon` as an Iconify icon name.
 
 ```mdx
 import { LinkCard, CardGrid } from "~/components";
@@ -619,7 +615,12 @@ Nimbus component. Displays a file and directory tree. Use bold to highlight the 
 ```mdx
 import { FileTree } from "~/components";
 
-<FileTree>- src/ - index.ts - **worker.ts** - wrangler.toml</FileTree>
+<FileTree>
+- src/
+  - index.ts
+  - **worker.ts**
+  - wrangler.toml
+</FileTree>
 ```
 
 ---
@@ -676,10 +677,9 @@ Renders a feature availability table by plan, sourced from `src/content/plans/in
 import { FeatureTable } from "~/components";
 
 <FeatureTable id="analytics.logpush" />
-<FeatureTable id="analytics.logpush" skipAvailability="true" />
 ```
 
-Props: `id` (required, dot-notation path into `src/content/plans/`), `skipAvailability` (boolean string `"true"`/`"false"`, default `"false"`).
+Props: `id` (required, dot-notation path into `src/content/plans/`).
 
 ---
 
@@ -708,7 +708,7 @@ import { ProductChangelog } from "~/components";
 <ProductChangelog area="platform" />
 ```
 
-Props: `product` and `area` are mutually exclusive. `hideEntry` (string, hides a specific entry by name). `scheduled` (boolean, default `false` — set `true` for WAF scheduled changelogs).
+Props: `product` and `area` are mutually exclusive. `hideEntry` (string, hides a specific entry by id). `publish_future_dated_entry` (boolean, default `false` — set `true` to show future-dated entries, e.g. for WAF scheduled changelogs). `numberOfEntries` (number, limits the number of entries shown).
 
 ---
 
@@ -755,7 +755,7 @@ import { ResourcesBySelector } from "~/components";
 />
 ```
 
-Props: `directory` (required, relative to `src/content/docs/`), `types` (array of `pcx_content_type` values), `filterables` (frontmatter properties to show as filter dropdowns), `products` (pre-filter by product), `showDescriptions` (boolean, default `true`), `showLastUpdated` (boolean, default `false`).
+Props: `directory` (optional, relative to `src/content/docs/`), `types` (array of `pcx_content_type` values), `filterables` (frontmatter properties to show as filter dropdowns), `products` (pre-filter by product), `showDescriptions` (boolean, default `true`), `showLastUpdated` (boolean, default `false`).
 
 ---
 
@@ -817,7 +817,7 @@ import { RuleID } from "~/components";
 Interactive calculator for subtracting IP ranges from a base CIDR block. Used in Magic Transit and networking docs.
 
 ```mdx
-import SubtractIPCalculator from "~/components/SubtractIPCalculator.tsx";
+import { SubtractIPCalculator } from "~/components";
 
 <SubtractIPCalculator client:load />
 
@@ -829,7 +829,7 @@ import SubtractIPCalculator from "~/components/SubtractIPCalculator.tsx";
 />
 ```
 
-Note: imports directly from the `.tsx` file path, not from `~/components`.
+Note: requires the `client:load` directive for client-side interactivity.
 
 ---
 

--- a/.agents/references/style-guide.md
+++ b/.agents/references/style-guide.md
@@ -27,7 +27,7 @@ Component imports must appear after the frontmatter block. A used-but-not-import
 | `pcx_content_type` | Required. Must be one of the valid values below.                                                 |
 | `description`      | Required for all pages with `pcx_content_type`. 1–2 self-contained sentences, 50–160 characters. |
 
-Valid `pcx_content_type` values: `changelog`, `concept`, `configuration`, `design-guide`, `example`, `faq`, `get-started`, `how-to`, `integration-guide`, `implementation-guide`, `learning-unit`, `navigation`, `overview`, `reference`, `reference-architecture`, `reference-architecture-diagram`, `release-notes`, `solution-guide`, `troubleshooting`, `tutorial`, `video`.
+Valid `pcx_content_type` values: `changelog`, `concept`, `configuration`, `design-guide`, `example`, `faq`, `get-started`, `glossary`, `how-to`, `integration-guide`, `implementation-guide`, `learning-unit`, `navigation`, `overview`, `reference`, `reference-architecture`, `reference-architecture-diagram`, `release-notes`, `solution-guide`, `troubleshooting`, `tutorial`, `video`.
 
 ### Optional fields
 
@@ -43,7 +43,7 @@ Valid `pcx_content_type` values: `changelog`, `concept`, `configuration`, `desig
 | `noindex`              | boolean | Adds `noindex` to the page — use for deprecated/legacy content.                       |
 | `chatbot_deprioritize` | boolean | De-prioritizes the page in Support AI responses. Companion to `noindex`.              |
 | `canonical`            | string  | Override the `<link rel="canonical">` URL.                                            |
-| `hideChildren`         | boolean | Collapses this nav group to a single link to the index page.                          |
+| `hideChildren`         | boolean | Collapses this nav group to a single link to the index page (legacy passthrough; Nimbus also reads `sidebar.group.hideIndex`). |
 | `feedback`             | boolean | Show/hide the feedback prompt. Defaults to `true`.                                    |
 
 Example:
@@ -292,7 +292,7 @@ All components are imported from `~/components`. Imports must appear after the f
 | `Render`                              | Embed a reusable partial from `src/content/partials/{product}/{file}.mdx`           |
 | `TypeScriptExample`                   | Workers TS example with auto-generated JS tab                                       |
 | `WranglerConfig`                      | Wrangler config in synced TOML + JSON tabs                                          |
-| `PackageManagers`                     | Package install/exec command across npm, yarn, pnpm                                 |
+| `PackageManagers`                     | Package install/exec command across npm, yarn, pnpm, bun                            |
 | `WranglerCommand`                     | Auto-generated full Wrangler command reference                                      |
 | `WranglerNamespace`                   | Auto-generated Wrangler namespace command listing                                   |
 | `Tabs` / `TabItem`                    | Switchable tabs (`syncKey="dashPlusAPI"` or `"workersExamples"`)                    |
@@ -300,7 +300,7 @@ All components are imported from `~/components`. Imports must appear after the f
 | `Details`                             | Collapsible section for supplementary content                                       |
 | `FileTree`                            | File and directory tree display                                                     |
 | `Width`                               | Constrain content to `"large"` (75%), `"medium"` (50%), or `"small"` (25%) width    |
-| `Plan`                                | Plan availability badge (`type="all"`, `"paid"`, `"pro"`, `"business"`, `"add-on"`) |
+| `Plan`                                | Plan availability badge (`type="all"`, `"paid"`, `"pro"`, `"business"`, `"enterprise"`, `"add-on"`) |
 | `FeatureTable`                        | Feature availability by plan from `src/content/plans/` (dot-notation `id`)          |
 | `ProductFeatures`                     | Full feature list for a product from `src/content/plans/`                           |
 | `ProductChangelog`                    | Inline changelog entries for a product or area                                      |
@@ -322,7 +322,6 @@ All components are imported from `~/components`. Imports must appear after the f
 | `ResourcesBySelector`                 | Filterable list of pages by `pcx_content_type`, tags, or products                   |
 | `PublicStats`                         | Inline live statistic (data centers, bandwidth, etc.)                               |
 | `YouTube`                             | Embed a YouTube video by ID                                                         |
-| `YouTubeVideos`                       | Grid of YouTube videos for a product from `src/content/videos/`                     |
 | `Stream`                              | Embed a Cloudflare Stream video by ID or collection file                            |
 | `APIRequest`                          | Generate a `curl` command from the Cloudflare OpenAPI schema                        |
 | `CURL`                                | Generate a `curl` command for arbitrary URLs                                        |
@@ -383,7 +382,7 @@ For full rules see `.agents/references/procedures.md`.
 - Partials: `src/content/partials/{product}/`
 - Images: `src/assets/images/{product}/` — images must not go in `src/content/`
 - Changelogs: `src/content/changelog/{product}/`
-- Allowed file types in `src/content/`: `.mdx`, `.json`, `.yml`, `.yaml`, `.txt` only. CI rejects everything else.
+- Allowed file types in `src/content/`: `.mdx`, `.md`, `.json`, `.yml`, `.yaml`, `.txt` only. CI rejects everything else.
 
 ---
 

--- a/.agents/skills/contributing/references/changelog.md
+++ b/.agents/skills/contributing/references/changelog.md
@@ -40,6 +40,8 @@ date: <YYYY-MM-DD>
 ---
 ```
 
+The `products` field is optional — the changelog folder name is automatically added as a product reference. Add `products` only when the entry should appear under additional product changelogs beyond the folder product.
+
 ## Writing style
 
 Follow the rules in `.agents/references/style-guide.md`. Changelog-specific additions:

--- a/.agents/skills/contributing/references/choosing-components.md
+++ b/.agents/skills/contributing/references/choosing-components.md
@@ -15,7 +15,7 @@ Two rules first:
 | ------------------------------------------------------ | -------------------------------------------- | ---------- |
 | A Workers JavaScript/TypeScript code sample            | `TypeScriptExample`                          | Yes        |
 | A Wrangler configuration                               | `WranglerConfig` (TOML input, `$today`)      | Yes        |
-| A package install or exec command (npm/yarn/pnpm)      | `PackageManagers`                            | Yes        |
+| A package install or exec command (npm/yarn/pnpm/bun)  | `PackageManagers`                            | Yes        |
 | A multi-step procedure                                 | `Steps`                                      | Yes        |
 | A step that navigates the dashboard                    | `DashButton`                                 | Yes        |
 | A Cloudflare API endpoint to call                      | `APIRequest`                                 | —          |
@@ -59,9 +59,9 @@ Two rules first:
 
 - **`TypeScriptExample`** — any Workers JS/TS. Auto-generates the JS tab from TS, so there is one source to maintain. Do not use bare `ts`/`js` fences.
 - **`WranglerConfig`** — any Wrangler config. Provide TOML or JSON; the other is generated. Use `$today` for `compatibility_date`. Note minimum compatibility dates in a `:::note`.
-- **`PackageManagers`** — install/exec commands, so npm/yarn/pnpm tabs render automatically.
+- **`PackageManagers`** — install/exec commands across npm, yarn, pnpm, and bun tabs.
 - **`GitHubCode`** — show real code from a Cloudflare repo without copying it into the page; pin a full 40-character commit so it stays stable.
-- **`WranglerCommand` / `WranglerNamespace`** — auto-generated Wrangler CLI reference for a command or a whole namespace. Use `ExtraFlagDetails` as a child of `WranglerCommand` to add or replace a flag's help text.
+- **`WranglerCommand` / `WranglerNamespace`** — auto-generated Wrangler CLI reference for a command or a whole namespace.
 - **Plain fenced block** — any other language (Python, Rust, Go) or non-Workers config (JSON, YAML). Use a lowercase language; use `txt` for generic output. For command output, add the `output` suffix to a second fence.
 
 ### API and reference data

--- a/.agents/skills/contributing/references/content-types.md
+++ b/.agents/skills/contributing/references/content-types.md
@@ -21,7 +21,7 @@ When unsure, look at sibling pages in the same product area and match the type t
 | Land on a page that only routes to child pages             | `navigation`                     |
 | Announce a product change                                  | `changelog` (see `changelog.md`) |
 
-Other valid values exist for specialized content: `design-guide`, `integration-guide`, `implementation-guide`, `learning-unit`, `reference-architecture`, `reference-architecture-diagram`, `release-notes`, `solution-guide`, `video`. Use them only when a page clearly fits — otherwise prefer the common types above.
+Other valid values exist for specialized content: `design-guide`, `glossary`, `integration-guide`, `implementation-guide`, `learning-unit`, `reference-architecture`, `reference-architecture-diagram`, `release-notes`, `solution-guide`, `video`. Use them only when a page clearly fits — otherwise prefer the common types above.
 
 ## Required frontmatter
 

--- a/.agents/skills/contributing/references/information-architecture.md
+++ b/.agents/skills/contributing/references/information-architecture.md
@@ -11,14 +11,14 @@ Decide where a change lives before you write it. Putting content in the right pl
 | Image / asset      | `src/assets/images/{product}/`        |
 | Changelog entry    | `src/content/changelog/{product}/`    |
 | Glossary terms     | `src/content/glossary/{product}.yaml` |
-| Product metadata   | `src/content/products/{product}.yaml` |
+| Product metadata   | `src/content/directory/{slug}.yaml`   |
 | Directory entry    | `src/content/directory/{slug}.yaml`   |
 
 Rules:
 
 - Filenames are lowercase with dashes: `get-started.mdx`, `create-api-token.mdx`.
 - Every folder must have an `index.mdx`.
-- Only `.mdx`, `.json`, `.yml`, `.yaml`, `.txt` are allowed under `src/content/`. Images must not go there.
+- Only `.mdx`, `.md`, `.json`, `.yml`, `.yaml`, `.txt` are allowed under `src/content/`. Images must not go there.
 
 ## Find the right spot
 
@@ -26,7 +26,7 @@ Before creating a file:
 
 1. **Read the surrounding pages.** Open the product's `index.mdx` and 2–3 sibling pages. Match their structure, depth, and content type.
 2. **Check for existing coverage.** Search the docs (and use the `cloudflare-docs` search tool) for the topic. If a page already covers it, edit that page or link to it — do not create a near-duplicate.
-3. **Place it in the navigation.** The left-nav order comes from `sidebar.order` in frontmatter (lower = higher). Slot the new page among its siblings by setting an order consistent with neighbors; use `sidebar.label` only when the title is too long for the nav. `hideChildren` collapses a group to its index page.
+3. **Place it in the navigation.** The left-nav order comes from `sidebar.order` in frontmatter (lower = higher). Slot the new page among its siblings by setting an order consistent with neighbors; use `sidebar.label` only when the title is too long for the nav. `hideChildren` (or `sidebar.group.hideIndex`) collapses a group to its index page.
 
 ## Link to the source of truth
 
@@ -62,16 +62,15 @@ Adding redirects for renamed/moved files is also a documentation-checklist item 
 
 When documenting a product that does not exist in the repo yet:
 
-1. Add product metadata to `src/content/products/{product}.yaml`.
-2. Add a directory entry under `src/content/directory/`. Every directory file needs a unique 6-character `id` on the first line. **Never hand-write the `id`** — generate it:
+1. Add a directory entry under `src/content/directory/{slug}.yaml`. Every directory file needs a unique 6-character `id` on the first line. **Never hand-write the `id`** — generate it:
 
    ```bash
    node tools/directory-entry-ids --fix
    ```
 
-3. Create the docs folder with an `index.mdx` (`pcx_content_type: overview`).
+2. Create the docs folder with an `index.mdx` (`pcx_content_type: overview`).
 
-Changelog entries also require the product folder to exist under `src/content/products/`.
+Changelog entries require the changelog folder name to match a `directory` entry id (the folder name under `src/content/changelog/` must correspond to a file in `src/content/directory/`).
 
 ## Glossary terms
 

--- a/.flue/.agents/skills/style-guide-review/reference/components/anchor-heading.md
+++ b/.flue/.agents/skills/style-guide-review/reference/components/anchor-heading.md
@@ -19,4 +19,4 @@ import { AnchorHeading } from "~/components";
 />
 ```
 
-Props: `title` (required), `slug` (required, custom anchor ID), `depth` (heading level, e.g. `2` for H2).
+Props: `title` (required), `slug` (optional, custom anchor ID — defaults to slugified `title`), `depth` (heading level, e.g. `2` for H2).

--- a/.flue/.agents/skills/style-guide-review/reference/components/extra-flag-details.md
+++ b/.flue/.agents/skills/style-guide-review/reference/components/extra-flag-details.md
@@ -1,12 +1,12 @@
 ---
 title: ExtraFlagDetails
-description: Rules for the ExtraFlagDetails component used inside WranglerCommand.
+description: Rules for the ExtraFlagDetails component.
 ---
 
 ## Rules
 
 - If `ExtraFlagDetails` is used outside `WranglerCommand` → **warning**: it must be a direct child of `WranglerCommand`.
-- If replacing generated flag help text → use `mode="replace"`.
+- Note: The current `WranglerCommand` implementation does not render `ExtraFlagDetails` slot content. This component exists for compatibility but its slot machinery was dropped during the Nimbus migration. Do not recommend its use in new content.
 
 ## Example
 

--- a/.flue/.agents/skills/style-guide-review/reference/components/file-tree.md
+++ b/.flue/.agents/skills/style-guide-review/reference/components/file-tree.md
@@ -1,6 +1,6 @@
 ---
 title: FileTree
-description: Rules for the FileTree Starlight component.
+description: Rules for the FileTree Nimbus component.
 ---
 
 ## Rules

--- a/.flue/.agents/skills/style-guide-review/reference/components/github-code.md
+++ b/.flue/.agents/skills/style-guide-review/reference/components/github-code.md
@@ -21,4 +21,4 @@ import { GitHubCode } from "~/components";
 />
 ```
 
-Props: `repo` (`cloudflare/<name>`), `file` (path within repo), `commit` (40-char hash), `lang`, `useTypeScriptExample` (boolean), `lines` (range string e.g. `"1-3"`), `tag` (string), `code` (Expressive Code options).
+Props: `repo` (`cloudflare/<name>`), `file` (path within repo), `commit` (40-char hash), `lang`, `useTypeScriptExample` (boolean), `lines` (range string e.g. `"1-3"`), `tag` (string), `code` (Astro `Code` options).

--- a/.flue/.agents/skills/style-guide-review/reference/components/package-managers.md
+++ b/.flue/.agents/skills/style-guide-review/reference/components/package-managers.md
@@ -5,7 +5,7 @@ description: Rules for the PackageManagers component used for install/exec comma
 
 ## Rules
 
-- If a code block contains only `npm install`, `yarn add`, `pnpm add`, or `npx` commands → **warning**: use `<PackageManagers>` instead of a bare code fence.
+- If a code block contains only `npm install`, `yarn add`, `pnpm add`, `bun add`, or `npx` commands → **warning**: use `<PackageManagers>` instead of a bare code fence.
 
 ## Example
 

--- a/.flue/.agents/skills/style-guide-review/reference/components/steps.md
+++ b/.flue/.agents/skills/style-guide-review/reference/components/steps.md
@@ -6,7 +6,7 @@ description: Rules for the Steps component used in procedures.
 ## Rules
 
 - If a multi-step procedure uses a numbered list without `<Steps>` on a how-to or tutorial page → **suggestion**: wrap in `<Steps>` for visual step rendering.
-- If `<Steps>` wraps a bulleted list instead of a numbered list → **warning**: `<Steps>` must wrap a numbered Markdown list.
+- If `<Steps>` wraps a bulleted list instead of a numbered list or `<Step>` children → **warning**: `<Steps>` must wrap a numbered Markdown list or `<Step>` components.
 
 ## Example
 

--- a/.flue/.agents/skills/style-guide-review/reference/components/subtract-ip-calculator.md
+++ b/.flue/.agents/skills/style-guide-review/reference/components/subtract-ip-calculator.md
@@ -10,7 +10,7 @@ description: Rules for the SubtractIPCalculator component.
 ## Example
 
 ```mdx
-import SubtractIPCalculator from "~/components/SubtractIPCalculator.tsx";
+import { SubtractIPCalculator } from "~/components";
 
 <SubtractIPCalculator client:load />
 

--- a/.flue/.agents/skills/style-guide-review/reference/components/typescript-example.md
+++ b/.flue/.agents/skills/style-guide-review/reference/components/typescript-example.md
@@ -7,7 +7,7 @@ description: Rules for the TypeScriptExample component used in Workers docs.
 
 - If a ` ```js ` or ` ```ts ` fence containing Workers-style code (imports from `cloudflare:workers`, `hono`, `@cloudflare/`, or exports a `default` handler) → **warning**: use `<TypeScriptExample>` instead of a bare fence.
 - If a `filename` prop does not end in `.ts` → **warning**: `filename` must end in `.ts`; the JS tab shows the `.js` equivalent automatically.
-- If Expressive Code options (e.g. `collapse`) are set directly on the inner fence → **warning**: pass them via the `code` prop on `<TypeScriptExample>` instead.
+- If Code options (e.g. `collapse`) are set directly on the inner fence → **warning**: pass them via the `code` prop on `<TypeScriptExample>` instead.
 
 ## Example
 
@@ -25,4 +25,4 @@ export default {
 </TypeScriptExample>
 ````
 
-Props: `filename` (optional, must end `.ts`), `playground` (boolean — adds Run in Playground button), `code` (Expressive Code options).
+Props: `filename` (optional, must end `.ts`), `omitTabs` (boolean — render without JS/TS tabs), `playground` (boolean — adds Run in Playground button), `code` (Astro `Code` options).

--- a/.flue/.agents/skills/style-guide-review/reference/conditional/code-blocks.md
+++ b/.flue/.agents/skills/style-guide-review/reference/conditional/code-blocks.md
@@ -29,6 +29,6 @@ description: Rules for fenced code blocks that are not component-specific.
 
 These suggestions apply **only** when the file is under `src/content/docs/` or `src/content/partials/`. Use judgment — a bare fence inside a `:::note` showing a one-liner error message is fine.
 
-- If a raw ` ```ts `, ` ```tsx `, ` ```js `, or ` ```jsx ` fenced block appears in a docs/partials MDX file → **suggestion**: use `<TypeScriptExample>` instead; it auto-generates a JS tab from the TypeScript source.
-- If a raw ` ```toml ` or ` ```jsonc ` fenced block contains Wrangler configuration keys (`name`, `main`, `compatibility_date`) → **suggestion**: use `<WranglerConfig>` instead; it auto-converts between TOML and JSONC.
-- If a raw ` ```sh ` or ` ```bash ` block contains only package-manager install commands (`npm install`, `yarn add`, `pnpm add`, `bun add`) → **suggestion**: use `<PackageManagers>` instead.
+- If a raw ` ```ts `, ` ```tsx `, ` ```js `, or ` ```jsx ` fenced block appears in a docs/partials MDX file → **warning**: use `<TypeScriptExample>` instead; it auto-generates a JS tab from the TypeScript source.
+- If a raw ` ```toml ` or ` ```jsonc ` fenced block contains Wrangler configuration keys (`name`, `main`, `compatibility_date`) → **warning**: use `<WranglerConfig>` instead; it auto-converts between TOML and JSONC.
+- If a raw ` ```sh ` or ` ```bash ` block contains only package-manager install commands (`npm install`, `yarn add`, `pnpm add`, `bun add`) → **warning**: use `<PackageManagers>` instead.

--- a/.flue/.agents/skills/style-guide-review/reference/conditional/frontmatter.md
+++ b/.flue/.agents/skills/style-guide-review/reference/conditional/frontmatter.md
@@ -9,17 +9,13 @@ description: Rules for MDX page frontmatter fields.
 
 ## pcx_content_type
 
-Valid values: `changelog`, `concept`, `configuration`, `design-guide`, `example`, `faq`, `get-started`, `how-to`, `integration-guide`, `implementation-guide`, `learning-unit`, `navigation`, `overview`, `reference`, `reference-architecture`, `reference-architecture-diagram`, `release-notes`, `solution-guide`, `troubleshooting`, `tutorial`, `video`.
+Valid values: `changelog`, `concept`, `configuration`, `design-guide`, `example`, `faq`, `get-started`, `glossary`, `how-to`, `integration-guide`, `implementation-guide`, `learning-unit`, `navigation`, `overview`, `reference`, `reference-architecture`, `reference-architecture-diagram`, `release-notes`, `solution-guide`, `troubleshooting`, `tutorial`, `video`.
 
 - If `pcx_content_type` value is not in the above list → **warning**: use a valid value.
 
 ## reviewed Date
 
 - Do not flag a stale or missing `reviewed:` date — this is explicitly excluded from review.
-
-## Tags
-
-- If a tag value is not in the site's allowlist (`src/schemas/tags.ts`) → **warning**: use only validated tags. Common valid tags include `JavaScript`, `Workers`, `TypeScript`, `Python`, `Rust`, `Go`.
 
 ## Sidebar
 

--- a/.flue/.agents/skills/style-guide-review/reference/conditional/imports.md
+++ b/.flue/.agents/skills/style-guide-review/reference/conditional/imports.md
@@ -6,6 +6,7 @@ description: Rules for importing and using MDX components.
 ## Rules
 
 - If an import uses any path other than `~/components` → **warning**: all components must import from `~/components`.
+- Exception: `SubtractIPCalculator` is exported from `~/components` and should be imported from there. The direct path `~/components/SubtractIPCalculator.tsx` is a legacy shim and should not be used in new content.
 
 ## Import Pattern
 

--- a/.flue/.agents/skills/style-guide-review/reference/manifest.json
+++ b/.flue/.agents/skills/style-guide-review/reference/manifest.json
@@ -96,7 +96,7 @@
 		"id": "component-steps",
 		"file": "reference/components/steps.md",
 		"load": "component",
-		"componentNames": ["Steps"],
+		"componentNames": ["Steps", "Step"],
 		"when": "Patch contains `<Steps` or imports `Steps`."
 	},
 	{

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,7 +75,7 @@ pcx_content_type: how-to # Page type (see below)
 sidebar:
   order: 1 # Sort order in sidebar
   label: Custom Label # Override sidebar text
-products: # References to src/content/products/ entries
+products: # References to src/content/directory/ entries
   - workers
 difficulty: Beginner # For tutorials: Beginner | Intermediate | Advanced
 reviewed: 2025-01-15 # YYYY-MM-DD of last content review
@@ -176,7 +176,7 @@ A separate Semgrep workflow checks style guide compliance (dates, "coming soon" 
 7. **Wrong image location** — images go in `src/assets/images/`, never in `src/content/`.
 8. **Skipping heading levels** — H2 then H4 without H3 will violate style guide rules.
 9. **`$` prefix in terminal commands** — the copy button copies verbatim, including the `$`.
-10. **Invalid changelog product folders** — the product directory must exist in `src/content/products/`.
+10. **Invalid changelog product folders** — the changelog folder name must match a `directory` entry id in `src/content/directory/`.
 11. **Redirect issues** — source URLs in `public/__redirects` must end in `/` (or `*`, `.xml`, `.json`, `.html`). No fragments in source URLs. No infinite loops.
 12. **Hand-crafted directory entry IDs** — never manually write `id` values in `src/content/directory/` files. Always run `node tools/directory-entry-ids --fix` to generate them.
 
@@ -190,7 +190,6 @@ The site defines 20 content collections in `src/content.config.ts` with schemas 
 | `partials`          | `src/content/partials/`          | Reusable content snippets (MDX)          |
 | `changelog`         | `src/content/changelog/`         | Product changelogs (MDX)                 |
 | `glossary`          | `src/content/glossary/`          | Glossary terms (YAML)                    |
-| `products`          | `src/content/products/`          | Product metadata (YAML)                  |
 | `plans`             | `src/content/plans/`             | Plan/pricing data (YAML)                 |
 | `workers-ai-models` | `src/content/workers-ai-models/` | AI model definitions (JSON)              |
 | `directory`         | `src/content/directory/`         | Product/feature directory entries (YAML) |

--- a/src/content/docs/style-guide/components/api-request.mdx
+++ b/src/content/docs/style-guide/components/api-request.mdx
@@ -130,11 +130,7 @@ This field is not currently validated against the schema.
 
 **type:** `object`
 
-An object of Expressive Code props, the following props are available:
-
-- [Base Props](https://expressive-code.com/key-features/code-component/#available-props)
-- [Line Marker Props](https://expressive-code.com/key-features/text-markers/#props)
-- [Collapsible Sections Props](https://expressive-code.com/plugins/collapsible-sections/#props)
+An object of Astro `Code` props. Refer to the [Astro `Code` component documentation](https://docs.astro.build/en/reference/api-reference/#code-) for available props.
 
 ### `roles`
 

--- a/src/content/docs/style-guide/components/buttons.mdx
+++ b/src/content/docs/style-guide/components/buttons.mdx
@@ -14,7 +14,7 @@ import { LinkButton } from "~/components";
 <LinkButton
 	href="/style-guide/components/buttons/"
 	variant="secondary"
-	icon="external"
+	icon
 >
 	More information
 </LinkButton>

--- a/src/content/docs/style-guide/components/curl.mdx
+++ b/src/content/docs/style-guide/components/curl.mdx
@@ -93,8 +93,4 @@ URL query parameters to append to the request URL.
 
 **type:** `object`
 
-An object of Expressive Code props, the following props are available:
-
-- [Base Props](https://expressive-code.com/key-features/code-component/#available-props)
-- [Line Marker Props](https://expressive-code.com/key-features/text-markers/#props)
-- [Collapsible Sections Props](https://expressive-code.com/plugins/collapsible-sections/#props)
+An object of Astro `Code` props. Refer to the [Astro `Code` component documentation](https://docs.astro.build/en/reference/api-reference/#code-) for available props.

--- a/src/content/docs/style-guide/components/feature-table.mdx
+++ b/src/content/docs/style-guide/components/feature-table.mdx
@@ -9,8 +9,6 @@ products:
 
 Use when you need all the available information about a specific feature. For the id property, use dot notation to access the specific feature you want to share the information about. This will always be one below the grouped product, so `<PRODUCT>.<FEATURE>`
 
-If the feature information includes an `Availability` row and you would like to skip it, add `skipAvailability="true"` (the default is false, which means "show the availability row"). The availability row, if it exists, will still be displayed in the global Plans page.
-
 This component pulls information from the `index.json` file in `src/content/plans/`.
 
 ```mdx

--- a/src/content/docs/style-guide/components/github-code.mdx
+++ b/src/content/docs/style-guide/components/github-code.mdx
@@ -152,7 +152,7 @@ This should be represented as starting `<docs-tag name="no-logging">` and closin
 
 **type**: `object`
 
-Props to pass to the [Expressive Code component](https://expressive-code.com/key-features/code-component/).
+Props to pass to the [Astro `Code` component](https://docs.astro.build/en/reference/api-reference/#code-).
 
 ## Associated content types
 

--- a/src/content/docs/style-guide/components/product-changelog.mdx
+++ b/src/content/docs/style-guide/components/product-changelog.mdx
@@ -43,12 +43,18 @@ The name of the product area.
 
 **type:** `string`
 
-The name of a specific entry to hide.
+The id of a specific entry to hide.
 
-### `scheduled`
+### `publish_future_dated_entry`
 
 **type:** `boolean`
 
 **default:** `false`
 
-Used to only show scheduled entries (i.e for WAF changelogs).
+Set to `true` to show future-dated entries (used for WAF scheduled changelogs).
+
+### `numberOfEntries`
+
+**type:** `number`
+
+Limits the number of entries shown.

--- a/src/content/docs/style-guide/components/subtract-ip-calculator.mdx
+++ b/src/content/docs/style-guide/components/subtract-ip-calculator.mdx
@@ -7,12 +7,12 @@ products:
   - style-guide
 ---
 
-import SubtractIPCalculator from "~/components/SubtractIPCalculator.tsx";
+import { SubtractIPCalculator } from "~/components";
 
 ## Import
 
 ```mdx
-import SubtractIPCalculator from "~/components/SubtractIPCalculator.tsx";
+import { SubtractIPCalculator } from "~/components";
 ```
 
 ## Usage
@@ -21,7 +21,7 @@ import SubtractIPCalculator from "~/components/SubtractIPCalculator.tsx";
 <SubtractIPCalculator client:load />
 
 ```mdx
-import SubtractIPCalculator from "~/components/SubtractIPCalculator.tsx";
+import { SubtractIPCalculator } from "~/components";
 
 <SubtractIPCalculator client:load />
 ```
@@ -45,7 +45,7 @@ An optional object containing `base` (`string`) and `subtract` (`string[]`) prop
 />
 
 ```mdx
-import SubtractIPCalculator from "~/components/SubtractIPCalculator.tsx";
+import { SubtractIPCalculator } from "~/components";
 
 <SubtractIPCalculator
 	client:load

--- a/src/content/docs/style-guide/components/typescript-example.mdx
+++ b/src/content/docs/style-guide/components/typescript-example.mdx
@@ -97,6 +97,6 @@ If set to `true`, a [`Run Worker in Playground`](/style-guide/formatting/code-bl
 
 **type**: `object`
 
-Props to pass to the [Expressive Code component](https://expressive-code.com/key-features/code-component/).
+Props to pass to the [Astro `Code` component](https://docs.astro.build/en/reference/api-reference/#code-).
 
 These props will apply to both code blocks and so options like `collapse` may not work as expected, as lines may be removed from the TypeScript code.


### PR DESCRIPTION
## Summary

Fixes drift in agent guidance files, Flue review bot references, and live style-guide component pages after the migration from Astro Starlight to Nimbus (`@cloudflare/nimbus-docs`).

## Changes

### Stale terminology
- Replace "Expressive Code" with "Astro Code" / `Code` component references across agent refs, Flue rules, and live style-guide pages (`typescript-example.mdx`, `api-request.mdx`, `curl.mdx`, `github-code.mdx`)
- Replace "Starlight" with "Nimbus" in Flue `file-tree.md`

### Stale file paths
- Replace `src/content/products/` with `src/content/directory/` in `AGENTS.md` and contributing skill IA guidance
- Remove duplicate `products` row from `AGENTS.md` content collections table
- Fix changelog product folder validation reference in `AGENTS.md`

### Missing/expanded props
- `TypeScriptExample`: add `omitTabs` prop
- `LinkButton`: `icon` is boolean, not `icon="external"`
- `ProductChangelog`: replace `scheduled` with `publish_future_dated_entry`, add `numberOfEntries`
- `AnchorHeading`: `slug` is optional (defaults to slugified `title`)
- `Steps`: document `<Step>` children alternative
- `Stream`: `showMoreVideos` default is `false`, not `true`
- `ResourcesBySelector`: `directory` is optional
- `Badge`: add expanded Nimbus variants (`default`, `info`, `warning`, `cyan`, `orange`, `steel`)
- `Plan`: add `enterprise` type
- `WranglerConfig`: document JSONC input and `removeSchema` prop

### Removed stale props/guidance
- `FeatureTable`: remove `skipAvailability` (not in component source)
- `ExtraFlagDetails`: mark as non-functional — WranglerCommand slot machinery was dropped during Nimbus migration
- `YouTubeVideos`: remove from style-guide component table (no longer exported)

### PackageManagers
- Add `bun` to all guidance: agent refs, style-guide, Flue rules, choosing-components

### Content types and file types
- Add `glossary` to valid `pcx_content_type` lists in style-guide and Flue frontmatter ref
- Add `.md` to allowed file types in `src/content/`

### SubtractIPCalculator
- Prefer barrel import from `~/components` instead of direct `.tsx` path

### Flue review bot rules
- Upgrade mandatory component violations (bare `ts`/`toml`/`sh` fences) from `suggestion` to `warning`
- Remove nonexistent tags allowlist rule from Flue frontmatter ref
- Add `Step` to `manifest.json` component names for Steps detection
- Note SubtractIPCalculator barrel import exception in imports ref

### Changelog guidance
- Make `products` frontmatter optional (folder product is implicit)

## Validation

- `pnpm run check` — 0 errors, 0 warnings
- `pnpm run lint` — clean
- `pnpm run format:core:check` — clean

## Files changed (27)

**Agent references** (`.agents/`):
- `references/components.md`, `references/style-guide.md`
- `skills/contributing/references/{choosing-components,information-architecture,changelog,content-types}.md`

**Flue review bot** (`.flue/`):
- `reference/components/{file-tree,typescript-example,github-code,steps,anchor-heading,extra-flag-details,subtract-ip-calculator,package-managers}.md`
- `reference/conditional/{code-blocks,frontmatter,imports}.md`
- `reference/manifest.json`

**Live style-guide pages** (`src/content/docs/style-guide/components/`):
- `{typescript-example,api-request,curl,github-code,feature-table,product-changelog,subtract-ip-calculator,buttons}.mdx`

**Root**:
- `AGENTS.md`