### PR TITLE
[Turnstile] Add Vue Turnstile package

### DIFF
--- a/src/content/docs/turnstile/community-resources.mdx
+++ b/src/content/docs/turnstile/community-resources.mdx
@@ -41,6 +41,7 @@ Cloudflare recommends [@marsidev/react-turnstile](https://www.npmjs.com/package/
   - [vue-cloudflare-turnstile](https://www.npmjs.com/package/vue-cloudflare-turnstile)
   - [cfturnstile-vue3](https://www.npmjs.com/package/cfturnstile-vue3)
   - [vue-turnstile](https://www.npmjs.com/package/vue-turnstile)
+  - [@delaneydev/laravel-turnstile-vue](https://www.npmjs.com/package/@delaneydev/laravel-turnstile-vue)
 - [Angular](https://www.npmjs.com/package/ngx-turnstile)
 - Svelte
   - [svelte-turnstile](https://www.npmjs.com/package/svelte-turnstile)


### PR DESCRIPTION
Adds `@delaneydev/laravel-turnstile-vue` to the Turnstile Vue community resources list.

This package is listed under client-side rendering libraries because it provides a Vue 3 client component and deliberately leaves server-side token validation to the application.

Why include it:

- It is a typed Vue 3 Turnstile component that is safe to import and render during SSR.
- It supports visible, deferred, and invisible challenge flows.
- It exposes current Cloudflare render options and lifecycle callbacks through typed props and events.
- It includes an imperative API for rendering, executing, challenging, resetting, removing, reading responses, checking expiry, and reading widget state.
- It includes a race-safe script loader with CSP nonce support and consumer-managed script support.
- It handles token lifecycle concerns such as single-flight `challenge()` calls, stale-token protection, reset/remove cleanup, and automatic cleanup across Vue/Inertia navigation.
- It documents Laravel/Inertia usage, server-side validation, testing with Cloudflare test keys, troubleshooting, migration from v1, and security guidance.

Package: https://www.npmjs.com/package/@delaneydev/laravel-turnstile-vue
Repository: https://github.com/DelaneyDev/laravel-turnstile-vue
Docs: https://github.com/DelaneyDev/laravel-turnstile-vue#readme

Disclosure: I maintain this package. It is independently developed and is not affiliated with, endorsed by, or sponsored by Cloudflare.