### PR TITLE
[AI Gateway] Add User Insights observability doc and changelog

### DIFF
--- a/src/content/changelog/ai-gateway/2026-08-04-ai-spend.mdx
+++ b/src/content/changelog/ai-gateway/2026-08-04-ai-spend.mdx
@@ -6,10 +6,10 @@ products:
 date: 2026-08-04
 ---
 
-AI Gateway now includes **AI Spend**, a dashboard that gives you two things at once: clear visibility into how much your organization spends on AI, and a security signal that surfaces users whose usage suddenly looks abnormal. It works on the traffic already flowing through your gateway, so there is no additional setup.
+AI Gateway now includes AI Spend, a dashboard that gives you two things at once: clear visibility into how much your organization spends on AI, and a security signal that surfaces users whose usage suddenly looks abnormal. It works on the traffic already flowing through your gateway, so there is no additional setup.
 
-On the spend side, AI Spend shows organization-wide totals for cost, requests, tokens, and adoption, and lets you drill into an individual user to see their spend, top models and providers, cache hit rate, and more. To attribute usage to individual users, add a user identifier with [custom metadata](/ai-gateway/observability/custom-metadata/) or put your gateway behind [Cloudflare Access](/cloudflare-one/access-controls/).
+On the spend side, AI Spend shows organization-wide totals for cost, requests, tokens, and adoption, and lets you drill into an individual user to see their spend, top models and providers, cache hit rate, and more. To attribute usage to individual users, add a user identifier with custom metadata or put your gateway behind Cloudflare Access.
 
 On the security side, AI Spend baselines each user's normal usage from their 95th percentile (p95) session cost over the last 30 days, then flags sessions that exceed both that baseline and an organization-level threshold. A sudden jump above a user's own pattern is often the first sign of a compromised credential or a misbehaving agent, so you can investigate before it shows up on your bill.
 
-AI Spend is available to all AI Gateway customers at no additional cost. For more details, refer to the [AI Spend documentation](/ai-gateway/observability/ai-spend/).
+AI Spend is available to all AI Gateway customers at no additional cost.

--- a/src/content/changelog/ai-gateway/2026-08-04-ai-spend.mdx
+++ b/src/content/changelog/ai-gateway/2026-08-04-ai-spend.mdx
@@ -1,0 +1,15 @@
+---
+title: Track AI spend and detect anomalies with AI Spend
+description: Monitor organization-wide AI spend, attribute usage to identities, and flag sessions that deviate from a user's baseline.
+products:
+  - ai-gateway
+date: 2026-08-04
+---
+
+AI Gateway now includes **AI Spend**, a dashboard that shows how much your organization spends on AI, which identities are responsible for that spend, and which users deviate from their typical usage. It works on the traffic already flowing through your gateway, so there is no additional setup.
+
+AI Spend baselines each user's normal usage from their 95th percentile (p95) session cost over the last 30 days, then flags sessions that exceed both that baseline and an organization-level threshold. This helps you catch a compromised credential or a misbehaving agent before it shows up on your bill.
+
+To attribute usage to individual users, add a user identifier with [custom metadata](/ai-gateway/observability/custom-metadata/) or put your gateway behind [Cloudflare Access](/cloudflare-one/access-controls/).
+
+AI Spend is available to all AI Gateway customers at no additional cost. For more details, refer to the [AI Spend documentation](/ai-gateway/observability/ai-spend/).

--- a/src/content/changelog/ai-gateway/2026-08-04-ai-spend.mdx
+++ b/src/content/changelog/ai-gateway/2026-08-04-ai-spend.mdx
@@ -1,15 +1,15 @@
 ---
-title: Track AI spend and detect anomalies with AI Spend
-description: Monitor organization-wide AI spend, attribute usage to identities, and flag sessions that deviate from a user's baseline.
+title: Track AI spend and catch anomalous usage with AI Spend
+description: See how much your organization spends on AI, attribute it to identities, and flag anomalous usage that can signal a security risk.
 products:
   - ai-gateway
 date: 2026-08-04
 ---
 
-AI Gateway now includes **AI Spend**, a dashboard that shows how much your organization spends on AI, which identities are responsible for that spend, and which users deviate from their typical usage. It works on the traffic already flowing through your gateway, so there is no additional setup.
+AI Gateway now includes **AI Spend**, a dashboard that gives you two things at once: clear visibility into how much your organization spends on AI, and a security signal that surfaces users whose usage suddenly looks abnormal. It works on the traffic already flowing through your gateway, so there is no additional setup.
 
-AI Spend baselines each user's normal usage from their 95th percentile (p95) session cost over the last 30 days, then flags sessions that exceed both that baseline and an organization-level threshold. This helps you catch a compromised credential or a misbehaving agent before it shows up on your bill.
+On the spend side, AI Spend shows organization-wide totals for cost, requests, tokens, and adoption, and lets you drill into an individual user to see their spend, top models and providers, cache hit rate, and more. To attribute usage to individual users, add a user identifier with [custom metadata](/ai-gateway/observability/custom-metadata/) or put your gateway behind [Cloudflare Access](/cloudflare-one/access-controls/).
 
-To attribute usage to individual users, add a user identifier with [custom metadata](/ai-gateway/observability/custom-metadata/) or put your gateway behind [Cloudflare Access](/cloudflare-one/access-controls/).
+On the security side, AI Spend baselines each user's normal usage from their 95th percentile (p95) session cost over the last 30 days, then flags sessions that exceed both that baseline and an organization-level threshold. A sudden jump above a user's own pattern is often the first sign of a compromised credential or a misbehaving agent, so you can investigate before it shows up on your bill.
 
 AI Spend is available to all AI Gateway customers at no additional cost. For more details, refer to the [AI Spend documentation](/ai-gateway/observability/ai-spend/).

--- a/src/content/changelog/ai-gateway/2026-08-05-ai-spend.mdx
+++ b/src/content/changelog/ai-gateway/2026-08-05-ai-spend.mdx
@@ -3,7 +3,7 @@ title: Track AI spend and catch anomalous usage with AI Spend
 description: See how much your organization spends on AI, attribute it to identities, and flag anomalous usage that can signal a security risk.
 products:
   - ai-gateway
-date: 2026-08-04
+date: 2026-08-05T12:00:00-08:00
 ---
 
 AI Gateway now includes AI Spend, a dashboard that gives you two things at once: clear visibility into how much your organization spends on AI, and a security signal that surfaces users whose usage suddenly looks abnormal. It works on the traffic already flowing through your gateway, so there is no additional setup.

--- a/src/content/docs/ai-gateway/observability/ai-spend.mdx
+++ b/src/content/docs/ai-gateway/observability/ai-spend.mdx
@@ -12,7 +12,7 @@ The AI Spend dashboard shows how much your organization spends on AI, which iden
 
 ## Attribute usage to identities
 
-AI Spend is available to all AI Gateway customers at no additional cost and works on any traffic through your gateway. Without an identity on each request, usage is grouped under an anonymous identifier.
+AI Spend is available to all AI Gateway customers at no additional cost and works on any traffic through your gateway. Without an identity or custom metadata on your requests, all usage is grouped under a single anonymous identifier, and AI Spend cannot distinguish between individual users.
 
 To attribute usage to individual users, add a user identifier with [custom metadata](/ai-gateway/observability/custom-metadata/), or put your gateway behind [Cloudflare Access](/cloudflare-one/access-controls/). With Access, each authenticated request carries a verified identity you can filter spend and analytics by.
 

--- a/src/content/docs/ai-gateway/observability/ai-spend.mdx
+++ b/src/content/docs/ai-gateway/observability/ai-spend.mdx
@@ -8,7 +8,7 @@ products:
   - ai-gateway
 ---
 
-The AI Spend dashboard shows how much your organization spends on AI, which identities are responsible for that spend, and which accounts deviate from their typical usage. It uses the traffic already flowing through your gateway, so there is no additional setup.
+The AI Spend dashboard shows how much your organization spends on AI, which identities are responsible for that spend, and which users deviate from their typical usage. It uses the traffic already flowing through your gateway, so there is no additional setup.
 
 ## Key metrics
 
@@ -25,18 +25,18 @@ At the top of the AI Spend page, you can view the following organization-wide me
 
 ## Anomaly detection
 
-AI Spend baselines each account's normal usage and flags sessions that fall outside it, which can indicate a compromised credential or a misbehaving agent.
+AI Spend baselines each user's normal usage and flags sessions that fall outside it, which can indicate a compromised credential or a misbehaving agent.
 
-Baselines are calculated per session, not per request. For each account, AI Spend uses the 95th percentile (p95) session cost over the last 30 days. The baseline is rolling and updates as usage changes.
+Baselines are calculated per session, not per request. For each user, AI Spend uses the 95th percentile (p95) session cost over the last 30 days. The baseline is rolling and updates as usage changes.
 
 A session is flagged when it exceeds both of the following thresholds:
 
-- **Relative**: More than 2x the account's own p95 session cost.
-- **Absolute**: Above the account-level p99 session cost for your organization.
+- **Relative**: More than 2x the user's own p95 session cost.
+- **Absolute**: Above the organization-level p99 session cost across all users.
 
-Both thresholds must be met. This avoids flagging small spikes from low-usage accounts and routine high-cost sessions from heavy users.
+Both thresholds must be met. This avoids flagging small spikes from low-usage users and routine high-cost sessions from heavy users.
 
-Flagged accounts appear in a filtered view with the sessions that triggered the flag and their cost. AI Spend does not block requests.
+Flagged users appear in a filtered view with the sessions that triggered the flag and their cost. AI Spend does not block requests.
 
 ## User view
 
@@ -57,6 +57,6 @@ Select a user to see their usage in detail:
 
 ## Attribute usage to identities
 
-AI Spend is available to all AI Gateway customers at no additional cost and works on any traffic through your gateway. Without an identity on each request, usage is grouped by the anonymous account that made the request.
+AI Spend is available to all AI Gateway customers at no additional cost and works on any traffic through your gateway. Without an identity on each request, usage is grouped under an anonymous identifier.
 
 To attribute usage to individual users, add a user identifier with [custom metadata](/ai-gateway/observability/custom-metadata/), or put your gateway behind [Cloudflare Access](/cloudflare-one/access-controls/). With Access, each authenticated request carries a verified identity you can filter spend and analytics by.

--- a/src/content/docs/ai-gateway/observability/ai-spend.mdx
+++ b/src/content/docs/ai-gateway/observability/ai-spend.mdx
@@ -10,6 +10,12 @@ products:
 
 The AI Spend dashboard shows how much your organization spends on AI, which identities are responsible for that spend, and which users deviate from their typical usage. It uses the traffic already flowing through your gateway, so there is no additional setup.
 
+## Attribute usage to identities
+
+AI Spend is available to all AI Gateway customers at no additional cost and works on any traffic through your gateway. Without an identity on each request, usage is grouped under an anonymous identifier.
+
+To attribute usage to individual users, add a user identifier with [custom metadata](/ai-gateway/observability/custom-metadata/), or put your gateway behind [Cloudflare Access](/cloudflare-one/access-controls/). With Access, each authenticated request carries a verified identity you can filter spend and analytics by.
+
 ## Key metrics
 
 At the top of the AI Spend page, you can view the following organization-wide metrics for the selected time range:
@@ -54,9 +60,3 @@ Select a user to see their usage in detail:
 - **Last seen**: Most recent activity, from the daily spend trend.
 - **Active days**: Number of days the user sent traffic in this range.
 - **Identity coverage**: Share of the user's requests attributed to an identity.
-
-## Attribute usage to identities
-
-AI Spend is available to all AI Gateway customers at no additional cost and works on any traffic through your gateway. Without an identity on each request, usage is grouped under an anonymous identifier.
-
-To attribute usage to individual users, add a user identifier with [custom metadata](/ai-gateway/observability/custom-metadata/), or put your gateway behind [Cloudflare Access](/cloudflare-one/access-controls/). With Access, each authenticated request carries a verified identity you can filter spend and analytics by.

--- a/src/content/docs/ai-gateway/observability/ai-spend.mdx
+++ b/src/content/docs/ai-gateway/observability/ai-spend.mdx
@@ -1,0 +1,62 @@
+---
+title: AI Spend
+description: Track organization-wide AI spend, attribute usage to identities, and detect anomalous sessions in AI Gateway.
+pcx_content_type: reference
+sidebar:
+  order: 3
+products:
+  - ai-gateway
+---
+
+The AI Spend dashboard shows how much your organization spends on AI, which identities are responsible for that spend, and which accounts deviate from their typical usage. It uses the traffic already flowing through your gateway, so there is no additional setup.
+
+## Key metrics
+
+At the top of the AI Spend page, you can view the following organization-wide metrics for the selected time range:
+
+- **Active users**: Identities with gateway usage.
+- **Total requests**: Gateway requests in this range.
+- **Adoption rate**: IdP identities with at least one request.
+- **Tokens per active user**: Median over this time range.
+- **Median spend / active user**: Observed spend per attributed identity.
+- **Top 10% request activity**: Share of attributed requests made by the most active users.
+- **Users to review**: Users whose cost is at least 2x the median spend.
+- **Identity coverage**: Share of requests attributed to users.
+
+## Anomaly detection
+
+AI Spend baselines each account's normal usage and flags sessions that fall outside it, which can indicate a compromised credential or a misbehaving agent.
+
+Baselines are calculated per session, not per request. For each account, AI Spend uses the 95th percentile (p95) session cost over the last 30 days. The baseline is rolling and updates as usage changes.
+
+A session is flagged when it exceeds both of the following thresholds:
+
+- **Relative**: More than 2x the account's own p95 session cost.
+- **Absolute**: Above the account-level p99 session cost for your organization.
+
+Both thresholds must be met. This avoids flagging small spikes from low-usage accounts and routine high-cost sessions from heavy users.
+
+Flagged accounts appear in a filtered view with the sessions that triggered the flag and their cost. AI Spend does not block requests.
+
+## User view
+
+Select a user to see their usage in detail:
+
+- **Spend**: Total observed spend for the user in this range.
+- **Requests**: Total gateway requests made by the user.
+- **Tokens**: Total tokens consumed by the user.
+- **Gateway cached requests**: Number of requests served from cache.
+- **Errored requests**: Number of requests that returned an error.
+- **Cache hit rate**: Share of requests served from cache.
+- **Sessions**: Approximate session count from request metadata.
+- **Top model**: The model the user sent the most requests to.
+- **Top provider**: The provider the user sent the most requests to.
+- **Last seen**: Most recent activity, from the daily spend trend.
+- **Active days**: Number of days the user sent traffic in this range.
+- **Identity coverage**: Share of the user's requests attributed to an identity.
+
+## Attribute usage to identities
+
+AI Spend is available to all AI Gateway customers at no additional cost and works on any traffic through your gateway. Without an identity on each request, usage is grouped by the anonymous account that made the request.
+
+To attribute usage to individual users, add a user identifier with [custom metadata](/ai-gateway/observability/custom-metadata/), or put your gateway behind [Cloudflare Access](/cloudflare-one/access-controls/). With Access, each authenticated request carries a verified identity you can filter spend and analytics by.


### PR DESCRIPTION
## Summary

Adds documentation for the **User Insights** dashboard under AI Gateway > Observability, plus a changelog entry.

User Insights gives you two things at once:
- **Spend visibility** — organization-wide totals for cost, requests, tokens, and adoption, with per-user drill-down (spend, top models/providers, cache hit rate, and more).
- **Security** — baselines each user's normal usage (p95 session cost over 30 days) and flags sessions that exceed both that baseline and an organization-level threshold, surfacing a compromised credential or misbehaving agent early.

## Files

- `src/content/docs/ai-gateway/observability/user-insights.mdx` — the doc page (sidebar order 3, between Costs and Custom metadata)
- `src/content/changelog/ai-gateway/2026-08-05-user-insights.mdx` — changelog entry, scheduled for Aug 5, 12pm PST

## Notes

- Style follows sibling observability docs (`analytics.mdx`, `costs.mdx`): `pcx_content_type: reference`, bulleted metric lists, plain descriptive prose.
- Internal links verified against the repo. A `custom-domains` link was intentionally omitted since that page does not yet exist in the docs.