### PR TITLE
docs(workflows): document step.sleep numeric duration as milliseconds

### DIFF
--- a/src/content/docs/workflows/build/workers-api.mdx
+++ b/src/content/docs/workflows/build/workers-api.mdx
@@ -152,7 +152,7 @@ export class MyWorkflow extends WorkflowEntrypoint<Env> {
 
 - <code>step.sleep(name: string, duration: WorkflowDuration): Promise&lt;void&gt;</code>
   - `name` - the name of the step.
-  - `duration` - the duration to sleep until, as a number of milliseconds or as a `WorkflowDuration` compatible string.
+  - `duration` - the duration to sleep for, as a `number` in milliseconds or as a `WorkflowDuration`-compatible string.
   - Refer to the [documentation on sleeping and retrying](/workflows/build/sleeping-and-retrying/) to learn more about how Workflows are retried.
 
 - <code>step.sleepUntil(name: string, timestamp: Date | number): Promise&lt;void&gt;</code>

--- a/src/content/docs/workflows/build/workers-api.mdx
+++ b/src/content/docs/workflows/build/workers-api.mdx
@@ -152,7 +152,7 @@ export class MyWorkflow extends WorkflowEntrypoint<Env> {
 
 - <code>step.sleep(name: string, duration: WorkflowDuration): Promise&lt;void&gt;</code>
   - `name` - the name of the step.
-  - `duration` - the duration to sleep until, in either seconds or as a `WorkflowDuration` compatible string.
+  - `duration` - the duration to sleep until, as a number of milliseconds or as a `WorkflowDuration` compatible string.
   - Refer to the [documentation on sleeping and retrying](/workflows/build/sleeping-and-retrying/) to learn more about how Workflows are retried.
 
 - <code>step.sleepUntil(name: string, timestamp: Date | number): Promise&lt;void&gt;</code>

--- a/src/content/docs/workflows/python/python-workers-api.mdx
+++ b/src/content/docs/workflows/python/python-workers-api.mdx
@@ -60,7 +60,7 @@ When returning state from a step, you must make sure that the returned value is 
 
 - <code>step.sleep(name, duration)</code>
   - `name` — the name of the step.
-  - `duration` — the duration to sleep until, in either seconds or as a `WorkflowDuration` compatible string.
+  - `duration` — the duration to sleep until, as a number of milliseconds or as a `WorkflowDuration` compatible string.
 
 ```python
 async def run(self, event, step):

--- a/src/content/docs/workflows/python/python-workers-api.mdx
+++ b/src/content/docs/workflows/python/python-workers-api.mdx
@@ -60,7 +60,7 @@ When returning state from a step, you must make sure that the returned value is 
 
 - <code>step.sleep(name, duration)</code>
   - `name` — the name of the step.
-  - `duration` — the duration to sleep until, as a number of milliseconds or as a `WorkflowDuration` compatible string.
+  - `duration` — the duration to sleep for, as a `number` in milliseconds or as a `WorkflowDuration`-compatible string.
 
 ```python
 async def run(self, event, step):


### PR DESCRIPTION
## Summary
- Correct `step.sleep` numeric `duration` units from "seconds" to "milliseconds" in the Workers API and Python API references.

Fixes #32100.

## Why
`/workflows/build/sleeping-and-retrying/` already documents a bare `number` as milliseconds. The API reference pages said seconds. Callers who pass `30` expecting a 30s pause get a 30ms sleep and hot-loop. Duration strings (`"30 seconds"`) are unchanged.

## Verification
- Canonical docs already state ms: `sleeping-and-retrying.mdx` ("`number` (milliseconds)").
- Upstream tests treat bare numbers as ms: `cloudflare/workers-sdk` `packages/workflows-shared/tests/binding.test.ts` uses `await step.sleep("sleep", 250)` inside a flow that completes well under a multi-second test timeout — that cannot be 250 seconds.
- Same suite uses `step.sleep("checkpoint", 1)` as a near-instant checkpoint in `engine.test.ts`.

## Test plan
- [x] Workers API + Python API bullets agree with sleeping-and-retrying
- [x] No remaining "in either seconds" wording for `step.sleep` duration on these pages
- [ ] Preview pages render the updated bullets
