### PR TITLE
[Access] Map session settings to dashboard

### DIFF
--- a/src/content/docs/cloudflare-one/access-controls/access-settings/session-management.mdx
+++ b/src/content/docs/cloudflare-one/access-controls/access-settings/session-management.mdx
@@ -100,11 +100,20 @@ Users who match a policy configured with a _Same as application session timeout_
 When [Authenticate with Cloudflare One Client](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/client-sessions/#configure-client-sessions-in-access) is enabled for an Access application, the Cloudflare One Client session duration takes precedence over all other session durations (application, policy, and global). As long as the Cloudflare One Client session is valid and the user is running the Cloudflare One Client, the user will not be prompted to re-authenticate with the IdP — even if the global session has expired.
 
 ### MFA session duration
+
 If you use [independent multi-factor authentication (MFA)](/cloudflare-one/access-controls/access-settings/independent-mfa/), the MFA session duration determines how long a user can log in to Cloudflare Access without being prompted for MFA. The MFA session is independent of the global, policy, and application session durations. When logging in to an Access app with [MFA enabled](/cloudflare-one/access-controls/policies/mfa-requirements/#configure-independent-mfa-for-an-application), users must complete an MFA challenge if their last MFA authentication falls outside the configured session duration. After authenticating with their identity provider, users are prompted for MFA. The [`CF_Device` cookie](/cloudflare-one/access-controls/applications/http-apps/authorization-cookie/#cf_device) ensures both authentication steps occur on the same device. MFA session durations do not affect how long a user has access to the application (that is controlled by the [application token](#session-durations)).
 
 ### Order of enforcement
 
 The following flowchart illustrates how Access enforces user sessions for a self-hosted application.
+
+| Flowchart setting                       | Dashboard location                                                                                                                                |
+| --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Authenticate with Cloudflare One Client | **Access controls** > **Applications** > select an application > **Configure** > **Authentication** > **Authenticate with Cloudflare One Client** |
+| Cloudflare One Client session duration  | **Access controls** > **Access settings** > **Cloudflare One Client authentication** > **Session duration**                                       |
+| Policy session duration                 | **Access controls** > **Policies** > select a policy > **Configure** > **Session duration**                                                       |
+| Application session duration            | **Access controls** > **Applications** > select an application > **Configure** > **Overview** > **Session Duration**                              |
+| Global session duration                 | **Access controls** > **Access settings** > **Set your global session duration**                                                                  |
 
 ```mermaid
 flowchart TB
@@ -114,8 +123,8 @@ flowchart TB
 
     %% In with user traffic
     start["User goes to Access application"]
-    start--"Authenticate with Cloudflare One Client enabled" -->warpsession[Device client session expired?]
-    start-- "Authenticate with Cloudflare One Client disabled" --> policysession[Policy session expired?]
+    start--"Enabled for this application" -->warpsession[Cloudflare One Client session expired?]
+    start-- "Disabled for this application" --> policysession[Policy session expired?]
 
 		warpsession--"Yes"-->idp[Prompt to log in to IdP]
 		warpsession--"No"-->accessgranted[Access granted]
@@ -140,9 +149,7 @@ Access provides two options for revoking user sessions: per-application and per-
 To immediately terminate all active sessions for a specific application:
 
 1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Access controls** > **Applications**.
-
 2. Locate the application for which you would like to revoke active sessions and select **Configure**.
-
 3. Select **Revoke existing tokens**.
 
 Unless there are changes to rules in the policy, users can start a new session if their profile in your identity provider is still active.
@@ -154,11 +161,8 @@ Access can immediately revoke a single user session across all applications in y
 If you want to permanently revoke a user's access:
 
 1. Disable their account in your identity provider so that they cannot authenticate.
-
 2. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Team & Resources** > **Users**.
-
 3. Select the checkbox next to the user you want to revoke.
-
 4. Select **Action** > **Revoke**.
 
 The user will no longer be able to log in to any application protected by Access. The user will still count towards your seat subscription until you [remove the user](/cloudflare-one/team-and-resources/users/seat-management) from your account.


### PR DESCRIPTION
## Summary

- map each Access session setting to its dashboard location
- use Cloudflare One Client terminology consistently in the enforcement flowchart
- simplify the flowchart branches to show whether client authentication is enabled for the application

## Tests

- `pnpm run format:core:check`
- `pnpm run build`
- `pnpm run check` (blocked by existing missing `Fetcher` and `ExportedHandler` globals in the generated `skills/turnstile-spin` template)