### PR TITLE
Gateway HTTP Host Selector Example is incorrect

### DIFF
--- a/src/content/partials/cloudflare-one/gateway/selectors/host.mdx
+++ b/src/content/partials/cloudflare-one/gateway/selectors/host.mdx
@@ -9,7 +9,7 @@ Use this selector to match against only the hostname specified. For example, you
 
 | UI name | API example                                         | Evaluation phase      |
 | ------- | --------------------------------------------------- | --------------------- |
-| Host    | <code>{props.APIendpoint} == \"example.com\"</code> | Before DNS resolution |
+| Host    | <code>{props.APIendpoint} == \"test.example.com\"</code> | Before DNS resolution |
 
 <Render
 	file="gateway/selectors/non-latin-characters"


### PR DESCRIPTION
### Summary

The Host selector example is incorrect.  The example should read test.example.com and not example.com

### Documentation checklist

<!-- Remove items that do not apply -->

- [n/a] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [n/a] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [n/a] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
