### PR TITLE
changelog: serve aus-mobile.mp4 from middlecache

### DIFF
--- a/src/content/changelog/stream/2025-03-06-media-transformations.mdx
+++ b/src/content/changelog/stream/2025-03-06-media-transformations.mdx
@@ -34,12 +34,12 @@ original is nearly 30 megabytes and wider than necessary for this layout.
 Consider a simple width adjustment:
 
 <video controls>
-	<source src="https://developers.cloudflare.com/cdn-cgi/media/width=640/https://pub-d9fcbc1abcd244c1821f38b99017347f.r2.dev/aus-mobile.mp4" />
+	<source src="https://developers.cloudflare.com/cdn-cgi/media/width=640/https://middlecache.ced.cloudflare.com/v1/aus-mobile/aus-mobile.mp4" />
 </video>
 
 ```text title="Example URL"
 https://example.com/cdn-cgi/media/width=640/<SOURCE-VIDEO>
-https://developers.cloudflare.com/cdn-cgi/media/width=640/https://pub-d9fcbc1abcd244c1821f38b99017347f.r2.dev/aus-mobile.mp4
+https://developers.cloudflare.com/cdn-cgi/media/width=640/https://middlecache.ced.cloudflare.com/v1/aus-mobile/aus-mobile.mp4
 ```
 
 The result is less than 3 megabytes, properly sized, and delivered dynamically


### PR DESCRIPTION
## What

Updates the [Media Transformations changelog](https://developers.cloudflare.com/changelog/stream/media-transformations/) to reference the `aus-mobile.mp4` video from middlecache instead of the external R2 public bucket.

## Why

The video was previously served from `pub-d9fcbc1abcd244c1821f38b99017347f.r2.dev`.

## Changes

- `src/content/changelog/stream/2025-03-06-media-transformations.mdx`
  - `<video>` source URL: `pub-d9fcbc1abcd244c1821f38b99017347f.r2.dev/aus-mobile.mp4` → `middlecache.ced.cloudflare.com/v1/aus-mobile/aus-mobile.mp4`
  - Example URL in code block: same replacement