### PR TITLE
[Cloudflare for SaaS] Clarify O2O works with full and partial DNS setups

### DIFF
--- a/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/saas-customers/how-it-works.mdx
+++ b/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/saas-customers/how-it-works.mdx
@@ -20,25 +20,25 @@ O2O is a specific traffic routing configuration where traffic routes through two
 
 If one or more hostnames are onboarded to a SaaS Provider that uses Cloudflare products as part of their platform - specifically the [Cloudflare for SaaS product](/cloudflare-for-platforms/cloudflare-for-saas/) - those hostnames will be created as [custom hostnames](/cloudflare-for-platforms/cloudflare-for-saas/domain-support/) in the SaaS Provider's zone.
 
-To give the SaaS provider permission to route traffic through their zone, any custom hostname must be activated by you (the SaaS customer) by placing a [CNAME record](/cloudflare-for-platforms/cloudflare-for-saas/start/getting-started/#3-have-customer-create-cname-record) on your authoritative DNS. Once traffic for that hostname reaches Cloudflare, your own Cloudflare zone can also participate in the path: if that zone contains a [proxied](/fundamentals/concepts/how-cloudflare-works/#application-services) CNAME for the same hostname targeting the SaaS provider, you have an O2O setup.
+To give the SaaS provider permission to route traffic through their zone, any custom hostname must be activated by you (the SaaS customer) by placing a [`CNAME` record](/cloudflare-for-platforms/cloudflare-for-saas/start/getting-started/#3-have-customer-create-cname-record) on your authoritative DNS. Once traffic for that hostname reaches Cloudflare, your own Cloudflare zone can also participate in the path: if that zone contains a [proxied](/fundamentals/concepts/how-cloudflare-works/#application-services) `CNAME` for the same hostname targeting the SaaS provider, you have an O2O setup.
 
 Your Cloudflare zone may use a [full setup](/dns/zone-setups/full-setup/) (Cloudflare is authoritative DNS) or a [partial setup](/dns/zone-setups/partial-setup/) (another DNS provider remains authoritative). O2O does not require Cloudflare to be your authoritative DNS provider.
 
-For provider-specific CNAME targets and extra steps, refer to the [provider guides](/cloudflare-for-platforms/cloudflare-for-saas/saas-customers/provider-guides/).
+For provider-specific `CNAME` targets and extra steps, refer to the [provider guides](/cloudflare-for-platforms/cloudflare-for-saas/saas-customers/provider-guides/).
 
 ## Prerequisites
 
 - You have your own Cloudflare zone for the domain (full or partial setup).
 - Your zone and the SaaS provider's zone are in different Cloudflare accounts.
-- In your Cloudflare zone, the hostname has a [proxied](/dns/proxy-status/) **CNAME** record whose target is the hostname provided by your SaaS provider.
+- In your Cloudflare zone, the hostname has a [proxied](/dns/proxy-status/) `CNAME` record whose target is the hostname provided by your SaaS provider.
 - Your SaaS provider has activated the hostname on their Cloudflare for SaaS configuration (usually as a [custom hostname](/cloudflare-for-platforms/cloudflare-for-saas/domain-support/)).
 - Visitors resolve the hostname to Cloudflare so the request reaches the Cloudflare network with that hostname.
 
-Since O2O is based on CNAME, it does not apply when an A or AAAA record is used to point to the SaaS provider ([apex proxying](/cloudflare-for-platforms/cloudflare-for-saas/start/advanced-settings/apex-proxying/) is a separate setup).
+Since O2O is based on `CNAME`, it does not apply when an `A` or `AAAA` record is used to point to the SaaS provider ([apex proxying](/cloudflare-for-platforms/cloudflare-for-saas/start/advanced-settings/apex-proxying/) is a separate setup).
 
 ## With O2O
 
-If you have your own Cloudflare zone (`example.com`) and your zone contains a [proxied DNS record](/dns/proxy-status/) matching the custom hostname (`mystore.example.com`) with a **CNAME** target defined by the SaaS Provider, then O2O will be enabled.
+If you have your own Cloudflare zone (`example.com`) and your zone contains a [proxied DNS record](/dns/proxy-status/) matching the custom hostname (`mystore.example.com`) with a `CNAME` target defined by the SaaS Provider, then O2O will be enabled.
 
 <Example>
 
@@ -50,7 +50,7 @@ DNS management for **example.com**
 
 </Example>
 
-Use the exact target hostname from your SaaS provider's documentation. Each provider publishes its own CNAME target.
+Use the exact target hostname from your SaaS provider's documentation. Each provider publishes its own `CNAME` target.
 
 With O2O enabled, the settings configured in your Cloudflare zone will be applied to the traffic first, and then the settings configured in the SaaS provider's zone will be applied to the traffic second. In the SaaS provider-owned zone, a HTTP header will be set to `cf-connecting-o2o: 1`.
 
@@ -74,36 +74,33 @@ C --> D
 
 ### Full setup and partial setup
 
-O2O works the same way whether your zone uses a full or partial DNS setup. What matters is the proxied CNAME in **your** Cloudflare zone and that visitor traffic reaches Cloudflare for that hostname.
+O2O works the same way whether your zone uses a full or partial DNS setup. What matters is the proxied `CNAME` in **your** Cloudflare zone and that visitor traffic reaches Cloudflare for that hostname.
 
 | Your zone setup | Authoritative DNS | What you configure |
 | --------------- | ----------------- | ------------------ |
-| [Full setup](/dns/zone-setups/full-setup/) | Cloudflare nameservers | Proxied CNAME to the SaaS provider target in your Cloudflare DNS |
-| [Partial setup](/dns/zone-setups/partial-setup/) (CNAME setup) | Your existing DNS provider | Proxied CNAME to the SaaS provider target **in your Cloudflare zone**, and DNS at your authoritative provider that still sends visitors to Cloudflare for that hostname |
+| [Full setup](/dns/zone-setups/full-setup/) | Cloudflare nameservers | Proxied `CNAME` to the SaaS provider target in your Cloudflare DNS |
+| [Partial setup](/dns/zone-setups/partial-setup/) (`CNAME` setup) | Your existing DNS provider | Proxied `CNAME` to the SaaS provider target **in your Cloudflare zone**, and DNS at your authoritative provider that still sends visitors to Cloudflare for that hostname |
 
 #### Authoritative DNS for partial setup
 
-On a partial setup, your authoritative DNS provider must still direct visitors to Cloudflare for the hostname. Common patterns include:
+On a partial setup, your authoritative DNS provider must still direct visitors to Cloudflare for the hostname. Common patterns include a `CNAME` to `{hostname}.cdn.cloudflare.net` (as described in [Partial setup](/dns/zone-setups/partial-setup/setup/)), or a `CNAME` to the SaaS provider's hostname when that hostname already resolves to Cloudflare (many [provider guides](/cloudflare-for-platforms/cloudflare-for-saas/saas-customers/provider-guides/) use this pattern).
 
-- CNAME to `{hostname}.cdn.cloudflare.net`, as described in [Partial setup](/dns/zone-setups/partial-setup/setup/)
-- CNAME to the SaaS provider's hostname, when that hostname already resolves to Cloudflare (many [provider guides](/cloudflare-for-platforms/cloudflare-for-saas/saas-customers/provider-guides/) use this pattern)
+In both cases, O2O depends on the **proxied `CNAME` inside your Cloudflare zone**, not only on the record at your authoritative DNS provider.
 
-In both cases, O2O depends on the **proxied CNAME inside your Cloudflare zone**, not only on the record at your authoritative DNS provider.
+### `CNAME` target requirements
 
-### CNAME target requirements
-
-O2O only applies when the proxied record in your zone is a CNAME to your SaaS provider's hostname.
+O2O only applies when the proxied record in your zone is a `CNAME` to your SaaS provider's hostname.
 
 | Record in your Cloudflare zone | Result |
 | ------------------------------ | ------ |
-| Proxied CNAME to the SaaS provider target | O2O: your zone, then the SaaS provider zone, then their origin |
-| Proxied A, AAAA, or CNAME to a different target | Not O2O to that SaaS provider. Your zone settings apply and traffic is sent to that target as the origin |
+| Proxied `CNAME` to the SaaS provider target | O2O: your zone, then the SaaS provider zone, then their origin |
+| Proxied `A`, `AAAA`, or `CNAME` to a different target | Not O2O to that SaaS provider. Your zone settings apply and traffic is sent to that target as the origin |
 | No matching proxied hostname in your zone | O2O is not enabled. Only the SaaS provider's zone applies if the hostname is configured there |
 
-Point the CNAME **directly** at the SaaS provider target. Do not target another proxied record in your zone that then points at the SaaS provider. Indirect targets can prevent O2O from applying for that hostname.
+Point the `CNAME` **directly** at the SaaS provider target. Do not target another proxied record in your zone that then points at the SaaS provider. Indirect targets can prevent O2O from applying for that hostname.
 
 :::note
-If a hostname already works only through your SaaS provider on Cloudflare, and you later add your own Cloudflare zone with a proxied CNAME to that provider, routing becomes O2O for that hostname. Settings in your zone (for example WAF, cache, and Workers) then apply to that traffic. Review those settings before you rely on the new path in production, and keep the DNS records your SaaS provider requires. Refer to [Product compatibility](/cloudflare-for-platforms/cloudflare-for-saas/saas-customers/product-compatibility/).
+If a hostname already works only through your SaaS provider on Cloudflare, and you later add your own Cloudflare zone with a proxied `CNAME` to that provider, routing becomes O2O for that hostname. Settings in your zone (for example WAF, cache, and Workers) then apply to that traffic. Review those settings before you rely on the new path in production, and keep the DNS records your SaaS provider requires. Refer to [Product compatibility](/cloudflare-for-platforms/cloudflare-for-saas/saas-customers/product-compatibility/).
 :::
 
 ## Detect O2O traffic
@@ -116,7 +113,7 @@ You can check for this header in your origin server or in a [Cloudflare Worker](
 
 If you do not have your own Cloudflare zone and have only onboarded one or more of your hostnames to a SaaS Provider, then O2O will not be enabled.
 
-O2O is also not enabled if you have your own zone but that zone does not contain a matching proxied CNAME to the SaaS provider for the hostname.
+O2O is also not enabled if you have your own zone but that zone does not contain a matching proxied `CNAME` to the SaaS provider for the hostname.
 
 Without O2O enabled, the settings configured in the SaaS Provider's zone will be applied to the traffic.
 

--- a/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/saas-customers/how-it-works.mdx
+++ b/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/saas-customers/how-it-works.mdx
@@ -20,12 +20,21 @@ O2O is a specific traffic routing configuration where traffic routes through two
 
 If one or more hostnames are onboarded to a SaaS Provider that uses Cloudflare products as part of their platform - specifically the [Cloudflare for SaaS product](/cloudflare-for-platforms/cloudflare-for-saas/) - those hostnames will be created as [custom hostnames](/cloudflare-for-platforms/cloudflare-for-saas/domain-support/) in the SaaS Provider's zone.
 
-To give the SaaS provider permission to route traffic through their zone, any custom hostname must be activated by you (the SaaS customer) by placing a [CNAME record](/cloudflare-for-platforms/cloudflare-for-saas/start/getting-started/#3-have-customer-create-cname-record) on your authoritative DNS. If your authoritative DNS is Cloudflare, you have the option to [proxy](/fundamentals/concepts/how-cloudflare-works/#application-services) your CNAME record, achieving an O2O setup.
+To give the SaaS provider permission to route traffic through their zone, any custom hostname must be activated by you (the SaaS customer) by placing a [CNAME record](/cloudflare-for-platforms/cloudflare-for-saas/start/getting-started/#3-have-customer-create-cname-record) on your authoritative DNS. Once traffic for that hostname reaches Cloudflare, your own Cloudflare zone can also participate in the path: if that zone contains a [proxied](/fundamentals/concepts/how-cloudflare-works/#application-services) CNAME for the same hostname targeting the SaaS provider, you have an O2O setup.
+
+Your Cloudflare zone may use a [full setup](/dns/zone-setups/full-setup/) (Cloudflare is authoritative DNS) or a [partial setup](/dns/zone-setups/partial-setup/) (another DNS provider remains authoritative). O2O does not require Cloudflare to be your authoritative DNS provider.
+
+For provider-specific CNAME targets and extra steps, refer to the [provider guides](/cloudflare-for-platforms/cloudflare-for-saas/saas-customers/provider-guides/).
 
 ## Prerequisites
 
-- O2O only applies when the two zones are part of different Cloudflare accounts.
-- Since O2O is based on CNAME, it does not apply when an A record is used to point to the SaaS provider's ([apex proxying](/cloudflare-for-platforms/cloudflare-for-saas/start/advanced-settings/apex-proxying/)).
+- You have your own Cloudflare zone for the domain (full or partial setup).
+- Your zone and the SaaS provider's zone are in different Cloudflare accounts.
+- In your Cloudflare zone, the hostname has a [proxied](/dns/proxy-status/) **CNAME** record whose target is the hostname provided by your SaaS provider.
+- Your SaaS provider has activated the hostname on their Cloudflare for SaaS configuration (usually as a [custom hostname](/cloudflare-for-platforms/cloudflare-for-saas/domain-support/)).
+- Visitors resolve the hostname to Cloudflare so the request reaches the Cloudflare network with that hostname.
+
+Since O2O is based on CNAME, it does not apply when an A or AAAA record is used to point to the SaaS provider ([apex proxying](/cloudflare-for-platforms/cloudflare-for-saas/start/advanced-settings/apex-proxying/) is a separate setup).
 
 ## With O2O
 
@@ -40,6 +49,8 @@ DNS management for **example.com**
 | `CNAME`  | `mystore`    | `customers.saasprovider.com` | Proxied          |
 
 </Example>
+
+Use the exact target hostname from your SaaS provider's documentation. Each provider publishes its own CNAME target.
 
 With O2O enabled, the settings configured in your Cloudflare zone will be applied to the traffic first, and then the settings configured in the SaaS provider's zone will be applied to the traffic second. In the SaaS provider-owned zone, a HTTP header will be set to `cf-connecting-o2o: 1`.
 
@@ -61,6 +72,40 @@ B --> C
 C --> D
 ```
 
+### Full setup and partial setup
+
+O2O works the same way whether your zone uses a full or partial DNS setup. What matters is the proxied CNAME in **your** Cloudflare zone and that visitor traffic reaches Cloudflare for that hostname.
+
+| Your zone setup | Authoritative DNS | What you configure |
+| --------------- | ----------------- | ------------------ |
+| [Full setup](/dns/zone-setups/full-setup/) | Cloudflare nameservers | Proxied CNAME to the SaaS provider target in your Cloudflare DNS |
+| [Partial setup](/dns/zone-setups/partial-setup/) (CNAME setup) | Your existing DNS provider | Proxied CNAME to the SaaS provider target **in your Cloudflare zone**, and DNS at your authoritative provider that still sends visitors to Cloudflare for that hostname |
+
+#### Authoritative DNS for partial setup
+
+On a partial setup, your authoritative DNS provider must still direct visitors to Cloudflare for the hostname. Common patterns include:
+
+- CNAME to `{hostname}.cdn.cloudflare.net`, as described in [Partial setup](/dns/zone-setups/partial-setup/setup/)
+- CNAME to the SaaS provider's hostname, when that hostname already resolves to Cloudflare (many [provider guides](/cloudflare-for-platforms/cloudflare-for-saas/saas-customers/provider-guides/) use this pattern)
+
+In both cases, O2O depends on the **proxied CNAME inside your Cloudflare zone**, not only on the record at your authoritative DNS provider.
+
+### CNAME target requirements
+
+O2O only applies when the proxied record in your zone is a CNAME to your SaaS provider's hostname.
+
+| Record in your Cloudflare zone | Result |
+| ------------------------------ | ------ |
+| Proxied CNAME to the SaaS provider target | O2O: your zone, then the SaaS provider zone, then their origin |
+| Proxied A, AAAA, or CNAME to a different target | Not O2O to that SaaS provider. Your zone settings apply and traffic is sent to that target as the origin |
+| No matching proxied hostname in your zone | O2O is not enabled. Only the SaaS provider's zone applies if the hostname is configured there |
+
+Point the CNAME **directly** at the SaaS provider target. Do not target another proxied record in your zone that then points at the SaaS provider. Indirect targets can prevent O2O from applying for that hostname.
+
+:::note
+If a hostname already works only through your SaaS provider on Cloudflare, and you later add your own Cloudflare zone with a proxied CNAME to that provider, routing becomes O2O for that hostname. Settings in your zone (for example WAF, cache, and Workers) then apply to that traffic. Review those settings before you rely on the new path in production, and keep the DNS records your SaaS provider requires. Refer to [Product compatibility](/cloudflare-for-platforms/cloudflare-for-saas/saas-customers/product-compatibility/).
+:::
+
 ## Detect O2O traffic
 
 When traffic flows through an O2O configuration, Cloudflare sets the HTTP header `cf-connecting-o2o: 1` on requests entering the SaaS provider's zone. There is no API field or zone setting that indicates whether O2O is active — it is a per-request routing behavior determined by the customer's DNS configuration.
@@ -70,6 +115,8 @@ You can check for this header in your origin server or in a [Cloudflare Worker](
 ## Without O2O
 
 If you do not have your own Cloudflare zone and have only onboarded one or more of your hostnames to a SaaS Provider, then O2O will not be enabled.
+
+O2O is also not enabled if you have your own zone but that zone does not contain a matching proxied CNAME to the SaaS provider for the hostname.
 
 Without O2O enabled, the settings configured in the SaaS Provider's zone will be applied to the traffic.
 

--- a/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/saas-customers/product-compatibility.mdx
+++ b/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/saas-customers/product-compatibility.mdx
@@ -13,6 +13,8 @@ head:
 
 As a general rule, settings on the customer zone will override settings on the SaaS zone. In addition, [O2O](/cloudflare-for-platforms/cloudflare-for-saas/saas-customers/) does not permit traffic directed to a custom hostname zone into another custom hostname zone.
 
+O2O works with customer zones on a [full](/dns/zone-setups/full-setup/) or [partial](/dns/zone-setups/partial-setup/) DNS setup. Your authoritative DNS does not need to be Cloudflare.
+
 The following table provides a list of compatibility guidelines for various Cloudflare products and features.
 
 :::note

--- a/src/content/docs/dns/zone-setups/partial-setup/setup.mdx
+++ b/src/content/docs/dns/zone-setups/partial-setup/setup.mdx
@@ -108,3 +108,16 @@ If your zone stays in **Pending Nameserver Update** status after adding the veri
 ## Other record types
 
 If you are preparing a conversion from CNAME setup (partial) to primary setup (full), or if you have a more specific use case, you can use the [Create DNS Record](/api/resources/dns/subresources/records/methods/create/) API endpoint to create DNS records of any supported type.
+
+
+---
+
+## Use with a SaaS provider (O2O)
+
+If you use a partial setup and a SaaS platform that runs on Cloudflare, you can send traffic through your Cloudflare zone and then the provider's zone. That path is called [orange-to-orange (O2O)](/cloudflare-for-platforms/cloudflare-for-saas/saas-customers/how-it-works/).
+
+1. In your Cloudflare zone, create a [proxied](/dns/proxy-status/) CNAME for the hostname that targets the name your SaaS provider specifies.
+2. At your authoritative DNS provider, keep DNS that delivers visitors to Cloudflare for that hostname (for example `{hostname}.cdn.cloudflare.net`, or the provider's Cloudflare hostname when their guide uses that pattern).
+3. Follow your [provider guide](/cloudflare-for-platforms/cloudflare-for-saas/saas-customers/provider-guides/) for activation and product limits.
+
+Partial setup does not require moving nameservers to Cloudflare. O2O depends on the proxied CNAME in your Cloudflare zone once visitor traffic reaches Cloudflare for that hostname.

--- a/src/content/docs/dns/zone-setups/partial-setup/setup.mdx
+++ b/src/content/docs/dns/zone-setups/partial-setup/setup.mdx
@@ -116,8 +116,8 @@ If you are preparing a conversion from CNAME setup (partial) to primary setup (f
 
 If you use a partial setup and a SaaS platform that runs on Cloudflare, you can send traffic through your Cloudflare zone and then the provider's zone. That path is called [orange-to-orange (O2O)](/cloudflare-for-platforms/cloudflare-for-saas/saas-customers/how-it-works/).
 
-1. In your Cloudflare zone, create a [proxied](/dns/proxy-status/) CNAME for the hostname that targets the name your SaaS provider specifies.
+1. In your Cloudflare zone, create a [proxied](/dns/proxy-status/) `CNAME` for the hostname that targets the name your SaaS provider specifies.
 2. At your authoritative DNS provider, keep DNS that delivers visitors to Cloudflare for that hostname (for example `{hostname}.cdn.cloudflare.net`, or the provider's Cloudflare hostname when their guide uses that pattern).
 3. Follow your [provider guide](/cloudflare-for-platforms/cloudflare-for-saas/saas-customers/provider-guides/) for activation and product limits.
 
-Partial setup does not require moving nameservers to Cloudflare. O2O depends on the proxied CNAME in your Cloudflare zone once visitor traffic reaches Cloudflare for that hostname.
+Partial setup does not require moving nameservers to Cloudflare. O2O depends on the proxied `CNAME` in your Cloudflare zone once visitor traffic reaches Cloudflare for that hostname.

--- a/src/content/docs/ssl/reference/certificate-and-hostname-priority.mdx
+++ b/src/content/docs/ssl/reference/certificate-and-hostname-priority.mdx
@@ -58,6 +58,12 @@ Cloudflare uses the following order to determine the certificate and settings us
 
 When multiple <GlossaryTooltip term="proxy status">proxied DNS records</GlossaryTooltip> exist for a hostname, in multiple <GlossaryTooltip term="zone">zones</GlossaryTooltip> — usually due to [Cloudflare for SaaS](/cloudflare-for-platforms/cloudflare-for-saas/) — only one record will control the zone settings and associated origin server.
 
+:::note[Orange-to-orange (O2O)]
+The priority order on this page decides which **single** configuration owns a hostname when the same name appears in more than one place.
+
+[Orange-to-orange (O2O)](/cloudflare-for-platforms/cloudflare-for-saas/saas-customers/how-it-works/) is different. When your zone has a proxied CNAME to a SaaS provider hostname on another account, Cloudflare applies your zone first and the SaaS provider zone second. Refer to the O2O documentation for that path.
+:::
+
 Cloudflare determines this priority in the following order, assuming each record exists and is proxied (orange-clouded):
 
 1. **Exact hostname match**:
@@ -77,7 +83,7 @@ If a hostname resource record is not proxied (gray-clouded) for a zone on Cloudf
 
 #### Scenario 1
 
-Customer1 uses Cloudflare as authoritative DNS for the zone `shop.example.com`. Customer2 is a SaaS provider that creates and successfully [verifies the new custom hostname](/cloudflare-for-platforms/cloudflare-for-saas/domain-support/hostname-validation/) `shop.example.com`. Afterward, traffic starts routing over Customer2's zone:
+Customer1 has a Cloudflare zone for `shop.example.com` (full or [partial](/dns/zone-setups/partial-setup/) setup). Customer2 is a SaaS provider that creates and successfully [verifies the new custom hostname](/cloudflare-for-platforms/cloudflare-for-saas/domain-support/hostname-validation/) `shop.example.com`. Afterward, traffic starts routing over Customer2's zone:
 
 * If Customer1 wants to regain control of their zone, Customer1 contacts Customer2 and requests them to delete the custom hostname record. Customer1 should make sure to have their record target updated to something other than the SaaS provider target, otherwise Customer1 would get a [`1014` error](/support/troubleshooting/http-status-codes/cloudflare-1xxx-errors/error-1014/).
 * If Customer1 already has a proxied record for `www.example.com` when Customer2 creates and verifies a new custom hostname `www.example.com`, [O2O](/cloudflare-for-platforms/cloudflare-for-saas/saas-customers/how-it-works/) applies.

--- a/src/content/docs/ssl/reference/certificate-and-hostname-priority.mdx
+++ b/src/content/docs/ssl/reference/certificate-and-hostname-priority.mdx
@@ -61,7 +61,7 @@ When multiple <GlossaryTooltip term="proxy status">proxied DNS records</Glossary
 :::note[Orange-to-orange (O2O)]
 The priority order on this page decides which **single** configuration owns a hostname when the same name appears in more than one place.
 
-[Orange-to-orange (O2O)](/cloudflare-for-platforms/cloudflare-for-saas/saas-customers/how-it-works/) is different. When your zone has a proxied CNAME to a SaaS provider hostname on another account, Cloudflare applies your zone first and the SaaS provider zone second. Refer to the O2O documentation for that path.
+[Orange-to-orange (O2O)](/cloudflare-for-platforms/cloudflare-for-saas/saas-customers/how-it-works/) is different. When your zone has a proxied `CNAME` to a SaaS provider hostname on another account, Cloudflare applies your zone first and the SaaS provider zone second. Refer to the O2O documentation for that path.
 :::
 
 Cloudflare determines this priority in the following order, assuming each record exists and is proxied (orange-clouded):


### PR DESCRIPTION
## What

Clarify that orange-to-orange (O2O) applies when a customer zone has a proxied CNAME to a SaaS provider on Cloudflare, including partial (CNAME) DNS setups where Cloudflare is not the authoritative DNS provider.

## Why

The O2O how-it-works page currently reads as if Cloudflare must be authoritative DNS ("If your authoritative DNS is Cloudflare, you have the option to proxy…"). Customers on partial setup with SaaS providers already use O2O; the docs should match that behavior and call out that the proxied CNAME in the customer zone is what enables O2O.

## Changes

- **How O2O works:** prerequisites, full vs partial setup, CNAME target requirements, note when adding your own zone later enables O2O
- **Hostname priority:** callout distinguishing single-zone hostname priority from O2O; Scenario 1 no longer requires "authoritative DNS"
- **Partial setup:** short cross-link section for SaaS / O2O
- **Product compatibility:** one line that full and partial setups are supported

Provider-specific steps remain in the existing provider guides.

## Pages

- `/cloudflare-for-platforms/cloudflare-for-saas/saas-customers/how-it-works/`
- `/ssl/reference/certificate-and-hostname-priority/`
- `/dns/zone-setups/partial-setup/setup/`
- `/cloudflare-for-platforms/cloudflare-for-saas/saas-customers/product-compatibility/`