### PR TITLE
[Email Security] Add Blocked content rules docs and changelog

### DIFF
--- a/src/content/changelog/email-security-cf1/2026-08-12-blocked-content-rules.mdx
+++ b/src/content/changelog/email-security-cf1/2026-08-12-blocked-content-rules.mdx
@@ -1,0 +1,21 @@
+---
+title: Block emails by content with blocked content rules
+description: Create plaintext or regular expression rules that block emails based on subject or body content.
+date: 2026-08-12 09:00:00 UTC
+---
+
+Cloudflare Email security now lets administrators write their own content-based blocking rules. A new **Blocked content** area under **Policies & rules** lets you define a plaintext string or a regular expression, choose whether to scan the message subject, body, or both, and automatically block any message that matches.
+
+- Create rules using either **plaintext** matches or **regular expressions** — useful for blocking targeted phishing campaigns, known-bad phrases, or content patterns unique to your organization.
+- Choose the **search location** for each rule: **subject**, **body**, or **subject and body**.
+- Use the built-in **regular expression checker** to validate your pattern against sample text before saving, so you can confirm the rule matches what you expect and avoid false positives.
+- Matching messages are marked with a malicious [disposition](/cloudflare-one/email-security/reference/dispositions-and-attributes/) and prevented from reaching users' inboxes.
+
+Blocked content rules currently only support the block action.
+
+This feature is available for the following Email security packages:
+
+- **Enterprise**
+- **Enterprise + PhishGuard**
+
+To get started, refer to [Blocked content](/cloudflare-one/email-security/settings/detection-settings/blocked-content/).

--- a/src/content/docs/cloudflare-one/email-security/settings/detection-settings/additional-detections.mdx
+++ b/src/content/docs/cloudflare-one/email-security/settings/detection-settings/additional-detections.mdx
@@ -5,7 +5,7 @@ description: Additional detections in Email Security.
 products:
   - cloudflare-one
 sidebar:
-  order: 5
+  order: 6
 ---
 
 Email security allows you to configure the following additional detections:

--- a/src/content/docs/cloudflare-one/email-security/settings/detection-settings/best-practices.mdx
+++ b/src/content/docs/cloudflare-one/email-security/settings/detection-settings/best-practices.mdx
@@ -5,7 +5,7 @@ description: Detection settings best practices in Email Security.
 products:
   - cloudflare-one
 sidebar:
-  order: 8
+  order: 9
 ---
 
 This guide describes how to configure detection settings to mitigate impersonation risks while ensuring legitimate delivery.

--- a/src/content/docs/cloudflare-one/email-security/settings/detection-settings/blocked-content.mdx
+++ b/src/content/docs/cloudflare-one/email-security/settings/detection-settings/blocked-content.mdx
@@ -1,0 +1,95 @@
+---
+title: Blocked content
+pcx_content_type: how-to
+description: Blocked content rules in Email Security.
+products:
+  - cloudflare-one
+sidebar:
+  order: 3
+---
+
+import { Example } from "~/components";
+
+Email security allows you to configure blocked content rules that match against the content of incoming messages. When a message matches a rule, Email security marks it with a malicious [disposition](/cloudflare-one/email-security/reference/dispositions-and-attributes/), preventing it from reaching users' inboxes.
+
+Blocked content rules are available for the following Email security packages:
+
+- **Enterprise**
+- **Enterprise + PhishGuard**
+
+## How blocked content works
+
+Blocked content rules let you define your own content-based blocking criteria. Each rule specifies a pattern — either a plaintext string or a regular expression — and the part of the message that Email security should scan for it.
+
+You can scan the following fields:
+
+- **Subject**: Match the pattern against the message subject line.
+- **Body**: Match the pattern against the message body.
+- **Subject and body**: Match the pattern against both the subject and the body.
+
+If the pattern matches, Email security marks the message as malicious. Blocked content rules only support the block action.
+
+<Example title="Example of a blocked content rule">
+
+Your organization is being targeted by a phishing campaign that uses subject lines containing variations of `Urgent: Payroll Update Required`. You can create a blocked content rule with the regular expression `(?i)urgent.*payroll.*update` scanning the **Subject** field to block any message that matches this pattern.
+
+</Example>
+
+## Configure a blocked content rule
+
+To create a blocked content rule:
+
+1. Log in to [Cloudflare One](https://one.dash.cloudflare.com/).
+2. Select **Email security**.
+3. Go to **Policies & rules** > **Blocked content**.
+4. Select **Add a rule**.
+5. Enter the rule information:
+   - **Name**: A descriptive name for the rule.
+   - **Match type**: Choose between:
+     - **Plaintext**: Email security matches the exact string you enter.
+     - **Regular expression**: Email security evaluates the pattern as a regular expression. Regular expressions must be valid Java expressions.
+   - **Pattern**: The plaintext string or regular expression to match against.
+   - **Search location**: Choose which parts of the message to scan:
+     - **Subject**
+     - **Body**
+     - **Subject and body**
+   - **Notes** (optional): Provide additional information about the rule.
+6. (Optional) Use the built-in **Regular expression checker** to validate your pattern before saving. The checker lets you test your pattern against sample text to confirm it matches as expected.
+7. Select **Save**.
+
+## Validate a regular expression
+
+When you choose **Regular expression** as the match type, Email security provides a regular expression checker to help you validate your pattern before saving the rule.
+
+To validate a regular expression:
+
+1. On the **Add a rule** page, select **Regular expression** as the match type.
+2. Enter your regular expression in the **Pattern** field.
+3. In the **Test your expression** field, enter sample text that represents the content you want to match.
+4. Email security displays whether the sample text matches your pattern.
+5. Adjust the pattern as needed and repeat until it behaves as expected.
+
+Cloudflare recommends validating every regular expression before saving to avoid false positives and false negatives.
+
+## Edit a blocked content rule
+
+To edit a blocked content rule:
+
+1. On the **Blocked content** page, select the rule you want to edit.
+2. Select the three dots > **Edit**.
+3. Edit the rule.
+4. Select **Save**.
+
+## Delete a blocked content rule
+
+To delete a blocked content rule:
+
+1. On the **Blocked content** page, select the rule you want to delete.
+2. Select the three dots > **Delete**.
+3. On the pop-up message, select **Delete**.
+
+To delete multiple blocked content rules at once:
+
+1. On the **Blocked content** page, select the rules you want to delete.
+2. Select **Action**.
+3. Select **Delete**.

--- a/src/content/docs/cloudflare-one/email-security/settings/detection-settings/blocked-content.mdx
+++ b/src/content/docs/cloudflare-one/email-security/settings/detection-settings/blocked-content.mdx
@@ -12,10 +12,7 @@ import { Example } from "~/components";
 
 Email security allows you to configure blocked content rules that match against the content of incoming messages. When a message matches a rule, Email security marks it with a malicious [disposition](/cloudflare-one/email-security/reference/dispositions-and-attributes/), preventing it from reaching users' inboxes.
 
-Blocked content rules are available for the following Email security packages:
-
-- **Enterprise**
-- **Enterprise + PhishGuard**
+Blocked content rules are available for the **Enterprise** and **Enterprise + PhishGuard** Email security packages.
 
 ## How blocked content works
 

--- a/src/content/docs/cloudflare-one/email-security/settings/detection-settings/configure-link-actions.mdx
+++ b/src/content/docs/cloudflare-one/email-security/settings/detection-settings/configure-link-actions.mdx
@@ -5,7 +5,7 @@ description: Configure link actions in Email Security.
 products:
   - cloudflare-one
 sidebar:
-  order: 6
+  order: 7
 ---
 
 You can configure how Email security handles links in emails.

--- a/src/content/docs/cloudflare-one/email-security/settings/detection-settings/configure-text-add-ons.mdx
+++ b/src/content/docs/cloudflare-one/email-security/settings/detection-settings/configure-text-add-ons.mdx
@@ -5,7 +5,7 @@ description: Configure text add-ons in Email Security.
 products:
   - cloudflare-one
 sidebar:
-  order: 7
+  order: 8
 ---
 
 You can create custom labels to be used as the subject or body prefix for emails with specific dispositions.

--- a/src/content/docs/cloudflare-one/email-security/settings/detection-settings/impersonation-registry.mdx
+++ b/src/content/docs/cloudflare-one/email-security/settings/detection-settings/impersonation-registry.mdx
@@ -5,7 +5,7 @@ description: Impersonation registry in Email Security.
 products:
   - cloudflare-one
 sidebar:
-  order: 4
+  order: 5
 ---
 
 The impersonation registry contains combinations of emails of users who are likely to be impersonated. If there is an email that is on the impersonation registry not listed as an alternative email address, that email will be reported as potential [business email compromise (BEC)](https://www.cloudflare.com/en-gb/learning/email-security/business-email-compromise-bec/).

--- a/src/content/docs/cloudflare-one/email-security/settings/detection-settings/trusted-domains.mdx
+++ b/src/content/docs/cloudflare-one/email-security/settings/detection-settings/trusted-domains.mdx
@@ -5,7 +5,7 @@ description: Trusted domains in Email Security.
 products:
   - cloudflare-one
 sidebar:
-  order: 3
+  order: 4
 ---
 
 Email security allows you to exempt known partner and internal domains from typical detection scanning. Adding trusted domains helps to reduce false positives on malicious, suspicious, and spoof [dispositions](/cloudflare-one/email-security/reference/dispositions-and-attributes/). Email security only checks the date when the domain is created.


### PR DESCRIPTION
## Summary

Adds documentation and a changelog entry for the new **Blocked content** feature in Email Security ([SHIP-13675](https://jira.cfdata.org/browse/SHIP-13675)).

Blocked content lets Email Security admins create block rules that match against message content using either plaintext strings or regular expressions. Rules can scan the subject, body, or both, and a built-in regex checker lets admins validate patterns before saving. Matching messages are marked with a malicious disposition. This feature is available for Enterprise and Enterprise + PhishGuard packages and currently only supports the block action.

## Changes

- **New docs page**: `src/content/docs/cloudflare-one/email-security/settings/detection-settings/blocked-content.mdx` — how-to page covering how blocked content works, how to configure a rule, how to validate a regex, and how to edit/delete rules. Placed at sidebar order 3, directly after Blocked senders.
- **New changelog entry**: `src/content/changelog/email-security-cf1/2026-08-12-blocked-content-rules.mdx` — announces the feature under Email Security.
- **Sidebar reorder**: bumped the sidebar order of six sibling detection-settings pages (`trusted-domains`, `impersonation-registry`, `additional-detections`, `configure-link-actions`, `configure-text-add-ons`, `best-practices`) by +1 to make room for the new page.

## Screenshots

N/A — text-only content additions.

## Documentation checklist

- [x] I have performed a self-review of my own writing and code.
- [x] I have added descriptive commit titles for my changes.
- [x] My changes generate no new warnings.
- [x] I have only submitted changes relevant to my issue.