### PR TITLE
[MCP Portals] Document nested Code Mode limitation

### DIFF
--- a/src/content/docs/cloudflare-one/access-controls/ai-controls/mcp-portals.mdx
+++ b/src/content/docs/cloudflare-one/access-controls/ai-controls/mcp-portals.mdx
@@ -647,9 +647,9 @@ Each portal has a Code Mode policy. The default policy is _Opt-in_.
 
 Use _Opt-in_ or _On by default_ if some clients run their own Code Mode implementation. These policies let clients avoid nested code execution.
 
-### Upstream servers with Code Mode enabled
+### Upstream servers with Code Mode turned on
 
-MCP portals do not support upstream MCP servers that have their own Code Mode enabled. When adding a server to your portal, connect to a version of the server that returns its full tool list. If the upstream server runs its own Code Mode, use the server's opt-out mechanism if available. Alternatively, consider disabling Code Mode on your MCP portal.
+MCP portals do not support upstream MCP servers that have their own Code Mode turned on. When adding a server to your portal, connect to a version of the server that returns its full tool list. If the upstream server runs its own Code Mode, use the server's opt-out mechanism if available. Alternatively, consider turning off Code Mode on your MCP portal.
 
 ### Configure a Code Mode policy
 

--- a/src/content/docs/cloudflare-one/access-controls/ai-controls/mcp-portals.mdx
+++ b/src/content/docs/cloudflare-one/access-controls/ai-controls/mcp-portals.mdx
@@ -647,6 +647,10 @@ Each portal has a Code Mode policy. The default policy is _Opt-in_.
 
 Use _Opt-in_ or _On by default_ if some clients run their own Code Mode implementation. These policies let clients avoid nested code execution.
 
+### Upstream servers with Code Mode enabled
+
+MCP portals do not support upstream MCP servers that have their own Code Mode enabled. When adding a server to your portal, connect to a version of the server that returns its full tool list. If the upstream server runs its own Code Mode, use the server's opt-out mechanism if available. Alternatively, consider disabling Code Mode on your MCP portal.
+
 ### Configure a Code Mode policy
 
 <Steps>


### PR DESCRIPTION
## Summary

Add guidance under the MCP Portals Code Mode section explaining that MCP Portals do not support upstream MCP servers that have their own Code Mode enabled.

## Context

When Code Mode is enabled on a portal, adding an upstream MCP server that also has its own Code Mode enabled limits what the portal can call on that server. This came up during discussion with Matt Carey (Agents team) — the recommended fix is at the portal-admin / docs layer rather than in the reference SDK.

## Workarounds documented

- Use the upstream server's opt-out mechanism if available.
- Alternatively, disable Code Mode on the MCP portal.

## Location

New `### Upstream servers with Code Mode enabled` subsection under the existing `## Code Mode` section in `src/content/docs/cloudflare-one/access-controls/ai-controls/mcp-portals.mdx`.