### PR TITLE
docs: remove TODO comments from BYOK documentation

### DIFF
--- a/src/content/docs/ai-gateway/configuration/bring-your-own-keys.mdx
+++ b/src/content/docs/ai-gateway/configuration/bring-your-own-keys.mdx
@@ -107,8 +107,6 @@ In the AI Gateway dashboard, you can:
 
 To rotate an API key:
 
-{/* TODO UPDATE */}
-
 1. Generate a new API key from your AI provider
 2. In the Cloudflare dashboard, edit the existing key entry
 3. Replace the old key with the new one
@@ -119,8 +117,6 @@ Your applications will immediately start using the new key without any code chan
 ### Revoking access
 
 To remove an API key:
-
-{/* TODO UPDATE */}
 
 1. In the AI Gateway dashboard, find the key you want to remove
 2. Click the **Delete** button


### PR DESCRIPTION
## Summary

Removes leftover TODO comments from the BYOK (Store Keys) documentation page.

## Changes

- Removed TODO comment in the API key rotation section
- Removed TODO comment in the API key revocation section
- No functional documentation changes

## Testing

-  Verified documentation renders correctly
-  No content or behavior changes