### PR TITLE
[Durable Objects] Fix pricing examples to reflect billable unit rounding

### DIFF
--- a/src/content/docs/durable-objects/platform/pricing.mdx
+++ b/src/content/docs/durable-objects/platform/pricing.mdx
@@ -44,14 +44,15 @@ In this scenario, the estimated monthly cost would be calculated as:
 
 **Requests**:
 
-- (1.5 million requests - included 1 million requests) x $0.15 / 1,000,000 = $0.075
+- 1.5 million requests - included 1 million requests = 500,000 billable requests.
+- (rounded) 1,000,000 requests x $0.15 / 1,000,000 = $0.15.
 
 **Compute Duration**:
 
-- 1,000,000 seconds \* 128 MB / 1 GB = 128,000 GB-s
-- (128,000 GB-s - included 400,000 GB-s) x $12.50 / 1,000,000 = $0.00
+- 1,000,000 seconds \* 128 MB / 1 GB = 128,000 GB-s.
+- 128,000 GB-s is within the 400,000 GB-s included allocation = $0.00.
 
-**Estimated total**: \~$0.075 (requests) + $0.00 (compute duration) + minimum $5/mo usage = $5.08 per month
+**Estimated total**: $0.15 (requests) + $0.00 (compute duration) + minimum $5/mo usage = $5.15 per month
 
 ### Example 2
 
@@ -67,15 +68,17 @@ In this scenario, the estimated monthly cost would be calculated as:
 - 50 WebSocket connections \* 100 Durable Objects to establish the WebSockets = 5,000 connections created each day \* 30 days = 150,000 WebSocket connection requests.
 - 50 messages per minute \* 100 Durable Objects \* 60 minutes \* 8 hours \* 30 days = 72,000,000 WebSocket message requests.
 - 150,000 + (72 million requests / 20 for WebSocket message billing ratio) = 3.75 million billing request.
-- (3.75 million requests - included 1 million requests) x $0.15 / 1,000,000 = $0.41.
+- 3.75 million requests - included 1 million requests = 2,750,000 billable requests.
+- (rounded) 3,000,000 requests x $0.15 / 1,000,000 = $0.45.
 
 **Compute Duration**:
 
 - 100 Durable Objects \* 60 seconds \* 60 minutes \* 8 hours \* 30 days = 86,400,000 seconds.
 - 86,400,000 seconds \* 128 MB / 1 GB = 11,059,200 GB-s.
-- (11,059,200 GB-s - included 400,000 GB-s) x $12.50 / 1,000,000 = $133.24.
+- 11,059,200 GB-s - included 400,000 GB-s = 10,659,200 GB-s
+- (rounded) 11,000,000 GB-s x $12.50 / 1,000,000 = $137.50.
 
-**Estimated total**: $0.41 (requests) + $133.24 (compute duration) + minimum $5/mo usage = $138.65 per month.
+**Estimated total**: $0.45 (requests) + $137.50 (compute duration) + minimum $5/mo usage = $142.95 per month.
 
 ### Example 3
 
@@ -91,15 +94,17 @@ In this scenario, the estimated monthly cost would be calculated as:
 - 100 WebSocket connection requests.
 - 1 message per second \* 100 connections \* 60 seconds \* 60 minutes \* 24 hours \* 30 days = 259,200,000 WebSocket message requests.
 - 100 + (259.2 million requests / 20 for WebSocket billing ratio) = 12,960,100 requests.
-- (12.9 million requests - included 1 million requests) x $0.15 / 1,000,000 = $1.79.
+- 12,960,100 requests - included 1 million requests = 11,960,100 billable requests.
+- (rounded) 12,000,000 requests x $0.15 / 1,000,000 = $1.80.
 
 **Compute Duration**:
 
 - 100 Durable Objects \* 60 seconds \* 60 minutes \* 24 hours \* 30 days = 259,200,000 seconds
 - 259,200,000 seconds \* 128 MB / 1 GB = 33,177,600 GB-s
-- (33,177,600 GB-s - included 400,000 GB-s) x $12.50 / 1,000,000 = $409.72
+- 33,177,600 GB-s - included 400,000 GB-s = 32,777,600 GB-s
+- (rounded) 33,000,000 GB-s x $12.50 / 1,000,000 = $412.50
 
-**Estimated total**: $1.79 (requests) + $409.72 (compute duration) + minimum $5/mo usage = $416.51 per month
+**Estimated total**: $1.80 (requests) + $412.50 (compute duration) + minimum $5/mo usage = $419.30 per month
 
 ### Example 4
 
@@ -115,15 +120,17 @@ In this scenario, the estimated monthly cost would be calculated as:
 - 100 WebSocket connections \* 100 Durable Objects to establish the WebSockets = 10,000 initial WebSocket connection requests.
 - 100 messages per minute<sup>1</sup> \* 100 Durable Objects \* 60 minutes \* 24 hours \* 30 days = 432,000,000 requests.
 - 10,000 + (432 million requests / 20 for WebSocket billing ratio) = 21,610,000 million requests.
-- (21.6 million requests - included 1 million requests) x $0.15 / 1,000,000 = $3.09.
+- 21,610,000 requests - included 1 million requests = 20,610,000 billable requests.
+- (rounded) 21,000,000 requests x $0.15 / 1,000,000 = $3.15.
 
 **Compute Duration**:
 
 - 100 Durable Objects \* 1 second<sup>2</sup> \* 60 minutes \* 24 hours \* 30 days = 4,320,000 seconds
 - 4,320,000 seconds \* 128 MB / 1 GB = 552,960 GB-s
-- (552,960 GB-s - included 400,000 GB-s) x $12.50 / 1,000,000 = $1.91
+- 552,960 GB-s - included 400,000 GB-s = 152,960 GB-s
+- (rounded) 1,000,000 GB-s x $12.50 / 1,000,000 = $12.50
 
-**Estimated total**: $3.09 (requests) + $1.91 (compute duration) + minimum $5/mo usage = $10.00 per month
+**Estimated total**: $3.15 (requests) + $12.50 (compute duration) + minimum $5/mo usage = $20.65 per month
 
 <sup>1</sup> 100 messages per minute comes from the fact that 100 clients
 connect to each DO, and each sends 1 message per minute.

--- a/src/content/partials/durable-objects/durable-objects-pricing.mdx
+++ b/src/content/partials/durable-objects/durable-objects-pricing.mdx
@@ -10,6 +10,8 @@ import { Render, Markdown, GlossaryTooltip, Details, AnchorHeading } from "~/com
 
 Durable Objects are billed for compute duration (wall-clock time) while the Durable Object is actively running or is idle in memory but unable to [hibernate](/durable-objects/concepts/durable-object-lifecycle/). Durable Objects that are idle and eligible for hibernation are not billed for duration, even before the runtime has hibernated them. Requests to a Durable Object keep it active or create the object if it was inactive.
 
+For each metered dimension, billable usage is the amount consumed in excess of the included monthly allocation. This billable usage is rounded up to the next billable unit before the corresponding rate is applied. For example, 500,000 GB-s of billable compute duration is rounded up to 1,000,000 GB-s and billed accordingly.
+
 |                      | Free plan         | Paid plan                                                                                                                               |
 | -------------------- | ----------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
 | Requests             | 100,000 / day     | 1 million / month, + $0.15/million<br/> Includes HTTP requests, RPC sessions<sup>1</sup>, WebSocket messages<sup>2</sup>, and alarm invocations |


### PR DESCRIPTION
### Summary

Corrects the Durable Objects pricing documentation to reflect how billable usage is charged. Previous examples implied pro-rated billing. In reality, billable usage is rounded up to the next whole billable unit before the rate is applied.

### Documentation checklist

- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
