### PR TITLE
[TOC] Fix 56 rendered-heading scrape failures from deprecated container renderer imports

### DIFF
--- a/src/util/rendered-toc.ts
+++ b/src/util/rendered-toc.ts
@@ -1,8 +1,7 @@
 import { getCollection } from "astro:content";
 import { experimental_AstroContainer as AstroContainer } from "astro/container";
-import { loadRenderers } from "astro:container";
-import { getContainerRenderer as getMdxRenderer } from "@astrojs/mdx";
-import { getContainerRenderer as getReactRenderer } from "@astrojs/react";
+import reactRenderer from "@astrojs/react/server.js";
+import mdxRenderer from "@astrojs/mdx/server.js";
 import { getHeadingsFromHtml, type Heading } from "@cloudflare/nimbus-docs";
 import type { AstroComponentFactory } from "astro/runtime/server/index.js";
 
@@ -71,10 +70,15 @@ export async function scrapeRenderedHeadings(
 	Content: AstroComponentFactory,
 	components: Record<string, unknown>,
 ): Promise<Heading[]> {
-	containerPromise ??= loadRenderers([
-		getMdxRenderer(),
-		getReactRenderer(),
-	]).then((renderers) => AstroContainer.create({ renderers }));
+	containerPromise ??= (async () => {
+		const container = await AstroContainer.create({});
+		container.addServerRenderer({ name: "astro:jsx", renderer: mdxRenderer });
+		container.addServerRenderer({
+			name: "@astrojs/react",
+			renderer: reactRenderer,
+		});
+		return container;
+	})();
 	const html = await (
 		await containerPromise
 	).renderToString(Content, { props: { components } });


### PR DESCRIPTION
## What changed

`src/util/rendered-toc.ts` used the deprecated `loadRenderers([getContainerRenderer()])` + `AstroContainer.create({ renderers })` API to render MDX pages at build time for TOC heading extraction. This path failed with `ERR_UNSUPPORTED_ESM_URL_SCHEME: Received protocol 'astro:'` for 56 pages that use `AnchorHeading` (which emits headings at runtime via `set:html`).

Replaced with `AstroContainer.create({})` + `container.addServerRenderer()` using direct `server.js` imports — the same pattern already used in `src/util/container.ts`.

## Results

| Metric | Before | After |
|--------|--------|-------|
| TOC scrape failures | 56 | 0 |
| Deprecated renderer import type hints | 4 | 0 |
| Pages built | 8,802 | 8,802 |

## Checklist

- [x] `pnpm run check` — 0 errors
- [x] `pnpm run build` — 8,802 pages, no new warnings
- [x] `pnpm exec prettier` — clean