### PR TITLE
[Browser Run] Update WebMCP authoring API

### DIFF
--- a/src/content/docs/browser-run/features/webmcp.mdx
+++ b/src/content/docs/browser-run/features/webmcp.mdx
@@ -15,6 +15,37 @@ import { Render, CURL, Example } from "~/components";
 
 ## Get started
 
+### Author a WebMCP tool
+
+Site authors register tools with `document.modelContext`. This authoring API is separate from the Browser Run DevTools testing API, `navigator.modelContextTesting`.
+
+The registration method returns a Promise. Await it when you expose a tool:
+
+```js
+await document.modelContext.registerTool({
+	name: "search-products",
+	description: "Search the product catalog",
+	inputSchema: {
+		type: "object",
+		properties: {
+			query: {
+				type: "string",
+				description: "The product name or category to search for",
+			},
+		},
+		required: ["query"],
+	},
+	async execute({ query }) {
+		const response = await fetch(
+			`/api/products?q=${encodeURIComponent(query)}`,
+		);
+		return response.json();
+	},
+});
+```
+
+Use `navigator.modelContextTesting` in a Browser Run lab session to inspect and invoke the tools that a site registers.
+
 ### Manual testing with DevTools
 
 #### 1. Start a Lab session and open DevTools
@@ -222,7 +253,7 @@ You can now view the live browser session and interact with it.
 ## Limitations
 
 - Lab sessions use Chrome 146 beta, which may have stability issues.
-- WebMCP APIs (`navigator.modelContext`, `navigator.modelContextTesting`) only work in lab sessions.
+- WebMCP APIs (`document.modelContext`, `navigator.modelContextTesting`) only work in lab sessions.
 - Lab sessions count against your regular [rate limits](/browser-run/limits/) and [pricing](/browser-run/pricing/).
 - The `lab` parameter is not yet supported in `@cloudflare/puppeteer` or `@cloudflare/playwright`. Acquire the session manually and connect with `sessionId`.
 

--- a/src/content/docs/browser-run/features/webmcp.mdx
+++ b/src/content/docs/browser-run/features/webmcp.mdx
@@ -9,7 +9,7 @@ products:
   - browser-run
 ---
 
-import { Render, CURL, Example } from "~/components";
+import { Render, CURL, Example, TypeScriptExample } from "~/components";
 
 [WebMCP](https://developer.chrome.com/blog/webmcp-epp) (Web Model Context Protocol) is a browser API that lets websites expose structured tools for AI agents to discover and execute directly. Instead of slow screenshot-analyze-click loops, agents can call website functions like `searchFlights()` or `bookTicket()` with typed parameters, making browser automation faster, more reliable, and less fragile.
 
@@ -21,7 +21,9 @@ Site authors register tools with `document.modelContext`. This authoring API is 
 
 The registration method returns a Promise. Await it when you expose a tool:
 
-```js
+<TypeScriptExample>
+
+```ts
 await document.modelContext.registerTool({
 	name: "search-products",
 	description: "Search the product catalog",
@@ -43,6 +45,8 @@ await document.modelContext.registerTool({
 	},
 });
 ```
+
+</TypeScriptExample>
 
 Use `navigator.modelContextTesting` in a Browser Run lab session to inspect and invoke the tools that a site registers.
 
@@ -253,7 +257,7 @@ You can now view the live browser session and interact with it.
 ## Limitations
 
 - Lab sessions use Chrome 146 beta, which may have stability issues.
-- WebMCP APIs (`document.modelContext`, `navigator.modelContextTesting`) only work in lab sessions.
+- In Browser Run, WebMCP and the `navigator.modelContextTesting` testing API are only available in lab sessions.
 - Lab sessions count against your regular [rate limits](/browser-run/limits/) and [pricing](/browser-run/pricing/).
 - The `lab` parameter is not yet supported in `@cloudflare/puppeteer` or `@cloudflare/playwright`. Acquire the session manually and connect with `sessionId`.
 

--- a/src/content/docs/browser-run/features/webmcp.mdx
+++ b/src/content/docs/browser-run/features/webmcp.mdx
@@ -41,6 +41,9 @@ await document.modelContext.registerTool({
 		const response = await fetch(
 			`/api/products?q=${encodeURIComponent(query)}`,
 		);
+		if (!response.ok) {
+			throw new Error(`Product search failed: ${response.status}`);
+		}
 		return response.json();
 	},
 });


### PR DESCRIPTION
### Summary

Fixes #31711.

Updates the WebMCP concept page to distinguish the site authoring API from Browser Run's DevTools testing API:

- Uses and awaits `document.modelContext.registerTool()` in the authoring example.
- Awaits each promise-returning `navigator.modelContextTesting.executeTool()` call while leaving synchronous `listTools()` unchanged.
- Links the current WebMCP specification.

### Validation

- `pnpm exec prettier --check src/content/docs/browser-run/features/webmcp.mdx`
- `pnpm run check:astro` (0 errors; 5 unrelated existing hints)
- Local browser smoke check: the full page rendered, the updated code blocks displayed correctly, and the browser reported no page errors.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [x] Issue #31711 tracks the out-of-date information corrected by this PR.