### PR TITLE
[Logs] Update Logpush dataset field definitions (2026-08-05)

### DIFF
--- a/src/content/changelog/logs/2026-08-05-log-fields-updated.mdx
+++ b/src/content/changelog/logs/2026-08-05-log-fields-updated.mdx
@@ -1,0 +1,14 @@
+---
+title: Updated fields across multiple Logpush datasets in Cloudflare Logs
+description: Fields have been updated across multiple Logpush datasets in Cloudflare Logs.
+date: 2026-08-05
+---
+
+Cloudflare has updated [Logpush datasets](/logs/logpush/logpush-job/datasets/):
+
+### Updated fields in existing datasets
+
+- **Gateway HTTP** (added): `ExperimentalFeatures` and `PackageInfo`.
+- **HTTP requests** (added): `ClientTLSKeyExchangeGroup`.
+
+For the complete field definitions for each dataset, refer to [Logpush datasets](/logs/logpush/logpush-job/datasets/).

--- a/src/content/docs/logs/logpush/logpush-job/datasets/account/gateway_http.md
+++ b/src/content/docs/logs/logpush/logpush-job/datasets/account/gateway_http.md
@@ -165,6 +165,12 @@ Type: `string`
 
 Email used to authenticate the client.
 
+## ExperimentalFeatures
+
+Type: `object`
+
+Experimental features which will be either permanently added to the schema or marked for deprecation. In that case, they will be removed 3 months after the notice. Current fields: 'mcp' - If MCP traffic was detected or not.
+
 ## FileInfo
 
 Type: `object`
@@ -206,6 +212,12 @@ Version name for the HTTP request.
 Type: `bool`
 
 If the requested was isolated with Cloudflare Browser Isolation or not.
+
+## PackageInfo
+
+Type: `object`
+
+Information about the software package detected in the HTTP request, including its ecosystem, namespace, name, version, and package URL (PURL).
 
 ## PolicyID
 

--- a/src/content/docs/logs/logpush/logpush-job/datasets/zone/http_requests.md
+++ b/src/content/docs/logs/logpush/logpush-job/datasets/zone/http_requests.md
@@ -249,6 +249,12 @@ Type: `int`
 
 The smoothed average of TCP round-trip time (SRTT). For the initial request on a connection, this is measured only during connection setup. For a subsequent request on the same connection, it is measured over the entire connection lifetime up until the time that request is received.
 
+## ClientTLSKeyExchangeGroup
+
+Type: `string`
+
+TLS key exchange group between the client and Cloudflare (for example, 'X25519MLKEM768'). 'UNK' means it could not be determined. 'NONE' means TLS was not used.
+
 ## ClientXRequestedWith
 
 Type: `string`


### PR DESCRIPTION
## Summary

Automated sync of Logpush dataset field definitions from [data/entities](https://gitlab.cfdata.org/cloudflare/data/entities).

### Updated fields in existing datasets

- **Gateway HTTP** (added): `ExperimentalFeatures` and `PackageInfo`.
- **HTTP requests** (added): `ClientTLSKeyExchangeGroup`.

### Files changed
- `src/content/docs/logs/logpush/logpush-job/datasets/account/` — dataset pages
- `src/content/docs/logs/logpush/logpush-job/datasets/zone/` — dataset pages
- `src/content/changelog/logs/2026-08-05-log-fields-updated.mdx` — changelog

### Documentation checklist
- [x] Changelog entry added
- [x] Content generated by code generator (DO NOT EDIT manually)
