### PR TITLE
[Wallets] Add Cloudflare Wallets handle reservation docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -34,6 +34,7 @@ package.json @cloudflare/content-engineering
 /src/content/partials/ai-gateway/ @abhishekkankani @palashgo @thebongy @roerohan @kathayl @mchenco @zeke @superhighfives @shridhar-cf @adriandlam @mattrothenberg @ethulia @aninibread @kflansburg @cloudflare/product-owners
 /src/content/release-notes/workers-ai.yaml @kathayl @mchenco @zeke @superhighfives @shridhar-cf @mattrothenberg @ethulia @aninibread @kflansburg @cloudflare/product-owners
 /src/content/release-notes/ai-gateway.yaml @abhishekkankani @palashgo @thebongy @roerohan @kathayl @mchenco @zeke @superhighfives @shridhar-cf @adriandlam @mattrothenberg @ethulia @aninibread @kflansburg @cloudflare/product-owners
+/src/content/docs/wallets/ @rohinlohe @willpapper @cloudflare/product-owners
 /src/content/release-notes/vectorize.yaml @elithrar @mchenco @sejoker @cloudflare/product-owners
 /src/content/docs/ai-search/ @rita3ko @irvinebroque @aninibread @G4brym @mchenco @cloudflare/product-owners
 /src/content/release-notes/ai-search.yaml @rita3ko @irvinebroque @aninibread @G4brym @mchenco @cloudflare/product-owners

--- a/src/components/landing/sidebar-data.ts
+++ b/src/components/landing/sidebar-data.ts
@@ -96,6 +96,7 @@ export const sidebarSections: SidebarSection[] = [
 					link("AI Gateway", "/ai-gateway/"),
 					link("Agents", "/agents/"),
 					link("Agent Memory", "/agent-memory/"),
+					link("Wallets", "/wallets/"),
 					link("Sandbox SDK", "/sandbox/"),
 					link("Vectorize", "/vectorize/"),
 					link("AI Search", "/ai-search/"),

--- a/src/content/directory/wallets.yaml
+++ b/src/content/directory/wallets.yaml
@@ -1,0 +1,14 @@
+id: 7AtrC6
+name: Cloudflare Wallets
+
+entry:
+  title: Cloudflare Wallets
+  url: /wallets/
+  group: Developer platform
+  additional_groups: [AI]
+  tags: [AI]
+
+meta:
+  title: Cloudflare Wallets docs
+  description: Reserve a wallet handle and give your account and its agents a stable, human-readable identity for agentic payments
+  author: "@cloudflare"

--- a/src/content/docs/wallets/faq.mdx
+++ b/src/content/docs/wallets/faq.mdx
@@ -1,0 +1,39 @@
+---
+title: FAQ
+pcx_content_type: faq
+description: Answers to common questions about reserving a Cloudflare Wallets handle.
+products:
+  - wallets
+sidebar:
+  order: 5
+head:
+  - tag: title
+    content: Cloudflare Wallets FAQ
+---
+
+Common questions about Cloudflare Wallet handles.
+
+## Where can I reserve a Cloudflare Wallet handle?
+
+Cloudflare Wallet handles can be reserved at [cloudflare.pay](https://cloudflare.pay/).
+
+## How much does it cost to reserve a Cloudflare Wallet handle?
+
+Reserving a Cloudflare Wallet handle is free.
+
+## How many Cloudflare Wallet handles can I reserve per account?
+
+Each Cloudflare account can reserve one handle. Reserving a handle does not guarantee access to a Cloudflare Wallet on release.
+
+## Who can reserve a Cloudflare Wallet handle?
+
+Anyone with a Cloudflare account can reserve a Cloudflare Wallet handle. Each account can reserve one handle. Cloudflare reserves the right to reject or reclaim wallet handle reservations for any reason.
+
+## How can I change a handle, release a handle, or move a handle to another account?
+
+Handles are allocated first come, first served, and Cloudflare does not currently offer a way to change, release, or move a handle once it is reserved. This includes changing a handle after a rebrand. To ask about a change, [contact Cloudflare Support](/support/contacting-cloudflare-support/).
+
+## Where can I report trademark infringements, abuse or spam?
+
+Submit abuse reports to Cloudflare via [abuse.cloudflare.com](https://abuse.cloudflare.com/).
+

--- a/src/content/docs/wallets/index.mdx
+++ b/src/content/docs/wallets/index.mdx
@@ -1,0 +1,85 @@
+---
+title: Cloudflare Wallets
+pcx_content_type: overview
+description: Cloudflare Wallets will let accounts and their AI agents pay for APIs and content. Reserve a wallet handle to hold a human-readable name for your account.
+products:
+  - wallets
+sidebar:
+  order: 1
+head:
+  - tag: title
+    content: Cloudflare Wallets docs
+---
+
+import {
+	CardGrid,
+	Description,
+	LinkButton,
+	LinkTitleCard,
+	RelatedProduct,
+} from "~/components";
+
+<Description>
+
+A programmable wallet that gives eligible Cloudflare accounts and AI agents a stable identity and a way to pay for APIs and content.
+
+</Description>
+
+:::note
+
+Cloudflare Wallet handle reservations are available today at [cloudflare.pay](https://cloudflare.pay/).
+
+:::
+
+Cloudflare Wallets will enable AI agents to easily purchase necessary APIs and content. At first, Cloudflare Wallets will be able to send, receive, and hold stablecoins.
+
+There will be two types of Cloudflare Wallets: Account Wallets and Virtual Wallets.
+
+Account Wallets are designed for humans who are owners and users of Cloudflare accounts. They will be able to add funds, delegate spend to virtual wallets managed by agents, and remove funds as needed. Account Wallets may also carry a [cloudflare.pay](https://cloudflare.pay/) stable identifier.
+
+Virtual Wallets, by contrast, are designed for agents and operate via API keys. Within a Virtual Wallet, an agent will be able to spend funds according to its permissions. Its maximum spend will be capped by the limit set by the owner of the Account Wallet. This framework gives agents freedom to act on behalf of users without constant manual approval while limiting an agent’s ability to overspend.
+
+For the full description of what Cloudflare Wallets, Account Wallets, and Virtual Wallets will do, refer to the [Cloudflare Wallets announcement](https://blog.cloudflare.com/wallets/).
+
+---
+
+## What is available today
+
+You can reserve one wallet handle for each Cloudflare account at [cloudflare.pay](https://cloudflare.pay/). A reserved handle:
+
+- Associates the name with your Cloudflare account
+- Publishes a page at `HANDLE.cloudflare.pay` showing only the handle
+- Registers your account to be notified when Cloudflare Wallets becomes available
+
+A reserved handle does not yet let you send, receive, or hold funds.
+
+
+---
+
+<CardGrid>
+
+<LinkTitleCard title="FAQ" href="/wallets/faq/" icon="document">
+	Answers to common questions about Cloudflare Wallet handle reservations.
+</LinkTitleCard>
+
+</CardGrid>
+
+---
+
+## Related products
+
+<RelatedProduct header="Agents" href="/agents/" product="agents">
+
+Build AI agents that can call tools, hold state, and pay for the services they use.
+
+</RelatedProduct>
+
+<RelatedProduct
+	header="Agentic Payments"
+	href="/agents/tools/payments/"
+	product="agents"
+>
+
+Charge for HTTP content and MCP tools, or pay for them from an agent, using the x402 protocol.
+
+</RelatedProduct>


### PR DESCRIPTION
### Summary

New product section documenting the Cloudflare Wallets handle reservation flow at `cloudflare.pay`, announced in [Announcing Cloudflare Wallets](https://blog.cloudflare.com/wallets/). The blog post is currently the only public source, so nothing published covers how reservations work.

Reviewed with the Agent Payments team. The policy below has been corrected from the first draft: reservations are **not** final, and Cloudflare reserves the right to reject or reclaim one. Still holding as draft pending the rest of that review.

Five pages under `/cloudflare-wallets/`:

| Page                            | Type      | Covers                                                                              |
| ------------------------------- | --------- | ----------------------------------------------------------------------------------- |
| `index.mdx`                     | overview  | What Cloudflare Wallets is, and that handle reservation is the only part open today |
| `wallet-handles.mdx`            | concept   | Allocation, what can be changed after reserving, account binding, trademark reports |
| `reserve-a-wallet-handle.mdx`   | how-to    | The reservation flow, and how to confirm `cloudflare.pay` is genuine                |
| `wallet-handle-requirements.mdx`| reference | Length, character, reserved name, and filtering rules                               |
| `faq.mdx`                       | faq       | Cost, plan requirements, published information, and reservation errors              |

Behaviour and policy documented:

- Handles are allocated first come, first served.
- Cloudflare reserves the right to reject or reclaim a handle reservation at any time, for any reason. Reserving a handle does not grant ownership of a name or any trademark rights.
- No self-service way to change, release, or transfer a handle exists today. Support is the route for those requests.
- Revoking the **Cloudflare Wallet Launch Site** connected application does not release a handle.
- Deleting a Cloudflare account does not release a handle, and a recreated account does not inherit it.
- Trademark holders can report a handle through the [abuse form](https://abuse.cloudflare.com/), consistent with [Complaint types](https://developers.cloudflare.com/fundamentals/reference/report-abuse/complaint-types/).
- `cloudflare.pay` is a genuine Cloudflare domain. Sign-in happens on `dash.cloudflare.com`, and the application requests read-only access.
- Handles are not case-sensitive, and the reserved word and profanity filters match on substrings.

Also adds the `cloudflare-wallets` directory entry and a landing nav link under Build > AI.

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
