### PR TITLE
[Cloudflare One] Fix incorrect resolver selection description in resolver policies

### DIFF
--- a/src/content/partials/cloudflare-one/gateway/create-resolver-policy.mdx
+++ b/src/content/partials/cloudflare-one/gateway/create-resolver-policy.mdx
@@ -78,4 +78,4 @@ When a user's query matches a resolver policy, Gateway will send the query to yo
 2. Private resolvers behind the default virtual network for your account
 3. Private resolvers behind a custom virtual network
 
-Gateway will cache the fastest resolver for use in subsequent queries. Resolver priority is cached on a per user basis for each data center.
+Within each of the three above scenarios, Gateway selects a resolver at random using uniform traffic distribution. If the selected resolver does not respond in time, Gateway will attempt the next resolver based on observed round-trip time.


### PR DESCRIPTION
## What

Fixes an inaccuracy in the resolver policies documentation. The docs stated that Gateway caches the fastest resolver for subsequent queries. This is not how the system works.

## Actual behavior

Gateway selects a resolver at random using uniform traffic distribution within each category (public, private-default-vnet, private-custom-vnet). If the selected resolver does not respond in time, Gateway attempts the next resolver based on observed round-trip time. Queries are staggered, not sent all at once.

The FastServer algorithm exists in EdgeDNS but is not used by gateway-resolver for custom resolvers.

## Change

In `src/content/partials/cloudflare-one/gateway/create-resolver-policy.mdx`:

**Before:**
> Gateway will cache the fastest resolver for use in subsequent queries. Resolver priority is cached on a per user basis for each data center.

**After:**
> Within each category, Gateway selects a resolver at random using uniform traffic distribution. If the selected resolver does not respond in time, Gateway will attempt the next resolver based on observed round-trip time.

## Context

This was identified by the Gateway engineering team during investigation of customer DNS resolution behavior with resolver policies.