### PR TITLE
Add 'Deploy an Internal Static Sites Platform' to Workers for Platforms templates

### DIFF
--- a/src/content/docs/cloudflare-for-platforms/workers-for-platforms/get-started.mdx
+++ b/src/content/docs/cloudflare-for-platforms/workers-for-platforms/get-started.mdx
@@ -93,3 +93,15 @@ With [VibeSDK](https://github.com/cloudflare/vibesdk), Cloudflare's open source 
 <LinkButton type="secondary" href="https://github.com/cloudflare/vibesdk">
 	View on GitHub
 </LinkButton>
+
+## Deploy an internal static sites platform
+
+[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/templates/tree/main/internal-sites-template)
+
+Deploy an internal drag-and-drop static site platform for your company. Employees upload files and get a live URL -- every site is protected behind [Cloudflare Access](/cloudflare-one/).
+
+Uses [Workers for Platforms](/cloudflare-for-platforms/workers-for-platforms/) and [Access](/cloudflare-one/) to handle site deployment and company-wide authentication.
+
+<LinkButton type="secondary" href="https://github.com/cloudflare/templates/tree/main/internal-sites-template">
+	View on GitHub
+</LinkButton>

--- a/src/content/docs/cloudflare-for-platforms/workers-for-platforms/platform-templates/internal-sites-platform.mdx
+++ b/src/content/docs/cloudflare-for-platforms/workers-for-platforms/platform-templates/internal-sites-platform.mdx
@@ -1,0 +1,12 @@
+---
+title: Deploy an Internal Static Sites Platform
+description: Deploy an internal drag-and-drop static site hosting platform protected by Cloudflare Access. Employees upload files and get live URLs behind company login.
+pcx_content_type: tutorial
+difficulty: Intermediate
+external_link: https://github.com/cloudflare/templates/tree/main/internal-sites-template
+sidebar:
+  order: 3
+reviewed: 2025-12-29
+products:
+  - cloudflare-for-platforms
+---


### PR DESCRIPTION
Adds a new platform template entry under **Workers for Platforms > Platform templates**.

Links to [cloudflare/templates#1100](https://github.com/cloudflare/templates/pull/1100) which adds the `internal-sites-template` to the templates repo.

## What this adds

A single `.mdx` file at `src/content/docs/cloudflare-for-platforms/workers-for-platforms/platform-templates/internal-sites-platform.mdx` with an `external_link` pointing to the template GitHub repo.

## About the template

- Drag-and-drop internal static site hosting behind Cloudflare Access
- Uses Workers for Platforms, D1, and Access
- Employees upload files and get live URLs protected by company SSO