### PR TITLE
[Routes] Eliminate route collision warnings from shadowed stubs, duplicate slugs, RSS conflicts, and llms.txt dupes

### DIFF
--- a/src/pages/[...product]/llms.txt.ts
+++ b/src/pages/[...product]/llms.txt.ts
@@ -20,23 +20,34 @@ export const getStaticPaths = (async () => {
 	const docs = await getCollection("docs");
 
 	// Deduplicate by URL path: multiple directory entries may share the same
-	// entry.url (e.g. SDK variants). Keep only the first per URL.
-	const seen = new Set<string>();
+	// entry.url (e.g. SDK variants). For shared URLs, prefer the generic
+	// entry (e.g. `sdk`) over language-specific variants (e.g. `go-sdk`).
+	const CANONICAL_IDS = new Set(["sdk"]);
 
-	return directory
+	const entriesByUrl = new Map<string, (typeof directory)[number]>();
+	for (const entry of directory) {
+		const productUrl = entry.data.entry?.url;
+		if (!productUrl || productUrl === "/" || productUrl.includes("#")) {
+			continue;
+		}
+		if (isDisallowedByRobots(productUrl)) continue;
+
+		const urlPath = productUrl.slice(1, -1);
+		if (!urlPath) continue;
+
+		const existing = entriesByUrl.get(urlPath);
+		if (!existing || CANONICAL_IDS.has(entry.id)) {
+			entriesByUrl.set(urlPath, entry);
+		}
+	}
+
+	return [...entriesByUrl.values()]
 		.map((entry) => {
 			const productUrl = entry.data.entry?.url;
-			if (!productUrl || productUrl === "/" || productUrl.includes("#")) {
-				return null;
-			}
-
-			if (isDisallowedByRobots(productUrl)) return null;
+			if (!productUrl) return null;
 
 			const urlPath = productUrl.slice(1, -1);
 			if (!urlPath) return null;
-
-			if (seen.has(urlPath)) return null;
-			seen.add(urlPath);
 
 			const prefix = urlPath;
 			const pages = docs.filter(

--- a/src/pages/[...product]/llms.txt.ts
+++ b/src/pages/[...product]/llms.txt.ts
@@ -19,6 +19,10 @@ export const getStaticPaths = (async () => {
 	const directory = await getCollection("directory");
 	const docs = await getCollection("docs");
 
+	// Deduplicate by URL path: multiple directory entries may share the same
+	// entry.url (e.g. SDK variants). Keep only the first per URL.
+	const seen = new Set<string>();
+
 	return directory
 		.map((entry) => {
 			const productUrl = entry.data.entry?.url;
@@ -30,6 +34,9 @@ export const getStaticPaths = (async () => {
 
 			const urlPath = productUrl.slice(1, -1);
 			if (!urlPath) return null;
+
+			if (seen.has(urlPath)) return null;
+			seen.add(urlPath);
 
 			const prefix = urlPath;
 			const pages = docs.filter(

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -23,7 +23,22 @@ import {
 const NOINDEX_PRODUCTS = ["email-security"];
 
 export const prerender = true;
-export const getStaticPaths = getDocsStaticPaths;
+export const getStaticPaths = (async (...args) => {
+	const paths = await getDocsStaticPaths(...args);
+	// Content stubs that have a corresponding explicit src/pages route.
+	// The explicit page wins; filtering them here avoids duplicate-slug warnings.
+	const shadowed = new Set([
+		"ai/models",
+		"workers-ai/models",
+		"ruleset-engine/rules-language/fields/reference",
+		"waf/change-log/changelog",
+	]);
+	return paths.filter((p) => {
+		const slug = p.params.slug;
+		if (!slug) return true;
+		return !shadowed.has(slug);
+	});
+}) as typeof getDocsStaticPaths;
 
 const { entry, Content, headings } = await getDocsPageProps(Astro, {
 	partialHeadings: {

--- a/src/pages/changelog/rss/[area].xml.ts
+++ b/src/pages/changelog/rss/[area].xml.ts
@@ -21,30 +21,23 @@ export const prerender = true;
 const slugifyArea = (value: string) => value.replaceAll(" ", "-").toLowerCase();
 
 export const getStaticPaths = (async () => {
-	const [products, directory] = await Promise.all([
-		getCollection("directory", (e) => Boolean(e.data.entry?.group)),
-		getCollection("directory"),
-	]);
-
-	// Product IDs that would collide with area slugs — the product route
-	// owns those URLs, so skip them here to avoid route conflicts.
-	const productIds = new Set(directory.map((e) => e.id));
+	const products = await getCollection("directory", (e) =>
+		Boolean(e.data.entry?.group),
+	);
 
 	const areas = Object.entries(
 		Object.groupBy(products, (p) => p.data.entry!.group!),
 	);
 
-	return areas
-		.map(([area, products]) => {
-			if (!products)
-				throw new Error(`[Changelog] No products attributed to "${area}"`);
+	return areas.map(([area, products]) => {
+		if (!products)
+			throw new Error(`[Changelog] No products attributed to "${area}"`);
 
-			return {
-				params: { area: slugifyArea(area) },
-				props: { title: area, products },
-			};
-		})
-		.filter((p) => !productIds.has(p.params.area));
+		return {
+			params: { area: slugifyArea(area) },
+			props: { title: area, products },
+		};
+	});
 }) satisfies GetStaticPaths;
 
 type Props = InferGetStaticPropsType<typeof getStaticPaths>;

--- a/src/pages/changelog/rss/[area].xml.ts
+++ b/src/pages/changelog/rss/[area].xml.ts
@@ -21,23 +21,30 @@ export const prerender = true;
 const slugifyArea = (value: string) => value.replaceAll(" ", "-").toLowerCase();
 
 export const getStaticPaths = (async () => {
-	const products = await getCollection("directory", (e) =>
-		Boolean(e.data.entry?.group),
-	);
+	const [products, directory] = await Promise.all([
+		getCollection("directory", (e) => Boolean(e.data.entry?.group)),
+		getCollection("directory"),
+	]);
+
+	// Product IDs that would collide with area slugs — the product route
+	// owns those URLs, so skip them here to avoid route conflicts.
+	const productIds = new Set(directory.map((e) => e.id));
 
 	const areas = Object.entries(
 		Object.groupBy(products, (p) => p.data.entry!.group!),
 	);
 
-	return areas.map(([area, products]) => {
-		if (!products)
-			throw new Error(`[Changelog] No products attributed to "${area}"`);
+	return areas
+		.map(([area, products]) => {
+			if (!products)
+				throw new Error(`[Changelog] No products attributed to "${area}"`);
 
-		return {
-			params: { area: slugifyArea(area) },
-			props: { title: area, products },
-		};
-	});
+			return {
+				params: { area: slugifyArea(area) },
+				props: { title: area, products },
+			};
+		})
+		.filter((p) => !productIds.has(p.params.area));
 }) satisfies GetStaticPaths;
 
 type Props = InferGetStaticPropsType<typeof getStaticPaths>;

--- a/src/pages/changelog/rss/[product].xml.ts
+++ b/src/pages/changelog/rss/[product].xml.ts
@@ -6,6 +6,7 @@ import rss from "@astrojs/rss";
 import { getCollection } from "astro:content";
 import { config } from "virtual:nimbus/config";
 import { getChangelogs, getRSSItems } from "~/util/changelog";
+import { groups } from "~/util/directory";
 
 import type {
 	APIRoute,
@@ -16,15 +17,23 @@ import type {
 
 export const prerender = true;
 
+const slugifyArea = (value: string) => value.replaceAll(" ", "-").toLowerCase();
+
 export const getStaticPaths = (async () => {
 	const directory = await getCollection("directory");
 
-	return directory.map((entry) => {
-		return {
-			params: { product: entry.id },
-			props: { product: entry },
-		};
-	});
+	// Area group slugs that would collide with product IDs — the area
+	// route owns those URLs, so skip them here to avoid route conflicts.
+	const areaSlugs = new Set(groups.map(slugifyArea));
+
+	return directory
+		.filter((entry) => !areaSlugs.has(entry.id))
+		.map((entry) => {
+			return {
+				params: { product: entry.id },
+				props: { product: entry },
+			};
+		});
 }) satisfies GetStaticPaths;
 
 type Props = InferGetStaticPropsType<typeof getStaticPaths>;

--- a/src/util/changelog.ts
+++ b/src/util/changelog.ts
@@ -108,11 +108,30 @@ export async function getChangelogs({
 }: GetChangelogsOptions): Promise<Array<CollectionEntry<"changelog">>> {
 	let entries = await getCollection("changelog");
 
+	// First pass: extract slug + folder for every entry (synchronous,
+	// deterministic — collection order is alphabetical by file path).
+	const parsed = entries.map((e) => {
+		const slug = e.id.split("/").slice(1).join("/");
+		const folder = e.id.split("/")[0];
+		return { entry: e, slug, folder };
+	});
+
+	// Identify which slugs appear more than once.
 	const slugCounts = new Map<string, number>();
+	for (const { slug } of parsed) {
+		slugCounts.set(slug, (slugCounts.get(slug) ?? 0) + 1);
+	}
+
+	// For duplicate slugs, the first folder in alphabetical order owns the
+	// bare slug; later folders are prefixed. This is deterministic because
+	// `getCollection` returns entries in alphabetical file-path order.
+	// Explicit overrides can force a specific canonical owner.
+	const CANONICAL_OWNERS: Record<string, string> = {
+		"2026-04-01-l4-transport-telemetry-fields": "workers",
+	};
+
 	entries = await Promise.all(
-		entries.map(async (e) => {
-			const slug = e.id.split("/").slice(1).join("/");
-			const folder = e.id.split("/")[0];
+		parsed.map(async ({ entry: e, slug, folder }) => {
 			const product = { collection: "directory", id: folder } as const;
 
 			const isValidProduct = await getEntry(product);
@@ -127,11 +146,24 @@ export async function getChangelogs({
 				e.data.products.push(product);
 			}
 
-			// Deduplicate: when entries from different product folders share
-			// the same slug, prefix later occurrences with the folder name.
-			const count = slugCounts.get(slug) ?? 0;
-			slugCounts.set(slug, count + 1);
-			const dedupedId = count === 0 ? slug : `${folder}/${slug}`;
+			const count = slugCounts.get(slug) ?? 1;
+			const canonicalOwner = CANONICAL_OWNERS[slug];
+			let dedupedId: string;
+
+			if (count <= 1) {
+				dedupedId = slug;
+			} else if (canonicalOwner && folder === canonicalOwner) {
+				dedupedId = slug;
+			} else if (canonicalOwner) {
+				dedupedId = `${folder}/${slug}`;
+			} else {
+				// No explicit owner: first folder alphabetically wins.
+				const folders = parsed
+					.filter((p) => p.slug === slug)
+					.map((p) => p.folder);
+				const firstFolder = folders.sort()[0];
+				dedupedId = folder === firstFolder ? slug : `${folder}/${slug}`;
+			}
 
 			return {
 				...e,

--- a/src/util/changelog.ts
+++ b/src/util/changelog.ts
@@ -108,6 +108,7 @@ export async function getChangelogs({
 }: GetChangelogsOptions): Promise<Array<CollectionEntry<"changelog">>> {
 	let entries = await getCollection("changelog");
 
+	const slugCounts = new Map<string, number>();
 	entries = await Promise.all(
 		entries.map(async (e) => {
 			const slug = e.id.split("/").slice(1).join("/");
@@ -126,9 +127,15 @@ export async function getChangelogs({
 				e.data.products.push(product);
 			}
 
+			// Deduplicate: when entries from different product folders share
+			// the same slug, prefix later occurrences with the folder name.
+			const count = slugCounts.get(slug) ?? 0;
+			slugCounts.set(slug, count + 1);
+			const dedupedId = count === 0 ? slug : `${folder}/${slug}`;
+
 			return {
 				...e,
-				id: slug,
+				id: dedupedId,
 			};
 		}),
 	);


### PR DESCRIPTION
### Summary

Four distinct route collision sources, all fixed without URL changes or redirects. The original approach traded route conflicts for semantic regressions (broken area RSS feed, non-deterministic changelog permalink ownership, wrong llms.txt metadata). This follow-up commit fixes the semantics while keeping the route conflicts eliminated.

#### 1. Content stubs shadowing explicit `src/pages` routes (4 routes)

Wrapped `getDocsStaticPaths` in `src/pages/[...slug].astro` to filter out content stubs that have a corresponding explicit page:
- `ai/models`
- `workers-ai/models`
- `ruleset-engine/rules-language/fields/reference`
- `waf/change-log/changelog`

#### 2. Duplicate changelog post slugs (1 collision)

`getChangelogs()` in `src/util/changelog.ts` strips the product folder from the ID, causing entries from different folders with the same date-filename to collide (e.g. `rules/2026-04-01-l4-transport-telemetry-fields.mdx` and `workers/2026-04-01-l4-transport-telemetry-fields.mdx`).

**Fix:** Two-pass dedup — first pass synchronously collects all slugs and identifies duplicates; second pass assigns canonical ownership deterministically. An explicit `CANONICAL_OWNERS` map forces `workers` to keep the bare slug for the known collision (matching production behavior); fallback is alphabetical-first folder. No more `await`-dependent ordering inside `Promise.all`.

#### 3. RSS product/group path collision (1 collision)

`/changelog/rss/cloudflare-one.xml` was generated by both `[product].xml.ts` (product ID `cloudflare-one`) and `[area].xml.ts` (group slug `cloudflare-one`).

**Fix:** The area feed owns this URL (matching production). `[area].xml.ts` generates all area slugs including `cloudflare-one`. `[product].xml.ts` skips any product ID that collides with an area group slug, so the product feed for `cloudflare-one` is not generated. The area feed includes all group products (Access, Gateway, CASB, etc.) with the description "Cloudflare changelogs for Cloudflare One products".

#### 4. Duplicate `llms.txt` static paths (3 collisions)

Four SDK directory entries (`sdk`, `go-sdk`, `python-sdk`, `typescript-sdk`) share `entry.url: /fundamentals/api/reference/sdks/`, causing `[...product]/llms.txt.ts` to emit the same static path 4 times.

**Fix:** Replaced "first entry wins" Set with a `Map<url, entry>` + `CANONICAL_IDS` set. The generic `sdk` entry is explicitly preferred over language-specific variants (`go-sdk`, `python-sdk`, `typescript-sdk`) for the shared URL. The generated `/fundamentals/api/reference/sdks/llms.txt` now shows `# SDK` with the generic description instead of `# Go SDK` or `# TypeScript SDK`.

### Results

| Metric | Before | After |
|--------|--------|-------|
| `Could not render` route conflicts | 9 | 0 |
| Pages built | 8,802 | 8,809 |

Verified against production:
- `/changelog/rss/cloudflare-one.xml` — area feed with all group items (Access, Gateway, etc.), description "Cloudflare changelogs for Cloudflare One products"
- `/changelog/post/2026-04-01-l4-transport-telemetry-fields/` — Workers content (matches production)
- `/fundamentals/api/reference/sdks/llms.txt` — `# SDK` with generic description

The Nimbus `duplicate-slug` informational warning (3 routes) persists — it is emitted by the framework during `getDocsStaticPaths` before our filter runs.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [x] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
