### PR TITLE
[Sandbox] Correct SDK 1.0 changelog date

### DIFF
--- a/src/content/changelog/sandbox/2026-08-07-sandbox-sdk-1-0-preview.mdx
+++ b/src/content/changelog/sandbox/2026-08-07-sandbox-sdk-1-0-preview.mdx
@@ -3,7 +3,7 @@ title: Sandbox SDK 1.0 preview on @next
 description: Preview a thinner Sandbox SDK on Cloudflare Containers — one process handle API, no sessions or transport selection, interpreter as an extension.
 products:
   - sandbox
-date: 2026-07-23
+date: 2026-08-07
 ---
 
 import { PackageManagers } from "~/components";


### PR DESCRIPTION
### Summary

Corrects the Sandbox SDK 1.0 preview changelog date from `2026-07-23` to `2026-08-07` (when [#32291](https://github.com/cloudflare/cloudflare-docs/pull/32291) merged).

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
