### PR TITLE
docs(cloudflare-one): remove unfinished PAC Firefox TODO

### DIFF
--- a/src/content/docs/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/best-practices.mdx
+++ b/src/content/docs/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/best-practices.mdx
@@ -278,10 +278,6 @@ If you have an issue with proxy routing, most browsers provide debugging tools t
 2. Go to the website you want to test with the affected browser.
 3. Look for messages related to proxy resolution.
 
-You can also test PAC file logic directly in the console by copying your `FindProxyForURL` function and calling it with test URLs. For example:
-
-TODO
-
 </Details>
 
 <Details header="Safari">


### PR DESCRIPTION
## Summary
- Remove the unfinished Firefox PAC console example that published a literal `TODO`.

Fixes #32342.

## Why
The Chromium and Safari sections stop at actionable browser steps. The Firefox section already tells readers to use the Browser Console; the extra "for example" block never received content and shipped as `TODO`, which is worse than omitting an example.

## Test plan
- [ ] Open the PAC best-practices page Firefox details: no `TODO`; steps 1–3 remain
