### PR TITLE
[Cloudflare One] Document Safari and iOS proxy endpoint incompatibility

### DIFF
--- a/src/content/docs/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/configure-pac-file-on-device.mdx
+++ b/src/content/docs/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/configure-pac-file-on-device.mdx
@@ -14,7 +14,7 @@ import { Details, Tabs, TabItem } from "~/components";
 
 After you [create a proxy endpoint](/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/) and [create a PAC file](/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/#2-create-a-pac-file), configure your devices to use the PAC file URL. You can configure system-level proxy settings (which apply to most browsers) or configure individual browsers separately.
 
-Chromium-based browsers (Google Chrome, Microsoft Edge, Brave) and Safari use the operating system proxy settings. Firefox uses its own proxy settings by default and must be configured separately.
+Chromium-based browsers (Google Chrome, Microsoft Edge, Brave) use the operating system proxy settings. Firefox uses its own proxy settings by default and must be configured separately. Safari and iOS/iPadOS do not support the HTTPS proxy type required by proxy endpoints.
 
 ## Prerequisites
 
@@ -26,7 +26,7 @@ Before you configure a PAC file on your device, make sure you have:
 
 ## Configure system proxy settings
 
-Configure your operating system to use the PAC file. This applies the proxy to all browsers that use system proxy settings (Chrome, Edge, Brave, Safari).
+Configure your operating system to use the PAC file. This applies the proxy to all browsers that use system proxy settings (Chrome, Edge, Brave).
 
 <Tabs>
 
@@ -57,7 +57,11 @@ For more information, refer to [Change proxy settings on Mac](https://support.ap
 5. Turn on **Automatic proxy configuration**.
 6. In the **URL** field, enter your PAC file URL.
 
-The setting saves automatically. Chromium-based browsers and Safari will now route traffic through your proxy endpoint.
+The setting saves automatically. Chromium-based browsers will now route traffic through your proxy endpoint.
+
+:::note
+Safari does not support the HTTPS proxy type required by Cloudflare proxy endpoints. Use a Chromium-based browser (Chrome, Edge, Brave) or [Firefox](/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/configure-pac-file-on-device/#configure-firefox-separately) on macOS instead.
+:::
 
 </TabItem>
 
@@ -92,16 +96,8 @@ Most Linux command-line tools (such as `curl` and `wget`) do not natively suppor
 
 <TabItem label="iOS / iPadOS">
 
-iOS does not have a global proxy setting. You must configure the proxy for each Wi-Fi network. Cellular connections do not support PAC files without MDM.
-
-1. Open **Settings** > **Wi-Fi**.
-2. Tap the info button next to your connected network.
-3. Scroll to **HTTP Proxy** and tap **Configure Proxy**.
-4. Select **Automatic**.
-5. In the **URL** field, enter your PAC file URL.
-
-:::note
-No official Apple Support page exists for iOS proxy configuration. For enterprise deployment, refer to [Network Proxy Configuration settings](https://support.apple.com/guide/deployment/network-proxy-configuration-settings-depb27492e34/web) in the Apple Platform Deployment guide.
+:::caution
+iOS and iPadOS do not support the HTTPS proxy type required by Cloudflare proxy endpoints. This is a platform-level limitation confirmed by Apple. Proxy endpoints cannot be used on iOS or iPadOS devices.
 :::
 
 </TabItem>

--- a/src/content/docs/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/configure-pac-file-on-device.mdx
+++ b/src/content/docs/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/configure-pac-file-on-device.mdx
@@ -97,7 +97,7 @@ Most Linux command-line tools (such as `curl` and `wget`) do not natively suppor
 <TabItem label="iOS / iPadOS">
 
 :::caution
-iOS and iPadOS do not support the HTTPS proxy type required by Cloudflare proxy endpoints. This is a platform-level limitation confirmed by Apple. Proxy endpoints cannot be used on iOS or iPadOS devices.
+iOS and iPadOS do not support the HTTPS proxy settings which are used by Gateway proxy endpoints. iOS and iPadOS are not supported at this time. Cloudflare recommends installing the [Cloudflare One Client](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/) where possible.
 :::
 
 </TabItem>

--- a/src/content/docs/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/index.mdx
+++ b/src/content/docs/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/index.mdx
@@ -336,7 +336,9 @@ Firefox uses its own proxy settings and does not inherit the operating system pr
 
 <Details header="Safari">
 
-Safari relies on your operating system's proxy server settings. Configure the PAC file URL in your [macOS proxy settings](/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/configure-pac-file-on-device/#configure-system-proxy-settings).
+:::caution
+Safari does not support the HTTPS proxy type required by Cloudflare proxy endpoints. Apple has confirmed that Safari (on both macOS and iOS/iPadOS) does not support HTTPS proxies. Use a [Chromium-based browser](#chromium-based-browsers) or [Firefox](#mozilla-firefox) instead.
+:::
 
 </Details>
 
@@ -522,6 +524,10 @@ To filter this traffic, you have two options:
 
 - Set up an [HTTP policy](/cloudflare-one/traffic-policies/http-policies/) to block or allow all traffic matching the `auth-proxy-non-identity@<your-team-name>.cloudflareaccess.com` email address.
 - To restrict non-identity traffic to specific source IPs, create a [network policy](/cloudflare-one/traffic-policies/network-policies/) that matches both the source IP and the proxy endpoint.
+
+### Safari and iOS not supported
+
+Safari (on macOS) and all browsers on iOS/iPadOS do not support the HTTPS proxy type that Cloudflare proxy endpoints require. This is a platform-level limitation confirmed by Apple. On macOS, use a Chromium-based browser or Firefox instead. On iOS/iPadOS, proxy endpoints cannot be used.
 
 ### Traffic limitations
 


### PR DESCRIPTION
## Summary

Safari and iOS/iPadOS do not support the HTTPS proxy type required by Cloudflare proxy endpoints. This is a platform-level limitation confirmed by Apple (via CUSTESC-49854). This PR updates the proxy endpoint documentation to reflect that.

## Changes

**`proxy-endpoints/index.mdx`**
- Updated the Safari details section under "Configure your devices" with a caution admonition instead of configuration instructions.
- Added a "Safari and iOS not supported" subsection under Limitations.

**`proxy-endpoints/configure-pac-file-on-device.mdx`**
- Removed Safari from browser lists that use OS proxy settings.
- Added a note to the macOS tab that Safari is not supported, directing users to Chromium or Firefox.
- Replaced the iOS/iPadOS configuration steps with a caution admonition stating the platform does not support HTTPS proxies.

Closes https://jira.cfdata.org/browse/PCX-21885