### PR TITLE
[Directory] Eliminate directory-entry lookup noise from non-product routes

### DIFF
--- a/src/components/PageHead.astro
+++ b/src/components/PageHead.astro
@@ -5,7 +5,6 @@
  */
 import { existsSync } from "node:fs";
 import { join } from "node:path";
-import { getEntry } from "astro:content";
 import { differenceInCalendarDays } from "date-fns";
 import { config } from "virtual:nimbus/config";
 import {
@@ -22,6 +21,7 @@ import {
 	resolveSocialImagePath,
 } from "~/util/page-head";
 import { stripMarkdownDescription } from "~/util/description";
+import { getDirectoryEntryBySection } from "~/util/directory";
 
 const PRODUCTION_GENERATOR = "Nimbus v0.2.2";
 
@@ -86,11 +86,11 @@ const versionAlternates =
 			}))
 		: [];
 
-// Section slug (first path segment, dots stripped) — matches production.
-const currentSection = pathname.split("/")[1]?.replaceAll(".", "") ?? "";
+// Section slug (first path segment) — matches production.
+const currentSection = pathname.split("/")[1] ?? "";
 const sectionProduct =
 	currentSection && currentSection !== "changelog"
-		? await getEntry("directory", currentSection)
+		? await getDirectoryEntryBySection(currentSection)
 		: undefined;
 const product = meta?.product ?? sectionProduct?.data.entry?.title;
 // productGroup (which honours meta.productGroup) drives the pcx_content_group

--- a/src/components/cf/ResourcesBySelector.astro
+++ b/src/components/cf/ResourcesBySelector.astro
@@ -26,6 +26,7 @@ import {
 	reference,
 } from "astro:content";
 import ResourcesBySelectorReact from "./ResourcesBySelector";
+import { getDirectoryEntryBySection } from "~/util/directory";
 
 type Props = z.input<typeof props>;
 
@@ -85,8 +86,8 @@ const filteredResources = [...docs, ...videos, ...learningPaths].filter(
 const resources = await Promise.all(
 	filteredResources.map(async (resource) => {
 		if (resource.collection === "docs") {
-			const currentSection = resource.id.split("/")[0].replaceAll(".", "");
-			const currentProduct = await getEntry("directory", currentSection);
+			const currentSection = resource.id.split("/")[0];
+			const currentProduct = await getDirectoryEntryBySection(currentSection);
 			if (currentProduct) {
 				// [D4] default to [] before pushing (docs.products is optional,
 				// no .default([])).

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -106,9 +106,7 @@ const socialImage = entry.data.socialImage ?? (await getOgImage(entry));
 // emits the direct-hit meta refresh and noindex metadata.
 const externalLink = entry.data.external_link;
 const head = entry.data.head ?? [];
-const sectionProduct = sectionSegment
-	? await getDirectoryEntryBySection(sectionSegment)
-	: undefined;
+const sectionProduct = await getDirectoryEntryBySection(sectionSegment);
 const productRefs = (entry.data.products ?? []).map((product) =>
 	typeof product === "string"
 		? ({ collection: "directory", id: product } as const)

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -1,6 +1,6 @@
 ---
 import DocsLayout from "../layouts/DocsLayout.astro";
-import { getEntries, getEntry } from "astro:content";
+import { getEntries } from "astro:content";
 import {
 	getDocsStaticPaths,
 	getDocsPageProps,
@@ -14,6 +14,7 @@ import { config } from "virtual:nimbus/config";
 import { docsSidebarTransform, getCfBreadcrumbs } from "../util/sidebar";
 import { components } from "../mdx-components";
 import { getOgImage } from "~/util/og";
+import { getDirectoryEntryBySection } from "~/util/directory";
 import {
 	pageHasRuntimeHeadings,
 	scrapeRenderedHeadings,
@@ -106,7 +107,7 @@ const socialImage = entry.data.socialImage ?? (await getOgImage(entry));
 const externalLink = entry.data.external_link;
 const head = entry.data.head ?? [];
 const sectionProduct = sectionSegment
-	? await getEntry("directory", sectionSegment.replaceAll(".", ""))
+	? await getDirectoryEntryBySection(sectionSegment)
 	: undefined;
 const productRefs = (entry.data.products ?? []).map((product) =>
 	typeof product === "string"

--- a/src/util/directory.ts
+++ b/src/util/directory.ts
@@ -5,9 +5,49 @@
  *
  * CF source: cloudflare-docs/src/util/directory.ts (faithful port).
  */
-import { getCollection } from "astro:content";
+import { getCollection, getEntry, type CollectionEntry } from "astro:content";
 
 export const directory = await getCollection("directory");
+
+// Map from URL first segment → directory entry, so route-section lookups
+// resolve products whose collection ID differs from their public URL (e.g.
+// `access.yaml` → `/cloudflare-one/`). Also includes the collection ID as
+// a key for `frontmatter.products` string refs. Entries without an `entry.url`
+// are indexed by their collection ID only.
+const directoryBySection = new Map<string, CollectionEntry<"directory">>();
+for (const entry of directory) {
+	directoryBySection.set(entry.id, entry);
+	if (entry.data.entry?.url) {
+		const section = entry.data.entry.url.split("/").filter(Boolean)[0];
+		if (section && !directoryBySection.has(section)) {
+			directoryBySection.set(section, entry);
+		}
+	}
+}
+
+// Non-product routes that should never trigger a directory lookup.
+const NON_PRODUCT_SECTIONS = new Set([
+	"404",
+	"directory",
+	"glossary",
+	"plans",
+	"resources",
+	"sponsorships",
+	"videos",
+]);
+
+/**
+ * Resolve a directory entry by URL path section. Returns `undefined`
+ * silently for non-product routes and unknown sections.
+ */
+export async function getDirectoryEntryBySection(
+	section: string | undefined,
+): Promise<CollectionEntry<"directory"> | undefined> {
+	if (!section || NON_PRODUCT_SECTIONS.has(section)) return undefined;
+	const cached = directoryBySection.get(section);
+	if (cached) return cached;
+	return await getEntry("directory", section);
+}
 
 export const directoryByGroup = Object.entries(
 	directory

--- a/src/util/directory.ts
+++ b/src/util/directory.ts
@@ -5,7 +5,7 @@
  *
  * CF source: cloudflare-docs/src/util/directory.ts (faithful port).
  */
-import { getCollection, getEntry, type CollectionEntry } from "astro:content";
+import { getCollection, type CollectionEntry } from "astro:content";
 
 export const directory = await getCollection("directory");
 
@@ -44,9 +44,7 @@ export async function getDirectoryEntryBySection(
 	section: string | undefined,
 ): Promise<CollectionEntry<"directory"> | undefined> {
 	if (!section || NON_PRODUCT_SECTIONS.has(section)) return undefined;
-	const cached = directoryBySection.get(section);
-	if (cached) return cached;
-	return await getEntry("directory", section);
+	return directoryBySection.get(section);
 }
 
 export const directoryByGroup = Object.entries(

--- a/src/util/sidebar.ts
+++ b/src/util/sidebar.ts
@@ -9,6 +9,7 @@ import type {
 	SidebarItem,
 	SidebarTransform,
 } from "@cloudflare/nimbus-docs/types";
+import { getDirectoryEntryBySection } from "~/util/directory";
 
 export const sectionTitleResolver: SectionTitleResolver = async ({
 	sectionSlug,
@@ -20,7 +21,7 @@ export const sectionTitleResolver: SectionTitleResolver = async ({
 		return entry ? { rail: `${entry.data.title} (Learning Paths)` } : undefined;
 	}
 
-	const entry = await getEntry("directory", sectionSlug);
+	const entry = await getDirectoryEntryBySection(sectionSlug);
 	return entry ? { rail: entry.data.entry?.title } : undefined;
 };
 
@@ -28,7 +29,7 @@ export const sectionTitleResolver: SectionTitleResolver = async ({
 const sectionTitleCache = new Map<string, string | undefined>();
 async function directoryTitle(seg0: string): Promise<string | undefined> {
 	if (sectionTitleCache.has(seg0)) return sectionTitleCache.get(seg0);
-	const entry = await getEntry("directory", seg0);
+	const entry = await getDirectoryEntryBySection(seg0);
 	const title = entry?.data.entry?.title;
 	sectionTitleCache.set(seg0, title);
 	return title;
@@ -105,7 +106,7 @@ export const agentResourcesTransform: SidebarTransform = async ({
 }) => {
 	if (!sectionSlug || NO_LLM_RESOURCES.has(sectionSlug)) return tree;
 
-	const product = await getEntry("directory", sectionSlug);
+	const product = await getDirectoryEntryBySection(sectionSlug);
 	if (!product) return tree;
 
 	const baseUrl = product.data.entry?.url ?? `/${sectionSlug}/`;


### PR DESCRIPTION
## What changed

Added `getDirectoryEntryBySection()` in `src/util/directory.ts` — a shared helper that resolves directory entries by URL section (first path segment) using a pre-built map from `entry.data.entry.url`. Preserves dots so `1.1.1.1` resolves correctly, and skips known non-product routes (`videos`, `glossary`, `plans`, `directory`, `sponsorships`, `resources`, `404`).

Replaced 6 scattered `getEntry("directory", section.replaceAll(".", ""))` call sites across 4 files with the shared helper:
- `src/pages/[...slug].astro`
- `src/components/PageHead.astro`
- `src/components/cf/ResourcesBySelector.astro`
- `src/util/sidebar.ts` (3 locations)

## Root causes

- `replaceAll(".", "")` corrupted `1.1.1.1` into `1111`, which has no directory entry (85 warnings)
- Non-product routes like `/videos/`, `/resources/`, `/glossary/` were looked up as directory entries (37 warnings)
- The lookup was duplicated across 4 files with no shared guard

## Results

| Metric | Before | After |
|--------|--------|-------|
| `Entry directory → ... was not found.` | 122 | 0 |
| Pages built | 8,802 | 8,802 |

## Checklist

- [x] `pnpm run check` — 0 errors
- [x] `pnpm run build` — 8,802 pages, no new warnings
- [x] `pnpm exec prettier` — clean