### PR TITLE
[agent-setup] Improvements & updates to agent setup instructions

### DIFF
--- a/src/components/agent-setup/AgentComparison.astro
+++ b/src/components/agent-setup/AgentComparison.astro
@@ -19,8 +19,8 @@ interface ColumnDef {
 const COLUMNS: ColumnDef[] = [
 	{ key: "name", label: "Agent", align: "left" },
 	{ key: "terminal", label: "Terminal" },
-	{ key: "ide", label: "IDE" },
-	{ key: "extension", label: "Extension" },
+	{ key: "desktop", label: "Desktop app" },
+	{ key: "extension", label: "IDE extension" },
 	{ key: "cloud", label: "Cloud" },
 	{ key: "pricing_model", label: "Pricing" },
 	{ key: "model_flexibility", label: "Model" },
@@ -33,7 +33,7 @@ function sortValue(agent: AgentData, key: string): string {
 		case "name":
 			return agent.name.toLowerCase();
 		case "terminal":
-		case "ide":
+		case "desktop":
 		case "extension":
 		case "cloud":
 		case "open_source":
@@ -66,7 +66,7 @@ const rows: RowData[] = sorted.map((agent) => {
 // Capability columns rendered as check / dash indicators, in table order.
 const CAP_COLUMNS: (keyof AgentData["capabilities"])[] = [
 	"terminal",
-	"ide",
+	"desktop",
 	"extension",
 	"cloud",
 ];
@@ -209,7 +209,7 @@ const dashIcon = `<svg width="16" height="16" viewBox="0 0 16 16" fill="none" ar
 		</div>
 	</div>
 	<p class="text-muted-foreground mt-3 text-center text-xs">
-		Every agent listed supports Skills and MCP.
+		Every agent listed supports Cloudflare Skills, MCP servers, or both.
 	</p>
 </div>
 

--- a/src/components/agent-setup/AgentHeader.astro
+++ b/src/components/agent-setup/AgentHeader.astro
@@ -28,12 +28,8 @@ const externalLinks = [
 		href: agent.links.skills,
 	},
 	agent.links.mcp_server && {
-		label: "Cloudflare Code Mode API MCP",
+		label: "Cloudflare MCP server",
 		href: agent.links.mcp_server,
-	},
-	agent.links.mcp_server_domain && {
-		label: "Cloudflare Domain Specific MCPs",
-		href: agent.links.mcp_server_domain,
 	},
 	agent.links.cli && { label: "CLI", href: agent.links.cli },
 	agent.links.docs && { label: `${agent.name} Docs`, href: agent.links.docs },

--- a/src/components/agent-setup/AgentPrimer.astro
+++ b/src/components/agent-setup/AgentPrimer.astro
@@ -11,9 +11,9 @@ const workflowTypes = [
 		icon: `<svg viewBox="0 0 24 24" fill="none" width="20" height="20"><path d="M4 5h16v14H4z" stroke="currentColor" stroke-width="2" stroke-linejoin="round"></path><path d="M7 10l3 2-3 2M12 14h5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path></svg>`,
 	},
 	{
-		label: "IDE",
-		desc: "Full code editor with AI first-class. Visual diffs, multi-file edits.",
-		icon: `<svg viewBox="0 0 24 24" fill="none" width="20" height="20"><path d="M3 5h18v12H3z" stroke="currentColor" stroke-width="2" stroke-linejoin="round"></path><path d="M8 21h8M12 17v4" stroke="currentColor" stroke-width="2" stroke-linecap="round"></path><path d="M7 9l-2 2 2 2M13 9l2 2-2 2M11 8l-2 6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path></svg>`,
+		label: "Desktop app",
+		desc: "Graphical agent app or AI code editor for local work.",
+		icon: `<svg viewBox="0 0 24 24" fill="none" width="20" height="20"><rect x="3" y="4" width="18" height="16" rx="2" stroke="currentColor" stroke-width="2"></rect><path d="M3 9h18M7 6.5h.01M10 6.5h.01" stroke="currentColor" stroke-width="2" stroke-linecap="round"></path></svg>`,
 	},
 	{
 		label: "Cloud",
@@ -21,7 +21,7 @@ const workflowTypes = [
 		icon: `<svg viewBox="0 0 24 24" fill="none" width="20" height="20"><path d="M7 16a4 4 0 010-8 5 5 0 019.584 1.5A4 4 0 0118 16H7z" stroke="currentColor" stroke-width="2" stroke-linejoin="round"></path></svg>`,
 	},
 	{
-		label: "Extension",
+		label: "IDE extension",
 		desc: "Plugs into an existing editor. Lightest install, keeps your setup.",
 		icon: `<svg viewBox="0 0 24 24" fill="none" width="20" height="20"><path d="M10 4h4v4h4v4h-4v4h-4v-4H6V8h4V4z" stroke="currentColor" stroke-width="2" stroke-linejoin="round"></path></svg>`,
 	},

--- a/src/components/agent-setup/CatalogWithFilter.astro
+++ b/src/components/agent-setup/CatalogWithFilter.astro
@@ -12,9 +12,9 @@ const { agents } = Astro.props;
 const FILTERS = [
 	{ key: "all", label: "All" },
 	{ key: "terminal", label: "Terminal" },
-	{ key: "ide", label: "IDE" },
+	{ key: "desktop", label: "Desktop app" },
 	{ key: "cloud", label: "Cloud" },
-	{ key: "extension", label: "Extension" },
+	{ key: "extension", label: "IDE extension" },
 ] as const;
 ---
 
@@ -136,7 +136,7 @@ const FILTERS = [
 	// clash. Handles filter chip selection, URL sync, visibility toggling, and
 	// the empty state.
 	const FILTER_PARAM = "workflow";
-	const VALID_FILTERS = ["all", "terminal", "ide", "cloud", "extension"];
+	const VALID_FILTERS = ["all", "terminal", "desktop", "cloud", "extension"];
 
 	// Initialize tippy tooltips on all capability badges. Appending to body
 	// escapes the table's overflow clip.

--- a/src/components/agent-setup/CatalogWithFilter.astro
+++ b/src/components/agent-setup/CatalogWithFilter.astro
@@ -52,6 +52,7 @@ const FILTERS = [
 		<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3" data-agent-grid>
 			{
 				agents.map((agent) => {
+					const baseHref = `/agent-setup/${agent.slug}/`;
 					const matchKeys = [
 						...Object.entries(agent.capabilities)
 							.filter(([, v]) => v)
@@ -62,7 +63,9 @@ const FILTERS = [
 
 					return (
 						<a
-							href={`/agent-setup/${agent.slug}/`}
+							href={baseHref}
+							data-base-href={baseHref}
+							data-workflow-links={JSON.stringify(agent.workflow_links ?? {})}
 							class="group/agent-card border-border bg-background text-foreground hover:bg-muted/40 focus-visible:outline-primary relative flex flex-col border-r border-b p-6 no-underline transition-colors focus-visible:outline-2 focus-visible:-outline-offset-2 [&[hidden]]:hidden"
 							data-agent-card
 							data-match={matchKeys}
@@ -136,7 +139,6 @@ const FILTERS = [
 	// clash. Handles filter chip selection, URL sync, visibility toggling, and
 	// the empty state.
 	const FILTER_PARAM = "workflow";
-	const VALID_FILTERS = ["all", "terminal", "desktop", "cloud", "extension"];
 
 	// Initialize tippy tooltips on all capability badges. Appending to body
 	// escapes the table's overflow clip.
@@ -151,6 +153,11 @@ const FILTERS = [
 
 	function initCatalog(root: HTMLElement) {
 		const chips = root.querySelectorAll<HTMLButtonElement>("[data-filter]");
+		const validFilters = new Set(
+			Array.from(chips, (chip) => chip.dataset.filter).filter(
+				(filter): filter is string => Boolean(filter),
+			),
+		);
 		const cards = root.querySelectorAll<HTMLElement>("[data-agent-card]");
 		const emptyEl = root.querySelector<HTMLElement>("[data-filter-empty]");
 		const clearBtn = root.querySelector<HTMLButtonElement>(
@@ -166,6 +173,12 @@ const FILTERS = [
 					(card.dataset.match?.split(/\s+/).includes(filter) ?? false);
 				card.hidden = !matches;
 				if (matches) visible++;
+
+				const baseHref = card.dataset.baseHref;
+				if (baseHref && card instanceof HTMLAnchorElement) {
+					const workflowLinks = JSON.parse(card.dataset.workflowLinks ?? "{}");
+					card.href = workflowLinks[filter] ?? baseHref;
+				}
 			});
 
 			// Chip active state (drives Tailwind `aria-pressed:` styling)
@@ -198,7 +211,7 @@ const FILTERS = [
 		// Read initial filter from URL
 		const params = new URLSearchParams(window.location.search);
 		const initial = params.get(FILTER_PARAM);
-		if (initial && VALID_FILTERS.includes(initial)) {
+		if (initial && validFilters.has(initial)) {
 			applyFilter(initial);
 		}
 	}

--- a/src/components/agent-setup/CloudflareToolsBanner.astro
+++ b/src/components/agent-setup/CloudflareToolsBanner.astro
@@ -23,15 +23,12 @@
 		<div class="cf-banner-item">
 			<p class="cf-banner-item-title">MCP</p>
 			<p class="cf-banner-item-desc">
-				Connect agents to your Cloudflare account. Two flavors: <a
+				Connect agents to your Cloudflare account and current developer
+				documentation with the <a
 					href="https://github.com/cloudflare/mcp"
 					target="_blank"
 					rel="noopener noreferrer">Code Mode &nearr;</a
-				> for broad API coverage across all products, or <a
-					href="https://github.com/cloudflare/mcp-server-cloudflare"
-					target="_blank"
-					rel="noopener noreferrer">domain-specific servers &nearr;</a
-				> for purpose-built tools within one product area.
+				> MCP server, which covers the complete API across all products.
 			</p>
 		</div>
 

--- a/src/components/agent-setup/McpServerList.astro
+++ b/src/components/agent-setup/McpServerList.astro
@@ -1,66 +1,68 @@
 ---
 import { getCollection } from "astro:content";
 
-interface Props {
-	/** Whether to show the "bundled" chip. Only relevant for plugin-based agents (Claude Code, Cursor). */
-	showBundled?: boolean;
-}
-
-const { showBundled = false } = Astro.props;
-
 const CODE_MODE_URL = "https://mcp.cloudflare.com/mcp";
 
 const allServers = await getCollection("mcp-servers");
-
-// Code Mode first, then the rest in manifest order
-const servers = [
-	...allServers.filter((s) => s.data.url === CODE_MODE_URL),
-	...allServers.filter((s) => s.data.url !== CODE_MODE_URL),
-];
-
-/**
- * URLs of servers included in the cloudflare/skills plugin bundle
- * (Claude Code, Cursor).
- */
-const BUNDLED = new Set([
-	"https://mcp.cloudflare.com/mcp",
-	"https://docs.mcp.cloudflare.com/mcp",
-	"https://bindings.mcp.cloudflare.com/mcp",
-	"https://builds.mcp.cloudflare.com/mcp",
-	"https://observability.mcp.cloudflare.com/mcp",
-]);
+const codeModeServer = allServers.find((s) => s.data.url === CODE_MODE_URL);
+const productServers = allServers.filter((s) => s.data.url !== CODE_MODE_URL);
 
 const tagBase =
 	"inline-flex items-center rounded-full border px-1.5 py-0.5 text-[0.625rem] font-medium uppercase tracking-wide";
 ---
 
-<ul class="not-content m-0 flex list-none flex-col gap-3 p-0">
-	{
-		servers.map((s) => (
-			<li class="flex flex-col gap-0.5">
-				<span class="text-foreground flex flex-wrap items-center gap-2 text-sm font-medium">
-					{s.data.name}
-					{s.data.url === CODE_MODE_URL && (
-						<span class={`${tagBase} border-primary/30 text-primary`}>
-							code mode
+<div class="not-content">
+	<section class="border-border border-t border-dashed pt-4">
+		<div class="flex flex-wrap items-center gap-2">
+			<p class="text-foreground m-0 text-sm font-semibold">
+				Cloudflare MCP server (Code Mode)
+			</p>
+			<span class={`${tagBase} border-primary/30 bg-primary/10 text-primary`}>
+				recommended
+			</span>
+		</div>
+		<p class="text-muted-foreground mt-2 mb-0 text-sm leading-relaxed">
+			The Cloudflare MCP server uses Code Mode to connect your agent to all
+			Cloudflare resources. Your agent writes JavaScript against the Cloudflare
+			API, allowing it to access more than 2,500 API endpoints with low token
+			overhead. Refer to the{" "}<a
+				href="/agents/model-context-protocol/cloudflare/servers-for-cloudflare/#cloudflare-mcp-server"
+				>Code Mode documentation</a
+			>{" "}
+			to learn more. This server also includes a <code>docs</code> tool that searches
+			current Cloudflare developer documentation.
+		</p>
+		{
+			codeModeServer && (
+				<span class="text-muted-foreground/70 mt-2 inline-block font-mono text-xs break-all">
+					{codeModeServer.data.url}
+				</span>
+			)
+		}
+	</section>
+
+	<section class="border-border mt-5 border-t border-dashed pt-4">
+		<p class="text-foreground m-0 text-sm font-semibold">Separate by product</p>
+		<p class="text-muted-foreground mt-2 mb-3 text-sm leading-relaxed">
+			If you do not want to use Code Mode, connect one or more focused servers
+			for the Cloudflare products you need.
+		</p>
+		<ul class="m-0 flex list-none flex-col gap-3 p-0">
+			{
+				productServers.map((s) => (
+					<li class="flex flex-col gap-0.5">
+						<span class="text-foreground text-sm font-medium">
+							{s.data.name}
 						</span>
-					)}
-					{showBundled && BUNDLED.has(s.data.url) && (
-						<span
-							class={`${tagBase} border-border bg-muted text-muted-foreground`}
-							title="Included in the cloudflare/skills plugin"
-						>
-							bundled
+						<span class="text-muted-foreground text-sm leading-relaxed">
+							{s.data.description}
 						</span>
-					)}
-				</span>
-				<span class="text-muted-foreground text-sm leading-relaxed">
-					{s.data.description}
-				</span>
-				<span class="text-muted-foreground/70 font-mono text-xs break-all">
-					{s.data.url}
-				</span>
-			</li>
-		))
-	}
-</ul>
+						<span class="text-muted-foreground/70 font-mono text-xs break-all">
+							{s.data.url}
+						</span>
+					</li>
+				))
+			}
+		</ul>
+	</section>
+</div>

--- a/src/components/agent-setup/PlatformAccessSection.astro
+++ b/src/components/agent-setup/PlatformAccessSection.astro
@@ -33,30 +33,14 @@ import SkillsList from "./SkillsList.astro";
 		</PlatformAccessDetails>
 
 		<PlatformAccessDetails header="MCP servers">
-			<p class="text-foreground font-medium">
-				Live access to the Cloudflare API, docs, and observability.
-			</p>
 			<p>
-				MCP servers provide typed tools to call into Cloudflare at runtime.
-				There are two options: <a
-					href="https://blog.cloudflare.com/code-mode-mcp/">Code Mode</a
-				> — a single server that covers the entire Cloudflare API (2,500+ endpoints
-				in ~1,000 tokens) — or a set of focused, domain-specific servers hosted in
-				the{" "}
+				MCP lets your agent inspect and update Cloudflare resources and search
+				current developer documentation. There are two ways to connect to
+				Cloudflare through MCP:{" "}
 				<a
-					href="https://github.com/cloudflare/mcp-server-cloudflare"
-					target="_blank"
-					rel="noopener noreferrer"
-				>
-					cloudflare/mcp-server-cloudflare
-				</a>{" "}
-				repo. The full catalog is also in the{" "}
-				<a
-					href="/agents/model-context-protocol/cloudflare/servers-for-cloudflare/"
-				>
-					MCP servers for Cloudflare
-				</a>{" "}
-				docs.
+					href="/agents/model-context-protocol/cloudflare/servers-for-cloudflare/#cloudflare-mcp-server"
+					>Code Mode</a
+				> and individual product servers.
 			</p>
 			<McpServerList />
 		</PlatformAccessDetails>

--- a/src/components/agent-setup/WorkflowOption.astro
+++ b/src/components/agent-setup/WorkflowOption.astro
@@ -1,0 +1,17 @@
+---
+interface Props {
+	label: string;
+	value: string;
+}
+
+const { label, value } = Astro.props;
+---
+
+<div
+	data-agent-workflow-option
+	data-label={label}
+	data-value={value}
+	role="region"
+>
+	<slot />
+</div>

--- a/src/components/agent-setup/WorkflowSelector.astro
+++ b/src/components/agent-setup/WorkflowSelector.astro
@@ -1,0 +1,47 @@
+---
+interface Props {
+	label?: string;
+	urlParam?: string;
+}
+
+const { label = "Workflow:", urlParam } = Astro.props;
+---
+
+<div class="my-4" data-agent-workflow-selector data-url-param={urlParam}>
+	<div class="mb-3 flex flex-wrap items-center gap-x-3 gap-y-2">
+		<span class="text-muted-foreground text-sm">{label}</span>
+		<div
+			class="flex flex-wrap items-center gap-2"
+			role="radiogroup"
+			aria-label={label.replace(/:$/, "")}
+			data-agent-workflow-options
+		>
+		</div>
+	</div>
+	<div data-agent-workflow-panels>
+		<slot />
+	</div>
+</div>
+
+<script>
+	import "./workflow-selector.client";
+</script>
+
+<style>
+	[data-agent-workflow-option] {
+		display: none;
+	}
+
+	[data-agent-workflow-option]:first-child {
+		display: block;
+	}
+
+	[data-agent-workflow-selector][data-ready] [data-agent-workflow-option] {
+		display: none;
+	}
+
+	[data-agent-workflow-selector][data-ready]
+		[data-agent-workflow-option][data-active] {
+		display: block;
+	}
+</style>

--- a/src/components/agent-setup/agents.ts
+++ b/src/components/agent-setup/agents.ts
@@ -30,7 +30,6 @@ export const AGENTS: AgentData[] = [
 		links: {
 			skills: "https://github.com/cloudflare/skills",
 			mcp_server: "https://github.com/cloudflare/mcp",
-			mcp_server_domain: "https://github.com/cloudflare/mcp-server-cloudflare",
 			docs: "https://docs.anthropic.com/en/docs/claude-code",
 			website: "https://claude.ai/code",
 		},
@@ -64,7 +63,6 @@ export const AGENTS: AgentData[] = [
 		links: {
 			skills: "https://github.com/cloudflare/skills",
 			mcp_server: "https://github.com/cloudflare/mcp",
-			mcp_server_domain: "https://github.com/cloudflare/mcp-server-cloudflare",
 			docs: "https://developers.openai.com/codex/",
 			website: "https://openai.com/codex",
 		},
@@ -95,7 +93,6 @@ export const AGENTS: AgentData[] = [
 		links: {
 			skills: "https://github.com/cloudflare/skills",
 			mcp_server: "https://github.com/cloudflare/mcp",
-			mcp_server_domain: "https://github.com/cloudflare/mcp-server-cloudflare",
 			docs: "https://docs.cursor.com",
 			website: "https://cursor.sh",
 		},
@@ -130,7 +127,6 @@ export const AGENTS: AgentData[] = [
 		links: {
 			skills: "https://github.com/cloudflare/skills",
 			mcp_server: "https://github.com/cloudflare/mcp",
-			mcp_server_domain: "https://github.com/cloudflare/mcp-server-cloudflare",
 			docs: "https://docs.github.com/en/copilot",
 			website: "https://github.com/features/copilot",
 		},
@@ -164,7 +160,6 @@ export const AGENTS: AgentData[] = [
 		links: {
 			skills: "https://github.com/cloudflare/skills",
 			mcp_server: "https://github.com/cloudflare/mcp",
-			mcp_server_domain: "https://github.com/cloudflare/mcp-server-cloudflare",
 			docs: "https://opencode.ai/docs",
 			website: "https://opencode.ai",
 		},
@@ -195,7 +190,6 @@ export const AGENTS: AgentData[] = [
 		links: {
 			skills: "https://github.com/cloudflare/skills",
 			mcp_server: "https://github.com/cloudflare/mcp",
-			mcp_server_domain: "https://github.com/cloudflare/mcp-server-cloudflare",
 			docs: "https://docs.windsurf.com",
 			website: "https://windsurf.com",
 		},
@@ -226,7 +220,6 @@ export const AGENTS: AgentData[] = [
 		links: {
 			skills: "https://github.com/cloudflare/skills",
 			mcp_server: "https://github.com/cloudflare/mcp",
-			mcp_server_domain: "https://github.com/cloudflare/mcp-server-cloudflare",
 			docs: "https://code.visualstudio.com/docs",
 			website: "https://code.visualstudio.com",
 		},
@@ -255,7 +248,6 @@ export const AGENTS: AgentData[] = [
 		model_flexibility: "multi_provider",
 		links: {
 			mcp_server: "https://github.com/cloudflare/mcp",
-			mcp_server_domain: "https://github.com/cloudflare/mcp-server-cloudflare",
 			docs: "https://lmstudio.ai/docs/bionic",
 			website: "https://lmstudio.ai/",
 		},

--- a/src/components/agent-setup/agents.ts
+++ b/src/components/agent-setup/agents.ts
@@ -24,6 +24,9 @@ export const AGENTS: AgentData[] = [
 		pricing_model: "subscription",
 		model_flexibility: "locked",
 		context_approach: "project_memory",
+		workflow_links: {
+			desktop: "/agent-setup/claude-code/?view=desktop",
+		},
 		links: {
 			skills: "https://github.com/cloudflare/skills",
 			mcp_server: "https://github.com/cloudflare/mcp",
@@ -55,6 +58,9 @@ export const AGENTS: AgentData[] = [
 		pricing_model: "hybrid",
 		model_flexibility: "locked",
 		context_approach: "project_memory",
+		workflow_links: {
+			desktop: "/agent-setup/codex/?view=desktop",
+		},
 		links: {
 			skills: "https://github.com/cloudflare/skills",
 			mcp_server: "https://github.com/cloudflare/mcp",
@@ -117,6 +123,10 @@ export const AGENTS: AgentData[] = [
 		pricing_model: "subscription",
 		model_flexibility: "multi_provider",
 		context_approach: "indexed_codebase",
+		workflow_links: {
+			terminal: "/agent-setup/github-copilot/?view=terminal",
+			desktop: "/agent-setup/github-copilot/?view=desktop",
+		},
 		links: {
 			skills: "https://github.com/cloudflare/skills",
 			mcp_server: "https://github.com/cloudflare/mcp",
@@ -148,6 +158,9 @@ export const AGENTS: AgentData[] = [
 		pricing_model: "byok",
 		model_flexibility: "multi_provider",
 		context_approach: "project_memory",
+		workflow_links: {
+			desktop: "/agent-setup/opencode/?view=desktop",
+		},
 		links: {
 			skills: "https://github.com/cloudflare/skills",
 			mcp_server: "https://github.com/cloudflare/mcp",

--- a/src/components/agent-setup/agents.ts
+++ b/src/components/agent-setup/agents.ts
@@ -7,11 +7,10 @@ export const AGENTS: AgentData[] = [
 		slug: "claude-code",
 		icon: "claude",
 		description:
-			"Terminal-based coding agent that understands your codebase, runs commands, edits files, and manages git. Made by Anthropic.",
+			"Coding agent available in the terminal, Claude desktop app, and supported editors. It understands your codebase, runs commands, and edits files.",
 		capabilities: {
-			ide: false,
 			terminal: true,
-			standalone: true,
+			desktop: true,
 			cloud: true,
 			extension: true,
 			open_source: false,
@@ -39,11 +38,10 @@ export const AGENTS: AgentData[] = [
 		slug: "codex",
 		icon: "codex",
 		description:
-			"OpenAI coding agent available as a terminal CLI and desktop app. It reads and writes files, runs commands, and browses the web in a sandbox.",
+			"OpenAI coding agent available through Codex CLI and Codex in the ChatGPT desktop app. It reads and writes files, runs commands, and browses the web in a sandbox.",
 		capabilities: {
-			ide: false,
 			terminal: true,
-			standalone: true,
+			desktop: true,
 			cloud: true,
 			extension: true,
 			open_source: true,
@@ -71,11 +69,10 @@ export const AGENTS: AgentData[] = [
 		slug: "cursor",
 		icon: "cursor",
 		description:
-			"AI-first IDE built on VS Code with multi-file Composer edits and background agents. Made by Cursor.",
+			"AI coding desktop app with multi-file edits, background agents, codebase search, and terminal access. Made by Cursor.",
 		capabilities: {
-			ide: true,
-			terminal: true,
-			standalone: true,
+			terminal: false,
+			desktop: true,
 			cloud: true,
 			extension: false,
 			open_source: false,
@@ -103,20 +100,19 @@ export const AGENTS: AgentData[] = [
 		slug: "github-copilot",
 		icon: "copilot",
 		description:
-			"Editor extension and CLI with agent mode, workspace context, and native PR integration. Made by GitHub.",
+			"Coding agent available as a desktop app, IDE extension, and CLI with agent sessions and native GitHub integration. Made by GitHub.",
 		capabilities: {
-			ide: false,
 			terminal: true,
-			standalone: false,
+			desktop: true,
 			cloud: true,
 			extension: true,
 			open_source: false,
 		},
 		features: [
-			"Agent mode",
+			"Parallel agent sessions",
 			"Workspace context",
 			"CLI integration",
-			"PR summaries",
+			"Pull request lifecycle",
 		],
 		pricing_model: "subscription",
 		model_flexibility: "multi_provider",
@@ -135,13 +131,12 @@ export const AGENTS: AgentData[] = [
 		slug: "opencode",
 		icon: "opencode",
 		description:
-			"Open-source terminal agent with a rich TUI that works with 75+ LLMs. Made by Anomaly.",
+			"Open-source coding agent available as a terminal interface and desktop app. It works with 75+ LLMs. Made by Anomaly.",
 		capabilities: {
-			ide: false,
 			terminal: true,
-			standalone: true,
+			desktop: true,
 			cloud: false,
-			extension: true,
+			extension: false,
 			open_source: true,
 		},
 		features: [
@@ -167,11 +162,10 @@ export const AGENTS: AgentData[] = [
 		slug: "windsurf",
 		icon: "windsurf",
 		description:
-			"Agentic IDE with Cascade context and Flows for multi-step tasks. Made by Cognition.",
+			"AI coding desktop app with Cascade context and Flows for multi-step tasks. Made by Cognition.",
 		capabilities: {
-			ide: true,
 			terminal: false,
-			standalone: true,
+			desktop: true,
 			cloud: false,
 			extension: false,
 			open_source: false,
@@ -199,20 +193,19 @@ export const AGENTS: AgentData[] = [
 		slug: "visual-studio-code",
 		icon: "visual-studio-code",
 		description:
-			"Free, open-source code editor with native Model Context Protocol (MCP) client support and Copilot Chat integration. Made by Microsoft.",
+			"Desktop code editor and agent control plane. Its Agents window can run and monitor Copilot, Claude, Codex, local, and cloud agent harnesses.",
 		capabilities: {
-			ide: true,
-			terminal: true,
-			standalone: true,
+			terminal: false,
+			desktop: true,
 			cloud: false,
-			extension: true,
+			extension: false,
 			open_source: true,
 		},
 		features: [
-			"Native MCP client",
-			"Copilot Chat integration",
+			"Multiple agent harnesses",
+			"Agents window",
 			"Terminal integration",
-			"Extension ecosystem",
+			"Native MCP client",
 		],
 		pricing_model: "byok",
 		model_flexibility: "multi_provider",
@@ -233,9 +226,8 @@ export const AGENTS: AgentData[] = [
 		description:
 			"Powerful agent for coding and work. Natively local, with open models in the cloud. By LM Studio.",
 		capabilities: {
-			ide: false,
 			terminal: false,
-			standalone: true,
+			desktop: true,
 			cloud: true,
 			extension: false,
 			open_source: false,

--- a/src/components/agent-setup/definitions.ts
+++ b/src/components/agent-setup/definitions.ts
@@ -3,13 +3,12 @@
 export const capabilityDefinitions = {
 	terminal:
 		"Runs as a command-line tool. Great for scripting, automation, and CI pipelines.",
-	ide: "A full code editor with AI built in. Visual diffs, inline suggestions, multi-file edits.",
+	desktop:
+		"Runs as a graphical desktop app, including dedicated agent apps and AI code editors.",
 	cloud:
 		"Runs on hosted infrastructure. Accessible from anywhere, good for async long-running tasks.",
 	extension:
 		"Add-on that plugs into an existing editor. Lightweight install, inherits the editor's features.",
-	standalone:
-		"Can run on its own without embedding in an editor or extension host.",
 	open_source: "Source code is openly licensed and available on GitHub.",
 } as const;
 
@@ -33,10 +32,9 @@ export const capabilityTooltips: Record<string, string> = {
 
 export const capabilityLabels: Record<string, string> = {
 	terminal: "Terminal",
-	ide: "IDE",
+	desktop: "Desktop app",
 	cloud: "Cloud",
-	extension: "Extension",
-	standalone: "Standalone",
+	extension: "IDE extension",
 	open_source: "Open Source",
 	subscription: "Subscription",
 	byok: "BYOK",

--- a/src/components/agent-setup/types.ts
+++ b/src/components/agent-setup/types.ts
@@ -9,9 +9,8 @@ export interface AgentData {
 	icon: string;
 	description: string;
 	capabilities: {
-		ide: boolean;
 		terminal: boolean;
-		standalone: boolean;
+		desktop: boolean;
 		cloud: boolean;
 		extension: boolean;
 		open_source: boolean;

--- a/src/components/agent-setup/types.ts
+++ b/src/components/agent-setup/types.ts
@@ -1,6 +1,7 @@
 export type PricingModel = "subscription" | "byok" | "hybrid";
 export type ModelFlexibility = "locked" | "multi_provider";
 export type ContextApproach = "session" | "project_memory" | "indexed_codebase";
+export type AgentSetupWorkflow = "terminal" | "desktop" | "cloud" | "extension";
 
 export interface AgentData {
 	name: string;
@@ -19,6 +20,7 @@ export interface AgentData {
 	pricing_model?: PricingModel;
 	model_flexibility?: ModelFlexibility;
 	context_approach?: ContextApproach;
+	workflow_links?: Partial<Record<AgentSetupWorkflow, string>>;
 	links: {
 		skills?: string;
 		mcp_server?: string;

--- a/src/components/agent-setup/types.ts
+++ b/src/components/agent-setup/types.ts
@@ -24,7 +24,6 @@ export interface AgentData {
 	links: {
 		skills?: string;
 		mcp_server?: string;
-		mcp_server_domain?: string;
 		cli?: string;
 		docs?: string;
 		website?: string;

--- a/src/components/agent-setup/workflow-selector.client.ts
+++ b/src/components/agent-setup/workflow-selector.client.ts
@@ -1,0 +1,118 @@
+import { mount } from "@cloudflare/nimbus-docs/client";
+
+const OPTION_CLASS =
+	"border-border text-muted-foreground hover:border-primary hover:text-foreground aria-checked:border-primary aria-checked:bg-primary aria-checked:text-primary-foreground focus-visible:outline-primary inline-flex h-8 cursor-pointer items-center justify-center rounded-full border px-4 text-sm font-medium transition-colors focus-visible:outline-2 focus-visible:outline-offset-2";
+
+let selectorCount = 0;
+
+function initWorkflowSelector(container: HTMLElement): () => void {
+	const id = `agent-workflow-${selectorCount++}`;
+	const optionList = container.querySelector<HTMLElement>(
+		"[data-agent-workflow-options]",
+	);
+	const panels = Array.from(
+		container.querySelectorAll<HTMLElement>("[data-agent-workflow-option]"),
+	).filter(
+		(panel) => panel.closest("[data-agent-workflow-selector]") === container,
+	);
+
+	if (!optionList || panels.length === 0) return () => {};
+
+	const buttons = panels.map((panel, index) => {
+		const button = document.createElement("button");
+		const buttonId = `${id}-option-${index}`;
+		const panelId = `${id}-panel-${index}`;
+
+		button.id = buttonId;
+		button.type = "button";
+		button.role = "radio";
+		button.className = OPTION_CLASS;
+		button.textContent = panel.dataset.label ?? `Option ${index + 1}`;
+		button.setAttribute("aria-controls", panelId);
+
+		panel.id = panelId;
+		panel.setAttribute("aria-labelledby", buttonId);
+		optionList.appendChild(button);
+
+		return button;
+	});
+
+	const select = (selectedIndex: number, focus = false, updateUrl = true) => {
+		buttons.forEach((button, index) => {
+			const selected = index === selectedIndex;
+			button.setAttribute("aria-checked", String(selected));
+			button.tabIndex = selected ? 0 : -1;
+			panels[index].toggleAttribute("data-active", selected);
+			panels[index].hidden = !selected;
+		});
+
+		const urlParam = container.dataset.urlParam;
+		if (updateUrl && urlParam) {
+			const url = new URL(window.location.href);
+			if (selectedIndex === 0) url.searchParams.delete(urlParam);
+			else
+				url.searchParams.set(
+					urlParam,
+					panels[selectedIndex].dataset.value ?? "",
+				);
+			window.history.replaceState({}, "", url);
+		}
+
+		if (focus) buttons[selectedIndex].focus();
+	};
+
+	const clickHandlers = buttons.map((button, index) => {
+		const handler = () => select(index);
+		button.addEventListener("click", handler);
+		return handler;
+	});
+
+	const handleKeydown = (event: KeyboardEvent) => {
+		const currentIndex = buttons.indexOf(event.target as HTMLButtonElement);
+		if (currentIndex === -1) return;
+
+		let nextIndex: number | undefined;
+		if (event.key === "ArrowRight" || event.key === "ArrowDown") {
+			nextIndex = (currentIndex + 1) % buttons.length;
+		} else if (event.key === "ArrowLeft" || event.key === "ArrowUp") {
+			nextIndex = (currentIndex - 1 + buttons.length) % buttons.length;
+		} else if (event.key === "Home") {
+			nextIndex = 0;
+		} else if (event.key === "End") {
+			nextIndex = buttons.length - 1;
+		}
+
+		if (nextIndex === undefined) return;
+		event.preventDefault();
+		select(nextIndex, true);
+	};
+
+	optionList.addEventListener("keydown", handleKeydown);
+	const requestedValue = container.dataset.urlParam
+		? new URLSearchParams(window.location.search).get(
+				container.dataset.urlParam,
+			)
+		: null;
+	const requestedIndex = panels.findIndex(
+		(panel) => panel.dataset.value === requestedValue,
+	);
+	select(requestedIndex === -1 ? 0 : requestedIndex, false, false);
+	container.setAttribute("data-ready", "");
+
+	return () => {
+		optionList.removeEventListener("keydown", handleKeydown);
+		buttons.forEach((button, index) => {
+			button.removeEventListener("click", clickHandlers[index]);
+			button.remove();
+		});
+		panels.forEach((panel) => {
+			panel.hidden = false;
+			panel.removeAttribute("data-active");
+			panel.removeAttribute("aria-labelledby");
+			panel.removeAttribute("id");
+		});
+		container.removeAttribute("data-ready");
+	};
+}
+
+mount("[data-agent-workflow-selector]", initWorkflowSelector);

--- a/src/content/agent-setup/prompt.md
+++ b/src/content/agent-setup/prompt.md
@@ -6,7 +6,7 @@ Use the correct section for your agent below. Claude Code and Codex can use a pl
 
 ---
 
-## Install Cloudflare Skills and MCP servers via a plugin
+## Install Cloudflare Skills and MCP server via a plugin
 
 ### Claude Code
 
@@ -32,7 +32,7 @@ Then instruct the user to run `/new` inside Codex to activate the new plugin.
 
 ---
 
-## Install Cloudflare skills and MCP servers separately
+## Install Cloudflare skills and MCP server separately
 
 ### Step 1: Install skills
 
@@ -42,29 +42,14 @@ npx -y skills add cloudflare/skills --skill '*' --yes --global
 
 Then register the MCP servers using the default config location for your agent. OAuth triggers automatically on first Cloudflare tool use.
 
-### Step 2: Install MCP servers
-
-#### Codex
-
-```
-codex mcp add cloudflare --url https://mcp.cloudflare.com/mcp
-codex mcp add cloudflare-docs --url https://docs.mcp.cloudflare.com/mcp
-codex mcp add cloudflare-bindings --url https://bindings.mcp.cloudflare.com/mcp
-codex mcp add cloudflare-builds --url https://builds.mcp.cloudflare.com/mcp
-codex mcp add cloudflare-observability --url https://observability.mcp.cloudflare.com/mcp
-codex mcp login cloudflare
-```
+### Step 2: Install MCP server
 
 #### OpenCode — `~/.config/opencode/opencode.jsonc`
 
 Add under `"mcp"`:
 
 ```json
-"cloudflare": { "type": "remote", "url": "https://mcp.cloudflare.com/mcp", "enabled": true, "oauth": {} },
-"cloudflare-docs": { "type": "remote", "url": "https://docs.mcp.cloudflare.com/mcp", "enabled": true },
-"cloudflare-bindings": { "type": "remote", "url": "https://bindings.mcp.cloudflare.com/mcp", "enabled": true, "oauth": {} },
-"cloudflare-builds": { "type": "remote", "url": "https://builds.mcp.cloudflare.com/mcp", "enabled": true, "oauth": {} },
-"cloudflare-observability": { "type": "remote", "url": "https://observability.mcp.cloudflare.com/mcp", "enabled": true, "oauth": {} }
+"cloudflare": { "type": "remote", "url": "https://mcp.cloudflare.com/mcp", "enabled": true, "oauth": {} }
 ```
 
 Then run:
@@ -78,11 +63,7 @@ opencode mcp auth cloudflare
 Add under `"mcpServers"` (note: `serverUrl`, not `url`):
 
 ```json
-"cloudflare": { "serverUrl": "https://mcp.cloudflare.com/mcp" },
-"cloudflare-docs": { "serverUrl": "https://docs.mcp.cloudflare.com/mcp" },
-"cloudflare-bindings": { "serverUrl": "https://bindings.mcp.cloudflare.com/mcp" },
-"cloudflare-builds": { "serverUrl": "https://builds.mcp.cloudflare.com/mcp" },
-"cloudflare-observability": { "serverUrl": "https://observability.mcp.cloudflare.com/mcp" }
+"cloudflare": { "serverUrl": "https://mcp.cloudflare.com/mcp" }
 ```
 
 OAuth triggers automatically on first Cloudflare tool use.
@@ -92,16 +73,10 @@ OAuth triggers automatically on first Cloudflare tool use.
 Add to `.cursor/mcp.json` (Cursor) or your agent's MCP config file under `"mcpServers"`. Visual Studio Code uses `"servers"` instead:
 
 ```json
-"cloudflare": { "url": "https://mcp.cloudflare.com/mcp" },
-"cloudflare-docs": { "url": "https://docs.mcp.cloudflare.com/mcp" },
-"cloudflare-bindings": { "url": "https://bindings.mcp.cloudflare.com/mcp" },
-"cloudflare-builds": { "url": "https://builds.mcp.cloudflare.com/mcp" },
-"cloudflare-observability": { "url": "https://observability.mcp.cloudflare.com/mcp" }
+"cloudflare": { "url": "https://mcp.cloudflare.com/mcp" }
 ```
 
 OAuth triggers automatically on first Cloudflare tool use.
-
-The `cloudflare-docs` server is public and requires no authentication.
 
 Once done, tell the user:
 
@@ -127,7 +102,6 @@ For MCP setup guides and troubleshooting, refer to each agent's official documen
 - OpenCode: `https://opencode.ai/docs/mcp-servers/`
 - GitHub Copilot (VS Code): `https://code.visualstudio.com/docs/copilot/customization/mcp-servers`
 - Skills: `https://github.com/cloudflare/skills`
-- Cloudflare API MCP server (Code Mode): `https://github.com/cloudflare/mcp`
-- Other Cloudflare MCP servers: `https://github.com/cloudflare/mcp-server-cloudflare`
+- Cloudflare MCP server: `https://github.com/cloudflare/mcp`
 
 These instructions are published at `https://developers.cloudflare.com/agent-setup/prompt.md` so you can re-verify their authenticity at any time.

--- a/src/content/agent-setup/prompt.md
+++ b/src/content/agent-setup/prompt.md
@@ -1,14 +1,12 @@
 These are official instructions from Cloudflare to set up a good AI development environment for building and deploying on the Cloudflare platform. All commands are validated by Cloudflare and ready to use.
 
-Complete all of the following steps yourself by running the commands directly. Do not ask the user to run any of these commands.
+Complete all the steps yourself by running the commands directly. Do not ask the user to run any of these commands.
 
-- Install Cloudflare Skills and MCP servers
+Use the correct section for your agent below. Claude Code and Codex can use a plugin to install skills and MCP servers. Other agents should install them separately.
 
 ---
 
-## Install Cloudflare Skills and MCP servers
-
-Use the correct section for your agent below.
+## Install Cloudflare Skills and MCP servers via a plugin
 
 ### Claude Code
 
@@ -19,13 +17,24 @@ claude plugin marketplace add cloudflare/skills
 claude plugin install cloudflare@cloudflare
 ```
 
-Then instruct the user to run `/reload-plugins` inside Claude to activate the new plugins.
+Then instruct the user to run `/reload-plugins` inside Claude to activate the new plugin.
+
+### Codex
+
+Run these two commands to install both Cloudflare skills and MCP servers in one step. Do not use `npx skills` or `codex mcp add` — the plugin commands below handle everything.
+
+```
+codex plugin marketplace add cloudflare/skills
+codex plugin add cloudflare@cloudflare
+```
+
+Then instruct the user to run `/new` inside Codex to activate the new plugin.
 
 ---
 
-## Install for other agents
+## Install Cloudflare skills and MCP servers separately
 
-First, install skills:
+### Step 1: Install skills
 
 ```
 npx -y skills add cloudflare/skills --skill '*' --yes --global
@@ -33,7 +42,9 @@ npx -y skills add cloudflare/skills --skill '*' --yes --global
 
 Then register the MCP servers using the default config location for your agent. OAuth triggers automatically on first Cloudflare tool use.
 
-### Codex
+### Step 2: Install MCP servers
+
+#### Codex
 
 ```
 codex mcp add cloudflare --url https://mcp.cloudflare.com/mcp
@@ -44,7 +55,7 @@ codex mcp add cloudflare-observability --url https://observability.mcp.cloudflar
 codex mcp login cloudflare
 ```
 
-### OpenCode — `~/.config/opencode/opencode.jsonc`
+#### OpenCode — `~/.config/opencode/opencode.jsonc`
 
 Add under `"mcp"`:
 
@@ -62,7 +73,7 @@ Then run:
 opencode mcp auth cloudflare
 ```
 
-### Windsurf — `~/.codeium/windsurf/mcp_config.json`
+#### Windsurf — `~/.codeium/windsurf/mcp_config.json`
 
 Add under `"mcpServers"` (note: `serverUrl`, not `url`):
 
@@ -76,9 +87,9 @@ Add under `"mcpServers"` (note: `serverUrl`, not `url`):
 
 OAuth triggers automatically on first Cloudflare tool use.
 
-### Cursor, GitHub Copilot, and all other agents
+#### Cursor, GitHub Copilot, and all other agents
 
-Add to `.cursor/mcp.json` (Cursor), `.vscode/mcp.json` (Copilot), or your agent's MCP config file under `"mcpServers"`:
+Add to `.cursor/mcp.json` (Cursor) or your agent's MCP config file under `"mcpServers"`. Visual Studio Code uses `"servers"` instead:
 
 ```json
 "cloudflare": { "url": "https://mcp.cloudflare.com/mcp" },
@@ -99,7 +110,7 @@ Once done, tell the user:
 │  ✓ Skills  <path>                                    │
 │  ✓ MCPs    <path>                                    │
 │                                                      │
-│  ⚡ Restart your agent to load the MCP servers       │
+│  ⚡ Restart your agent to load the MCP servers        │
 └──────────────────────────────────────────────────────┘
 ```
 
@@ -110,6 +121,7 @@ Once done, tell the user:
 For MCP setup guides and troubleshooting, refer to each agent's official documentation:
 
 - Claude Code: `https://docs.anthropic.com/en/docs/claude-code/mcp`
+- Codex: `https://developers.openai.com/codex/plugins/`
 - Cursor: `https://cursor.com/docs/mcp`
 - Windsurf: `https://docs.windsurf.com/windsurf/cascade/mcp`
 - OpenCode: `https://opencode.ai/docs/mcp-servers/`

--- a/src/content/docs/agent-setup/bionic.mdx
+++ b/src/content/docs/agent-setup/bionic.mdx
@@ -63,7 +63,7 @@ import OtherAgents from "~/components/agent-setup/OtherAgents.astro";
 <TipsList>
 
 - Use a **Code Project** for local Cloudflare source files. Use a **Work Project** for research, writing, and document tasks.
-- Use the Cloudflare API MCP server for account resources and domain-specific servers for focused workflows.
+- Use the Cloudflare MCP server for account resources and current developer documentation.
 - Review Bionic diffs and command output before keeping changes.
 
 </TipsList>
@@ -72,7 +72,7 @@ import OtherAgents from "~/components/agent-setup/OtherAgents.astro";
 
 <FAQList>
 	<FAQItem question="Should I use the MCP server, Wrangler CLI, or both?">
-		Use both. The Cloudflare API MCP server handles Cloudflare account operations,
+		Use both. The Cloudflare MCP server handles Cloudflare account operations,
 		such as DNS, WAF, R2, and Zero Trust. Wrangler handles local development,
 		deployments, and migrations. In a Code Project, Bionic can run local shell
 		commands, including Wrangler commands.
@@ -88,10 +88,10 @@ import OtherAgents from "~/components/agent-setup/OtherAgents.astro";
 		deployment command for that project.
 	</FAQItem>
 	<FAQItem question="What does Code Mode mean for MCP?">
-		Code Mode is how the Cloudflare API MCP server fits all 2,500+ API endpoints
-		into about 1,000 tokens. Instead of exposing every endpoint as a separate tool,
-		it exposes <code>search()</code> and <code>execute()</code>. Bionic writes
-		JavaScript to call them. For more information, refer to
+		Code Mode is how the Cloudflare MCP server fits all 2,500+ API endpoints
+		into about 1,100 tokens. It exposes <code>docs</code>, <code>search()</code>, and
+		<code>execute()</code>. Bionic writes JavaScript to call the API tools. For more
+		information, refer to
 		<a href="https://blog.cloudflare.com/code-mode-mcp/">Code Mode</a>.
 	</FAQItem>
 </FAQList>
@@ -104,9 +104,8 @@ import OtherAgents from "~/components/agent-setup/OtherAgents.astro";
 		Remove and re-add the remote MCP server in Bionic, then try connecting again.
 	</TroubleshootingItem>
 	<TroubleshootingItem issue="Getting outdated information about Cloudflare products">
-		Add the Cloudflare documentation MCP server at
-		<code>https://docs.mcp.cloudflare.com/mcp</code> so Bionic can retrieve current
-		documentation. Alternatively, point Bionic to
+		Enable the <a href="https://github.com/cloudflare/mcp" target="_blank" rel="noopener noreferrer">Cloudflare MCP server</a> so Bionic can retrieve current
+		documentation. You can also point Bionic to
 		<a href="/llms.txt">developers.cloudflare.com/llms.txt</a> for a directory of
 		all products, or <code>developers.cloudflare.com/&lt;product&gt;/llms.txt</code>
 		for a product-specific index.

--- a/src/content/docs/agent-setup/claude-code.mdx
+++ b/src/content/docs/agent-setup/claude-code.mdx
@@ -1,14 +1,16 @@
 ---
 title: Claude Code + Cloudflare
-description: "Terminal-based coding agent that understands your codebase, runs commands, edits files, and manages git. Made by Anthropic."
+description: "Coding agent available in the terminal, Claude desktop app, and supported editors. It understands your codebase, runs commands, and edits files."
 template: splash
 pcx_content_type: how-to
 products:
   - agent-setup
 ---
 
-import { Steps } from "~/components";
+import { Steps, Tabs, TabItem } from "~/components";
 import AgentHeader from "~/components/agent-setup/AgentHeader.astro";
+import WorkflowOption from "~/components/agent-setup/WorkflowOption.astro";
+import WorkflowSelector from "~/components/agent-setup/WorkflowSelector.astro";
 import PlatformAccess from "~/components/agent-setup/PlatformAccessSection.astro";
 import ExamplePromptsList from "~/components/agent-setup/ExamplePromptsList.astro";
 import RandomPrompt from "~/components/agent-setup/RandomPrompt.astro";
@@ -19,44 +21,81 @@ import TroubleshootingList from "~/components/agent-setup/TroubleshootingList.as
 import TroubleshootingItem from "~/components/agent-setup/TroubleshootingItem.astro";
 import BuildAgentsCallout from "~/components/agent-setup/BuildAgentsCallout.astro";
 import OtherAgents from "~/components/agent-setup/OtherAgents.astro";
-import { LinkCard } from "~/components";
 
 <AgentHeader slug="claude-code" />
 
 ## Quick start
 
-<Steps>
-	1. **Install Claude Code**
+<WorkflowSelector urlParam="view">
+	<WorkflowOption label="Terminal" value="terminal">
+		<Steps>
+			1. **Install Claude Code**
 
-		Install the Claude Code CLI. For Windows, Homebrew, WinGet, or npm, see the [Claude Code setup guide](https://docs.anthropic.com/en/docs/claude-code/setup).
+				<Tabs>
+					<TabItem label="macOS and Linux">
+						```sh
+						curl -fsSL https://claude.ai/install.sh | bash
+						```
+					</TabItem>
+					<TabItem label="Windows">
+						```powershell
+						irm https://claude.ai/install.ps1 | iex
+						```
+					</TabItem>
+				</Tabs>
 
-		```bash
-		curl -fsSL https://claude.ai/install.sh | bash
-		```
+				For Homebrew, WinGet, or npm, refer to the [Claude Code setup guide](https://code.claude.com/docs/en/setup).
 
-	2. **Launch Claude Code in your project**
+			2. **Install the Cloudflare plugin**
 
-		Start Claude Code from the root of your project, where `wrangler.jsonc` lives (if it already exists).
+				Run these two commands to install both Cloudflare skills and MCP servers in one step.
 
-		```bash
-		claude
-		```
+				```sh
+				claude plugin marketplace add cloudflare/skills
+				claude plugin install cloudflare@cloudflare
+				```
 
-	3. **Install the Cloudflare plugin**
+			3. **Launch Claude Code**
 
-		In Claude Code, run these two slash commands. This installs Cloudflare Skills and registers the Cloudflare MCP servers.
+				Start Claude Code from your project root.
 
-		```txt
-		/plugin marketplace add cloudflare/skills
-		/plugin install cloudflare@cloudflare
-		```
+				```sh
+				claude
+				```
 
-	4. **Try a prompt**
+			4. **Try a prompt**
 
-		For example:
+				For example:
 
-		<RandomPrompt />
-</Steps>
+				<RandomPrompt />
+		</Steps>
+	</WorkflowOption>
+	<WorkflowOption label="Claude Code Desktop" value="desktop">
+		<Steps>
+			1. **Install Claude Desktop**
+
+				Download and install [Claude Desktop](https://claude.com/download) for your operating system.
+
+			2. **Open Claude Code Desktop**
+
+				Open Claude Desktop, sign in, and select the **Code** tab.
+
+			3. **Install the Cloudflare plugin**
+
+				Next to the prompt box, select **+** > **Plugins** > **Browse plugin**. Search for **Cloudflare** in the **Partners** tab, then select **+** to install the plugin.
+
+			4. **Start a local session**
+
+				Select `Local` as the environment. Choose your Cloudflare project folder, model, and permission mode.
+
+			5. **Try a prompt**
+
+				For example:
+
+				<RandomPrompt />
+		</Steps>
+	</WorkflowOption>
+</WorkflowSelector>
 
 ## Cloudflare platform access
 
@@ -72,18 +111,11 @@ import { LinkCard } from "~/components";
 
 - The Skills plugin includes a wrangler Skill — Claude knows when to reach for `npx wrangler deploy`, `wrangler d1 migrations apply`, and other CLI commands automatically.
 - Try the `/cloudflare:build-agent` slash command to scaffold a complete Agents SDK project, or `/cloudflare:build-mcp` for a remote MCP server.
-- The Cloudflare API MCP server uses Code Mode — Claude writes JavaScript against a TypeScript API to hit any of 2,500+ endpoints in ~1,000 tokens.
+- The Cloudflare MCP server uses Code Mode so Claude can use JavaScript against a TypeScript API to reach any of 2,500+ endpoints and current developer documentation in approximately 1,100 tokens.
 - Claude Code works best from the root of your Workers project where `wrangler.jsonc` lives — this is what the agent uses to understand your bindings.
 - Use `claude mcp list` to verify Cloudflare servers are connected. For CI/CD, skip OAuth by passing a Cloudflare API token as a bearer token instead.
 
 </TipsList>
-
-<LinkCard
-	title="Cloudflare MCP server repository"
-	href="https://github.com/cloudflare/mcp-server-cloudflare"
-	icon="github"
-	description="Installing additional MCP servers, and when to use Code Mode versus traditional MCP servers."
-/>
 
 ## FAQ
 
@@ -91,7 +123,7 @@ import { LinkCard } from "~/components";
 	<FAQItem question="Should I use Skills, the MCP server, Wrangler CLI, or all of them?">
 		All three — and the Skills plugin configures them together. Skills give
 		Claude persistent Cloudflare knowledge (when to use Durable Objects vs KV,
-		what a good Workers project layout looks like). The Cloudflare API MCP
+		what a good Workers project layout looks like). The Cloudflare MCP
 		server handles platform operations (DNS, WAF, R2 buckets, Zero Trust).
 		Wrangler runs local dev and Workers-specific commands. The `wrangler` Skill
 		teaches Claude when to reach for which.
@@ -106,10 +138,10 @@ import { LinkCard } from "~/components";
 		configuration and deploy accordingly.
 	</FAQItem>
 	<FAQItem question="What does Code Mode mean for MCP?">
-		Code Mode is how the Cloudflare API MCP server fits all 2,500+ API endpoints
-		into ~1,000 tokens. Instead of exposing every endpoint as a separate tool,
-		it exposes two — `search()` and `execute()` — and Claude writes JavaScript
-		to call them. [Learn more about Code Mode](https://blog.cloudflare.com/code-mode-mcp/).
+		Code Mode is how the Cloudflare MCP server fits all 2,500+ API endpoints
+		into approximately 1,100 tokens. It exposes `docs`, `search()`, and
+		`execute()`, and Claude writes JavaScript to call the API tools. [Learn more
+		about Code Mode](https://blog.cloudflare.com/code-mode-mcp/).
 	</FAQItem>
 </FAQList>
 
@@ -127,8 +159,8 @@ import { LinkCard } from "~/components";
 		bearer token instead.
 	</TroubleshootingItem>
 	<TroubleshootingItem issue="Getting outdated information about Cloudflare products">
-		Enable the <a href="https://github.com/cloudflare/mcp-server-cloudflare" target="_blank" rel="noopener noreferrer">Cloudflare docs MCP server</a> so the agent can fetch
-		current documentation at runtime. If you prefer not to use the MCP server, point
+		Enable the <a href="https://github.com/cloudflare/mcp" target="_blank" rel="noopener noreferrer">Cloudflare MCP server</a> so the agent can fetch
+		current documentation at runtime. You can also point
 		the agent directly at <a href="/llms.txt">developers.cloudflare.com/llms.txt</a> for
 		a directory of every product, or <code>developers.cloudflare.com/&lt;product&gt;/llms.txt</code>
 		for a product-specific index.

--- a/src/content/docs/agent-setup/codex.mdx
+++ b/src/content/docs/agent-setup/codex.mdx
@@ -1,14 +1,16 @@
 ---
 title: Codex + Cloudflare
-description: "OpenAI coding agent available as a terminal CLI and desktop app. It reads and writes files, runs commands, and browses the web in a sandbox."
+description: "OpenAI coding agent available through Codex CLI and Codex in the ChatGPT desktop app. It reads and writes files, runs commands, and browses the web in a sandbox."
 template: splash
 pcx_content_type: how-to
 products:
   - agent-setup
 ---
 
-import { Steps, Tabs, TabItem, LinkCard } from "~/components";
+import { Steps, Tabs, TabItem } from "~/components";
 import AgentHeader from "~/components/agent-setup/AgentHeader.astro";
+import WorkflowOption from "~/components/agent-setup/WorkflowOption.astro";
+import WorkflowSelector from "~/components/agent-setup/WorkflowSelector.astro";
 import PlatformAccess from "~/components/agent-setup/PlatformAccessSection.astro";
 import ExamplePromptsList from "~/components/agent-setup/ExamplePromptsList.astro";
 import RandomPrompt from "~/components/agent-setup/RandomPrompt.astro";
@@ -24,31 +26,43 @@ import OtherAgents from "~/components/agent-setup/OtherAgents.astro";
 
 ## Quick start
 
-<Tabs>
-	<TabItem label="Terminal">
+<WorkflowSelector urlParam="view">
+	<WorkflowOption label="Terminal" value="terminal">
 		<Steps>
 			1. **Install Codex**
 
-				Install the Codex CLI. macOS and Linux are fully supported; use WSL2 on Windows. For Homebrew or other install methods, see the [Codex CLI setup guide](https://developers.openai.com/codex/cli/).
+				Install the Codex CLI with the native installer.
 
-				```bash
-				npm install -g @openai/codex
+				<Tabs>
+					<TabItem label="macOS and Linux">
+						```sh
+						curl -fsSL https://chatgpt.com/codex/install.sh | sh
+						```
+					</TabItem>
+					<TabItem label="Windows">
+						```powershell
+						irm https://chatgpt.com/codex/install.ps1 | iex
+						```
+					</TabItem>
+				</Tabs>
+
+				For Homebrew or other install methods, refer to the [Codex CLI setup guide](https://developers.openai.com/codex/cli/).
+
+			2. **Install the Cloudflare plugin**
+
+				Install the official Cloudflare plugin before starting Codex. This installs Cloudflare Skills and registers the Cloudflare MCP server.
+
+				```sh
+				codex plugin marketplace add cloudflare/skills
+				codex plugin add cloudflare@cloudflare
 				```
 
-			2. **Launch Codex in your project**
+			3. **Launch Codex in your project**
 
 				Start Codex from the root of your project, where `wrangler.jsonc` lives (if it already exists).
 
-				```bash
+				```sh
 				codex
-				```
-
-			3. **Install the Cloudflare plugin**
-
-				Inside Codex, run `/plugins`, then search for and install **Cloudflare**. This installs Cloudflare Skills and registers the Cloudflare MCP servers.
-
-				```txt
-				/plugins
 				```
 
 			4. **Try a prompt**
@@ -57,21 +71,35 @@ import OtherAgents from "~/components/agent-setup/OtherAgents.astro";
 
 				<RandomPrompt />
 		</Steps>
-	</TabItem>
-	<TabItem label="Desktop">
+	</WorkflowOption>
+	<WorkflowOption label="ChatGPT desktop app" value="desktop">
 		<Steps>
-			1. **Download Codex**
+			1. **Install the ChatGPT desktop app**
 
-				Follow the download instructions for your operating system at [developers.openai.com/codex/app](https://developers.openai.com/codex/app).
+				Follow the [ChatGPT desktop app setup guide](https://learn.chatgpt.com/docs/app) for macOS or Windows. Open the app and sign in to your ChatGPT account.
 
-			2. **Install the Cloudflare plugin**
+			2. **Open Codex**
 
-				In the Codex app, go to **Plugins** and install **Cloudflare**.
+				In the app, open the ChatGPT dropdown and select **Codex**.
 
-				![Install the Cloudflare plugin in the Codex desktop app.](~/assets/images/agent-setup/codex-desktop.png)
+			3. **Install the Cloudflare plugin**
+
+				In Codex, open **Plugins**. Search for **Cloudflare**, open the plugin details, and select the plus (+) button.
+
+				![Cloudflare plugin details in the Plugins Directory in Codex.](~/assets/images/agent-setup/codex-desktop.png)
+
+			4. **Start a new chat**
+
+				Open your project and start a new chat. The Cloudflare plugin becomes available in new chats, so you do not need to restart the app.
+
+			5. **Try a prompt**
+
+				For example:
+
+				<RandomPrompt />
 		</Steps>
-	</TabItem>
-</Tabs>
+	</WorkflowOption>
+</WorkflowSelector>
 
 ## Cloudflare platform access
 
@@ -85,17 +113,10 @@ import OtherAgents from "~/components/agent-setup/OtherAgents.astro";
 
 <TipsList>
 
-- The Cloudflare API MCP server uses Code Mode — Codex writes JavaScript against a typed API to reach any of 2,500+ endpoints in ~1,000 tokens.
+- The Cloudflare MCP server uses Code Mode so Codex can use JavaScript against a typed API to reach any of 2,500+ endpoints and current developer documentation in approximately 1,100 tokens.
 - Try the `/cloudflare:build-agent` slash command to scaffold a complete Agents SDK project, or `/cloudflare:build-mcp` for a remote MCP server.
 
 </TipsList>
-
-<LinkCard
-	title="Cloudflare MCP server repository"
-	href="https://github.com/cloudflare/mcp-server-cloudflare"
-	icon="github"
-	description="Installing additional MCP servers, and when to use Code Mode versus traditional MCP servers."
-/>
 
 ## FAQ
 
@@ -103,7 +124,7 @@ import OtherAgents from "~/components/agent-setup/OtherAgents.astro";
 	<FAQItem question="Should I use Skills, the MCP server, Wrangler CLI, or all of them?">
 		All three. Skills load Cloudflare knowledge into every Codex session (when
 		to use Durable Objects, how to structure a Workers project, etc.). The
-		Cloudflare API MCP server handles platform operations (DNS, WAF, Zero
+		Cloudflare MCP server handles platform operations (DNS, WAF, Zero
 		Trust). Wrangler handles local dev, deploys, and migrations. The bundled
 		`wrangler` Skill teaches Codex when to run CLI commands vs. call the MCP
 		API.
@@ -126,8 +147,8 @@ import OtherAgents from "~/components/agent-setup/OtherAgents.astro";
 		Run `codex mcp list` to confirm it appears, then use `/mcp` inside the Codex TUI to check its status.
 	</TroubleshootingItem>
 	<TroubleshootingItem issue="Getting outdated information about Cloudflare products">
-		Enable the <a href="https://github.com/cloudflare/mcp-server-cloudflare" target="_blank" rel="noopener noreferrer">Cloudflare docs MCP server</a> so the agent can fetch
-		current documentation at runtime. If you prefer not to use the MCP server, point
+		Enable the <a href="https://github.com/cloudflare/mcp" target="_blank" rel="noopener noreferrer">Cloudflare MCP server</a> so the agent can fetch
+		current documentation at runtime. You can also point
 		the agent directly at <a href="/llms.txt">developers.cloudflare.com/llms.txt</a> for
 		a directory of every product, or <code>developers.cloudflare.com/&lt;product&gt;/llms.txt</code>
 		for a product-specific index.

--- a/src/content/docs/agent-setup/cursor.mdx
+++ b/src/content/docs/agent-setup/cursor.mdx
@@ -1,6 +1,6 @@
 ---
 title: Cursor + Cloudflare
-description: "AI-first IDE built on VS Code with multi-file Composer edits and background agents. Made by Cursor."
+description: "AI coding desktop app built on VS Code with multi-file Composer edits and background agents. Made by Cursor."
 template: splash
 pcx_content_type: how-to
 products:

--- a/src/content/docs/agent-setup/cursor.mdx
+++ b/src/content/docs/agent-setup/cursor.mdx
@@ -7,7 +7,7 @@ products:
   - agent-setup
 ---
 
-import { Steps, LinkCard } from "~/components";
+import { Steps } from "~/components";
 import AgentHeader from "~/components/agent-setup/AgentHeader.astro";
 import PlatformAccess from "~/components/agent-setup/PlatformAccessSection.astro";
 import ExamplePromptsList from "~/components/agent-setup/ExamplePromptsList.astro";
@@ -31,7 +31,7 @@ import OtherAgents from "~/components/agent-setup/OtherAgents.astro";
 
 	2. **Install the Cloudflare plugin**
 
-		In Cursor, run the following command or install from the [Cursor Marketplace](https://cursor.com/marketplace/cloudflare). This installs Cloudflare Skills and registers the Cloudflare MCP servers.
+		In Cursor, run the following command or install from the [Cursor Marketplace](https://cursor.com/marketplace/cloudflare). This installs Cloudflare Skills and registers the Cloudflare MCP server.
 
 		```txt
 		/add-plugin cloudflare
@@ -56,24 +56,17 @@ import OtherAgents from "~/components/agent-setup/OtherAgents.astro";
 
 <TipsList>
 
-- The Cloudflare API MCP server uses Code Mode — Cursor writes JavaScript against a typed API to reach any of 2,500+ endpoints in ~1,000 tokens.
+- The Cloudflare MCP server uses Code Mode so Cursor can use JavaScript against a typed API to reach any of 2,500+ endpoints and current developer documentation in approximately 1,100 tokens.
 - Add `@wrangler.jsonc` to your Composer prompts so Cursor sees your current bindings when generating or modifying code.
 
 </TipsList>
-
-<LinkCard
-	title="Cloudflare MCP server repository"
-	href="https://github.com/cloudflare/mcp-server-cloudflare"
-	icon="github"
-	description="Available MCP servers, and when to use Code Mode versus traditional MCP servers."
-/>
 
 ## FAQ
 
 <FAQList>
 	<FAQItem question="Should I use Skills, the MCP server, Wrangler CLI, or all of them?">
 		All three work together. Skills give Cursor persistent Cloudflare knowledge
-		loaded into every Composer prompt. The Cloudflare API MCP server handles
+		loaded into every Composer prompt. The Cloudflare MCP server handles
 		platform operations (DNS, WAF, R2 buckets, Zero Trust). Wrangler runs local
 		dev and Workers-specific commands. The bundled `wrangler` Skill teaches
 		Cursor when to reach for which.
@@ -99,15 +92,15 @@ import OtherAgents from "~/components/agent-setup/OtherAgents.astro";
 		after making changes to the MCP config.
 	</TroubleshootingItem>
 	<TroubleshootingItem issue="Getting outdated information about Cloudflare products">
-		Enable the <a href="https://github.com/cloudflare/mcp-server-cloudflare" target="_blank" rel="noopener noreferrer">Cloudflare docs MCP server</a> so the agent can fetch
-		current documentation at runtime. If you prefer not to use the MCP server, point
+		Enable the <a href="https://github.com/cloudflare/mcp" target="_blank" rel="noopener noreferrer">Cloudflare MCP server</a> so the agent can fetch
+		current documentation at runtime. You can also point
 		the agent directly at <a href="/llms.txt">developers.cloudflare.com/llms.txt</a> for
 		a directory of every product, or <code>developers.cloudflare.com/&lt;product&gt;/llms.txt</code>
 		for a product-specific index.
 	</TroubleshootingItem>
 	<TroubleshootingItem issue="Composer does not understand Workers APIs">
-		Add the Cloudflare docs MCP server and Workers documentation to your project
-		context. Use @-mentions to reference `wrangler.jsonc`.
+		Add Workers documentation to your project context. Use @-mentions to reference
+		`wrangler.jsonc`.
 	</TroubleshootingItem>
 </TroubleshootingList>
 

--- a/src/content/docs/agent-setup/github-copilot.mdx
+++ b/src/content/docs/agent-setup/github-copilot.mdx
@@ -1,14 +1,16 @@
 ---
 title: GitHub Copilot + Cloudflare
-description: "Editor extension and CLI with agent mode, workspace context, and native PR integration. Made by GitHub."
+description: "Coding agent available as a desktop app, IDE extension, and CLI with agent sessions and native GitHub integration. Made by GitHub."
 template: splash
 pcx_content_type: how-to
 products:
   - agent-setup
 ---
 
-import { Steps } from "~/components";
+import { Steps, Tabs, TabItem } from "~/components";
 import AgentHeader from "~/components/agent-setup/AgentHeader.astro";
+import WorkflowOption from "~/components/agent-setup/WorkflowOption.astro";
+import WorkflowSelector from "~/components/agent-setup/WorkflowSelector.astro";
 import PlatformAccess from "~/components/agent-setup/PlatformAccessSection.astro";
 import ExamplePromptsList from "~/components/agent-setup/ExamplePromptsList.astro";
 import RandomPrompt from "~/components/agent-setup/RandomPrompt.astro";
@@ -24,43 +26,121 @@ import OtherAgents from "~/components/agent-setup/OtherAgents.astro";
 
 ## Quick start
 
-<Steps>
-	1. **Install GitHub Copilot**
+<WorkflowSelector urlParam="view">
+	<WorkflowOption label="IDE extension" value="extension">
+		<Steps>
+			1. **Install GitHub Copilot**
 
-		Install the GitHub Copilot extension in VS Code from the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=GitHub.copilot). For JetBrains IDEs, Visual Studio, or Xcode, see the [Install the Copilot extension](https://docs.github.com/en/copilot/how-tos/set-up/install-copilot-extension) guide.
+				Install the GitHub Copilot extension in VS Code from the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=GitHub.copilot). For JetBrains IDEs, Visual Studio, or Xcode, refer to [Install the Copilot extension](https://docs.github.com/en/copilot/how-tos/set-up/install-copilot-extension).
 
-	2. **Install Cloudflare Skills**
+			2. **Install Cloudflare Skills**
 
-		```bash
-		npx skills add https://github.com/cloudflare/skills
-		```
+				```bash
+				npx skills add https://github.com/cloudflare/skills
+				```
 
-	3. **Configure Cloudflare MCP servers**
+			3. **Configure the Cloudflare MCP server**
 
-		For VS Code, add to `.vscode/mcp.json`. For Copilot CLI, add to `~/.copilot/mcp-config.json` for user-level configuration or `.mcp.json` or `.github/mcp.json` for project-level configuration. For domain-specific MCP servers, refer to [mcp-server-cloudflare](https://github.com/cloudflare/mcp-server-cloudflare). For the full Cloudflare API MCP server (Code Mode), refer to [cloudflare/mcp](https://github.com/cloudflare/mcp).
+				For VS Code, add the server to `.vscode/mcp.json`.
 
-		```json
-		{
-		  "mcpServers": {
-		    "cloudflare": { "url": "https://mcp.cloudflare.com/mcp" },
-		    "cloudflare-docs": { "url": "https://docs.mcp.cloudflare.com/mcp" },
-		    "cloudflare-bindings": { "url": "https://bindings.mcp.cloudflare.com/mcp" },
-		    "cloudflare-builds": { "url": "https://builds.mcp.cloudflare.com/mcp" },
-		    "cloudflare-observability": { "url": "https://observability.mcp.cloudflare.com/mcp" }
-		  }
-		}
-		```
+				```json
+				{
+				  "servers": {
+				    "cloudflare-api": {
+				      "type": "http",
+				      "url": "https://mcp.cloudflare.com/mcp"
+				    }
+				  }
+				}
+				```
 
-		:::note
-		In Visual Studio Code, `.vscode/mcp.json` uses `servers` as the root key instead of `mcpServers`. For the Visual Studio Code setup, refer to the [Visual Studio Code guide](/agent-setup/visual-studio-code/).
-		:::
+			4. **Try a prompt**
 
-	4. **Try a prompt**
+				Open Copilot Chat, switch to agent mode, and try a prompt. For example:
 
-		Open Copilot Chat (**Ctrl+Shift+I**), switch to agent mode, and try a prompt — for example:
+				<RandomPrompt />
+		</Steps>
+	</WorkflowOption>
+	<WorkflowOption label="Terminal" value="terminal">
+		<Steps>
+			1. **Install GitHub Copilot CLI**
 
-		<RandomPrompt />
-</Steps>
+				Choose the command for your operating system.
+
+				<Tabs>
+					<TabItem label="macOS and Linux">
+						```sh
+						curl -fsSL https://gh.io/copilot-install | bash
+						```
+					</TabItem>
+					<TabItem label="Windows">
+						```powershell
+						winget install GitHub.Copilot
+						```
+					</TabItem>
+				</Tabs>
+
+			2. **Install Cloudflare Skills**
+
+				From your project root, install the Skills before starting Copilot CLI.
+
+				```sh
+				npx skills add https://github.com/cloudflare/skills
+				```
+
+			3. **Add the Cloudflare MCP server**
+
+				Add the Code Mode server to your user configuration.
+
+				```sh
+				copilot mcp add --transport http cloudflare https://mcp.cloudflare.com/mcp
+				```
+
+			4. **Launch Copilot CLI**
+
+				Start Copilot from your project root. If prompted, enter `/login` and follow the authentication instructions.
+
+				```sh
+				copilot
+				```
+
+			5. **Try a prompt**
+
+				For example:
+
+				<RandomPrompt />
+		</Steps>
+	</WorkflowOption>
+	<WorkflowOption label="Desktop app" value="desktop">
+		<Steps>
+			1. **Install Cloudflare Skills**
+
+				In a system terminal, install the Skills before starting your first agent session.
+
+				```bash
+				npx skills add https://github.com/cloudflare/skills
+				```
+
+			2. **Install the GitHub Copilot app**
+
+				Download the [GitHub Copilot app](https://github.com/features/ai/github-app) for macOS, Linux, or Windows. Open the app and sign in to GitHub.
+
+			3. **Add the Cloudflare MCP server**
+
+				In the app settings, select **MCP Servers**. Add the Code Mode server at `https://mcp.cloudflare.com/mcp` as a custom server.
+
+			4. **Open your project**
+
+				Add a local folder or GitHub repository. Start an agent session in the project. The app automatically uses Skills configured for the repository or Copilot CLI.
+
+			5. **Try a prompt**
+
+				For example:
+
+				<RandomPrompt />
+		</Steps>
+	</WorkflowOption>
+</WorkflowSelector>
 
 ## Cloudflare platform access
 
@@ -74,7 +154,7 @@ import OtherAgents from "~/components/agent-setup/OtherAgents.astro";
 
 <TipsList>
 
-- The Cloudflare API MCP server uses Code Mode — Copilot writes JavaScript against a typed API to reach any of 2,500+ endpoints in ~1,000 tokens.
+- The Cloudflare MCP server uses Code Mode so Copilot can use JavaScript against a typed API to reach any of 2,500+ endpoints and current developer documentation in approximately 1,100 tokens.
 - Use `@workspace` in Copilot Chat to give the agent full context of your Workers project before asking it to build or deploy.
 - Commit a `.github/copilot-instructions.md` file with repository-wide conventions — Copilot loads it automatically on every interaction, complementing Skills which are loaded on demand.
 
@@ -84,8 +164,8 @@ import OtherAgents from "~/components/agent-setup/OtherAgents.astro";
 
 <FAQList>
 	<FAQItem question="Does Copilot support Cloudflare Skills?">
-		Yes. GitHub Copilot added Agent Skills support for VS Code agent mode, the
-		Copilot CLI, and the cloud agent. Run `npx skills add
+		Yes. GitHub Copilot supports Agent Skills in the desktop app, VS Code agent
+		mode, Copilot CLI, and the cloud agent. Run `npx skills add
 		https://github.com/cloudflare/skills` to install them. Refer to the [About
 		agent
 		skills](https://docs.github.com/en/copilot/concepts/agents/about-agent-skills)
@@ -93,7 +173,7 @@ import OtherAgents from "~/components/agent-setup/OtherAgents.astro";
 	</FAQItem>
 	<FAQItem question="Should I use Skills, the MCP server, Wrangler CLI, or all of them?">
 		All three. Skills load Cloudflare expertise into every agent-mode session.
-		The Cloudflare API MCP server handles platform operations (DNS, WAF, Zero
+		The Cloudflare MCP server handles platform operations (DNS, WAF, Zero
 		Trust, R2 buckets). Wrangler runs local dev and deploys in the VS Code
 		terminal. The bundled `wrangler` Skill teaches Copilot when to reach for
 		which.
@@ -105,8 +185,8 @@ import OtherAgents from "~/components/agent-setup/OtherAgents.astro";
 		only load when relevant.
 	</FAQItem>
 	<FAQItem question="Can Copilot deploy to Cloudflare directly?">
-		Yes, via Wrangler in the VS Code terminal, or via a GitHub Actions workflow
-		that Copilot can generate for you.
+		Yes. Copilot can run Wrangler from an agent session or the VS Code terminal.
+		It can also create a GitHub Actions workflow for deployment.
 	</FAQItem>
 </FAQList>
 
@@ -114,9 +194,10 @@ import OtherAgents from "~/components/agent-setup/OtherAgents.astro";
 
 <TroubleshootingList>
 	<TroubleshootingItem issue="Skills do not load in Copilot">
-		Skills only work in VS Code agent mode, the Copilot CLI, and the cloud agent
-		— not with inline completion or plain chat. Switch Copilot Chat to agent
-		mode. If Skills are still not discovered, refer to [About agent
+		Skills work in the GitHub Copilot app, VS Code agent mode, Copilot CLI, and
+		the cloud agent. They do not work with inline completion or plain chat. In
+		VS Code, switch Copilot Chat to agent mode. If Skills are still not
+		discovered, refer to [About agent
 		skills](https://docs.github.com/en/copilot/concepts/agents/about-agent-skills)
 		for the paths Copilot checks.
 	</TroubleshootingItem>
@@ -125,8 +206,8 @@ import OtherAgents from "~/components/agent-setup/OtherAgents.astro";
 		server configuration to `.vscode/mcp.json`.
 	</TroubleshootingItem>
 	<TroubleshootingItem issue="Getting outdated information about Cloudflare products">
-		Enable the <a href="https://github.com/cloudflare/mcp-server-cloudflare" target="_blank" rel="noopener noreferrer">Cloudflare docs MCP server</a> so the agent can fetch
-		current documentation at runtime. If you prefer not to use the MCP server, point
+		Enable the <a href="https://github.com/cloudflare/mcp" target="_blank" rel="noopener noreferrer">Cloudflare MCP server</a> so the agent can fetch
+		current documentation at runtime. You can also point
 		the agent directly at <a href="/llms.txt">developers.cloudflare.com/llms.txt</a> for
 		a directory of every product, or <code>developers.cloudflare.com/&lt;product&gt;/llms.txt</code>
 		for a product-specific index.

--- a/src/content/docs/agent-setup/opencode.mdx
+++ b/src/content/docs/agent-setup/opencode.mdx
@@ -1,6 +1,6 @@
 ---
 title: OpenCode + Cloudflare
-description: "Open-source terminal agent with a rich TUI that works with 75+ LLMs. Made by Anomaly."
+description: "Open-source coding agent available as a terminal interface and desktop app. It works with 75+ LLMs. Made by Anomaly."
 template: splash
 pcx_content_type: how-to
 products:
@@ -9,6 +9,8 @@ products:
 
 import { Steps } from "~/components";
 import AgentHeader from "~/components/agent-setup/AgentHeader.astro";
+import WorkflowOption from "~/components/agent-setup/WorkflowOption.astro";
+import WorkflowSelector from "~/components/agent-setup/WorkflowSelector.astro";
 import PlatformAccess from "~/components/agent-setup/PlatformAccessSection.astro";
 import ExamplePromptsList from "~/components/agent-setup/ExamplePromptsList.astro";
 import RandomPrompt from "~/components/agent-setup/RandomPrompt.astro";
@@ -24,51 +26,90 @@ import OtherAgents from "~/components/agent-setup/OtherAgents.astro";
 
 ## Quick start
 
-<Steps>
-	1. **Install OpenCode**
+<WorkflowSelector urlParam="view">
+	<WorkflowOption label="Terminal" value="terminal">
+		<Steps>
+			1. **Install OpenCode**
 
-		Install OpenCode. For npm, Homebrew, Bun, Scoop, or Windows options, see the [OpenCode install guide](https://opencode.ai/docs/).
+				Install OpenCode with its native installation script.
 
-		```bash
-		curl -fsSL https://opencode.ai/install | bash
-		```
+				```sh
+				curl -fsSL https://opencode.ai/install | bash
+				```
 
-	2. **Install Cloudflare Skills**
+			2. **Install Cloudflare Skills**
 
-		```bash
-		npx skills add https://github.com/cloudflare/skills
-		```
+				```sh
+				npx skills add https://github.com/cloudflare/skills
+				```
 
-	3. **Add Cloudflare MCP servers**
+			3. **Add the Cloudflare MCP server**
 
-		Add MCP servers to `.opencode.jsonc`. For domain-specific MCP servers, refer to [mcp-server-cloudflare](https://github.com/cloudflare/mcp-server-cloudflare). For the full Cloudflare API MCP server (Code Mode), refer to [cloudflare/mcp](https://github.com/cloudflare/mcp).
+				Add the servers to `opencode.json` in your project root. OpenCode uses the same configuration in its terminal and desktop apps.
 
-		```json
-		{
-		  "mcp": {
-		    "cloudflare": { "type": "remote", "url": "https://mcp.cloudflare.com/mcp", "enabled": true },
-		    "cloudflare-docs": { "type": "remote", "url": "https://docs.mcp.cloudflare.com/mcp", "enabled": true },
-		    "cloudflare-bindings": { "type": "remote", "url": "https://bindings.mcp.cloudflare.com/mcp", "enabled": true },
-		    "cloudflare-builds": { "type": "remote", "url": "https://builds.mcp.cloudflare.com/mcp", "enabled": true },
-		    "cloudflare-observability": { "type": "remote", "url": "https://observability.mcp.cloudflare.com/mcp", "enabled": true }
-		  }
-		}
-		```
+				```json
+				{
+				  "$schema": "https://opencode.ai/config.json",
+				  "mcp": {
+				    "cloudflare": { "type": "remote", "url": "https://mcp.cloudflare.com/mcp", "enabled": true }
+				  }
+				}
+				```
 
-	4. **Launch OpenCode**
+			4. **Launch OpenCode**
 
-		Start OpenCode from the root of your project, where `wrangler.jsonc` lives (if it already exists).
+				Start OpenCode from your project root.
 
-		```bash
-		opencode
-		```
+				```sh
+				opencode
+				```
 
-	5. **Try a prompt**
+			5. **Try a prompt**
 
-		For example:
+				For example:
 
-		<RandomPrompt />
-</Steps>
+				<RandomPrompt />
+		</Steps>
+	</WorkflowOption>
+	<WorkflowOption label="Desktop app" value="desktop">
+		<Steps>
+			1. **Install OpenCode Desktop**
+
+				Download and install [OpenCode Desktop](https://opencode.ai/download) for your operating system.
+
+			2. **Install Cloudflare Skills**
+
+				In a system terminal, install the Skills before opening your project.
+
+				```sh
+				npx skills add https://github.com/cloudflare/skills
+				```
+
+			3. **Add the Cloudflare MCP server**
+
+				Create `opencode.json` in your project root.
+
+				```json
+				{
+				  "$schema": "https://opencode.ai/config.json",
+				  "mcp": {
+				    "cloudflare": { "type": "remote", "url": "https://mcp.cloudflare.com/mcp", "enabled": true }
+				  }
+				}
+				```
+
+			4. **Open your project**
+
+				Open OpenCode Desktop and add your Cloudflare project folder. The app loads the Skills and MCP configuration for the first session.
+
+			5. **Try a prompt**
+
+				For example:
+
+				<RandomPrompt />
+		</Steps>
+	</WorkflowOption>
+</WorkflowSelector>
 
 ## Cloudflare platform access
 
@@ -82,7 +123,7 @@ import OtherAgents from "~/components/agent-setup/OtherAgents.astro";
 
 <TipsList>
 
-- The Cloudflare API MCP server uses Code Mode — OpenCode writes JavaScript to reach any of 2,500+ endpoints in ~1,000 tokens.
+- The Cloudflare MCP server uses Code Mode so OpenCode can use JavaScript to reach any of 2,500+ endpoints and current developer documentation in approximately 1,100 tokens.
 - OpenCode supports 75+ LLMs — you can use Cloudflare Workers AI as the model provider for a fully Cloudflare-native workflow.
 - Use OpenCode's plan agent (Tab key) to break down complex Workers projects before coding — pair it with `/cloudflare:build-agent` or `/cloudflare:build-mcp` slash commands.
 
@@ -94,7 +135,7 @@ import OtherAgents from "~/components/agent-setup/OtherAgents.astro";
 	<FAQItem question="Should I use Skills, the MCP server, Wrangler CLI, or all of them?">
 		All three. Skills provide persistent Cloudflare expertise so OpenCode knows
 		when to reach for Durable Objects vs KV, how to structure a Workers project,
-		and when to call CLI vs API. The Cloudflare API MCP server handles platform
+		and when to call CLI vs API. The Cloudflare MCP server handles platform
 		operations (DNS, WAF, Zero Trust, R2 buckets). Wrangler handles local dev,
 		deploys, and Workers-specific commands. The bundled `wrangler` Skill teaches
 		OpenCode which to use.
@@ -105,10 +146,18 @@ import OtherAgents from "~/components/agent-setup/OtherAgents.astro";
 	</FAQItem>
 	<FAQItem question="Can I use Workers AI as the model provider in OpenCode?">
 		Yes. OpenCode supports 75+ model providers, including Cloudflare Workers AI.
-		Configure your model in `.opencode.jsonc`.
+		Configure your model in `opencode.json`.
 	</FAQItem>
 	<FAQItem question="Is OpenCode open source?">
-		Yes. OpenCode is fully open source and available at <a href="https://github.com/anomalyco/opencode" target="_blank" rel="noopener noreferrer">github.com/anomalyco/opencode</a>.
+		Yes. OpenCode is fully open source and available at{" "}
+		<a
+			href="https://github.com/anomalyco/opencode"
+			target="_blank"
+			rel="noopener noreferrer"
+		>
+			github.com/anomalyco/opencode
+		</a>
+		.
 	</FAQItem>
 </FAQList>
 
@@ -116,11 +165,11 @@ import OtherAgents from "~/components/agent-setup/OtherAgents.astro";
 
 <TroubleshootingList>
 	<TroubleshootingItem issue="MCP server connection fails">
-		Verify the MCP configuration in `.opencode.jsonc` uses `"type": "remote"`
+		Verify the MCP configuration in `opencode.json` uses `"type": "remote"`
 		with the correct URL. Run `opencode mcp list` to check connected servers.
 	</TroubleshootingItem>
 	<TroubleshootingItem issue="Getting outdated information about Cloudflare products">
-		Enable the <a href="https://github.com/cloudflare/mcp-server-cloudflare" target="_blank" rel="noopener noreferrer">Cloudflare docs MCP server</a> so the agent can fetch
+		Enable the <a href="https://github.com/cloudflare/mcp" target="_blank" rel="noopener noreferrer">Cloudflare MCP server</a> so the agent can fetch
 		current documentation at runtime. If you prefer not to use the MCP server, point
 		the agent directly at <a href="/llms.txt">developers.cloudflare.com/llms.txt</a> for
 		a directory of every product, or <code>developers.cloudflare.com/&lt;product&gt;/llms.txt</code>

--- a/src/content/docs/agent-setup/visual-studio-code/detailed-walkthrough.mdx
+++ b/src/content/docs/agent-setup/visual-studio-code/detailed-walkthrough.mdx
@@ -10,9 +10,9 @@ tableOfContents: false
 
 import { Steps } from "~/components";
 
-This walkthrough connects Visual Studio Code directly to the Cloudflare API using the [Cloudflare MCP server](https://github.com/cloudflare/mcp-server-cloudflare). By the end, you can create a DNS record by typing a sentence, without leaving the editor.
+This walkthrough connects Visual Studio Code directly to the Cloudflare API using the [Cloudflare MCP server](https://github.com/cloudflare/mcp). By the end, you can create a DNS record by typing a sentence, without leaving the editor.
 
-The Cloudflare MCP server at `mcp.cloudflare.com` exposes the Cloudflare API to any MCP-capable agent. The Visual Studio Code Copilot agent connects to it, and you run API calls from natural language.
+The Cloudflare MCP server at `mcp.cloudflare.com` exposes the Cloudflare API and current developer documentation to any MCP-capable agent. The Visual Studio Code Copilot agent connects to it, and you run API calls from natural language.
 
 For the condensed version, refer to the [Visual Studio Code quick start](/agent-setup/visual-studio-code/).
 
@@ -196,5 +196,5 @@ You now have an AI agent with read and write access to Cloudflare services in th
 ## Related resources
 
 - [Visual Studio Code quick start](/agent-setup/visual-studio-code/) — condensed setup, tips, FAQ, and troubleshooting.
-- [Cloudflare MCP server](https://github.com/cloudflare/mcp-server-cloudflare) — domain-specific MCP servers.
+- [Cloudflare MCP server](https://github.com/cloudflare/mcp) — source code and configuration details.
 - [Cloudflare API](/api/) — the full REST API reference.

--- a/src/content/docs/agent-setup/visual-studio-code/index.mdx
+++ b/src/content/docs/agent-setup/visual-studio-code/index.mdx
@@ -7,7 +7,8 @@ products:
   - agent-setup
 ---
 
-import { Steps } from "~/components";
+import { Details, LinkButton, Steps } from "~/components";
+import { Icon } from "astro-icon/components";
 import AgentHeader from "~/components/agent-setup/AgentHeader.astro";
 import PlatformAccess from "~/components/agent-setup/PlatformAccessSection.astro";
 import ExamplePromptsList from "~/components/agent-setup/ExamplePromptsList.astro";
@@ -29,28 +30,18 @@ import OtherAgents from "~/components/agent-setup/OtherAgents.astro";
 
 		Install [Visual Studio Code](https://code.visualstudio.com/) and make sure it is fully up to date. Then install the [GitHub Copilot extension](https://marketplace.visualstudio.com/items?itemName=GitHub.copilot) and sign in with a GitHub account. The Copilot free tier is enough to try this.
 
-	2. **Configure the Cloudflare MCP server**
+	2. **Install the Cloudflare plugin**
 
-		Create `.vscode/mcp.json` inside your workspace folder:
+		<LinkButton href="vscode://chat-plugin/install?source=Y2xvdWRmbGFyZS9za2lsbHM%3D&plugin=cloudflare">
+			<Icon name="simple-icons:visualstudiocode" class="h-4 w-4" />
+			Install in Visual Studio Code
+		</LinkButton>
 
-		```json
-		{
-		  "servers": {
-		    "cloudflare-api": {
-		      "type": "http",
-		      "url": "https://mcp.cloudflare.com/mcp"
-		    }
-		  }
-		}
-		```
+		<Details header="Install manually">
+			If you cannot install with the button, install manually by opening the command palette (`CMD/CTRL+SHIFT+P`) and typing `Chat: Install plugin from source`. Paste the repository name `cloudflare/skills`, press **Enter**, and then select **Install** next to the plugin.
+		</Details>
 
-		Visual Studio Code uses `servers` as the root key. Configurations copied from Cursor or Claude Desktop use `mcpServers` and will silently do nothing here. For domain-specific MCP servers, refer to [mcp-server-cloudflare](https://github.com/cloudflare/mcp-server-cloudflare). For the full Cloudflare API MCP server (Code Mode), refer to [cloudflare/mcp](https://github.com/cloudflare/mcp).
-
-	3. **Start the server and authorize**
-
-		After you save `mcp.json`, Visual Studio Code shows a **Start** CodeLens on the `cloudflare-api` server definition. Select it and complete the OAuth flow to authorize the Cloudflare MCP server against your account. Start with a demo account until you are comfortable with the scope you grant.
-
-	4. **Try a prompt**
+	3. **Try a prompt**
 
 		Open Copilot Chat (**Ctrl+Shift+I** / **Cmd+Shift+I**), switch to agent mode, and try a prompt — for example:
 
@@ -72,7 +63,7 @@ For a screenshot-by-screenshot walkthrough — including the OAuth authorization
 
 <TipsList>
 
-- The Cloudflare API MCP server uses Code Mode — the agent writes JavaScript against a typed API to reach any of 2,500+ endpoints in ~1,000 tokens. That is why you see only three tools registered, not thousands.
+- The Cloudflare MCP server uses Code Mode so the agent can use JavaScript against a typed API to reach any of 2,500+ endpoints and current developer documentation in approximately 1,100 tokens. That is why you see only three tools registered, not thousands.
 - Visual Studio Code's MCP configuration uses `servers` as the root key. Configurations copied from other agents (Cursor, Claude Desktop) use `mcpServers` and will not work in Visual Studio Code.
 - Scope the OAuth grant to a single account, and start with **Read only** or a **Custom** permission set before granting **Full access**.
 - Revoke the grant at any time from the Cloudflare dashboard under **My Profile → Access Management → Connected Applications**.

--- a/src/content/docs/agent-setup/windsurf.mdx
+++ b/src/content/docs/agent-setup/windsurf.mdx
@@ -35,18 +35,14 @@ import OtherAgents from "~/components/agent-setup/OtherAgents.astro";
 		npx skills add https://github.com/cloudflare/skills
 		```
 
-	3. **Configure Cloudflare MCP servers**
+	3. **Configure the Cloudflare MCP server**
 
-		Add the Cloudflare API and docs servers to `~/.codeium/windsurf/mcp_config.json`. For domain-specific MCP servers, refer to [mcp-server-cloudflare](https://github.com/cloudflare/mcp-server-cloudflare). For the full Cloudflare API MCP server (Code Mode), refer to [cloudflare/mcp](https://github.com/cloudflare/mcp).
+		Add the Cloudflare MCP server to `~/.codeium/windsurf/mcp_config.json`. For more information, refer to [cloudflare/mcp](https://github.com/cloudflare/mcp).
 
 		```json
 		{
 		  "mcpServers": {
-		    "cloudflare": { "serverUrl": "https://mcp.cloudflare.com/mcp" },
-		    "cloudflare-docs": { "serverUrl": "https://docs.mcp.cloudflare.com/mcp" },
-		    "cloudflare-bindings": { "serverUrl": "https://bindings.mcp.cloudflare.com/mcp" },
-		    "cloudflare-builds": { "serverUrl": "https://builds.mcp.cloudflare.com/mcp" },
-		    "cloudflare-observability": { "serverUrl": "https://observability.mcp.cloudflare.com/mcp" }
+		    "cloudflare": { "serverUrl": "https://mcp.cloudflare.com/mcp" }
 		  }
 		}
 		```
@@ -70,9 +66,8 @@ import OtherAgents from "~/components/agent-setup/OtherAgents.astro";
 
 <TipsList>
 
-- The Cloudflare API MCP server uses Code Mode — Cascade writes JavaScript to reach any of 2,500+ endpoints in ~1,000 tokens.
+- The Cloudflare MCP server uses Code Mode so Cascade can use JavaScript to reach any of 2,500+ endpoints and current developer documentation in approximately 1,100 tokens.
 - Use `@`-mention to include your `wrangler.jsonc` in Cascade prompts — Cascade uses this to understand your current bindings when generating code.
-- Add the observability MCP server to let Cascade automatically check Workers logs and debug deployments without leaving the IDE.
 
 </TipsList>
 
@@ -88,7 +83,7 @@ import OtherAgents from "~/components/agent-setup/OtherAgents.astro";
 	</FAQItem>
 	<FAQItem question="Should I use Skills, the MCP server, Wrangler CLI, or all of them?">
 		All three complement each other. Cloudflare Skills teach Cascade the
-		patterns and conventions for Workers development. The Cloudflare API MCP
+		patterns and conventions for Workers development. The Cloudflare MCP
 		server handles platform operations (DNS, WAF, Zero Trust, R2 buckets).
 		Wrangler in Windsurf's integrated terminal covers local dev and deploys.
 		Cascade coordinates between them naturally.
@@ -108,8 +103,8 @@ import OtherAgents from "~/components/agent-setup/OtherAgents.astro";
 		changes. Ensure the MCP server URL ends with `/mcp`.
 	</TroubleshootingItem>
 	<TroubleshootingItem issue="Getting outdated information about Cloudflare products">
-		Enable the <a href="https://github.com/cloudflare/mcp-server-cloudflare" target="_blank" rel="noopener noreferrer">Cloudflare docs MCP server</a> so the agent can fetch
-		current documentation at runtime. If you prefer not to use the MCP server, point
+		Enable the <a href="https://github.com/cloudflare/mcp" target="_blank" rel="noopener noreferrer">Cloudflare MCP server</a> so the agent can fetch
+		current documentation at runtime. You can also point
 		the agent directly at <a href="/llms.txt">developers.cloudflare.com/llms.txt</a> for
 		a directory of every product, or <code>developers.cloudflare.com/&lt;product&gt;/llms.txt</code>
 		for a product-specific index.

--- a/src/content/docs/agent-setup/windsurf.mdx
+++ b/src/content/docs/agent-setup/windsurf.mdx
@@ -1,6 +1,6 @@
 ---
 title: Windsurf + Cloudflare
-description: "Agentic IDE with Cascade context and Flows for multi-step tasks. Made by Cognition."
+description: "AI coding desktop app with Cascade context and Flows for multi-step tasks. Made by Cognition."
 template: splash
 pcx_content_type: how-to
 products:

--- a/src/content/docs/agents/model-context-protocol/cloudflare/servers-for-cloudflare/index.mdx
+++ b/src/content/docs/agents/model-context-protocol/cloudflare/servers-for-cloudflare/index.mdx
@@ -10,15 +10,15 @@ products:
   - agents
 ---
 
-Cloudflare runs a catalog of managed remote MCP servers which you can connect to using OAuth on clients like [Claude](https://modelcontextprotocol.io/quickstart/user), [Windsurf](https://docs.windsurf.com/windsurf/cascade/mcp), our own [AI Playground](https://playground.ai.cloudflare.com/) or any [SDK that supports MCP](https://github.com/cloudflare/agents/tree/main/packages/agents/src/mcp).
+Cloudflare runs a catalog of managed remote MCP servers which you can connect to using OAuth on clients like [Claude](https://modelcontextprotocol.io/quickstart/user), [Windsurf](https://docs.windsurf.com/windsurf/cascade/mcp), our own [AI Playground](https://playground.ai.cloudflare.com/), or any [SDK that supports MCP](https://github.com/cloudflare/agents/tree/main/packages/agents/src/mcp).
 
 These MCP servers allow your MCP client to read configurations from your account, process information, make suggestions based on data, and even make those suggested changes for you. All of these actions can happen across Cloudflare's many services including application development, security and performance.
 
 Use the Streamable HTTP endpoint at `/mcp` for new connections. The servers support the new MCP 2026-07-28 Specification and stateless requests from 2025 Streamable HTTP clients. Historical `/sse` URLs remain available as aliases for the same Streamable HTTP handler, but they do not serve the deprecated HTTP+SSE transport. Clients configured to force SSE transport must switch to Streamable HTTP or automatic transport detection.
 
-## Cloudflare API MCP server
+## Cloudflare MCP server (Code Mode) {/* cloudflare-mcp-server */}
 
-The [Cloudflare API MCP server](https://github.com/cloudflare/mcp) provides access to the entire [Cloudflare API](/api/) — over 2,500 endpoints across DNS, Workers, R2, Zero Trust, and every other product — through just two tools: `search()` and `execute()`.
+The [Cloudflare MCP server](https://github.com/cloudflare/mcp) provides access to the entire [Cloudflare API](/api/) — over 2,500 endpoints across DNS, Workers, R2, Zero Trust, and every other product — through just two tools: `search()` and `execute()`.
 
 It uses [the search-and-execute Code Mode pattern](/agents/model-context-protocol/codemode/#search-and-execute), a technique where the model writes JavaScript against a typed representation of the OpenAPI spec and the Cloudflare API client, rather than loading individual tool definitions for each endpoint. The generated code runs inside an isolated [Dynamic Worker](/workers/runtime-apis/bindings/worker-loader/) sandbox.
 
@@ -30,7 +30,7 @@ This approach uses approximately 1,000 tokens regardless of how many API endpoin
 | Native MCP (required params only) | 2,594 | ~244,000   |
 | Code Mode                         | 2     | ~1,000     |
 
-### Connect to the Cloudflare API MCP server
+### Connect to the Cloudflare MCP server
 
 Add the following configuration to your MCP client:
 
@@ -52,43 +52,11 @@ For more information, refer to the [Cloudflare MCP repository](https://github.co
 
 ### Install via agent and IDE plugins
 
-You can install the [Cloudflare Skills plugin](https://github.com/cloudflare/skills), which bundles the Cloudflare MCP servers alongside contextual skills and slash commands for building on Cloudflare. The plugin works with any agent that supports the Agent Skills standard, including Claude Code, OpenCode, OpenAI Codex, and Pi.
-
-#### Claude Code
-
-Install using the [plugin marketplace](https://code.claude.com/docs/en/discover-plugins#add-from-github):
-
-```txt
-/plugin marketplace add cloudflare/skills
-```
-
-#### Cursor
-
-Install from the **Cursor Marketplace**, or add manually via **Settings** > **Rules** > **Add Rule** > **Remote Rule (Github)** with `cloudflare/skills`.
-
-#### npx skills
-
-Install using the [`npx skills`](https://skills.sh) CLI:
-
-```sh
-npx skills add https://github.com/cloudflare/skills
-```
-
-#### Clone or copy
-
-Clone the [cloudflare/skills](https://github.com/cloudflare/skills) repository and copy the skill folders into the appropriate directory for your agent:
-
-| Agent        | Skill directory              | Docs                                                                                                 |
-| ------------ | ---------------------------- | ---------------------------------------------------------------------------------------------------- |
-| Claude Code  | `~/.claude/skills/`          | [Claude Code skills](https://code.claude.com/docs/en/skills)                                         |
-| Cursor       | `~/.cursor/skills/`          | [Cursor skills](https://cursor.com/docs/context/skills)                                              |
-| OpenCode     | `~/.config/opencode/skills/` | [OpenCode skills](https://opencode.ai/docs/skills/)                                                  |
-| OpenAI Codex | `~/.codex/skills/`           | [OpenAI Codex skills](https://developers.openai.com/codex/skills/)                                   |
-| Pi           | `~/.pi/agent/skills/`        | [Pi coding agent skills](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent#skills) |
+You can install the [Cloudflare plugin](https://github.com/cloudflare/skills), which bundles the Cloudflare MCP server alongside contextual skills and slash commands for building on Cloudflare. For more information about installing skills and MCP across agents, refer to [Agent setup](/agent-setup/).
 
 ## Product-specific MCP servers
 
-In addition to the Cloudflare API MCP server, Cloudflare provides product-specific MCP servers for targeted use cases:
+In addition to the Cloudflare MCP server, Cloudflare provides product-specific MCP servers for targeted use cases:
 
 | Server Name                                                                                                             | Description                                                                                     | Server URL                                     |
 | ----------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- | ---------------------------------------------- |

--- a/src/content/docs/agents/model-context-protocol/codemode.mdx
+++ b/src/content/docs/agents/model-context-protocol/codemode.mdx
@@ -89,7 +89,7 @@ async () => {
 
 Authentication stays in the host request callback. The generated code receives a request function, not the credential.
 
-The [Cloudflare API MCP server](/agents/model-context-protocol/cloudflare/servers-for-cloudflare/) uses this pattern to expose the Cloudflare API through `search` and `execute`. For the design rationale and context savings, refer to [Code Mode: give agents an entire API in 1,000 tokens](https://blog.cloudflare.com/code-mode-mcp/).
+The [Cloudflare MCP server](/agents/model-context-protocol/cloudflare/servers-for-cloudflare/) uses this pattern to expose the Cloudflare API through `search` and `execute`. For the design rationale and context savings, refer to [Code Mode: give agents an entire API in 1,000 tokens](https://blog.cloudflare.com/code-mode-mcp/).
 
 To implement this pattern, refer to [Build a search and execute MCP server](/agents/model-context-protocol/guides/build-codemode-openapi-mcp-server/).
 

--- a/src/content/docs/docs-for-agents/index.mdx
+++ b/src/content/docs/docs-for-agents/index.mdx
@@ -50,7 +50,7 @@ Cloudflare runs managed remote MCP servers that give your agent the ability to s
 
 There are two approaches:
 
-- **[Cloudflare API MCP server](/agents/model-context-protocol/cloudflare/servers-for-cloudflare/)**: A Code Mode server that covers the entire Cloudflare API (over 2,500 endpoints). Use this when your agent needs broad access across multiple Cloudflare products.
+- **[Cloudflare MCP server](/agents/model-context-protocol/cloudflare/servers-for-cloudflare/)**: A Code Mode server that covers the entire Cloudflare API (over 2,500 endpoints). Use this when your agent needs broad access across multiple Cloudflare products.
 - **Domain-specific servers**: Focused servers for documentation, observability, DNS analytics, and more. Use these when your agent only needs access to a specific area. The full catalog is in the [cloudflare/mcp-server-cloudflare](https://github.com/cloudflare/mcp-server-cloudflare) repository.
 
 Each agent's [Agent setup](#set-up-your-agent) guide includes MCP server installation as part of its Quick start. For the full list of available MCP servers, refer to [MCP servers for Cloudflare](/agents/model-context-protocol/cloudflare/servers-for-cloudflare/).

--- a/src/pages/agent-setup/index.astro
+++ b/src/pages/agent-setup/index.astro
@@ -27,7 +27,7 @@ const agents = AGENTS;
 		<PageShell>
 			<PageHeader
 				title="Agent setup"
-				tagline="Connect your AI coding agent to Cloudflare, then build and deploy straight from your editor or terminal."
+				tagline="Connect your AI coding agent to Cloudflare, then build and deploy from a desktop app, IDE extension, or terminal."
 			>
 				<div class="mt-8 flex flex-wrap items-center justify-center gap-3">
 					<CopyPromptButton tooltip="Sets up your AI agent for Cloudflare" />


### PR DESCRIPTION
### Summary

<!-- Add context such as the type of documentation being updated or added -->

- Adds desktop app apps in agent setup instructions
- Users filtering by desktop app will be taken to the desktop app tab in the setup pages
- Removes redundant mcp servers just leaving the codemode server
- Update install instructions for multiple agents
- Prioritise installing skills + MCPs via plugins where possible (more agents will support plugins in very near future due to the Agent Plugins 1.0 spec having just released)
- Change instructions to install plugin before launching the agent so that the user doesn't have to reload

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).