### PR TITLE
fix: eliminate 4.3 MB Phosphor icon client chunk

### DIFF
--- a/src/components/react/PhosphorIcon.tsx
+++ b/src/components/react/PhosphorIcon.tsx
@@ -1,42 +1,33 @@
-// Renders a Phosphor icon inside a React island. astro-icon's <Icon> is
-// Astro-only, so React islands can't use it directly — this resolves icon
-// data from the already-installed @iconify-json/ph set at runtime (cheap,
-// synchronous, no network fetch) via the same @iconify/utils helpers already
-// used for build-time icon resolution in src/pages/directory.astro.
-import { getIconData, iconToSVG } from "@iconify/utils";
-import phIcons from "@iconify-json/ph/icons.json";
+import thumbsUp from "@phosphor-icons/core/regular/thumbs-up.svg?raw";
+import thumbsDown from "@phosphor-icons/core/regular/thumbs-down.svg?raw";
+import checkCircle from "@phosphor-icons/core/regular/check-circle.svg?raw";
+import magnifyingGlass from "@phosphor-icons/core/regular/magnifying-glass.svg?raw";
+import x from "@phosphor-icons/core/regular/x.svg?raw";
+import checkBold from "@phosphor-icons/core/bold/check-bold.svg?raw";
+
+const icons = {
+	"thumbs-up": thumbsUp,
+	"thumbs-down": thumbsDown,
+	"check-circle": checkCircle,
+	"magnifying-glass": magnifyingGlass,
+	x,
+	"check-bold": checkBold,
+};
+
+type IconName = keyof typeof icons;
 
 interface Props {
-	/** Icon name from the Phosphor set, e.g. "thumbs-up", "magnifying-glass". */
-	name: string;
+	name: IconName;
 	className?: string;
 }
 
-const cache = new Map<string, { viewBox: string; body: string }>();
-
-function resolve(name: string) {
-	let entry = cache.get(name);
-	if (!entry) {
-		const data = getIconData(phIcons, name);
-		if (!data) {
-			throw new Error(`PhosphorIcon: unknown icon "${name}"`);
-		}
-		const { attributes, body } = iconToSVG(data);
-		entry = { viewBox: String(attributes.viewBox), body };
-		cache.set(name, entry);
-	}
-	return entry;
-}
-
 export default function PhosphorIcon({ name, className }: Props) {
-	const { viewBox, body } = resolve(name);
+	const svg = icons[name];
 	return (
-		<svg
-			viewBox={viewBox}
-			fill="currentColor"
+		<span
 			aria-hidden
 			className={className}
-			dangerouslySetInnerHTML={{ __html: body }}
+			dangerouslySetInnerHTML={{ __html: svg }}
 		/>
 	);
 }


### PR DESCRIPTION
### Summary

Replaces the full `@iconify-json/ph/icons.json` import in `PhosphorIcon.tsx` (27,693-line JSON containing every Phosphor icon) with six `?raw` SVG imports from `@phosphor-icons/core` for the only icons actually used by React islands: `thumbs-up`, `thumbs-down`, `check-circle`, `magnifying-glass`, `x`, `check-bold`.

The full-set import produced a **4.3 MB client-side JS chunk** (`PhosphorIcon.cbrmX4Sq.js`) that shipped to every page with a feedback widget or resource selector. The replacement inlines ~2 KB of SVG markup total, eliminating the chunk entirely.

| Metric | Before | After |
| --- | --- | --- |
| PhosphorIcon chunk | 4.3 MB | gone (inlined into consumer chunks) |
| Chunks > 500 KB | 2 | 1 |

The `name` prop is now a union type (`keyof typeof icons`) instead of `string`, providing compile-time safety for unknown icon names rather than a runtime throw.

