### PR TITLE
Remove outdated Workers Logs billing notice

### DIFF
--- a/src/content/docs/workers/observability/logs/workers-logs.mdx
+++ b/src/content/docs/workers/observability/logs/workers-logs.mdx
@@ -226,10 +226,6 @@ truncated and the log's `$cloudflare.truncated` field will be set to true.
 
 ## Pricing
 
-:::note[Billing start date]
-Workers Logs billing will begin on April 21, 2025.
-:::
-
 <Render file="workers_logs_pricing" product="workers" />
 
 ### Examples

--- a/src/content/docs/workers/observability/traces/index.mdx
+++ b/src/content/docs/workers/observability/traces/index.mdx
@@ -121,4 +121,4 @@ Starting on October 1, 2026, tracing will be billed as part of your usage on the
 |                  | Events (trace spans or log events)                                 | Retention |
 | ---------------- | ------------------------------------------------------------------ | --------- |
 | **Workers Free** | 200,000 per day                                                    | 3 Days    |
-| **Workers Paid** | 10 million included per month +$0.60 per additional million events | 7 Days    |
+| **Workers Paid** | 20 million included per month +$0.60 per additional million events | 7 Days    |


### PR DESCRIPTION
## Summary

Removed the outdated billing-start notice from the Workers Logs pricing section.

## Details

- Deleted the `Billing start date` note from `src/content/docs/workers/observability/logs/workers-logs.mdx`
- Left the pricing content otherwise unchanged

## Verification

- Not provided in the source changes