### PR TITLE
ci: fail astro check on hints

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 		"build": "astro build",
 		"typegen:worker": "wrangler types ./worker/worker-configuration.d.ts",
 		"check": "pnpm run check:astro && pnpm run check:worker",
-		"check:astro": "astro check",
+		"check:astro": "astro check --minimumFailingSeverity=warning",
 		"check:worker": "tsc --noEmit -p ./worker/tsconfig.json",
 		"predev": "tsx bin/fetch-skills.ts --soft",
 		"dev": "astro dev",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 		"build": "astro build",
 		"typegen:worker": "wrangler types ./worker/worker-configuration.d.ts",
 		"check": "pnpm run check:astro && pnpm run check:worker",
-		"check:astro": "astro check --minimumFailingSeverity=warning",
+		"check:astro": "astro check --minimumFailingSeverity=hint",
 		"check:worker": "tsc --noEmit -p ./worker/tsconfig.json",
 		"predev": "tsx bin/fetch-skills.ts --soft",
 		"dev": "astro dev",


### PR DESCRIPTION
## Summary

Tightens CI to fail `astro check` when hints are present, not just errors.

`astro check` defaults to `--minimumFailingSeverity=error`, so warnings and hints pass silently. After #32617 resolved all remaining hints (0 errors, 0 warnings, 0 hints), this is the right time to lock in that cleanliness and prevent regressions.

## Changes

- `package.json` — add `--minimumFailingSeverity=hint` to the `check:astro` script

## Validation

- `pnpm run check:astro` — 0 errors, 0 warnings, 0 hints
- `pnpm run format:core:check` — clean