### PR TITLE
[AI Gateway] Add Seedance 2.5 model catalog entry

### DIFF
--- a/src/content/catalog-models/bytedance-seedance-2.5.json
+++ b/src/content/catalog-models/bytedance-seedance-2.5.json
@@ -1,0 +1,55 @@
+{
+	"model_id": "bytedance/seedance-2.5",
+	"provider_id": "bytedance",
+	"name": "Seedance 2.5",
+	"description": "ByteDance's audio-video generation model for creating 30-second videos with reference control and editing capabilities. It supports extended storytelling, audio and visual editing, white-model control, and green-screen editing.",
+	"task": "Text-to-Video",
+	"tags": [
+		"Video Generation",
+		"Audio Generation",
+		"Video Editing",
+		"Multimodal"
+	],
+	"context_length": null,
+	"max_output_tokens": null,
+	"schema_version": "1.0.0",
+	"examples": [
+		{
+			"name": "Text to Video",
+			"description": "Generate an audio-video clip from a text prompt.",
+			"input": {
+				"prompt": "A rain-soaked city street at night. A cyclist passes glowing storefronts as distant traffic and rainfall create a quiet urban soundtrack."
+			},
+			"output": {},
+			"code_snippets": [
+				{
+					"label": "typescript",
+					"language": "typescript",
+					"code": "const response = await env.AI.run(\n  'bytedance/seedance-2.5',\n  {\n    prompt:\n      'A rain-soaked city street at night. A cyclist passes glowing storefronts as distant traffic and rainfall create a quiet urban soundtrack.',\n  },\n)\nconsole.log(response)"
+				},
+				{
+					"label": "curl",
+					"language": "bash",
+					"code": "curl https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/run \\\n  --header \"Authorization: Bearer $CLOUDFLARE_API_TOKEN\" \\\n  --header \"Content-Type: application/json\" \\\n  --data '{\n  \"model\": \"bytedance/seedance-2.5\",\n  \"input\": {\n    \"prompt\": \"A rain-soaked city street at night. A cyclist passes glowing storefronts as distant traffic and rainfall create a quiet urban soundtrack.\"\n  }\n}'"
+				}
+			]
+		}
+	],
+	"default_example": null,
+	"code_snippets": [],
+	"supports_async": false,
+	"zdr": false,
+	"zdr_comment": null,
+	"external_info": "https://seed.bytedance.com/en/seedance2_5",
+	"terms": null,
+	"cover_image_url": null,
+	"metadata": {
+		"Max Duration": "30 seconds",
+		"Extensions": "Up to 2",
+		"Audio-Video Generation": "Yes",
+		"Reference Control": "Yes",
+		"Editing": "Audio, visual, white-model, and green-screen"
+	},
+	"request_formats": null,
+	"banner": null
+}


### PR DESCRIPTION
### Summary

Adds the `bytedance/seedance-2.5` Unified Catalog model entry, including usage examples and verified model capabilities.

### Documentation checklist

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
