### PR TITLE
[Workers] Document npm package bundling compatibility

### DIFF
--- a/src/content/docs/workers/local-development/wrangler-vs-vite.mdx
+++ b/src/content/docs/workers/local-development/wrangler-vs-vite.mdx
@@ -14,6 +14,8 @@ Wrangler and the Cloudflare Vite plugin both provide local development environme
 
 Choose based on the build tools your project uses. You can also use the Vite plugin for development and builds while using Wrangler for deployment and other Workers commands.
 
+Vite 8 uses Rolldown to handle CommonJS and ECMAScript module (ESM) dependencies and produce optimized output chunks. This can affect packages that depend on Node.js module behavior. For details, refer to [npm package compatibility](/workers/runtime-apis/nodejs/#npm-package-compatibility).
+
 ## Compare Wrangler and Vite
 
 | Capability or workflow                         | Wrangler                                           | Cloudflare Vite plugin                                         |
@@ -28,10 +30,6 @@ Choose based on the build tools your project uses. You can also use the Vite plu
 | Deployment and resource management             | Supported                     | Use Wrangler after `vite build`                                |
 | [Rust Workers](/workers/languages/rust/)       | Supported | Not supported                         |
 | [Python Workers](/workers/languages/python/)   | Use [`pywrangler`](/workers/languages/python/) instead of `wrangler`             | Not supported                               |
-
-Use the [Cloudflare Vite plugin](/workers/vite-plugin/) when your project already uses Vite or would benefit from its build pipeline. Vite is valid for standalone backend Workers, not only frontend applications.
-
-Use [`wrangler dev`](/workers/wrangler/commands/general/#dev) when your project does not use Vite or you want a direct command-line workflow. Wrangler also provides deployment and resource management commands.
 
 For local development that requires deployed resources, both tools support [remote bindings](/workers/local-development/#remote-bindings). Your Worker runs locally while selected bindings connect to deployed Cloudflare resources.
 

--- a/src/content/docs/workers/local-development/wrangler-vs-vite.mdx
+++ b/src/content/docs/workers/local-development/wrangler-vs-vite.mdx
@@ -31,6 +31,10 @@ Vite 8 uses Rolldown to handle CommonJS and ECMAScript module (ESM) dependencies
 | [Rust Workers](/workers/languages/rust/)       | Supported | Not supported                         |
 | [Python Workers](/workers/languages/python/)   | Use [`pywrangler`](/workers/languages/python/) instead of `wrangler`             | Not supported                               |
 
+Use the [Cloudflare Vite plugin](/workers/vite-plugin/) when your project already uses Vite or would benefit from its build pipeline. Vite is valid for standalone backend Workers, not only frontend applications.
+
+Use [`wrangler dev`](/workers/wrangler/commands/general/#dev) when your project does not use Vite or you want a direct command-line workflow. Wrangler also provides deployment and resource management commands.
+
 For local development that requires deployed resources, both tools support [remote bindings](/workers/local-development/#remote-bindings). Your Worker runs locally while selected bindings connect to deployed Cloudflare resources.
 
 For configuration differences when moving an existing project, refer to [Migrating from wrangler dev](/workers/vite-plugin/reference/migrating-from-wrangler-dev/).

--- a/src/content/docs/workers/runtime-apis/nodejs/index.mdx
+++ b/src/content/docs/workers/runtime-apis/nodejs/index.mdx
@@ -109,7 +109,45 @@ This allows you to import packages that use these Node.js modules, even if certa
 
 Runtime API support is one part of npm package compatibility. Your build tool also selects package entry points, handles CommonJS and ECMAScript modules (ESM), and determines which module boundaries reach the Workers runtime.
 
-For new JavaScript and TypeScript projects that use NPM packages, Cloudflare recommends [Vite 8 with the Cloudflare Vite plugin](/workers/vite-plugin/). Vite 8 uses [Rolldown](https://vite.dev/blog/announcing-vite8/) for dependency pre-bundling and production builds. The Cloudflare Vite plugin configures Rolldown's [`node` platform](https://rolldown.rs/reference/InputOptions.platform) when it builds your Worker. This setting ensures maximum compatibility with CommonJS modules that you `require()` in your code. Rolldown provides [CommonJS and ESM interoperability](https://rolldown.rs/in-depth/bundling-cjs), and the Cloudflare Vite plugin uploads each JavaScript output chunk as a separate Workers runtime module.
+For new JavaScript and TypeScript projects that use npm packages, Cloudflare recommends [Vite 8 with the Cloudflare Vite plugin](/workers/vite-plugin/). Vite 8 uses [Rolldown](https://vite.dev/blog/announcing-vite8/) for dependency pre-bundling and production builds. Rolldown provides [CommonJS and ESM interoperability](https://rolldown.rs/in-depth/bundling-cjs) and produces optimized output chunks. Wrangler deploys each JavaScript output chunk as a separate Workers runtime module.
+
+### Configure the Rolldown platform
+
+The Cloudflare Vite plugin currently configures Rolldown's [`neutral` platform](https://rolldown.rs/reference/InputOptions.platform). If a dependency expects Node-style `require()` behavior, you can configure the `node` platform for your Worker's Vite environment:
+
+```ts title="vite.config.ts"
+import { cloudflare } from "@cloudflare/vite-plugin";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+	plugins: [
+		cloudflare(),
+		{
+			name: "worker-node-platform",
+			configEnvironment(name) {
+				if (name !== "my_worker") {
+					return;
+				}
+
+				return {
+					build: {
+						rolldownOptions: { platform: "node" },
+					},
+					optimizeDeps: {
+						rolldownOptions: { platform: "node" },
+					},
+				};
+			},
+		},
+	],
+});
+```
+
+Replace `my_worker` with your [Worker's Vite environment name](/workers/vite-plugin/reference/vite-environments/). By default, a standalone Worker uses its Worker name with hyphens replaced by underscores. Framework integrations often use `ssr`.
+
+Setting both `build` and `optimizeDeps` applies the platform consistently in production builds and local development. If the package imports Node.js built-in modules, enable the `nodejs_compat` flag as described in [Get Started](#get-started).
+
+The `node` platform does not add unsupported Node.js APIs or guarantee that every npm package will work. Rolldown also does not automatically rewrite CommonJS `__dirname` when producing ESM output. Packages that use `__dirname` to load adjacent files may require package-specific changes.
 
 With the [`new_module_registry` compatibility flag](/workers/configuration/compatibility-flags/), Workers compiles an uploaded runtime module when it is first imported. Workers can also reuse compiled code across isolate replicas. Each uploaded ESM module receives metadata such as `import.meta.url` and `import.meta.resolve()`. Modules with `file:` URLs also receive `import.meta.dirname` and `import.meta.filename`.
 

--- a/src/content/docs/workers/runtime-apis/nodejs/index.mdx
+++ b/src/content/docs/workers/runtime-apis/nodejs/index.mdx
@@ -105,6 +105,16 @@ Adding polyfills maximizes compatibility with existing npm packages by providing
 
 This allows you to import packages that use these Node.js modules, even if certain methods are not supported.
 
+## npm package compatibility
+
+Runtime API support is one part of npm package compatibility. Your build tool also selects package entry points, handles CommonJS and ECMAScript modules (ESM), and determines which module boundaries reach the Workers runtime.
+
+For new JavaScript and TypeScript projects that use NPM packages, Cloudflare recommends [Vite 8 with the Cloudflare Vite plugin](/workers/vite-plugin/). Vite 8 uses [Rolldown](https://vite.dev/blog/announcing-vite8/) for dependency pre-bundling and production builds. The Cloudflare Vite plugin configures Rolldown's [`node` platform](https://rolldown.rs/reference/InputOptions.platform) when it builds your Worker. This setting ensures maximum compatibility with CommonJS modules that you `require()` in your code. Rolldown provides [CommonJS and ESM interoperability](https://rolldown.rs/in-depth/bundling-cjs), and the Cloudflare Vite plugin uploads each JavaScript output chunk as a separate Workers runtime module.
+
+With the [`new_module_registry` compatibility flag](/workers/configuration/compatibility-flags/), Workers compiles an uploaded runtime module when it is first imported. Workers can also reuse compiled code across isolate replicas. Each uploaded ESM module receives metadata such as `import.meta.url` and `import.meta.resolve()`. Modules with `file:` URLs also receive `import.meta.dirname` and `import.meta.filename`.
+
+Wrangler's built-in [`esbuild` bundler](/workers/wrangler/bundling/) combines JavaScript dependencies into one output module by default. You can still use Wrangler for deployment and resource management while building with Vite.
+
 ## Enable only AsyncLocalStorage
 
 If you need to enable only the Node.js `AsyncLocalStorage` API, you can enable the `nodejs_als` compatibility flag:


### PR DESCRIPTION
### Summary

- Adds npm package bundling guidance to the Node.js compatibility documentation.
- Explains how Vite 8, Rolldown, Wrangler, and the Workers module registry affect module boundaries.
- Documents the Cloudflare Vite plugin's current `platform: "neutral"` default and an explicit Vite 8 `configEnvironment` override for Node-style `require()` behavior.
- Describes the limitations of `platform: "node"`, including unsupported Node.js APIs and CommonJS `__dirname` handling.
- Links to the canonical guidance from the Wrangler and Vite comparison page.

### Validation

- Confirmed that a normal Vite environment override is replaced by the Cloudflare plugin default.
- Confirmed with Vite 8 config resolution that `configEnvironment` applies `platform: "node"` to both production builds and dependency optimization.
- Ran `git diff --check`.
- Full local docs validation was unavailable because dependency installation could not complete in this checkout.

### Screenshots (optional)

Not applicable.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).