### PR TITLE
[Workers] Document missing ReadableStream APIs

### DIFF
--- a/src/content/docs/workers/runtime-apis/streams/readablestream.mdx
+++ b/src/content/docs/workers/runtime-apis/streams/readablestream.mdx
@@ -28,12 +28,34 @@ A `ReadableStream` is returned by the `readable` property inside [`TransformStre
 
   * Pipes the readable stream to a given writable stream `destination` and returns a promise that is fulfilled when the `write` operation succeeds or rejects it if the operation fails.
 
+* <code>pipeThrough(transformStream, optionsPipeToOptions)</code> : ReadableStream
+
+  * Pipes the readable stream to the writable side of a given [`TransformStream`](/workers/runtime-apis/streams/transformstream/) and returns the transform's readable side, so that calls can be chained. `options` accepts the same values as `pipeTo()`.
+
 * <code>getReader(optionsObject)</code> : ReadableStreamDefaultReader
 
   * Gets an instance of `ReadableStreamDefaultReader` and locks the `ReadableStream` to that reader instance. This method accepts an object argument indicating options. The only supported option is `mode`, which can be set to `byob` to create a [`ReadableStreamBYOBReader`](/workers/runtime-apis/streams/readablestreambyobreader/), as shown here:
 
 ```js
 let reader = readable.getReader({ mode: 'byob' });
+```
+
+* <code>cancel(reasonstringoptional)</code> : Promise\<void>
+
+  * Cancels the stream. `reason` is an optional human-readable string indicating the reason for cancellation. `reason` will be passed to the underlying source’s cancel algorithm. Any data not yet read is lost.
+
+* `tee()` : \[ReadableStream, ReadableStream]
+
+  * Locks the stream and returns an array of two new `ReadableStream` instances, each of which reads the same data as the original stream. Chunks are shared between the two branches, not copied, and backpressure to the underlying source follows the branch with the most unread data. This avoids unbounded buffering when one branch reads more slowly than the other, as long as the underlying source responds to backpressure. Refer to [workerd's streams documentation](https://github.com/cloudflare/workerd/blob/main/src/workerd/api/streams/README.md#tee-behavior) for implementation details.
+
+* <code>values(optionsObject)</code> : AsyncIterableIterator
+
+  * Returns an async iterator that reads and consumes the chunks of the stream. This method accepts an object argument indicating options. The only supported option is `preventCancel`, which, when `true`, prevents the stream from being canceled when the iterator exits early (for example, from a `break` statement). A `ReadableStream` is also async iterable directly:
+
+```js
+for await (const chunk of readable) {
+  console.log(chunk);
+}
 ```
 
 
@@ -49,6 +71,21 @@ let reader = readable.getReader({ mode: 'byob' });
 * `preventAbort` bool
 
   * When `true`, errors in the source `ReadableStream` will no longer abort the destination `WritableStream`. `pipeTo` will return a rejected promise with the error from the source or any error that occurred while aborting the destination.
+
+## Static methods
+
+* <code>ReadableStream.from(asyncIterable)</code> : ReadableStream
+
+  * Creates a new `ReadableStream` whose chunks are the values yielded by `asyncIterable`, which may be any iterable or async iterable, including an async generator.
+
+```js
+const stream = ReadableStream.from(
+  (async function* () {
+    yield 'hello ';
+    yield 'world';
+  })()
+);
+```
 
 ***
 

--- a/src/content/docs/workers/runtime-apis/streams/readablestream.mdx
+++ b/src/content/docs/workers/runtime-apis/streams/readablestream.mdx
@@ -7,6 +7,8 @@ products:
   - workers
 ---
 
+import { TypeScriptExample } from "~/components";
+
 ## Background
 
 A `ReadableStream` is returned by the `readable` property inside [`TransformStream`](/workers/runtime-apis/streams/transformstream/).
@@ -46,17 +48,21 @@ let reader = readable.getReader({ mode: 'byob' });
 
 * `tee()` : \[ReadableStream, ReadableStream]
 
-  * Locks the stream and returns an array of two new `ReadableStream` instances, each of which reads the same data as the original stream. Chunks are shared between the two branches, not copied, and backpressure to the underlying source follows the branch with the most unread data. This avoids unbounded buffering when one branch reads more slowly than the other, as long as the underlying source responds to backpressure. Refer to [workerd's streams documentation](https://github.com/cloudflare/workerd/blob/main/src/workerd/api/streams/README.md#tee-behavior) for implementation details.
+  * Locks the stream and returns an array of two new `ReadableStream` instances, each of which reads the same data as the original stream. Backpressure to the underlying source follows the branch with the most unread data, which avoids unbounded buffering when one branch reads more slowly than the other, as long as the underlying source responds to backpressure. Refer to [workerd's streams documentation](https://github.com/cloudflare/workerd/blob/main/src/workerd/api/streams/README.md#tee-behavior) for implementation details.
 
 * <code>values(optionsObject)</code> : AsyncIterableIterator
 
   * Returns an async iterator that reads and consumes the chunks of the stream. This method accepts an object argument indicating options. The only supported option is `preventCancel`, which, when `true`, prevents the stream from being canceled when the iterator exits early (for example, from a `break` statement). A `ReadableStream` is also async iterable directly:
 
-```js
+<TypeScriptExample>
+
+```ts
 for await (const chunk of readable) {
   console.log(chunk);
 }
 ```
+
+</TypeScriptExample>
 
 
 
@@ -78,7 +84,9 @@ for await (const chunk of readable) {
 
   * Creates a new `ReadableStream` whose chunks are the values yielded by `asyncIterable`, which may be any iterable or async iterable, including an async generator.
 
-```js
+<TypeScriptExample>
+
+```ts
 const stream = ReadableStream.from(
   (async function* () {
     yield 'hello ';
@@ -86,6 +94,8 @@ const stream = ReadableStream.from(
   })()
 );
 ```
+
+</TypeScriptExample>
 
 ***
 


### PR DESCRIPTION
### Summary

Documents the `ReadableStream` APIs the runtime ships but this page omits. Prompted by sveltejs/kit#16622, where the gap led a maintainer to assume `ReadableStream.from` does not exist on Workers.

The `tee()` entry sticks to user-facing behavior, per the review feedback on #10026.

Fixes #9285

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [x] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
