### PR TITLE
fix: remove cacheDir override and node_modules CI caching

### DIFF
--- a/.github/workflows/anchor-link-audit.yml
+++ b/.github/workflows/anchor-link-audit.yml
@@ -29,16 +29,8 @@ jobs:
           node-version: 24.x
           cache: pnpm
 
-      - name: Restore node_modules (cache hit)
-        id: node-modules-cache
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
-        with:
-          path: node_modules
-          key: node-modules-${{ runner.os }}-node-${{ steps.setup-node.outputs.node-version }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ hashFiles('package.json') }}
-
-      - name: Install node_modules (cache miss)
+      - name: Install dependencies
         run: pnpm install --frozen-lockfile
-        if: steps.node-modules-cache.outputs.cache-hit != 'true'
 
       - run: pnpm run build
         env:
@@ -63,13 +55,6 @@ jobs:
         run: |
           ./bin/htmltest -c ./bin/.htmltest.yml 2>&1 | grep -v "#_top" | tee /tmp/htmltest-filtered.txt || true
           if grep -q "hash does not exist" /tmp/htmltest-filtered.txt; then exit 1; fi
-
-      - name: Save node_modules cache
-        if: always()
-        uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
-        with:
-          path: node_modules
-          key: node-modules-${{ runner.os }}-node-${{ steps.setup-node.outputs.node-version }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ hashFiles('package.json') }}
 
       - name: Create issue on failure
         if: ${{ failure() }}

--- a/.github/workflows/bigbonk.yml
+++ b/.github/workflows/bigbonk.yml
@@ -40,16 +40,8 @@ jobs:
           node-version: 24.x
           cache: pnpm
 
-      - name: Restore node_modules (cache hit)
-        id: node-modules-cache
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
-        with:
-          path: node_modules
-          key: node-modules-${{ runner.os }}-node-${{ steps.setup-node.outputs.node-version }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ hashFiles('package.json') }}
-
-      - name: Install node_modules (cache miss)
+      - name: Install dependencies
         run: pnpm install --frozen-lockfile
-        if: steps.node-modules-cache.outputs.cache-hit != 'true'
 
       - name: Run Bonk
         uses: ask-bonk/ask-bonk/github@main

--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -64,16 +64,8 @@ jobs:
           node-version: 24.x
           cache: pnpm
 
-      - name: Restore node_modules (cache hit)
-        id: node-modules-cache
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
-        with:
-          path: node_modules
-          key: node-modules-${{ runner.os }}-node-${{ steps.setup-node.outputs.node-version }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ hashFiles('package.json') }}
-
-      - name: Install node_modules (cache miss)
+      - name: Install dependencies
         run: pnpm install --frozen-lockfile
-        if: steps.node-modules-cache.outputs.cache-hit != 'true'
 
       - name: Run Lil Bonk
         uses: ask-bonk/ask-bonk/github@main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,16 +63,8 @@ jobs:
             exit 1
           fi
 
-      - name: Restore node_modules (cache hit)
-        id: node-modules-cache
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
-        with:
-          path: node_modules
-          key: node-modules-${{ runner.os }}-node-${{ steps.setup-node.outputs.node-version }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ hashFiles('package.json') }}
-
-      - name: Install node_modules (cache miss)
+      - name: Install dependencies
         run: pnpm install --frozen-lockfile
-        if: steps.node-modules-cache.outputs.cache-hit != 'true'
 
       - name: Post codeowners comment
         run: pnpm exec tsx bin/post-codeowners-comment/index.ts
@@ -135,22 +127,14 @@ jobs:
           node-version: 24.x
           cache: pnpm
 
-      - name: Restore node_modules (cache hit)
-        id: node-modules-cache
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
-        with:
-          path: node_modules
-          key: node-modules-${{ runner.os }}-node-${{ steps.setup-node.outputs.node-version }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ hashFiles('package.json') }}
-
-      - name: Install node_modules (cache miss)
+      - name: Install dependencies
         run: pnpm install --frozen-lockfile
-        if: steps.node-modules-cache.outputs.cache-hit != 'true'
 
       - name: Restore Astro assets from cache
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         with:
           path: |
-            .astro-cache/assets
+            node_modules/.astro/assets
           key: astro-assets-${{ hashFiles('src/assets/**') }}
           restore-keys: |
             astro-assets-
@@ -204,16 +188,8 @@ jobs:
           node-version: 24.x
           cache: pnpm
 
-      - name: Restore node_modules (cache hit)
-        id: node-modules-cache
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
-        with:
-          path: node_modules
-          key: node-modules-${{ runner.os }}-node-${{ steps.setup-node.outputs.node-version }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ hashFiles('package.json') }}
-
-      - name: Install node_modules (cache miss)
+      - name: Install dependencies
         run: pnpm install --frozen-lockfile
-        if: steps.node-modules-cache.outputs.cache-hit != 'true'
 
       - name: Download artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -250,16 +226,8 @@ jobs:
           node-version: 24.x
           cache: pnpm
 
-      - name: Restore node_modules (cache hit)
-        id: node-modules-cache
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
-        with:
-          path: node_modules
-          key: node-modules-${{ runner.os }}-node-${{ steps.setup-node.outputs.node-version }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ hashFiles('package.json') }}
-
-      - name: Install node_modules (cache miss)
+      - name: Install dependencies
         run: pnpm install --frozen-lockfile
-        if: steps.node-modules-cache.outputs.cache-hit != 'true'
 
       - name: Post PR CI failure comment
         continue-on-error: true
@@ -293,16 +261,8 @@ jobs:
           node-version: 24.x
           cache: pnpm
 
-      - name: Restore node_modules (cache hit)
-        id: node-modules-cache
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
-        with:
-          path: node_modules
-          key: node-modules-${{ runner.os }}-node-${{ steps.setup-node.outputs.node-version }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ hashFiles('package.json') }}
-
-      - name: Install node_modules (cache miss)
+      - name: Install dependencies
         run: pnpm install --frozen-lockfile
-        if: steps.node-modules-cache.outputs.cache-hit != 'true'
 
       - name: Download artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8

--- a/.github/workflows/publish-production.yml
+++ b/.github/workflows/publish-production.yml
@@ -26,22 +26,14 @@ jobs:
           node-version: 24.x
           cache: pnpm
 
-      - name: Restore node_modules (cache hit)
-        id: node-modules-cache
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
-        with:
-          path: node_modules
-          key: node-modules-${{ runner.os }}-node-${{ steps.setup-node.outputs.node-version }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ hashFiles('package.json') }}
-
-      - name: Install node_modules (cache miss)
+      - name: Install dependencies
         run: pnpm install --frozen-lockfile
-        if: steps.node-modules-cache.outputs.cache-hit != 'true'
 
       - name: Restore Astro assets from cache
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         with:
           path: |
-            .astro-cache/assets
+            node_modules/.astro/assets
           key: astro-assets-${{ hashFiles('src/assets/**') }}
           restore-keys: |
             astro-assets-

--- a/.gitignore
+++ b/.gitignore
@@ -6,9 +6,6 @@ distllms/
 # generated types
 .astro/
 
-# Astro build cache
-.astro-cache/
-
 # skills/ is fetched from middlecache via bin/fetch-skills.ts
 skills/
 !.agents/skills/

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -278,7 +278,6 @@ export default defineConfig({
 		defaultStrategy: "hover",
 	},
 	outDir: "./dist",
-	cacheDir: ".astro-cache",
 	markdown,
 	image: {
 		service: {
@@ -296,7 +295,7 @@ export default defineConfig({
 		...appVite,
 		server: {
 			watch: {
-				ignored: ["**/dist/**", "**/.astro-cache/**"],
+				ignored: ["**/dist/**"],
 			},
 		},
 	},


### PR DESCRIPTION
### Summary

Removes the `cacheDir: ".astro-cache"` override from `astro.config.ts`, reverting to Astro's default `node_modules/.astro`. This was originally added in #31192 to work around a stale-cache problem caused by CI caching the entire `node_modules` directory — the dependency-only cache key (`pnpm-lock.yaml` + `package.json` hashes) didn't account for content/source changes, so stale Astro content-layer state persisted across runs.

Instead of working around the problem by moving the cache directory, this PR removes the root cause: the direct `node_modules` caching in all GitHub Actions workflows. All jobs now rely solely on `setup-node`'s `cache: pnpm` (which caches the pnpm store, not `node_modules` itself) and run `pnpm install --frozen-lockfile` unconditionally. The targeted Astro assets cache is kept but updated to use the default path (`node_modules/.astro/assets`).

This also aligns the repo with Workers Builds' built-in Astro caching, which hardcodes `node_modules/.astro` as the cache directory.

**Files changed:**
- `astro.config.ts` — removed `cacheDir` override and `.astro-cache` from Vite watch ignored paths
- `.gitignore` — removed `.astro-cache/` entry
- `.github/workflows/ci.yml` — removed `node_modules` cache/restore steps from all 5 jobs; updated Astro assets cache path to `node_modules/.astro/assets`
- `.github/workflows/publish-production.yml` — same
- `.github/workflows/bonk.yml`, `bigbonk.yml`, `anchor-link-audit.yml` — removed `node_modules` cache/restore steps
