### PR TITLE
[Workers] Document wrangler dev --infer-origin-from-routes

### DIFF
--- a/src/content/docs/workers/wrangler/commands/workers.mdx
+++ b/src/content/docs/workers/wrangler/commands/workers.mdx
@@ -92,6 +92,8 @@ None of the options for this command are required. Many of these options can be 
   - Path to a custom certificate.
 - `--local-upstream` <Type text="string" /> <MetaInfo text="optional" />
   - Host to act as origin in local mode, defaults to `dev.host` or route.
+- `--infer-origin-from-routes` <Type text="boolean" /> <MetaInfo text="(default: true) optional" />
+  - Use the first configured route to infer the origin (`request.url` and the `Host` header) seen by the Worker in local mode. Set to `false` to preserve the real local origin, for example `localhost:8787`, so that Host- or Origin-sensitive logic behaves the same as the actual local request. An explicit `--host`, `--local-upstream`, or `dev.host` takes precedence either way.
 - `--assets` <Type text="string" /> <MetaInfo text="optional beta" />
   - Folder of static assets to be served. Replaces [Workers Sites](/workers/configuration/sites/). Visit [assets](/workers/static-assets/) for more information.
 - `--site` <Type text="string" /> <MetaInfo text="optional deprecated, use `--assets`" />


### PR DESCRIPTION
## Summary

Documents the new `--infer-origin-from-routes` flag for `wrangler dev`, added in cloudflare/workers-sdk#14865.

When a config has `routes`, local dev infers the origin from the first route, so the Worker sees `request.url`, the `Host` header, and any `Origin` header rewritten to the route's host even though the client connected to `localhost`. That default is intentional and unchanged. The flag documents the opt-out: `--infer-origin-from-routes=false` preserves the real local origin so Host- or Origin-sensitive logic (for example CORS checks allowlisting `localhost`) can be exercised locally without removing `routes` from the config.

The entry follows the existing format of the `wrangler dev` flag list and sits next to `--local-upstream`, which takes precedence over the inference either way.

## Documentation checklist

- [x] The documentation follows the style guide.
