### PR TITLE
docs(durable-objects): fix duplicated million in pricing example

### DIFF
--- a/src/content/docs/durable-objects/platform/pricing.mdx
+++ b/src/content/docs/durable-objects/platform/pricing.mdx
@@ -119,7 +119,7 @@ In this scenario, the estimated monthly cost would be calculated as:
 
 - 100 WebSocket connections \* 100 Durable Objects to establish the WebSockets = 10,000 initial WebSocket connection requests.
 - 100 messages per minute<sup>1</sup> \* 100 Durable Objects \* 60 minutes \* 24 hours \* 30 days = 432,000,000 requests.
-- 10,000 + (432 million requests / 20 for WebSocket billing ratio) = 21,610,000 million requests.
+- 10,000 + (432 million requests / 20 for WebSocket billing ratio) = 21,610,000 requests.
 - 21,610,000 requests - included 1 million requests = 20,610,000 billable requests.
 - (rounded) 21,000,000 requests x $0.15 / 1,000,000 = $3.15.
 


### PR DESCRIPTION
## Summary
- Fix a duplicated unit word in Example 4: `21,610,000 million requests` → `21,610,000 requests`.

## Why
The preceding lines already compute `10,000 + (432M / 20) = 21,610,000`. The extra "million" is a typo, not a change to the pricing model.

Related: #32590 discusses billable-unit rounding separately; that needs Billing/DO confirmation before examples are recalculated (see closed #32621).

## Test plan
- [ ] Example 4 request bullet reads `21,610,000 requests` and still matches the arithmetic above it
