### PR TITLE
[Fundamentals] Add changelog for dashboard Free account creation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -275,6 +275,10 @@ Shared reference files in `.agents/references/`:
 | `components.md`  | Full MDX component catalog with props and usage examples    |
 | `procedures.md`  | Rules for writing step-by-step procedural instructions      |
 
+## Terminology and naming preferences
+
+- **Do not use "PayGo" in public-facing documentation.** Leadership prefers the term **"Free"** when referring to standalone Free accounts that can be created from the dashboard.
+
 ## Commit conventions
 
 - Format: `[Product] description` or `type: description`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -277,7 +277,7 @@ Shared reference files in `.agents/references/`:
 
 ## Terminology and naming preferences
 
-- **Do not use "PayGo" in public-facing documentation.** Leadership prefers the term **"Free"** when referring to standalone Free accounts that can be created from the dashboard.
+- **Do not use "PayGo" in public-facing documentation.** Instead use the term **"Free"** when referring to standalone Free accounts that can be created from the dashboard.
 
 ## Commit conventions
 

--- a/src/content/changelog/fundamentals/2026-08-04-free-dashboard-button.mdx
+++ b/src/content/changelog/fundamentals/2026-08-04-free-dashboard-button.mdx
@@ -16,7 +16,9 @@ When creating a Free account:
 
 To create a Free account, go to the [**Cloudflare dashboard**](https://dash.cloudflare.com/) and select **Create Account** from either the account switcher in the top left (where your account name appears) or from the **Account** page.
 
-Super Administrator controls are coming in a future update to manage account creation privileges.
+## Limitations
+* This feature can only be used to create a Cloudflare Free account. To create an Enterprise Account under you existing contract, please contact Cloudflare Support. 
+* All users can create a Cloudflare Free account, however, Enterprises wish to restrict this action to only Super Administrators. We will deliver this improvement in a future release. 
 
 ## Next steps
 

--- a/src/content/changelog/fundamentals/2026-08-04-free-dashboard-button.mdx
+++ b/src/content/changelog/fundamentals/2026-08-04-free-dashboard-button.mdx
@@ -14,7 +14,7 @@ When creating a Free account:
 - Your user account must have at least **7 days of tenure** to be eligible.
 - The account is created immediately and ready to use.
 
-To create a Free account, go to the [**Cloudflare dashboard**](https://dash.cloudflare.com/) and select **Create Account** from either the account switcher in the top left (where your account name appears) or from the **Account** page.
+To create a Free account, go to the [**Cloudflare dashboard**](https://dash.cloudflare.com/) and select **Create Account** from either the account switcher in the top left (where your account name appears) or from the **Accounts** page.
 
 ## Limitations
 * This feature can only be used to create a Cloudflare Free account. To create an Enterprise Account under you existing contract, please contact Cloudflare Support. 

--- a/src/content/changelog/fundamentals/2026-08-04-free-dashboard-button.mdx
+++ b/src/content/changelog/fundamentals/2026-08-04-free-dashboard-button.mdx
@@ -17,7 +17,7 @@ When creating a Free account:
 To create a Free account, go to the [**Cloudflare dashboard**](https://dash.cloudflare.com/) and select **Create Account** from either the account switcher in the top left (where your account name appears) or from the **Accounts** page.
 
 ## Limitations
-* This feature can only be used to create a Cloudflare Free account. To create an Enterprise Account under you existing contract, please contact Cloudflare Support. 
+* This feature can only be used to create a Cloudflare Free account. To create an Enterprise Account under your existing contract, please contact Cloudflare Support. 
 * All users can create a Cloudflare Free account, however, Enterprises wish to restrict this action to only Super Administrators. We will deliver this improvement in a future release. 
 
 ## Next steps

--- a/src/content/changelog/fundamentals/2026-08-04-free-dashboard-button.mdx
+++ b/src/content/changelog/fundamentals/2026-08-04-free-dashboard-button.mdx
@@ -1,0 +1,26 @@
+---
+title: Create Free accounts from the dashboard
+description: All users can now create standalone Free accounts directly from the Cloudflare dashboard.
+products:
+  - fundamentals
+date: 2026-08-04T12:00:00
+---
+
+You can now create standalone Free accounts directly from the Cloudflare dashboard using the new **Create Account** button. This feature is currently available to all users, with Super Administrator controls coming in a future update to manage account creation privileges.
+
+When creating a Free account:
+
+- You can create up to **5 Free accounts**.
+- Your user account must have at least **7 days of tenure** to be eligible.
+- The account is created immediately and ready to use.
+
+To create a Free account, go to the [**Cloudflare dashboard**](https://dash.cloudflare.com/) and select **Create Account** from either the account switcher in the top left (where your account name appears) or from the **Account** page.
+
+## Next steps
+
+After creating your Free account, you can:
+
+- [Add a payment method](/billing/get-started/create-billing-profile/) to enable additional Cloudflare products and services.
+- [Update billing information](/billing/get-started/update-billing-info/) to manage payment methods, billing address, or tax IDs.
+- [Review how Cloudflare billing works](/billing/understand/how-billing-works/) to understand the billing lifecycle and charge types.
+- [Assign accounts to an Enterprise Organization](/fundamentals/organizations/for-enterprise/) to centrally manage multiple accounts from a single dashboard.

--- a/src/content/changelog/fundamentals/2026-08-04-free-dashboard-button.mdx
+++ b/src/content/changelog/fundamentals/2026-08-04-free-dashboard-button.mdx
@@ -3,10 +3,10 @@ title: Create Free accounts from the dashboard
 description: All users can now create standalone Free accounts directly from the Cloudflare dashboard.
 products:
   - fundamentals
-date: 2026-08-04T12:00:00
+date: 2026-08-04
 ---
 
-You can now create standalone Free accounts directly from the Cloudflare dashboard using the new **Create Account** button. This feature is currently available to all users, with Super Administrator controls coming in a future update to manage account creation privileges.
+You can now create standalone Free accounts directly from the Cloudflare dashboard using the new **Create Account** button. This feature is currently available to all users.
 
 When creating a Free account:
 
@@ -15,6 +15,8 @@ When creating a Free account:
 - The account is created immediately and ready to use.
 
 To create a Free account, go to the [**Cloudflare dashboard**](https://dash.cloudflare.com/) and select **Create Account** from either the account switcher in the top left (where your account name appears) or from the **Account** page.
+
+Super Administrator controls are coming in a future update to manage account creation privileges.
 
 ## Next steps
 

--- a/src/content/docs/fundamentals/organizations/for-mssp-distributors.mdx
+++ b/src/content/docs/fundamentals/organizations/for-mssp-distributors.mdx
@@ -119,7 +119,7 @@ Move customer accounts from one MSSP Organization to another when ownership chan
 
 ## Manage members
 
-Distributor and MSSP Organization admins can add and manage Organization members directly from the Cloudflare dashboard. No support ticket is required.
+Distributor and MSSP Organization Super Administrators can add and manage Organization members directly from the Cloudflare dashboard. No support ticket is required.
 
 ### Organization Super Administrator
 


### PR DESCRIPTION
This changelog entry documents the new ability for all users to create standalone Free accounts directly from the Cloudflare dashboard.

Key details:
- Available to all users (not just Super Admins)
- Limit of up to 5 Free accounts
- Requires 7-day account tenure
- Accessible via the Create Account button in the account switcher and Account page
- Super Administrator controls coming in a future update