### PR TITLE
[Access] Remove service token cookie guidance

### DIFF
--- a/src/content/docs/cloudflare-one/access-controls/service-credentials/service-tokens.mdx
+++ b/src/content/docs/cloudflare-one/access-controls/service-credentials/service-tokens.mdx
@@ -32,7 +32,7 @@ You can now configure your Access applications and [device enrollment permission
 
 ## Connect your service to Access
 
-### Initial request
+### Request
 
 To authenticate to an Access application using your service token, add the following to the headers of any HTTP request:
 
@@ -45,8 +45,6 @@ For example,
 ```sh
 curl -H "CF-Access-Client-Id: <CLIENT_ID>" -H "CF-Access-Client-Secret: <CLIENT_SECRET>" https://app.example.com
 ```
-
-If the service token is valid, Access generates a JWT scoped to the application in the form of a [`CF_Authorization` cookie](/cloudflare-one/access-controls/applications/http-apps/authorization-cookie/). You can use this cookie to authenticate [subsequent requests](#subsequent-requests) to the application.
 
 #### Authenticate with a single header
 
@@ -78,27 +76,6 @@ To authenticate using a single header:
    ```sh
    curl -H "Authorization: {\"cf-access-client-id\": \"<CLIENT_ID>\", \"cf-access-client-secret\": \"<CLIENT_SECRET>\"}" https://app.example.com
    ```
-
-### Subsequent requests
-
-After you have [authenticated to the application](#initial-request) using the service token, add the resulting `CF_Authorization` cookie to the headers of all subsequent requests:
-
-```sh
-curl -H "cookie: CF_Authorization=<CF_AUTHORIZATION_COOKIE>" https://app.example.com
-```
-
-If you prefer to use a raw header, send the value as `cf-access-token`:
-
-```sh
-curl -H "cf-access-token: <CF_AUTHORIZATION_COOKIE>" https://app.example.com
-```
-
-All requests with this cookie will succeed until the JWT expires.
-
-:::note
-
-If your Access application only has Service Auth policies, you must send the service token on every subsequent request. You can only use the JWT if the application has at least one Allow policy.
-:::
 
 ## Renew service tokens
 


### PR DESCRIPTION
### Summary

In the future, requests made with service tokens will no longer return a `CF_Authorization` token. This pattern is no longer recommended, and should be removed from the documentation.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).