### PR TITLE
[R2 Data Catalog] Fix Trino schema example

### DIFF
--- a/src/content/docs/r2-data-catalog/config-examples/trino.mdx
+++ b/src/content/docs/r2-data-catalog/config-examples/trino.mdx
@@ -81,8 +81,8 @@ iceberg.rest-catalog.oauth2.token=<Your R2 authentication token>
     -- Show all schemas in the R2 catalog
     SHOW SCHEMAS IN r2;
 
-    -- Show all schemas in the R2 catalog
-    CREATE SCHEMA r2.example_schema
+    -- Create a schema in the R2 catalog
+    CREATE SCHEMA r2.example_schema;
 
     -- Create a table with some values in it
     CREATE TABLE r2.example_schema.yearly_clicks (


### PR DESCRIPTION
### Summary

Fixes the R2 Data Catalog Trino example by terminating the `CREATE SCHEMA` statement with a semicolon. This prevents the Trino CLI from consuming the following `CREATE TABLE` statement. Also corrects the duplicated SQL comment.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).