### PR TITLE
[Workers AI] Search model description in catalog and support multi-word queries

### DIFF
--- a/src/components/models/ModelCard.astro
+++ b/src/components/models/ModelCard.astro
@@ -48,6 +48,10 @@ const authorLogo = authorData[model.author]?.logo;
 <div
 	data-models-cell
 	data-name={model.name.toLowerCase()}
+	data-search={[model.name, model.shortName, model.description]
+		.filter(Boolean)
+		.join(" ")
+		.toLowerCase()}
 	data-facet-tasks={facetValues(model, "tasks").join("|")}
 	data-facet-capabilities={facetValues(model, "capabilities").join("|")}
 	data-facet-providers={facetValues(model, "providers").join("|")}

--- a/src/components/models/ModelCatalog.astro
+++ b/src/components/models/ModelCatalog.astro
@@ -193,10 +193,10 @@ const facetMatchMaps = Object.fromEntries(
 
 		const matches = cells.filter((cell) => {
 			const haystack = cell.dataset.search ?? cell.dataset.name ?? "";
-			const nameOk =
+			const searchOk =
 				queryTokens.length === 0 ||
 				queryTokens.every((token) => haystack.includes(token));
-			if (!nameOk) return false;
+			if (!searchOk) return false;
 			return facetKeys.every((key) => {
 				const chosen = selMatch[key];
 				if (chosen.length === 0) return true;

--- a/src/components/models/ModelCatalog.astro
+++ b/src/components/models/ModelCatalog.astro
@@ -173,7 +173,15 @@ const facetMatchMaps = Object.fromEntries(
 		const cells = Array.from(
 			grid.querySelectorAll<HTMLElement>("[data-models-cell]"),
 		);
-		const query = state.search.trim().toLowerCase();
+		// Split the query into whitespace-separated tokens; each must appear
+		// somewhere in the card's searchable text (name + shortName +
+		// description). This lets "happy horse" match a "HappyHorse" model
+		// whose term only lives in the description.
+		const queryTokens = state.search
+			.trim()
+			.toLowerCase()
+			.split(/\s+/)
+			.filter(Boolean);
 
 		// Convert selected values to match strings using the match maps.
 		const selMatch: Record<string, string[]> = {};
@@ -184,7 +192,10 @@ const facetMatchMaps = Object.fromEntries(
 		}
 
 		const matches = cells.filter((cell) => {
-			const nameOk = !query || (cell.dataset.name ?? "").includes(query);
+			const haystack = cell.dataset.search ?? cell.dataset.name ?? "";
+			const nameOk =
+				queryTokens.length === 0 ||
+				queryTokens.every((token) => haystack.includes(token));
 			if (!nameOk) return false;
 			return facetKeys.every((key) => {
 				const chosen = selMatch[key];


### PR DESCRIPTION
The models catalog search at /ai/models and /workers-ai/models only matched the query against a model's id/name, using a single-substring check. Searching "happy horse" returned nothing even though the HappyHorse models exist, because their ids look like `hh1.1-i2v` and the term "HappyHorse" only appears in the description — which was never searched. A spaceless `happyhorse` also failed as a multi-word query.

This makes the description a secondary search source and tokenizes the query so multi-word searches work.

- `ModelCard.astro`: stamp a combined `data-search` attribute (name + shortName + description), alongside the existing `data-name`.
- `ModelCatalog.astro`: split the query on whitespace and require every token to appear in that combined text. Falls back to `data-name` if `data-search` is missing. Single-word name searches behave exactly as before.

Result: both `happy horse` and `happyhorse` now match all five HappyHorse models, and description text is searchable in general.

## Documentation checklist
- [x] The documentation style guide has been adhered to.
- [ ] If a larger change - such as adding a new page - an issue has been opened in relation to any incorrect or out of date information.
- [x] Files have been formatted through the standard formatting process.