### PR TITLE
[Zero Trust] Update Kolide device posture attribute and API reference

### DIFF
--- a/src/content/docs/cloudflare-one/integrations/service-providers/kolide.mdx
+++ b/src/content/docs/cloudflare-one/integrations/service-providers/kolide.mdx
@@ -62,8 +62,8 @@ import { Render } from "~/components";
 
 ## Device posture attributes
 
-Device posture data is gathered from the [Kolide K2 API](https://kolidek2.readme.io/reference/get_issues).
+Device posture data is gathered from the [Kolide API](https://kolideapi.readme.io/reference/get_devices-id).
 
 | Selector    | Description                                   |
 | ----------- | --------------------------------------------- |
-| Issue count | Total number of issues detected on the device |
+| Auth state  | The authorization status of the device, one of: 'Good', 'Notified', 'Will Block' or 'Blocked' |

--- a/src/content/docs/cloudflare-one/integrations/service-providers/kolide.mdx
+++ b/src/content/docs/cloudflare-one/integrations/service-providers/kolide.mdx
@@ -66,4 +66,4 @@ Device posture data is gathered from the [Kolide API](https://kolideapi.readme.i
 
 | Selector    | Description                                   |
 | ----------- | --------------------------------------------- |
-| Auth state  | The authorization status of the device, one of: 'Good', 'Notified', 'Will Block' or 'Blocked' |
+| Auth state  | The authorization status of the device, one of: 'Good', 'Notified', 'Will Block', or 'Blocked' |


### PR DESCRIPTION
### Summary

Updates the Kolide integration doc: the device posture data source has moved from the [Kolide K2 API](https://kolidek2.readme.io/reference/get_issues) to the [Kolide API](https://kolideapi.readme.io/reference/get_devices-id), and the available device posture attribute is now `Auth state` (device authorization status) rather than `Issue count`.

### Documentation checklist

- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
