### PR TITLE
[AI Gateway] Correct required API token permission for REST API

### DIFF
--- a/src/content/docs/ai-gateway/usage/rest-api.mdx
+++ b/src/content/docs/ai-gateway/usage/rest-api.mdx
@@ -31,7 +31,11 @@ The `/ai/v1/messages` endpoint strictly uses Anthropic's API schema and supports
 
 ## Authentication
 
-Authenticate with a [Cloudflare API token](/fundamentals/api/get-started/create-token/) that has `AI Gateway` permission. Pass it in the `Authorization` header.
+Authenticate with a [Cloudflare API token](/fundamentals/api/get-started/create-token/) that has the **Account** > **Workers AI** > **Read** permission. Pass it in the `Authorization` header.
+
+All `/accounts/{account_id}/ai/*` endpoints require the Workers AI permission. This applies to third-party models and to Workers AI (`@cf/`) models. A token that holds only an `AI Gateway` permission returns `401` with error code `10000`.
+
+The `AI Gateway` permissions apply to the `/accounts/{account_id}/ai-gateway/*` endpoints, which manage gateway configuration, logs, and routes.
 
 :::note
 Ensure your Cloudflare account has [sufficient credits loaded](/ai-gateway/features/unified-billing/#load-credits) before calling third-party models.


### PR DESCRIPTION
## Summary

The Authentication section of the AI Gateway REST API page states that the token needs the `AI Gateway` permission. That permission does not grant access to these endpoints. A token holding only `AI Gateway Read` or `AI Gateway Run` returns `401` with error code `10000`.

The permission the `/accounts/{account_id}/ai/*` endpoints actually require is `Workers AI Read`, whose own permission group description is "Grants access to invoke Workers AI models". This holds for third-party models as well as `@cf/` models, because the check applies to the API path rather than to the routed provider.

## How this was verified

Four single-permission user API tokens, each scoped to one account, against `POST /accounts/{account_id}/ai/v1/chat/completions` with `model: openai/gpt-4.1` (a third-party model):

| Token permission | `GET /ai-gateway/gateways` | `POST /ai/v1/chat/completions` |
| --- | --- | --- |
| AI Gateway Read | `200` | `401` / `10000` |
| AI Gateway Run | `403` | `401` / `10000` |
| Workers AI Read | `403` | `402` / `2021` (reached gateway) |
| Workers AI Edit | `403` | `402` / `2021` (reached gateway) |

The `402` responses are Unified Billing rejections raised inside AI Gateway, which confirms the request passed authentication and reached the gateway.

With a `Workers AI Read` token only, the following also pass authentication:

- `POST /ai/run`
- requests carrying `cf-aig-gateway-id`
- requests targeting a dynamic route (`model: dynamic/{route}`)
- `@cf/` models on the same token

## Impact

This wording sends users to configure `AI Gateway Run`, which produces a `401` with no entry in AI Gateway logs, because the request is rejected before it reaches the gateway. The failure is indistinguishable from an invalid token, so it is expensive to diagnose from the response alone.
