### PR TITLE
chore: Add shridhar-cf as AI codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,7 +18,7 @@ package.json @cloudflare/content-engineering
 /src/scripts/analytics/search.ts @cloudflare/content-engineering @cloudflare/ai-search
 /src/scripts/webmcp.ts @cloudflare/content-engineering @cloudflare/ai-search
 /src/util/search.ts @cloudflare/content-engineering @cloudflare/ai-search
-/src/content/workers-ai-models/ @craigsdennis @mchenco @superhighfives @ethulia @kflansburg @cloudflare/product-owners @kodster28
+/src/content/workers-ai-models/ @craigsdennis @mchenco @superhighfives @shridhar-cf @ethulia @kflansburg @cloudflare/product-owners @kodster28
 /public/__redirects @cloudflare/content-engineering @cloudflare/product-owners
 
 
@@ -27,22 +27,22 @@ package.json @cloudflare/content-engineering
 /src/content/docs/agent-lee/ @kczajkowski @Brayden @cloudflare/ax @cloudflare/product-owners
 /src/content/docs/agents/ @irvinebroque @rita3ko @elithrar @cloudflare/product-owners @cloudflare/ai-agents @cloudflare/dev-plat-leads
 /src/content/partials/agents/ @elithrar @rita3ko @irvinebroque @vy-ton @thomasgauvin @cloudflare/product-owners
-/src/content/docs/ai-gateway/ @abhishekkankani @palashgo @thebongy @roerohan @kathayl @mchenco @zeke @superhighfives @adriandlam @mattrothenberg @ethulia @aninibread @kflansburg @cloudflare/product-owners
-/src/content/docs/workers-ai/ @rita3ko @craigsdennis @mchenco @zeke @superhighfives @mattrothenberg @ethulia @aninibread @kflansburg @cloudflare/product-owners
+/src/content/docs/ai-gateway/ @abhishekkankani @palashgo @thebongy @roerohan @kathayl @mchenco @zeke @superhighfives @shridhar-cf @adriandlam @mattrothenberg @ethulia @aninibread @kflansburg @cloudflare/product-owners
+/src/content/docs/workers-ai/ @rita3ko @craigsdennis @mchenco @zeke @superhighfives @shridhar-cf @mattrothenberg @ethulia @aninibread @kflansburg @cloudflare/product-owners
 /src/content/docs/vectorize/ @elithrar @vy-ton @sejoker @mchenco @cloudflare/product-owners
 /src/content/partials/vectorize/ @elithrar @mchenco @sejoker @cloudflare/product-owners
-/src/content/partials/ai-gateway/ @abhishekkankani @palashgo @thebongy @roerohan @kathayl @mchenco @zeke @superhighfives @adriandlam @mattrothenberg @ethulia @aninibread @kflansburg @cloudflare/product-owners
-/src/content/release-notes/workers-ai.yaml @kathayl @mchenco @zeke @superhighfives @mattrothenberg @ethulia @aninibread @kflansburg @cloudflare/product-owners
-/src/content/release-notes/ai-gateway.yaml @abhishekkankani @palashgo @thebongy @roerohan @kathayl @mchenco @zeke @superhighfives @adriandlam @mattrothenberg @ethulia @aninibread @kflansburg @cloudflare/product-owners
+/src/content/partials/ai-gateway/ @abhishekkankani @palashgo @thebongy @roerohan @kathayl @mchenco @zeke @superhighfives @shridhar-cf @adriandlam @mattrothenberg @ethulia @aninibread @kflansburg @cloudflare/product-owners
+/src/content/release-notes/workers-ai.yaml @kathayl @mchenco @zeke @superhighfives @shridhar-cf @mattrothenberg @ethulia @aninibread @kflansburg @cloudflare/product-owners
+/src/content/release-notes/ai-gateway.yaml @abhishekkankani @palashgo @thebongy @roerohan @kathayl @mchenco @zeke @superhighfives @shridhar-cf @adriandlam @mattrothenberg @ethulia @aninibread @kflansburg @cloudflare/product-owners
 /src/content/release-notes/vectorize.yaml @elithrar @mchenco @sejoker @cloudflare/product-owners
 /src/content/docs/ai-search/ @rita3ko @irvinebroque @aninibread @G4brym @mchenco @cloudflare/product-owners
 /src/content/release-notes/ai-search.yaml @rita3ko @irvinebroque @aninibread @G4brym @mchenco @cloudflare/product-owners
-/src/content/catalog-models/ @abhishekkankani @palashgo @thebongy @roerohan @kathayl @mchenco @zeke @superhighfives @mattrothenberg @ethulia @kflansburg @cloudflare/content-engineering @cloudflare/product-owners
-/src/components/models/ @mchenco @superhighfives @ethulia @kflansburg @cloudflare/content-engineering @cloudflare/product-owners @kodster28
-/src/pages/ai/models/ @mchenco @superhighfives @ethulia @kflansburg @cloudflare/content-engineering @cloudflare/product-owners @kodster28
-/src/pages/workers-ai/models/ @mchenco @superhighfives @ethulia @kflansburg @cloudflare/content-engineering @cloudflare/product-owners @kodster28
-/src/util/models/ @mchenco @superhighfives @ethulia @kflansburg @cloudflare/content-engineering @cloudflare/product-owners @kodster28
-/bin/fetch-catalog-models.ts @abhishekkankani @palashgo @thebongy @roerohan @kathayl @mchenco @zeke @superhighfives @mattrothenberg @ethulia @kflansburg @cloudflare/content-engineering @cloudflare/product-owners @kodster28
+/src/content/catalog-models/ @abhishekkankani @palashgo @thebongy @roerohan @kathayl @mchenco @zeke @superhighfives @shridhar-cf @mattrothenberg @ethulia @kflansburg @cloudflare/content-engineering @cloudflare/product-owners
+/src/components/models/ @mchenco @superhighfives @shridhar-cf @ethulia @kflansburg @cloudflare/content-engineering @cloudflare/product-owners @kodster28
+/src/pages/ai/models/ @mchenco @superhighfives @shridhar-cf @ethulia @kflansburg @cloudflare/content-engineering @cloudflare/product-owners @kodster28
+/src/pages/workers-ai/models/ @mchenco @superhighfives @shridhar-cf @ethulia @kflansburg @cloudflare/content-engineering @cloudflare/product-owners @kodster28
+/src/util/models/ @mchenco @superhighfives @shridhar-cf @ethulia @kflansburg @cloudflare/content-engineering @cloudflare/product-owners @kodster28
+/bin/fetch-catalog-models.ts @abhishekkankani @palashgo @thebongy @roerohan @kathayl @mchenco @zeke @superhighfives @shridhar-cf @mattrothenberg @ethulia @kflansburg @cloudflare/content-engineering @cloudflare/product-owners @kodster28
 /src/content/docs/agent-memory/ @lambrospetrou @rts-rob @pmesgari @cloudflare/product-owners
 /public/icons/agents @cloudflare/product-owners @cloudflare/ai-agents @cloudflare/dev-plat-leads
 /src/assets/images/agent-setup @cloudflare/product-owners @cloudflare/ai-agents @cloudflare/dev-plat-leads


### PR DESCRIPTION
### Summary

Adds `@shridhar-cf` beside `@superhighfives` for all AI model-related CODEOWNERS paths.
