### PR TITLE
[R2 Data Catalog] Fix Python indentation

### DIFF
--- a/src/content/docs/r2-data-catalog/deleting-data.mdx
+++ b/src/content/docs/r2-data-catalog/deleting-data.mdx
@@ -86,8 +86,8 @@ spark.sql("DROP NAMESPACE r2dc.namespace_name CASCADE")
 # This can be done with a loop over all tables in the namespace
 tables = spark.sql("SHOW TABLES IN r2dc.namespace_name").collect()
 for row in tables:
-	table_name = row['tableName']
-  spark.sql(f"DROP TABLE r2dc.namespace_name.{table_name} PURGE")
+    table_name = row['tableName']
+    spark.sql(f"DROP TABLE r2dc.namespace_name.{table_name} PURGE")
 spark.sql("DROP NAMESPACE r2dc.namespace_name CASCADE")
 ```
 


### PR DESCRIPTION
### Summary

Fixes inconsistent indentation in the R2 Data Catalog Python example. Both statements inside the table-deletion loop now use four spaces, making the example valid Python.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).