### PR TITLE
Document FUSE in wrangler dev

### DIFF
--- a/src/content/changelog/containers/2026-08-20-fuse-local-development.mdx
+++ b/src/content/changelog/containers/2026-08-20-fuse-local-development.mdx
@@ -1,0 +1,15 @@
+---
+title: Use FUSE in local Containers development
+description: Local Containers support FUSE with compatible Docker configurations.
+products:
+  - containers
+date: 2026-08-20
+---
+
+Miniflare now automatically grants local Containers the Docker privileges required for Filesystem in Userspace (FUSE). This applies to `wrangler dev`, the Cloudflare Vite plugin, and direct Miniflare use.
+
+Miniflare grants these privileges when the local Docker daemon runs inside a virtual machine (VM). This includes Docker engines on macOS and through Windows Subsystem for Linux (WSL). On Linux, Miniflare grants the privileges for local rootless Docker when `/dev/fuse` is available.
+
+Rootful Docker on Linux does not support FUSE by default during local development. Miniflare does not grant FUSE privileges when the Docker daemon does not meet these conditions or cannot be inspected.
+
+For requirements and troubleshooting, refer to [FUSE support during local development](/containers/local-dev/#fuse-support). For a complete example, refer to [Mount R2 buckets with FUSE](/containers/examples/r2-fuse-mount/).

--- a/src/content/docs/containers/examples/r2-fuse-mount.mdx
+++ b/src/content/docs/containers/examples/r2-fuse-mount.mdx
@@ -15,6 +15,8 @@ import { Details, TypeScriptExample } from "~/components";
 
 FUSE (Filesystem in Userspace) allows you to mount [R2 buckets](/r2/) as filesystems within Containers. Applications can then interact with R2 using standard filesystem operations rather than object storage APIs.
 
+To run a FUSE container locally, refer to [FUSE support during local development](/containers/local-dev/#fuse-support).
+
 Common use cases include:
 
 - **Bootstrapping containers with assets** - Mount datasets, models, or dependencies for sandboxes and agent environments

--- a/src/content/docs/containers/local-dev.mdx
+++ b/src/content/docs/containers/local-dev.mdx
@@ -44,6 +44,14 @@ out old container images (using `docker image prune` or similar) to reduce disk 
 
 :::
 
+## FUSE support
+
+Miniflare automatically grants local containers the Docker privileges required for Filesystem in Userspace (FUSE). This applies to `wrangler dev`, the Cloudflare Vite plugin, and direct Miniflare use.
+
+Miniflare grants these privileges when the local Docker daemon runs inside a virtual machine (VM). This includes Docker engines on macOS and through Windows Subsystem for Linux (WSL). On Linux, Miniflare grants the privileges for local rootless Docker when `/dev/fuse` is available.
+
+Rootful Docker on Linux does not support FUSE by default during local development. Miniflare does not grant FUSE privileges when the Docker daemon does not meet these conditions or cannot be inspected.
+
 ## Iterating on Container code
 
 When you develop with Wrangler or Vite, your Worker's code is automatically reloaded each time you save a change,


### PR DESCRIPTION
### Summary

Add documentation for FUSE support in `wrangler dev`.

https://github.com/cloudflare/workers-sdk/pull/15134

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
