### PR TITLE
Document containers rollout none option

### DIFF
--- a/src/content/docs/workers/wrangler/commands/workers.mdx
+++ b/src/content/docs/workers/wrangler/commands/workers.mdx
@@ -239,8 +239,9 @@ None of the options for this command are required. Also, many can be set in your
   - Specify the [Workers for Platforms dispatch namespace](/cloudflare-for-platforms/workers-for-platforms/how-workers-for-platforms-works/#dispatch-namespace) to upload this Worker to.
 - `--metafile` <Type text="string" /> <MetaInfo text="optional" />
   - Specify a file to write the build metadata from esbuild to. If flag is used without a path string, this defaults to `bundle-meta.json` inside the directory specified by `--outdir`. This can be useful for understanding the bundle size.
-- `--containers-rollout` <Type text="immediate | gradual" /> <MetaInfo text="optional" />
+- `--containers-rollout` <Type text="immediate | gradual | none" /> <MetaInfo text="optional" />
   - Specify the [rollout strategy](/containers/faq#how-do-container-updates-and-rollouts-work) for [Containers](/containers) associated with the Worker. If set to `immediate`, 100% of container instances will be updated in one rollout step, overriding any configuration in `rollout_step_percentage`. Note that `rollout_active_grace_period`, if configured, still applies.
+  - If set to `none`, Wrangler deploys the Worker without building or updating associated Containers.
   - Defaults to `gradual`, where the default rollout is 10% then 100% of instances.
 - `--strict` <Type text="boolean" /> <MetaInfo text="(default: false) optional" />
   - Turns on strict mode for the deployment command, meaning that the command will be more defensive and prevent deployments which could introduce potential issues. In particular, this mode prevents deployments if the deployment would potentially override remote settings in non-interactive environments.


### PR DESCRIPTION
### Summary

Documents `--containers-rollout=none` in the Wrangler `deploy` command reference. This option deploys Worker changes without building or updating associated Containers, which is useful when the container code has not changed.

This documents existing Wrangler behavior, so no changelog entry is needed.

### Screenshots (optional)

Not applicable; this is a command reference update.

### Documentation checklist

- [x] The change adheres to the [[documentation style guide](https://developers.cloudflare.com/style-guide/)](https://developers.cloudflare.com/style-guide/).