### PR TITLE
[R2 SQL] Update Node.js prerequisite

### DIFF
--- a/src/content/docs/r2-sql/tutorials/end-to-end-pipeline.mdx
+++ b/src/content/docs/r2-sql/tutorials/end-to-end-pipeline.mdx
@@ -30,13 +30,11 @@ This tutorial demonstrates how to:
 ## Prerequisites
 
 1. Sign up for a [Cloudflare account](https://dash.cloudflare.com/sign-up).
-2. Install [Node.js](https://nodejs.org/en/).
+2. Install a [Node.js version supported by Wrangler](/workers/wrangler/install-and-update/#install-wrangler).
 3. Install [Python 3.8+](https://python.org) for the data generation script.
 
 :::note[Node.js version manager]
 Use a Node version manager like [Volta](https://volta.sh/) or [nvm](https://github.com/nvm-sh/nvm) to avoid permission issues and change Node.js versions.
-
-Wrangler requires a Node version of 16.17.0 or later.
 :::
 
 ## 1. Set up authentication


### PR DESCRIPTION
### Summary

Updates the R2 SQL pipeline tutorial to remove the obsolete Node.js 16.17 minimum. The prerequisite now links to Wrangler’s maintained Node.js support policy so the guidance remains current as supported releases change.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).