### PR TITLE
[D1] Correct preview database binding docs

### DIFF
--- a/src/content/docs/workers/wrangler/configuration.mdx
+++ b/src/content/docs/workers/wrangler/configuration.mdx
@@ -567,7 +567,7 @@ To bind D1 databases to your Worker, assign an array of the below object to the 
   - The ID of the database. The database ID is available when you first use `wrangler d1 create` or when you call `wrangler d1 list`, and uniquely identifies your database.
 
 - `preview_database_id` <Type text="string" /> <MetaInfo text="optional" />
-  - The preview ID of this D1 database. If provided, `wrangler dev` uses this ID. Otherwise, it uses `database_id`.
+  - The preview ID of this D1 database. If provided, `wrangler dev` uses this ID. Otherwise, it uses `database_id`. This option is recommended when using `wrangler dev --remote` to avoid using your production database.
 
 - `migrations_dir` <Type text="string" /> <MetaInfo text="optional" />
   - The migration directory containing the migration files. By default, `wrangler d1 migrations create` creates a folder named `migrations`. You can use `migrations_dir` to specify a different folder containing the migration files (for example, if you have a mono-repo setup, and want to use a single D1 instance across your apps/packages).

--- a/src/content/docs/workers/wrangler/configuration.mdx
+++ b/src/content/docs/workers/wrangler/configuration.mdx
@@ -567,7 +567,7 @@ To bind D1 databases to your Worker, assign an array of the below object to the 
   - The ID of the database. The database ID is available when you first use `wrangler d1 create` or when you call `wrangler d1 list`, and uniquely identifies your database.
 
 - `preview_database_id` <Type text="string" /> <MetaInfo text="optional" />
-  - The preview ID of this D1 database. If provided, `wrangler dev` uses this ID. Otherwise, it uses `database_id`. This option is required when using `wrangler dev --remote`.
+  - The preview ID of this D1 database. If provided, `wrangler dev` uses this ID. Otherwise, it uses `database_id`.
 
 - `migrations_dir` <Type text="string" /> <MetaInfo text="optional" />
   - The migration directory containing the migration files. By default, `wrangler d1 migrations create` creates a folder named `migrations`. You can use `migrations_dir` to specify a different folder containing the migration files (for example, if you have a mono-repo setup, and want to use a single D1 instance across your apps/packages).


### PR DESCRIPTION
### Summary

Corrects the `preview_database_id` binding reference: it is optional for remote development and falls back to `database_id` when omitted.

This has come up in one of the D1 escalation ticket and caused some confusion. The field is not required but highly recommended when using `wrangler dev --remote`  https://github.com/cloudflare/workers-sdk/blob/ed666a14156b5600acc11fdc3e1cfec0b0d9f6df/packages/wrangler/src/dev.ts#L508-L527

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
