### PR TITLE
[D1] Document US jurisdiction

### DIFF
--- a/src/content/changelog/d1/2026-08-06-us-jurisdiction.mdx
+++ b/src/content/changelog/d1/2026-08-06-us-jurisdiction.mdx
@@ -1,0 +1,20 @@
+---
+title: United States jurisdiction
+description: Create D1 databases that remain within the United States.
+products:
+  - d1
+date: 2026-08-06
+hidden: true
+---
+
+You can create D1 databases with the `us` jurisdiction. These databases run and persist data within the United States.
+
+Use this option for regional data residency requirements.
+
+To create a database with the `us` jurisdiction, run:
+
+```sh
+npx wrangler@latest d1 create db-with-us-jurisdiction --jurisdiction=us
+```
+
+For more information, refer to [D1 data location](/d1/configuration/data-location/).

--- a/src/content/docs/d1/configuration/data-location.mdx
+++ b/src/content/docs/d1/configuration/data-location.mdx
@@ -33,6 +33,7 @@ Jurisdictions can only be set on database creation and cannot be added or update
 | --------- | ------------------------------ |
 | eu        | The European Union             |
 | fedramp   | FedRAMP-compliant data centers |
+| us        | The United States              |
 
 ### Use the dashboard
 


### PR DESCRIPTION
### Summary

Adds a draft changelog entry and updates D1 data location documentation for the new US jurisdiction.

- Adds a hidden changelog entry with a Wrangler example so the announcement remains unpublished pending review.
- Adds `us` to the supported jurisdictions table so the location reference matches the available option.

### Documentation checklist

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
