### PR TITLE
docs(durable-objects): apply billable unit rounding in pricing examples

### DIFF
--- a/src/content/docs/durable-objects/platform/pricing.mdx
+++ b/src/content/docs/durable-objects/platform/pricing.mdx
@@ -27,6 +27,15 @@ On Workers Free plan:
 
 ## Compute billing examples
 
+:::caution[Billable unit rounding]
+Cloudflare rounds up billable compute usage above the included allowance to the next billing unit:
+
+- Requests: units of 1 million requests ($0.15 per unit on the Paid plan)
+- Duration: units of 1 million GB-s ($12.50 per unit on the Paid plan)
+
+For example, 152,960 GB-s of duration above the included allowance is billed as 1 million GB-s ($12.50), not a proportional fraction of that unit.
+:::
+
 These examples exclude the costs for the Workers calling the Durable Objects. When modelling the costs of a Durable Object, note that:
 
 - Inactive objects receiving no requests do not incur any duration charges.
@@ -44,14 +53,14 @@ In this scenario, the estimated monthly cost would be calculated as:
 
 **Requests**:
 
-- (1.5 million requests - included 1 million requests) x $0.15 / 1,000,000 = $0.075
+- (1.5 million requests - included 1 million requests) = 0.5 million billable requests, rounded up to 1 million × $0.15 = $0.15
 
 **Compute Duration**:
 
 - 1,000,000 seconds \* 128 MB / 1 GB = 128,000 GB-s
-- (128,000 GB-s - included 400,000 GB-s) x $12.50 / 1,000,000 = $0.00
+- (128,000 GB-s - included 400,000 GB-s) = $0.00 (within included allowance)
 
-**Estimated total**: \~$0.075 (requests) + $0.00 (compute duration) + minimum $5/mo usage = $5.08 per month
+**Estimated total**: $0.15 (requests) + $0.00 (compute duration) + minimum $5/mo usage = $5.15 per month
 
 ### Example 2
 
@@ -66,16 +75,16 @@ In this scenario, the estimated monthly cost would be calculated as:
 
 - 50 WebSocket connections \* 100 Durable Objects to establish the WebSockets = 5,000 connections created each day \* 30 days = 150,000 WebSocket connection requests.
 - 50 messages per minute \* 100 Durable Objects \* 60 minutes \* 8 hours \* 30 days = 72,000,000 WebSocket message requests.
-- 150,000 + (72 million requests / 20 for WebSocket message billing ratio) = 3.75 million billing request.
-- (3.75 million requests - included 1 million requests) x $0.15 / 1,000,000 = $0.41.
+- 150,000 + (72 million requests / 20 for WebSocket message billing ratio) = 3.75 million billing requests.
+- (3.75 million requests - included 1 million requests) = 2.75 million billable requests, rounded up to 3 million × $0.15 = $0.45
 
 **Compute Duration**:
 
 - 100 Durable Objects \* 60 seconds \* 60 minutes \* 8 hours \* 30 days = 86,400,000 seconds.
 - 86,400,000 seconds \* 128 MB / 1 GB = 11,059,200 GB-s.
-- (11,059,200 GB-s - included 400,000 GB-s) x $12.50 / 1,000,000 = $133.24.
+- (11,059,200 GB-s - included 400,000 GB-s) = 10,659,200 GB-s, rounded up to 11 million GB-s × $12.50 = $137.50
 
-**Estimated total**: $0.41 (requests) + $133.24 (compute duration) + minimum $5/mo usage = $138.65 per month.
+**Estimated total**: $0.45 (requests) + $137.50 (compute duration) + minimum $5/mo usage = $142.95 per month.
 
 ### Example 3
 
@@ -91,15 +100,15 @@ In this scenario, the estimated monthly cost would be calculated as:
 - 100 WebSocket connection requests.
 - 1 message per second \* 100 connections \* 60 seconds \* 60 minutes \* 24 hours \* 30 days = 259,200,000 WebSocket message requests.
 - 100 + (259.2 million requests / 20 for WebSocket billing ratio) = 12,960,100 requests.
-- (12.9 million requests - included 1 million requests) x $0.15 / 1,000,000 = $1.79.
+- (12,960,100 requests - included 1 million requests) = 11,960,100 billable requests, rounded up to 12 million × $0.15 = $1.80
 
 **Compute Duration**:
 
 - 100 Durable Objects \* 60 seconds \* 60 minutes \* 24 hours \* 30 days = 259,200,000 seconds
 - 259,200,000 seconds \* 128 MB / 1 GB = 33,177,600 GB-s
-- (33,177,600 GB-s - included 400,000 GB-s) x $12.50 / 1,000,000 = $409.72
+- (33,177,600 GB-s - included 400,000 GB-s) = 32,777,600 GB-s, rounded up to 33 million GB-s × $12.50 = $412.50
 
-**Estimated total**: $1.79 (requests) + $409.72 (compute duration) + minimum $5/mo usage = $416.51 per month
+**Estimated total**: $1.80 (requests) + $412.50 (compute duration) + minimum $5/mo usage = $419.30 per month
 
 ### Example 4
 
@@ -114,16 +123,16 @@ In this scenario, the estimated monthly cost would be calculated as:
 
 - 100 WebSocket connections \* 100 Durable Objects to establish the WebSockets = 10,000 initial WebSocket connection requests.
 - 100 messages per minute<sup>1</sup> \* 100 Durable Objects \* 60 minutes \* 24 hours \* 30 days = 432,000,000 requests.
-- 10,000 + (432 million requests / 20 for WebSocket billing ratio) = 21,610,000 million requests.
-- (21.6 million requests - included 1 million requests) x $0.15 / 1,000,000 = $3.09.
+- 10,000 + (432 million requests / 20 for WebSocket billing ratio) = 21,610,000 requests.
+- (21,610,000 requests - included 1 million requests) = 20,610,000 billable requests, rounded up to 21 million × $0.15 = $3.15
 
 **Compute Duration**:
 
 - 100 Durable Objects \* 1 second<sup>2</sup> \* 60 minutes \* 24 hours \* 30 days = 4,320,000 seconds
 - 4,320,000 seconds \* 128 MB / 1 GB = 552,960 GB-s
-- (552,960 GB-s - included 400,000 GB-s) x $12.50 / 1,000,000 = $1.91
+- (552,960 GB-s - included 400,000 GB-s) = 152,960 GB-s, rounded up to 1 million GB-s × $12.50 = $12.50
 
-**Estimated total**: $3.09 (requests) + $1.91 (compute duration) + minimum $5/mo usage = $10.00 per month
+**Estimated total**: $3.15 (requests) + $12.50 (compute duration) + minimum $5/mo usage = $20.65 per month
 
 <sup>1</sup> 100 messages per minute comes from the fact that 100 clients
 connect to each DO, and each sends 1 message per minute.


### PR DESCRIPTION
## Summary
- Document that Durable Objects compute overages round up to the next request / GB-s billing unit (same model as other Cloudflare billable-unit products).
- Recalculate the four compute examples so request and duration line items use rounded units instead of proportional fractions.
- Correct a stray `21,610,000 million` typo on the same request line already being updated.

Fixes #32590.

## Why
The examples previously implied fractional million request / GB-s overages are billed proportionally (e.g. 152,960 GB-s × $12.50 / 1M = $1.91). Production bills whole units: that overage is 1 million GB-s ($12.50). Leaving the proportional math in place mis-trains cost modeling.

## Test plan
- [ ] Preview Durable Objects pricing page: caution renders; example totals match the rounded arithmetic above
- [ ] Spot-check Example 4 duration: `(552,960 - 400,000) → 152,960 → $12.50`
