### PR TITLE
[R2] Reintroduce R2 Data Catalog in sidebar and reorder

### DIFF
--- a/src/content/docs/r2/r2-data-catalog.mdx
+++ b/src/content/docs/r2/r2-data-catalog.mdx
@@ -1,0 +1,13 @@
+---
+pcx_content_type: navigation
+title: R2 Data Catalog
+external_link: /r2-data-catalog/
+sidebar:
+  order: 14
+  group:
+    badge: Beta
+description: >-
+  R2 Data Catalog is a managed Apache Iceberg data catalog built directly into your R2 bucket.
+products:
+  - r2
+---

--- a/src/content/docs/r2/r2-sql.mdx
+++ b/src/content/docs/r2/r2-sql.mdx
@@ -3,7 +3,7 @@ pcx_content_type: navigation
 title: R2 SQL
 external_link: /r2-sql/
 sidebar:
-  order: 7
+  order: 15
   group:
     badge: Beta
 description: >-


### PR DESCRIPTION
### Summary

Reintroduces R2 Data Catalog in the R2 side bar after the R2 Data Catalog docs migration and changes the order for both R2 Data Catalog and R2 SQL.

Resulting sidebar order (tail):

| order | item              |
| ----- | ----------------- |
| 13    | Pricing           |
| 14    | R2 Data Catalog   |
| 15    | R2 SQL            |

### Screenshots (optional)

<!-- TODO: add screenshots before requesting review -->

### Documentation checklist

- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
