### PR TITLE
[DO] Fix SQLite storage API anchor links

### DIFF
--- a/src/content/docs/durable-objects/api/sqlite-storage-api.mdx
+++ b/src/content/docs/durable-objects/api/sqlite-storage-api.mdx
@@ -345,7 +345,7 @@ ctx.storage.onNextSessionRestoreBookmark(bookmark)
 
 ### `sql`
 
-`sql` is a readonly property of type `DurableObjectStorage` encapsulating the [SQL API](/durable-objects/api/sqlite-storage-api/#synchronous-sql-api).
+`sql` is a readonly property of type `DurableObjectStorage` encapsulating the [SQL API](/durable-objects/api/sqlite-storage-api/#sql-api).
 
 ## Related resources
 

--- a/src/content/docs/durable-objects/reference/durable-objects-migrations.mdx
+++ b/src/content/docs/durable-objects/reference/durable-objects-migrations.mdx
@@ -384,7 +384,7 @@ A pending transfer persists until the source Worker commits with a `transferred`
 
 Live entries (`state: "created"` and `state: "expecting-transfer"`) must declare a `storage` value:
 
-- `"sqlite"` selects the SQLite storage backend. This is the recommended and only path for new namespaces. SQLite-backed namespaces support [SQL](/durable-objects/api/sqlite-storage-api/), [Point-in-Time Recovery](/durable-objects/api/sqlite-storage-api/#point-in-time-recovery-api), and a higher per-object storage limit.
+- `"sqlite"` selects the SQLite storage backend. This is the recommended and only path for new namespaces. SQLite-backed namespaces support [SQL](/durable-objects/api/sqlite-storage-api/), [Point-in-Time Recovery](/durable-objects/api/sqlite-storage-api/#pitr-point-in-time-recovery-api), and a higher per-object storage limit.
 - `"legacy-kv"` selects the key-value storage backend. Cloudflare only accepts this value for namespaces that were already provisioned with key-value storage (typically Workers that started on the [legacy `migrations` array](/durable-objects/reference/durable-object-class-migrations-legacy/) before SQLite was the default). You cannot create a **new** key-value-backed namespace through `exports`.
 
 <Render file="do-plans-note" product="durable-objects" />


### PR DESCRIPTION
### Summary

Fixes broken fragment links in the Durable Objects SQLite storage documentation after the target section headings were renamed. The links now direct readers to the SQL API and point-in-time recovery sections.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).