### PR TITLE
fix: resolve remaining Astro check hints

### DIFF
--- a/src/components/OneTrust.astro
+++ b/src/components/OneTrust.astro
@@ -24,7 +24,7 @@ const uuid = isProductionDeployment
 	data-domain-script={uuid}
 	is:inline></script>
 <script type="text/javascript" is:inline>
-	window.OptanonWrapper = function OptanonWrapper() {};
+	window.OptanonWrapper = () => {};
 </script>
 <!-- OneTrust Cookies Settings button start -->
 <div class="inline-flex items-center gap-2">

--- a/src/components/OneTrust.astro
+++ b/src/components/OneTrust.astro
@@ -24,8 +24,7 @@ const uuid = isProductionDeployment
 	data-domain-script={uuid}
 	is:inline></script>
 <script type="text/javascript" is:inline>
-	// eslint-disable-next-line @typescript-eslint/no-unused-vars
-	function OptanonWrapper() {}
+	window.OptanonWrapper = function OptanonWrapper() {};
 </script>
 <!-- OneTrust Cookies Settings button start -->
 <div class="inline-flex items-center gap-2">

--- a/src/components/PageHead.astro
+++ b/src/components/PageHead.astro
@@ -288,7 +288,11 @@ const hasRssAlternate = headExtras.some(
 	)
 }
 
-{!noindex && jsonLd && <script type="application/ld+json" set:html={jsonLd} />}
+{
+	!noindex && jsonLd && (
+		<script type="application/ld+json" set:html={jsonLd} is:inline />
+	)
+}
 
 {
 	headExtras.map(({ tag: Tag, attrs = {}, content }) =>

--- a/src/components/cf/CURL.astro
+++ b/src/components/cf/CURL.astro
@@ -21,7 +21,7 @@ const props = z.object({
 	method: z
 		.enum(["GET", "HEAD", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"])
 		.default("GET"),
-	url: z.string().url(),
+	url: z.url(),
 	headers: z.record(z.string(), z.string()).default({}),
 	json: z.union([Record, z.array(Record)]).optional(),
 	form: Record.optional(),

--- a/src/components/ui/search/Search.astro
+++ b/src/components/ui/search/Search.astro
@@ -264,7 +264,7 @@ const aiSearchApiUrl =
 			this.prepareModal();
 
 			const modifier = this.querySelector("[data-search-shortcut-modifier]");
-			if (modifier && /Mac|iPhone|iPad|iPod/.test(navigator.platform)) {
+			if (modifier && /Mac|iPhone|iPad|iPod/.test(navigator.userAgent)) {
 				modifier.textContent = "⌘";
 			}
 		}

--- a/src/util/custom-loaders.ts
+++ b/src/util/custom-loaders.ts
@@ -24,7 +24,7 @@ export async function downloadToDotTempIfNotPresent(
 	url: string,
 	dotTmpDestination: string,
 ) {
-	const source = z.string().url().parse(url);
+	const source = z.url().parse(url);
 	const relativeDestination = z
 		.string()
 		.refine((val) => !val.includes("\\"), {


### PR DESCRIPTION
## Summary

Resolves the last 5 `astro check` hints — now 0 errors, 0 warnings, 0 hints.

## Changes

- **`src/components/OneTrust.astro`** — Assign `OptanonWrapper` to `window` instead of declaring a local unused function. OneTrust requires it as a global callback; the assignment eliminates the TS6133 "declared but never read" hint.
- **`src/components/PageHead.astro`** — Add `is:inline` to the JSON-LD `<script>` tag using `set:html`. Astro warns when `set:html` is used without `is:inline` because it cannot process the content at build time.
- **`src/components/cf/CURL.astro`** — Replace deprecated `z.string().url()` with `z.url()` (Zod v4 API).
- **`src/util/custom-loaders.ts`** — Replace deprecated `z.string().url()` with `z.url()` (Zod v4 API).
- **`src/components/ui/search/Search.astro`** — Replace deprecated `navigator.platform` with `navigator.userAgent` for Apple device detection. The regex `/Mac|iPhone|iPad|iPod/` matches the same substrings in `userAgent`.

## Validation

```bash
pnpm run check              # 0 errors, 0 warnings, 0 hints
pnpm run lint               # clean
pnpm run format:core:check  # clean
pnpm run test               # 108 passed (10 files)
```

## Checklist

- [x] No behavior changes intended
- [x] All checks pass
- [x] No new dependencies