### PR TITLE
[Logpush] Document destination error codes, upload timeouts, and retry behavior

### DIFF
--- a/src/content/docs/logs/logpush/logpush-health.mdx
+++ b/src/content/docs/logs/logpush/logpush-health.mdx
@@ -54,7 +54,7 @@ Indicates that a batch of logs was uploaded to your destination without errors o
 
 #### Retry attempts
 
-Additional upload attempts made after an initial failure. The count includes the first failed attempt. Retries continue until the batch is successfully delivered or the retry limit is reached.
+Additional upload attempts made after an initial failure. The count includes the first failed attempt. Retries continue until the batch is successfully delivered or the buffered data ages out of the retention window.
 
 #### Failed
 
@@ -129,14 +129,63 @@ The Logpush Health Dashboards help you monitor the status, reliability, and perf
 | **Avg. Upload Duration** | Long upload times | Uploads are taking longer than expected, indicating latency or oversized batches. | - Large batches or uncompressed payloads. <br/> - Network or regional latency. <br/> - Destination processing delays. | - Review **Avg. Upload Duration** trends. <br/> - Reduce batch size for faster uploads. <br/> - Verify destination throughput and rate limit settings. |
 | **Destination Availability** | Low or unstable availability | Cloudflare cannot consistently connect to your destination. | - Destination downtime, DNS errors, or authentication issues. <br/> - Firewall or network restrictions blocking Cloudflare. | - Check **Destination Availability** for dips. <br/> - Confirm destination credentials and endpoint uptime. <br/> - Review allowlists or network access settings. |
 
-## Understanding retry behavior
+## Destination error codes
 
-Logpush is designed to handle temporary destination issues through automatic retries. When your destination is temporarily unavailable, Logpush will retry approximately five times over five minutes. However, if Cloudflare persistently receives errors from your destination and cannot keep up with incoming batches, Logpush will eventually drop logs.
+When Cloudflare cannot receive an HTTP status code from your destination — for example, the connection never completes or the request is aborted — the delivery attempt is recorded with a Cloudflare-generated error code instead of an HTTP status. These codes appear in the [Health Dashboard](#upload-reliability) and in the `logpushHealthAdaptiveGroups` GraphQL dataset.
 
-If errors continue for a prolonged period, Logpush assumes the destination is permanently unavailable and disables your push job. You can re-enable the job once the destination issue is resolved.
+| Code | Name | Meaning |
+| ---- | ---- | ------- |
+| `1101` | `ConnectionError` | A non-timeout network error occurred while Cloudflare was connecting to your destination (for example, a TCP reset or a refused connection). |
+| `1102` | `ConnectionTimeout` | Cloudflare could not open a TCP connection to your destination within the [connection timeout](#upload-timeouts). Typically caused by firewalls, network paths, or unreachable hosts. |
+| `1103` | `InternalLogpushError` | Cloudflare encountered an internal error while processing the upload. If you see this code repeatedly, [contact Cloudflare Support](/support/contacting-cloudflare-support/). |
+| `1104` | `ConfigError` | The job configuration is invalid or references credentials that can no longer be used (for example, a revoked destination token). Re-validate the job with the [validate endpoint](/logs/logpush/logpush-job/api-configuration/#validate-logpush-jobs). |
+| `1105` | `DNSError` | Cloudflare could not resolve the hostname of your destination. Verify DNS records for the destination endpoint. |
+| `1106` | `Timeout` | The request stalled or exceeded the [overall HTTP client timeout](#upload-timeouts). Common when a destination accepts the connection but stops reading the body, or when a TLS handshake takes too long. |
+| `1107` | `RequestError` | The HTTP request failed before a status code was returned, and the failure is not classified as a timeout. Often caused by an HTTP/2 connection being closed by the destination mid-request. |
+| `1108` | `TransferError` | Cloudflare encountered an error while transferring the request body — typically the connection was reset during the upload. |
+| `1201` | `FlushMaxLag` | Cloudflare dropped a batch because the buffered data aged out of the retention window before it could be delivered. This code indicates persistent delivery failure — investigate the destination and the earlier codes in the same time range. |
 
 :::note
-These retry counts and timeframes are approximations. Actual behavior may vary based on the nature of the error and destination response times.
+Codes in the `1100` range describe Cloudflare-side connection or request failures. When your destination returns an HTTP status code (for example, `403`, `429`, or `5xx`), that status appears instead in the **Uploaded Logs by Status Code** chart.
 :::
 
-To monitor retry behavior and destination availability, use the [Health Dashboard](#upload-reliability) metrics, particularly the **Retry Attempts** and **Destination Availability** charts.
+## Upload timeouts
+
+Cloudflare applies several timeouts at different layers of the upload path. Understanding each layer helps you interpret [destination error codes](#destination-error-codes) and tune your destination endpoint.
+
+| Timeout | Default | Applies to | Related error code |
+| ------- | ------- | ---------- | ------------------ |
+| TCP connection (dial) | 5 seconds | All destinations that use HTTP | `1102 ConnectionTimeout` |
+| TLS handshake | 5 seconds | All HTTPS destinations | `1106 Timeout` |
+| No-progress watchdog | 10 seconds | Most destinations (HTTP endpoints, Cloudflare R2, Amazon S3, Google Cloud Storage, Microsoft Azure) | `1106 Timeout` |
+| Idle connection reuse | 10 seconds | Persistent HTTP connections | Not surfaced as an error; the connection is closed and reopened as needed |
+| Overall HTTP client timeout | 2 minutes | HTTP endpoint family only: `https://`, Datadog, New Relic, CrowdStrike, Cloudflare Pipelines | `1106 Timeout` |
+| HTTP/2 idle read plus ping | 10 seconds idle, 15 seconds ping timeout | HTTP/2 connections | `1107 RequestError` |
+| HTTP/2 write stall | 10 seconds | HTTP/2 connections | `1106 Timeout` or `1107 RequestError` |
+
+### Guidance for HTTP endpoint operators
+
+- Ensure your endpoint acknowledges each `POST` within 2 minutes end-to-end, and keeps the request body flowing with no gap longer than 10 seconds between chunks.
+- If you terminate connections at a load balancer or WAF, verify that idle-connection and read timeouts are not shorter than the values above. Aggressive tuning at the receiver frequently manifests as `1106` or `1107` errors on the Cloudflare side.
+- If you rely on HTTP/2, make sure your server responds to `PING` frames within 15 seconds.
+
+### Object storage and SDK-based destinations
+
+Amazon S3, Cloudflare R2, Google Cloud Storage, Microsoft Azure, and Splunk destinations do not use the 2-minute overall HTTP client timeout. They use timeouts provided by their respective vendor SDKs. The 10-second no-progress watchdog still applies. Individual object-store uploads may therefore run longer than 2 minutes before failing.
+
+## Understanding retry behavior
+
+Logpush is designed to handle temporary destination issues through automatic retries. When your destination is temporarily unavailable, Cloudflare buffers the affected batches and retries them.
+
+Retries do not stop after a fixed number of attempts. Instead, Cloudflare continues to retry a batch until one of the following happens:
+
+- The upload succeeds and the batch is marked as delivered.
+- The buffered data ages out of the internal retention window, at which point the batch is dropped (recorded as [`1201 FlushMaxLag`](#destination-error-codes)) and its log lines are permanently lost.
+
+If no batch has been successfully delivered for **24 hours**, Cloudflare assumes the destination is permanently unavailable and disables the job. You can re-enable the job from the [Cloudflare dashboard](https://dash.cloudflare.com/) once the destination issue is resolved. Cloudflare cannot backfill logs generated while the job was disabled.
+
+When a destination is slow but still accepting uploads, Logpush automatically increases the number of parallel uploads to catch up. Once the destination recovers and lag returns to normal, concurrency scales back down.
+
+:::note
+Retry cadence and concurrency are automatic and cannot be configured. To monitor them, use the **Retry Attempts** and **Destination Availability** charts on the [Health Dashboard](#upload-reliability).
+:::

--- a/src/content/docs/logs/logpush/logpush-health.mdx
+++ b/src/content/docs/logs/logpush/logpush-health.mdx
@@ -138,7 +138,7 @@ When Cloudflare cannot receive an HTTP status code from your destination — for
 | `1101` | `ConnectionError` | A non-timeout network error occurred while Cloudflare was connecting to your destination (for example, a TCP reset or a refused connection). |
 | `1102` | `ConnectionTimeout` | Cloudflare could not open a TCP connection to your destination within the [connection timeout](#upload-timeouts). Typically caused by firewalls, network paths, or unreachable hosts. |
 | `1103` | `InternalLogpushError` | Cloudflare encountered an internal error while processing the upload. If you see this code repeatedly, [contact Cloudflare Support](/support/contacting-cloudflare-support/). |
-| `1104` | `ConfigError` | The job configuration is invalid or references credentials that can no longer be used (for example, a revoked destination token). Re-validate the job with the [validate endpoint](/logs/logpush/logpush-job/api-configuration/#validate-logpush-jobs). |
+| `1104` | `ConfigError` | The job configuration is invalid. Verify the destination URL, credentials, and access permissions, and use the [validate endpoints](/logs/logpush/logpush-job/api-configuration/#endpoints) to test the configuration. |
 | `1105` | `DNSError` | Cloudflare could not resolve the hostname of your destination. Verify DNS records for the destination endpoint. |
 | `1106` | `Timeout` | The request stalled or exceeded the [overall HTTP client timeout](#upload-timeouts). Common when a destination accepts the connection but stops reading the body, or when a TLS handshake takes too long. |
 | `1107` | `RequestError` | The HTTP request failed before a status code was returned, and the failure is not classified as a timeout. Often caused by an HTTP/2 connection being closed by the destination mid-request. |
@@ -157,7 +157,7 @@ Cloudflare applies several timeouts at different layers of the upload path. Unde
 | ------- | ------- | ---------- | ------------------ |
 | TCP connection (dial) | 5 seconds | All destinations that use HTTP | `1102 ConnectionTimeout` |
 | TLS handshake | 5 seconds | All HTTPS destinations | `1106 Timeout` |
-| No-progress watchdog | 10 seconds | Most destinations (HTTP endpoints, Cloudflare R2, Amazon S3, Google Cloud Storage, Microsoft Azure) | `1106 Timeout` |
+| No-progress watchdog | 10 seconds | Destinations that use the shared Cloudflare HTTP transport (HTTP endpoints, Cloudflare R2, Splunk, Datadog, New Relic, CrowdStrike, Cloudflare Pipelines) | `1106 Timeout` |
 | Idle connection reuse | 10 seconds | Persistent HTTP connections | Not surfaced as an error. The connection is closed and reopened as needed. |
 | Overall HTTP client timeout | 2 minutes | HTTP endpoint family only: `https://`, Datadog, New Relic, CrowdStrike, Cloudflare Pipelines | `1106 Timeout` |
 | HTTP/2 idle read plus ping | 10 seconds idle, 15 seconds ping timeout | HTTP/2 connections | `1107 RequestError` |
@@ -169,9 +169,9 @@ Cloudflare applies several timeouts at different layers of the upload path. Unde
 - If you terminate connections at a load balancer or WAF, verify that idle-connection and read timeouts are not shorter than the values in the timeout table. Aggressive tuning at the receiver frequently manifests as `1106` or `1107` errors on the Cloudflare side.
 - If you rely on HTTP/2, make sure your server responds to `PING` frames within 15 seconds.
 
-### Object storage and SDK-based destinations
+### Object storage destinations
 
-Amazon S3, Cloudflare R2, Google Cloud Storage, Microsoft Azure, and Splunk destinations do not use the 2-minute overall HTTP client timeout. They use timeouts provided by their respective vendor SDKs. The 10-second no-progress watchdog still applies. Individual object-store uploads may therefore run longer than 2 minutes before failing.
+Amazon S3, Google Cloud Storage, and Microsoft Azure destinations do not use the shared Cloudflare HTTP transport. They use client libraries that configure their own timeouts, so none of the values in the timeout table apply. Individual uploads may therefore run longer than 2 minutes before failing.
 
 ## Retry behavior
 

--- a/src/content/docs/logs/logpush/logpush-health.mdx
+++ b/src/content/docs/logs/logpush/logpush-health.mdx
@@ -158,7 +158,7 @@ Cloudflare applies several timeouts at different layers of the upload path. Unde
 | TCP connection (dial) | 5 seconds | All destinations that use HTTP | `1102 ConnectionTimeout` |
 | TLS handshake | 5 seconds | All HTTPS destinations | `1106 Timeout` |
 | No-progress watchdog | 10 seconds | Most destinations (HTTP endpoints, Cloudflare R2, Amazon S3, Google Cloud Storage, Microsoft Azure) | `1106 Timeout` |
-| Idle connection reuse | 10 seconds | Persistent HTTP connections | Not surfaced as an error; the connection is closed and reopened as needed |
+| Idle connection reuse | 10 seconds | Persistent HTTP connections | Not surfaced as an error. The connection is closed and reopened as needed. |
 | Overall HTTP client timeout | 2 minutes | HTTP endpoint family only: `https://`, Datadog, New Relic, CrowdStrike, Cloudflare Pipelines | `1106 Timeout` |
 | HTTP/2 idle read plus ping | 10 seconds idle, 15 seconds ping timeout | HTTP/2 connections | `1107 RequestError` |
 | HTTP/2 write stall | 10 seconds | HTTP/2 connections | `1106 Timeout` or `1107 RequestError` |
@@ -166,21 +166,18 @@ Cloudflare applies several timeouts at different layers of the upload path. Unde
 ### Guidance for HTTP endpoint operators
 
 - Ensure your endpoint acknowledges each `POST` within 2 minutes end-to-end, and keeps the request body flowing with no gap longer than 10 seconds between chunks.
-- If you terminate connections at a load balancer or WAF, verify that idle-connection and read timeouts are not shorter than the values above. Aggressive tuning at the receiver frequently manifests as `1106` or `1107` errors on the Cloudflare side.
+- If you terminate connections at a load balancer or WAF, verify that idle-connection and read timeouts are not shorter than the values in the timeout table. Aggressive tuning at the receiver frequently manifests as `1106` or `1107` errors on the Cloudflare side.
 - If you rely on HTTP/2, make sure your server responds to `PING` frames within 15 seconds.
 
 ### Object storage and SDK-based destinations
 
 Amazon S3, Cloudflare R2, Google Cloud Storage, Microsoft Azure, and Splunk destinations do not use the 2-minute overall HTTP client timeout. They use timeouts provided by their respective vendor SDKs. The 10-second no-progress watchdog still applies. Individual object-store uploads may therefore run longer than 2 minutes before failing.
 
-## Understanding retry behavior
+## Retry behavior
 
 Logpush is designed to handle temporary destination issues through automatic retries. When your destination is temporarily unavailable, Cloudflare buffers the affected batches and retries them.
 
-Retries do not stop after a fixed number of attempts. Instead, Cloudflare continues to retry a batch until one of the following happens:
-
-- The upload succeeds and the batch is marked as delivered.
-- The buffered data ages out of the internal retention window, at which point the batch is dropped (recorded as [`1201 FlushMaxLag`](#destination-error-codes)) and its log lines are permanently lost.
+Retries do not stop after a fixed number of attempts. Instead, Cloudflare continues to retry a batch until either the upload succeeds and the batch is marked as delivered, or the buffered data ages out of the internal retention window. When data ages out, the batch is dropped (recorded as [`1201 FlushMaxLag`](#destination-error-codes)) and the log lines it contained are permanently lost.
 
 If no batch has been successfully delivered for **24 hours**, Cloudflare assumes the destination is permanently unavailable and disables the job. You can re-enable the job from the [Cloudflare dashboard](https://dash.cloudflare.com/) once the destination issue is resolved. Cloudflare cannot backfill logs generated while the job was disabled.
 

--- a/src/content/docs/logs/logpush/logpush-job/api-configuration.mdx
+++ b/src/content/docs/logs/logpush/logpush-job/api-configuration.mdx
@@ -290,6 +290,10 @@ These parameters control the size of each upload batch — not how quickly data 
 These settings influence upload size, not delivery latency. Logpush processes data approximately once per minute, regardless of these parameter values. Adjusting these settings results in smaller or larger uploads per batch, which can help you avoid overloading destinations that have memory or request-size constraints.
 :::
 
+:::note
+When a Logpush job is catching up after a period of buffering (for example, after a destination outage), Cloudflare limits each upload to at most 2 minutes of log data. Very large `max_upload_bytes` or `max_upload_records` values will not produce a single oversized batch during catch-up.
+:::
+
 ### When to adjust these parameters
 
 - Reduce `max_upload_records` if your destination struggles with large payloads or runs out of memory processing big batches.


### PR DESCRIPTION
## What

Documents Cloudflare Logpush destination error codes (`1101`–`1108`, `1201`), the upload timeout matrix, and corrected retry behavior on the Logpush Health Dashboards page. Adds a note on the catch-up upload cap to the API configuration page.

## Why

Today, the synthetic error codes surfaced in the Health Dashboard and GraphQL have no public reference. The existing "Understanding retry behavior" section describes a fixed five-retry ceiling and a vague "prolonged period" auto-disable threshold; both are inaccurate. This change:

- Adds a reference table for error codes `1101`–`1108` and `1201` with remediation hints.
- Adds an upload timeout matrix (TCP dial, TLS handshake, no-progress watchdog, overall HTTP client, HTTP/2 read/write) plus operator guidance.
- Corrects the retry-behavior wording — retries are bounded by the retention window, not a fixed count — and documents the 24-hour auto-disable threshold.
- Notes that object-store and SDK-based destinations (Amazon S3, Cloudflare R2, Google Cloud Storage, Microsoft Azure, Splunk) use vendor SDK timeouts.
- Notes the ~2-minute cap on log data per upload while a job catches up.

DEE-3750
