### PR TITLE
[Fundamentals] Document OAuth consent screen shield icons

### DIFF
--- a/src/content/changelog/fundamentals/2026-08-04-oauth-consent-shields.mdx
+++ b/src/content/changelog/fundamentals/2026-08-04-oauth-consent-shields.mdx
@@ -1,9 +1,9 @@
 ---
-title: OAuth consent shields
-description: OAuth consent screens identify application ownership and domain verification status with shield icons.
+title: Improved publisher verification details on OAuth consent screens
+description: OAuth consent screens now show publisher verification details inline, so users can more easily understand who owns an application before granting access.
 products:
   - fundamentals
-date: 2026-08-04
+date: 2026-08-05
 ---
 
 OAuth consent screens now display a shield icon with explanatory text beneath the consent screen title. Each shield icon indicates who owns the application and whether its domain ownership is verified.
@@ -12,6 +12,6 @@ OAuth consent screens now display a shield icon with explanatory text beneath th
 - **Blue outlined shield**: A third-party application with verified ownership of its domain.
 - **Amber filled shield**: A third-party application without verified ownership of a domain.
 
-Domain verification only confirms that the application owner controls the displayed domain. It does not mean that Cloudflare owns or endorses the application.
+Domain verification only confirms that the application owner controls the displayed domain. 
 
 For more information, refer to [Authorizing an application](/fundamentals/oauth/authorizing-an-application/).

--- a/src/content/changelog/fundamentals/2026-08-04-oauth-consent-shields.mdx
+++ b/src/content/changelog/fundamentals/2026-08-04-oauth-consent-shields.mdx
@@ -1,0 +1,17 @@
+---
+title: OAuth consent shields
+description: OAuth consent screens identify application ownership and domain verification status with shield icons.
+products:
+  - fundamentals
+date: 2026-08-04
+---
+
+OAuth consent screens now display a shield icon with explanatory text beneath the consent screen title. Each shield icon indicates who owns the application and whether its domain ownership is verified.
+
+- **Green filled shield**: Cloudflare owns and manages the application.
+- **Blue outlined shield**: A third-party application with verified ownership of its domain.
+- **Amber filled shield**: A third-party application without verified ownership of a domain.
+
+Domain verification only confirms that the application owner controls the displayed domain. It does not mean that Cloudflare owns or endorses the application.
+
+For more information, refer to [Authorizing an application](/fundamentals/oauth/authorizing-an-application/).

--- a/src/content/docs/fundamentals/oauth/authorizing-an-application.mdx
+++ b/src/content/docs/fundamentals/oauth/authorizing-an-application.mdx
@@ -20,9 +20,17 @@ When you authorize a third-party OAuth application, you grant it permission to a
 When a third-party application requests access to your Cloudflare account, you will see a consent screen that displays:
 
 - **Application name and logo**: The name and branding of the requesting application
-- **Publisher domain**: The verified domain of the application publisher
+- **Publisher domain**: The domain and verification status of the application publisher
 - **Account selection**: Choose which Cloudflare account(s) the application can access
 - **Requested permissions**: After selecting the account(s) the application may access, the specific scopes the application is requesting will be displayed before consent is complete. To finish the authorization process, review the permissions the application is requesting and click “**Authorize**”
+
+Each shield icon indicates who owns the application and whether its domain ownership is verified:
+
+- **Green filled shield**: Cloudflare owns and manages the application.
+- **Blue outlined shield**: A third-party application with verified ownership of its domain.
+- **Amber filled shield**: A third-party application without verified ownership of a domain.
+
+Domain verification only confirms that the application owner controls the displayed domain. It does not mean that Cloudflare owns or endorses the application.
 
 ## View and revoke authorized applications
 

--- a/src/content/docs/fundamentals/oauth/authorizing-an-application.mdx
+++ b/src/content/docs/fundamentals/oauth/authorizing-an-application.mdx
@@ -30,7 +30,7 @@ Each shield icon indicates who owns the application and whether its domain owner
 - **Blue outlined shield**: A third-party application with verified ownership of its domain.
 - **Amber filled shield**: A third-party application without verified ownership of a domain.
 
-Domain verification only confirms that the application owner controls the displayed domain. It does not mean that Cloudflare owns or endorses the application.
+Domain verification only confirms that the application owner controls the displayed domain.
 
 ## View and revoke authorized applications
 


### PR DESCRIPTION
### Summary

Adds the documentation for the OAuth consent shield icons and what each variant represents. Also, clarifies that domain verification does not imply Cloudflare ownership or endorsement, and adds a corresponding changelog entry.

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
