### PR TITLE
[Access] Clarify when custom block pages appear

### DIFF
--- a/src/content/docs/cloudflare-one/reusable-components/custom-pages/access-block-page.mdx
+++ b/src/content/docs/cloudflare-one/reusable-components/custom-pages/access-block-page.mdx
@@ -1,6 +1,6 @@
 ---
 pcx_content_type: how-to
-description: Access custom block pages in Zero Trust.
+description: Customize the block page that Cloudflare Access displays when an Access policy denies a request.
 products:
   - cloudflare-one
 title: Access custom block pages

--- a/src/content/partials/cloudflare-one/access/block-page.mdx
+++ b/src/content/partials/cloudflare-one/access/block-page.mdx
@@ -2,7 +2,7 @@
 {}
 ---
 
-You can customize the block page that displays when users fail to authenticate to an Access application. Each application can have a different block page.
+Cloudflare Access displays a block page when an Access policy denies a request. You can customize a different block page for each application.
 
 :::note[Gateway block page]
 To customize the page that users see when they are blocked by a Gateway firewall policy, refer to [Gateway block page](/cloudflare-one/reusable-components/custom-pages/gateway-block-page/).


### PR DESCRIPTION
### Summary

Corrects the Access custom block-page documentation to distinguish policy denials from authentication failures. Users can authenticate successfully and still see a block page when an Access policy denies their request.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).

### PM handoff - Access Custom Pages

This Draft PR changes two lines describing current block-page behavior. It does not document or authorize any future feature, availability, rollout, or release.

#### Customer-facing baseline

- Access block pages appear when an Access policy denies a request.
- Successful authentication does not guarantee policy authorization.
- Existing documentation covers current block-page types and customization options.

#### Publication gates

Future documentation should be published only after customer-visible behavior, availability, workflows, and limitations are finalized, verified, and approved by the appropriate owners.

#### Remaining checklist

- [ ] Refresh the branch from `production`.
- [ ] Revalidate the changed wording after the refresh.
- [ ] Obtain final approval to publish the current wording correction.
- [ ] Keep future feature documentation in a separately scoped change.

#### Explicit non-goals

- Documenting future Access Custom Pages capabilities
- Announcing availability or release timing
- Authorizing a rollout or product launch
- Changing product behavior, APIs, or dashboard workflows
