### PR TITLE
[API Shield] Update API Discovery operation workflow

### DIFF
--- a/src/content/docs/api-shield/security/api-discovery.mdx
+++ b/src/content/docs/api-shield/security/api-discovery.mdx
@@ -46,26 +46,24 @@ Cloudflare consolidates these to `{hostVar1}.example.com/api/v1/users/{var1}`.
 
 For more technical details, refer to the [blog post](https://blog.cloudflare.com/ml-api-discovery-and-schema-learning/).
 
-### Inbox view
+### Discovered operations
 
-API Shield first catalogs your discovered API endpoints in an inbox-style view. From API Discovery, you can save endpoints to [Endpoint Management](/api-shield/management-and-monitoring/) or ignore endpoints to remove them from view.
+Web Assets adds discovered API endpoints to the operation inventory as candidate operations. Candidate operations provide context for matching, logging, detections, and rules before you manually review them.
 
-Save all discovered API endpoints to Endpoint Management. Ignore any false positives by selecting **Save** or **Ignore** on each line, or use bulk selection.
+You do not need to promote every discovered operation. Promote an operation to move it to the `full` state and start profile learning. Full operations support persisted API profiles, risk findings, and protections that require a known API endpoint.
 
-To get started, search for `var1` in the search box to find all endpoints with path variables and save them first. You can examine endpoints without path variables later.
+To promote a discovered operation:
 
-Adding endpoints to Endpoint Management unlocks additional [security](/api-shield/security/), [visibility](/api-shield/management-and-monitoring/#endpoint-analysis), and [management](/api-shield/management-and-monitoring/) features.
+<Steps>
+1. In the Cloudflare dashboard, go to the **Web Assets** page.
 
-To restore any errantly ignored endpoints, you can filter by **Ignored** and select **Restore**.
+   <DashButton url="/?to=/:account/:zone/security/web-assets" />
+2. Go to the **Operations** tab.
+3. Open the row actions for a candidate or shadow operation.
+4. Select **Learn profile**.
+</Steps>
 
-API Discovery is an ongoing process. Check back regularly for new results — a badge in the dashboard shows how many endpoints need review.
-
-The **Needs Review** and **Ignored** counts may change over time as your API or traffic patterns change. Discovery results that are not saved can disappear.
-
-:::note
-
-Cloudflare will use your feedback on ignored endpoints to improve the API Discovery machine learning model in a future release.
-:::
+Cloudflare moves the operation to the `full` state. The row action then changes to **Profile learned**. For more information, refer to [Promote an operation](/security/web-assets/manage-operations/#promote-an-operation).
 
 ### Machine learning-based discovery
 


### PR DESCRIPTION
### Summary

- Replaces the obsolete API Discovery inbox, save, and ignore workflow.
- Explains how Web Assets represents discovered endpoints as candidate operations.
- Documents promotion to the `full` state through **Learn profile**.

### Testing

- `pnpm exec prettier --check src/content/docs/api-shield/security/api-discovery.mdx`
- `pnpm run check`
- `pnpm run build`
- `git diff --check`

### Screenshots (optional)

Not applicable. This PR updates documentation content only.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
