### PR TITLE
docs(billing): point invoice email prefs to Subscriptions tab

### DIFF
--- a/src/content/docs/billing/manage/invoices.mdx
+++ b/src/content/docs/billing/manage/invoices.mdx
@@ -33,8 +33,8 @@ To receive invoice emails when you add or remove subscriptions from your account
 
    <DashButton url="/?to=/:account/billing" />
 
-2. Select **Invoices and documents**.
-3. From **Billing email preferences**, turn on invoice emails.
+2. Select **Subscriptions**.
+3. From the **Billing Email** card, turn on invoice emails.
 
 </Steps>
 

--- a/src/content/docs/billing/understand/how-billing-works.mdx
+++ b/src/content/docs/billing/understand/how-billing-works.mdx
@@ -143,10 +143,10 @@ The bottom of the invoice shows:
 
 The Cloudflare dashboard organizes billing information across four tabs under **Manage Account** > **Billing**:
 
-- **Invoices and documents** — view, download, and pay invoices. Configure your billing email preference and set up billable usage notifications.
+- **Invoices and documents** — view, download, and pay invoices.
 - **Billable Usage** — track daily usage-based costs across all products for the current or previous billing period.
 - **Payment** — manage your primary and additional payment methods, billing address, and tax-exempt status.
-- **Subscriptions** — view all active subscriptions with their renewal dates, pricing, and invoice status. Cancel or modify subscriptions from this tab.
+- **Subscriptions** — view active subscriptions (renewal dates, pricing, invoice status) and cancel or modify them. Invoice email preferences are on the **Billing Email** card.
 
 ### Billable usage dashboard
 


### PR DESCRIPTION
## Summary
- Point "Turn on invoice emails" to **Subscriptions** → **Billing Email** (not **Invoices and documents**).
- Align the billing dashboard overview so invoice email preferences are listed under Subscriptions.

Fixes #31128.

## Why
Users cannot find the control where the docs send them. Closed PR #31608 already had the correct path but was auto-closed for staleness without merge. Download-invoice steps stay on **Invoices and documents** — only the email opt-in path changes.

## Verification
- Matches the path from closed #31608 and reporter confirmation that preferences live on the Subscriptions **Billing Email** card.
- Diff limited to the opt-in steps + one overview bullet; download flow untouched.

## Test plan
- [ ] On a non-Enterprise account: Billing → Subscriptions → Billing Email shows invoice email opt-in
- [ ] Download invoice section still says Invoices and documents
