### PR TITLE
AI Gateway: clarify /compat is required for Dynamic Routing despite deprecation notice

### DIFF
--- a/src/content/docs/ai-gateway/features/dynamic-routing/index.mdx
+++ b/src/content/docs/ai-gateway/features/dynamic-routing/index.mdx
@@ -60,4 +60,10 @@ Ensure your gateway has [authentication](/ai-gateway/configuration/authenticatio
    - Click **Save** to save the state. You can always roll back to earlier versions from **Versions**.
    - Deploy the version to make it live.
 5. Call the route from your code.
-   - Use the [OpenAI compatible](/ai-gateway/usage/chat-completion/) endpoint, and use the route name in place of the model, for example, `dynamic/support`.
+   - Use the [OpenAI compatible](/ai-gateway/usage/chat-completion/) endpoint (`/compat/chat/completions`), and use the route name in place of the model, for example, `dynamic/support`. See [Using a dynamic route](/ai-gateway/features/dynamic-routing/usage/) for examples.
+
+:::note
+
+The OpenAI-compatible endpoint is marked **Deprecated** for standard single-model chat completions, but it remains the required way to call dynamic routes. Dynamic routing is not currently available on the [REST API](/ai-gateway/usage/rest-api/).
+
+:::

--- a/src/content/docs/ai-gateway/features/dynamic-routing/usage.mdx
+++ b/src/content/docs/ai-gateway/features/dynamic-routing/usage.mdx
@@ -1,7 +1,7 @@
 ---
 pcx_content_type: how-to
 title: Using a dynamic route
-description: Send requests through an AI Gateway dynamic route using the OpenAI SDK or REST API.
+description: Send requests through an AI Gateway dynamic route using the OpenAI SDK, a direct HTTP request, or the Workers AI binding.
 sidebar:
   order: 2
 products:

--- a/src/content/docs/ai-gateway/usage/chat-completion.mdx
+++ b/src/content/docs/ai-gateway/usage/chat-completion.mdx
@@ -18,8 +18,12 @@ import {
 } from "~/components";
 import CodeSnippets from "~/components/ai-gateway/code-examples.astro";
 
-:::caution[Deprecated]
-This endpoint is deprecated. Use the [REST API](/ai-gateway/usage/rest-api/) instead, which provides OpenAI-compatible endpoints at `api.cloudflare.com/client/v4/accounts/{ACCOUNT_ID}/ai/v1/chat/completions`. The `/compat/chat/completions` endpoint will continue to work for existing integrations.
+:::caution[Deprecated for single-model calls]
+For standard single-model chat completions, this endpoint is deprecated. Use the [REST API](/ai-gateway/usage/rest-api/) instead, which provides OpenAI-compatible endpoints at `api.cloudflare.com/client/v4/accounts/{ACCOUNT_ID}/ai/v1/chat/completions`. The `/compat/chat/completions` endpoint will continue to work for existing integrations.
+:::
+
+:::note[Required for dynamic routing]
+[Dynamic routes](/ai-gateway/features/dynamic-routing/) (`dynamic/{route}`) are invoked through this `/compat/chat/completions` endpoint. The REST API does not currently cover dynamic routing, so continue to use this endpoint when calling a dynamic route. See [Using a dynamic route](/ai-gateway/features/dynamic-routing/usage/) for examples.
 :::
 
 Cloudflare's AI Gateway offers an OpenAI-compatible `/chat/completions` endpoint, enabling integration with multiple AI providers using a single URL. This feature simplifies the integration process, allowing for seamless switching between different models without significant code modifications.


### PR DESCRIPTION
### Summary

Documentation fix. The AI Gateway docs currently contradict themselves on how to call a dynamic route, and the contradiction actively sends readers down a path that cannot work.

[Unified API (OpenAI compat)](https://developers.cloudflare.com/ai-gateway/usage/chat-completion/) opens with a blanket `Deprecated` callout telling readers to use the REST API instead. But dynamic routes are invoked *only* through that same `/compat/chat/completions` endpoint — every example on [Using a dynamic route](https://developers.cloudflare.com/ai-gateway/features/dynamic-routing/usage/) hits `/compat`, and `src/content/docs/ai-gateway/usage/rest-api.mdx` contains zero references to dynamic routing. So for anyone using Dynamic Routing, "use the REST API instead" is not just unhelpful, it is wrong, and there is nothing on the REST API page to correct the impression.

This came out of a real customer engagement (Amazon Bedrock on dynamic routes) where the deprecation notice led to time lost building against an endpoint that does not support the feature.

Changes:

1. **`ai-gateway/usage/chat-completion.mdx`** — scope the deprecation to standard single-model chat completions, and add a `note` stating that dynamic routes (`dynamic/{route}`) are invoked through this endpoint and that the REST API does not currently cover dynamic routing. Links to the dynamic routing usage page for examples.
2. **`ai-gateway/features/dynamic-routing/index.mdx`** — name the endpoint explicitly (`/compat/chat/completions`) in step 5 of Getting Started, link to the usage page, and add a `note` pre-empting the deprecation badge the reader is about to hit.
3. **`ai-gateway/features/dynamic-routing/usage.mdx`** — the page description read "using the OpenAI SDK or REST API", but none of its three examples use the REST API (they are OpenAI SDK, direct HTTP, and the Workers AI binding). Corrected, since it repeats the same false claim.

No behaviour or product change, wording only. Happy to adjust the callout titles if maintainers prefer different phrasing — the substance is that `/compat` needs a documented carve-out for dynamic routing.

I left `sidebar.badge: Deprecated` on `chat-completion.mdx` alone, since the nav slot only fits one word and I did not want to make that call unilaterally. Flagging it as the remaining piece of the same confusion, if you want it changed.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
