### PR TITLE
[Zero Trust] Add client mode pass/fail table to Require Gateway and Require WARP posture checks

### DIFF
--- a/src/content/docs/cloudflare-one/reusable-components/posture-checks/client-checks/require-gateway.mdx
+++ b/src/content/docs/cloudflare-one/reusable-components/posture-checks/client-checks/require-gateway.mdx
@@ -17,6 +17,18 @@ import { Render } from "~/components";
 
 With Require Gateway, you can allow access to your applications only to devices enrolled in your Zero Trust organization. Unlike [Require WARP](/cloudflare-one/reusable-components/posture-checks/client-checks/require-warp/), which will check for any WARP instance (including the consumer version), Require Gateway will only allow requests coming from devices whose traffic is filtered by your organization's Cloudflare Gateway configuration. This policy is best used when you want to protect company-owned assets by only allowing access to employees.
 
+## Check result per client mode
+
+The check result depends on the [client mode](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/modes/) configured on the device.
+
+| Client mode          | Result   | Reason                                                        |
+| -------------------- | -------- | ------------------------------------------------------------- |
+| Traffic and DNS mode | ✅ Pass  | Device traffic is routed through and filtered by your organization's Gateway |
+| Traffic only mode    | ✅ Pass  | Device traffic is routed through Gateway (DNS handled by the OS) |
+| DNS only mode        | ❌ Fail  | Only DNS queries are forwarded; network traffic does not flow through Gateway |
+| Local proxy mode     | ❌ Fail  | Only explicitly proxied application traffic is sent; the device is not fully enrolled in Gateway |
+| Posture only mode    | ❌ Fail  | The client is enrolled and collects posture data, but does not route traffic through Gateway |
+
 ## Prerequisites
 
 - <Render

--- a/src/content/docs/cloudflare-one/reusable-components/posture-checks/client-checks/require-gateway.mdx
+++ b/src/content/docs/cloudflare-one/reusable-components/posture-checks/client-checks/require-gateway.mdx
@@ -23,10 +23,10 @@ The check result depends on the [client mode](/cloudflare-one/team-and-resources
 
 | Client mode          | Result   | Reason                                                        |
 | -------------------- | -------- | ------------------------------------------------------------- |
-| Traffic and DNS mode | ✅ Pass  | Device traffic is routed through and filtered by your organization's Gateway |
-| Traffic only mode    | ✅ Pass  | Device traffic is routed through Gateway (DNS handled by the OS) |
+| Traffic and DNS mode | ✅ Pass  | Device traffic is routed through and filtered by Gateway |
+| Traffic only mode    | ✅ Pass  | Device traffic is routed through Gateway except the DNS queries |
 | DNS only mode        | ❌ Fail  | Only DNS queries are forwarded; network traffic does not flow through Gateway |
-| Local proxy mode     | ❌ Fail  | Only explicitly proxied application traffic is sent; the device is not fully enrolled in Gateway |
+| Local proxy mode     | ⚠️ Partial | The check passes only for traffic explicitly configured to use the local SOCKS/HTTP proxy on port `40000`, as this traffic is tunneled through Gateway. Traffic not routed through the proxy bypasses Gateway and fails the check. |
 | Posture only mode    | ❌ Fail  | The client is enrolled and collects posture data, but does not route traffic through Gateway |
 
 ## Prerequisites

--- a/src/content/docs/cloudflare-one/reusable-components/posture-checks/client-checks/require-warp.mdx
+++ b/src/content/docs/cloudflare-one/reusable-components/posture-checks/client-checks/require-warp.mdx
@@ -23,6 +23,18 @@ This device posture attribute will check for all versions of WARP, including the
 
 Cloudflare One enables you to restrict access to your applications to devices running the Cloudflare One Client. This allows you to flexibly ensure that a user's traffic is secure and encrypted before allowing access to a resource protected behind Cloudflare One.
 
+## Check result per client mode
+
+The check result depends on the [client mode](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/modes/) configured on the device.
+
+| Client mode          | Result   | Reason                                                        |
+| -------------------- | -------- | ------------------------------------------------------------- |
+| Traffic and DNS mode | ✅ Pass  | An active WARP tunnel is established                          |
+| Traffic only mode    | ✅ Pass  | An active WARP tunnel is established                          |
+| DNS only mode        | ❌ Fail  | No WARP tunnel is established; only DNS is forwarded          |
+| Local proxy mode     | ❌ Fail  | No WARP tunnel is established; traffic is sent via localhost proxy only |
+| Posture only mode    | ❌ Fail  | The client is enrolled and collects posture data, but does not establish a WARP tunnel |
+
 ## Prerequisites
 
 - <Render

--- a/src/content/docs/cloudflare-one/reusable-components/posture-checks/client-checks/require-warp.mdx
+++ b/src/content/docs/cloudflare-one/reusable-components/posture-checks/client-checks/require-warp.mdx
@@ -29,11 +29,11 @@ The check result depends on the [client mode](/cloudflare-one/team-and-resources
 
 | Client mode          | Result   | Reason                                                        |
 | -------------------- | -------- | ------------------------------------------------------------- |
-| Traffic and DNS mode | ✅ Pass  | An active WARP tunnel is established                          |
-| Traffic only mode    | ✅ Pass  | An active WARP tunnel is established                          |
-| DNS only mode        | ❌ Fail  | No WARP tunnel is established; only DNS is forwarded          |
-| Local proxy mode     | ❌ Fail  | No WARP tunnel is established; traffic is sent via localhost proxy only |
-| Posture only mode    | ❌ Fail  | The client is enrolled and collects posture data, but does not establish a WARP tunnel |
+| Traffic and DNS mode | ✅ Pass  | An active Cloudflare One Client tunnel is established                          |
+| Traffic only mode    | ✅ Pass  | An active Cloudflare One Client tunnel is established                          |
+| DNS only mode        | ❌ Fail  | No Cloudflare One Client tunnel is established; only DNS is forwarded          |
+| Local proxy mode     | ⚠️ Partial | The Cloudflare One Client is running and authenticated, and traffic explicitly routed through the local SOCKS/HTTP proxy on port `40000` is tunneled through Cloudflare. Traffic not routed through the proxy bypasses the client and fails the check. |
+| Posture only mode    | ❌ Fail  | The client is enrolled and collects posture data, but does not establish a Cloudflare One Client tunnel |
 
 ## Prerequisites
 


### PR DESCRIPTION
### Summary

Adds a "Check result per client mode" table to the Require Gateway and Require WARP posture check pages. Each table shows whether the check passes or fails depending on the Cloudflare One Client mode (Traffic and DNS, Traffic only, DNS only, Local proxy, Posture only), with a brief reason for each result.

This clarification is currently missing from the docs and is a common source of confusion — for example, Posture only mode enrolls the device and collects posture data but does not establish a WARP tunnel, so Require WARP and Require Gateway both return false in that mode.

### Documentation checklist

- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
