### PR TITLE
[Logs] Update Logpush dataset field definitions (2026-08-07)

### DIFF
--- a/src/content/changelog/logs/2026-08-07-log-fields-updated.mdx
+++ b/src/content/changelog/logs/2026-08-07-log-fields-updated.mdx
@@ -1,0 +1,16 @@
+---
+title: Updated fields across multiple Logpush datasets in Cloudflare Logs
+description: Fields have been updated across multiple Logpush datasets in Cloudflare Logs.
+date: 2026-08-07
+---
+
+Cloudflare has updated [Logpush datasets](/logs/logpush/logpush-job/datasets/):
+
+### Updated fields in existing datasets
+
+- **Firewall events** (added): `AISecurityCustomTopicCategories`.
+- **Gateway HTTP** (added): `ExperimentalFeatures` and `PackageInfo`.
+- **Firewall events** (added): `AISecurityCustomTopicCategories`.
+- **HTTP requests** (added): `AISecurityCustomTopicCategories` and `ClientTLSKeyExchangeGroup`.
+
+For the complete field definitions for each dataset, refer to [Logpush datasets](/logs/logpush/logpush-job/datasets/).

--- a/src/content/docs/logs/logpush/logpush-job/datasets/account/firewall_events.md
+++ b/src/content/docs/logs/logpush/logpush-job/datasets/account/firewall_events.md
@@ -9,6 +9,12 @@ sidebar:
 
 The descriptions below detail the fields available for `firewall_events`.
 
+## AISecurityCustomTopicCategories
+
+Type: `object`
+
+Customer-defined AI Security topic labels and their relevance scores. A score of 1 indicates the highest relevance, and 99 indicates the lowest relevance.
+
 ## AISecurityInjectionScore
 
 Type: `int`

--- a/src/content/docs/logs/logpush/logpush-job/datasets/account/gateway_http.md
+++ b/src/content/docs/logs/logpush/logpush-job/datasets/account/gateway_http.md
@@ -165,6 +165,12 @@ Type: `string`
 
 Email used to authenticate the client.
 
+## ExperimentalFeatures
+
+Type: `object`
+
+Experimental features which will be either permanently added to the schema or marked for deprecation. In that case, they will be removed 3 months after the notice. Current fields: 'mcp' - If MCP traffic was detected or not.
+
 ## FileInfo
 
 Type: `object`
@@ -206,6 +212,12 @@ Version name for the HTTP request.
 Type: `bool`
 
 If the requested was isolated with Cloudflare Browser Isolation or not.
+
+## PackageInfo
+
+Type: `object`
+
+Information about the software package detected in the HTTP request, including its ecosystem, namespace, name, version, and package URL (PURL).
 
 ## PolicyID
 

--- a/src/content/docs/logs/logpush/logpush-job/datasets/zone/firewall_events.md
+++ b/src/content/docs/logs/logpush/logpush-job/datasets/zone/firewall_events.md
@@ -9,6 +9,12 @@ sidebar:
 
 The descriptions below detail the fields available for `firewall_events`.
 
+## AISecurityCustomTopicCategories
+
+Type: `object`
+
+Customer-defined AI Security topic labels and their relevance scores. A score of 1 indicates the highest relevance, and 99 indicates the lowest relevance.
+
 ## AISecurityInjectionScore
 
 Type: `int`

--- a/src/content/docs/logs/logpush/logpush-job/datasets/zone/http_requests.md
+++ b/src/content/docs/logs/logpush/logpush-job/datasets/zone/http_requests.md
@@ -9,6 +9,12 @@ sidebar:
 
 The descriptions below detail the fields available for `http_requests`.
 
+## AISecurityCustomTopicCategories
+
+Type: `object`
+
+Customer-defined AI Security topic labels and their relevance scores. A score of 1 indicates the highest relevance, and 99 indicates the lowest relevance.
+
 ## AISecurityInjectionScore
 
 Type: `int`
@@ -248,6 +254,12 @@ Client source port.
 Type: `int`
 
 The smoothed average of TCP round-trip time (SRTT). For the initial request on a connection, this is measured only during connection setup. For a subsequent request on the same connection, it is measured over the entire connection lifetime up until the time that request is received.
+
+## ClientTLSKeyExchangeGroup
+
+Type: `string`
+
+TLS key exchange group between the client and Cloudflare (for example, 'X25519MLKEM768'). 'UNK' means it could not be determined. 'NONE' means TLS was not used.
 
 ## ClientXRequestedWith
 


### PR DESCRIPTION
## Summary

Automated sync of Logpush dataset field definitions from [data/entities](https://gitlab.cfdata.org/cloudflare/data/entities).

### Updated fields in existing datasets

- **Firewall events** (added): `AISecurityCustomTopicCategories`.
- **Gateway HTTP** (added): `ExperimentalFeatures` and `PackageInfo`.
- **Firewall events** (added): `AISecurityCustomTopicCategories`.
- **HTTP requests** (added): `AISecurityCustomTopicCategories` and `ClientTLSKeyExchangeGroup`.

### Files changed
- `src/content/docs/logs/logpush/logpush-job/datasets/account/` — dataset pages
- `src/content/docs/logs/logpush/logpush-job/datasets/zone/` — dataset pages
- `src/content/changelog/logs/2026-08-07-log-fields-updated.mdx` — changelog

### Documentation checklist
- [x] Changelog entry added
- [x] Content generated by code generator (DO NOT EDIT manually)
