### PR TITLE
[Support] Update docs for the new Cloudflare Status page

### DIFF
--- a/src/content/changelog/support/2026-08-11-new-status-page.mdx
+++ b/src/content/changelog/support/2026-08-11-new-status-page.mdx
@@ -1,0 +1,34 @@
+---
+title: New Cloudflare Status page
+description: The Cloudflare Status page has a new design, Markdown output for AI agents, and a notification system that runs independently of Cloudflare.
+date: 2026-08-11
+---
+
+The Cloudflare Status page at [www.cloudflarestatus.com](https://www.cloudflarestatus.com/) has been rebuilt. It is available at the same address, and every previously documented [Status API](https://www.cloudflarestatus.com/api) endpoint remains supported, so existing bookmarks, integrations, and monitoring continue to work.
+
+## Notifications that fire even when Cloudflare is down
+
+The status page now has its own notification system, delivered independently of Cloudflare infrastructure. You can subscribe by email, webhook, Slack, Discord, or Google Chat.
+
+The **Maintenance Notification** and **Incident Alerts** in [Cloudflare Notifications](/notifications/) remain supported, and deliver to the destinations already configured on your account.
+
+## Markdown for AI agents
+
+Every page on the status page returns Markdown when requested with an `Accept: text/markdown` header, so agents can read the current status without parsing HTML:
+
+```sh
+curl -H "Accept: text/markdown" https://www.cloudflarestatus.com/locations
+```
+
+## Separate feeds for incidents and maintenance
+
+Incidents and maintenance are published as separate feeds, each available in RSS and Atom, so you can subscribe to one without the other:
+
+```txt
+https://www.cloudflarestatus.com/api/v3/incidents.rss
+https://www.cloudflarestatus.com/api/v3/incidents.atom
+https://www.cloudflarestatus.com/api/v3/maintenance.rss
+https://www.cloudflarestatus.com/api/v3/maintenance.atom
+```
+
+For more information, refer to [Cloudflare Status](/support/cloudflare-status/).

--- a/src/content/docs/support/cloudflare-status.mdx
+++ b/src/content/docs/support/cloudflare-status.mdx
@@ -8,21 +8,42 @@ products:
   - support
 ---
 
-Cloudflare provides updates on the status of our services and network at https://www.cloudflarestatus.com/, which you should check if you notice unexpected behavior with Cloudflare.
+Cloudflare provides updates on the status of our services and network on the [Cloudflare Status page](https://www.cloudflarestatus.com/), which you should check if you notice unexpected behavior with Cloudflare.
 
 Beyond looking at the page itself, there are programmatic ways to consume this information.
 
 ## Configure notifications
 
-Cloudflare offers a dedicated notification called **Incident Alert**, which lets you know when Cloudflare is experiencing an incident.
+There are two ways to be notified about Cloudflare incidents and maintenance.
+
+### Status page notifications
+
+The status page has its own notification system, delivered independently of Cloudflare infrastructure, so these notifications fire even if Cloudflare itself is down. You can subscribe by email, webhook, Slack, Discord, or Google Chat.
+
+For more information, refer to [status page notifications](https://www.cloudflarestatus.com/docs/notifications).
+
+### Cloudflare Notifications
+
+Cloudflare offers a dedicated notification called **Incident Alerts**, which lets you know when Cloudflare is experiencing an incident. Because it runs on your account, it delivers to the destinations you have already configured and can be filtered to the impact levels and components you care about.
 
 You can configure this notification to send via [email](/notifications/get-started/), [Webhooks](/notifications/get-started/configure-webhooks/), or [PagerDuty](/notifications/get-started/configure-pagerduty/).
+
+A separate **Maintenance Notification** covers planned maintenance. For more information, refer to [Disruptive Maintenance](/support/disruptive-maintenance/).
+
+## Check location status
+
+The [locations view](https://www.cloudflarestatus.com/locations) lists the status of each Cloudflare data center as **Operational**, **Re-routed**, or **Partially Re-routed**. A location that has been removed from the network for planned or unplanned maintenance is listed as **Re-routed**.
 
 ## Use the API
 
 Cloudflare also provides status information through the [Cloudflare Status API](https://www.cloudflarestatus.com/api).
 
-Endpoints are displayed with examples using cURL and our embedded JavaScript widget (if available).
+Incidents and maintenance are published as separate feeds, each available in RSS and Atom:
+
+| Feed        | RSS                                                       | Atom                                                       |
+| ----------- | --------------------------------------------------------- | ---------------------------------------------------------- |
+| Incidents   | `https://www.cloudflarestatus.com/api/v3/incidents.rss`   | `https://www.cloudflarestatus.com/api/v3/incidents.atom`   |
+| Maintenance | `https://www.cloudflarestatus.com/api/v3/maintenance.rss` | `https://www.cloudflarestatus.com/api/v3/maintenance.atom` |
 
 ## Related resources
 

--- a/src/content/docs/support/disruptive-maintenance.mdx
+++ b/src/content/docs/support/disruptive-maintenance.mdx
@@ -11,25 +11,19 @@ products:
 
 import { AvailableNotifications, Render } from "~/components";
 
-## Scheduled Maintenance Windows
+## Scheduled maintenance windows
 
-Planned maintenances will be published on the status page using a _calendar_ that is updated on a daily basis.
+Planned maintenance is published on the [Cloudflare Status page](https://www.cloudflarestatus.com/).
 
 During these maintenance windows, customers may experience a slight increase in latency to the edge location which is under maintenance.
 
-:::note
-
-All dates in the calendar are in UTC Timezone.
-:::
-
-### Maintenance Calendar links
-
-[Download iCal](https://calendar.google.com/calendar/ical/c_83vui762nfm498l9a0ciojbju0%40group.calendar.google.com/public/basic.ics "Download iCal")
-[Add to Google Calendar](https://calendar.google.com/calendar/u/0?cid=Y184M3Z1aTc2Mm5mbTQ5OGw5YTBjaW9qYmp1MEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t "Add to Google Calendar")
-
 ### Notifications
 
-Scheduled maintenances can also be sent out via [Cloudflare Notifications](/notifications/).
+There are two ways to be notified about scheduled maintenance.
+
+Status page notifications are delivered independently of Cloudflare infrastructure and fire even if Cloudflare itself is down. You can subscribe by email, webhook, Slack, Discord, or Google Chat. For more information, refer to [status page notifications](https://www.cloudflarestatus.com/docs/notifications).
+
+You can also receive maintenance updates through [Cloudflare Notifications](/notifications/), which delivers to the destinations configured on your account.
 
 <AvailableNotifications
 	product="Cloudflare Status"
@@ -38,15 +32,15 @@ Scheduled maintenances can also be sent out via [Cloudflare Notifications](/noti
 
 <Render file="get-started" product="notifications" />
 
-## Unplanned Maintenance
+## Unplanned maintenance
 
 Cloudflare operates a redundant [anycast network](https://www.cloudflare.com/en-gb/learning/cdn/glossary/anycast-network/) that is capable of automatically removing locations from our network if they require unplanned maintenance or experience an emergency event. In such cases, traffic will be rerouted automatically to alternative locations.
 
-To check for unplanned maintenance, you can confirm at all times if a location was re-routed by verifying if its status is listed as "Re-routed" in our status page [https://www.cloudflarestatus.com](https://www.cloudflarestatus.com). Exceptionally, an incident may be declared for maintenance at a location, in which case updates will be available in our status page at [https://www.cloudflarestatus.com](https://www.cloudflarestatus.com).
+To check for unplanned maintenance, confirm whether a location was re-routed by checking if its status is listed as **Re-routed** in the [status page locations view](https://www.cloudflarestatus.com/locations). Exceptionally, an incident may be declared for maintenance at a location, in which case updates are available on the [Cloudflare Status page](https://www.cloudflarestatus.com/).
 
 ## Interconnections at locations under maintenance
 
-If you have a [CNI connection](/network-interconnect/) with Cloudflare at a re-routed location, it may become temporarily unavailable during planned or unplanned maintenance, and regular internet routing may be used instead to reach your network.
+If you have a [CNI connection](/network-interconnect/) with Cloudflare at a re-routed location, it may become temporarily unavailable during planned or unplanned maintenance, and regular Internet routing may be used instead to reach your network.
 
 In the Magic family of products, the routing is defined explicitly using [static routes](/cloudflare-wan/configuration/how-to/configure-routes/#create-a-static-route) to send traffic to the specified tunnels, with customer-configured priorities. If you have a CNI tunnel, we strongly recommend that you also add routes to an alternative tunnel, such as a fallback Internet tunnel, to make sure your traffic can be routed at all times.
 

--- a/src/content/docs/support/troubleshooting/general-troubleshooting/gathering-information-for-troubleshooting-sites.mdx
+++ b/src/content/docs/support/troubleshooting/general-troubleshooting/gathering-information-for-troubleshooting-sites.mdx
@@ -227,7 +227,7 @@ These tools are run from your terminal or command prompt and are useful for test
 Use this when you need to **determine which Cloudflare Point of Presence (PoP) is serving your requests**. This is helpful when troubleshooting regional issues or verifying traffic routing.
 :::
 
-[A map of our data centers](https://www.cloudflare.com/network-map) is listed on the [Cloudflare status page](https://www.cloudflarestatus.com/), sorted by continent.
+[A map of our data centers](https://www.cloudflare.com/network-map) is listed on the [status page locations view](https://www.cloudflarestatus.com/locations), sorted by continent.
 The three-letter code in the data center name is the [IATA code](http://en.wikipedia.org/wiki/IATA_airport_code) of the nearest major international airport.
 Determine the Cloudflare data center serving requests for your browser by visiting:
 `http://``_www.example.com_``/cdn-cgi/trace.`


### PR DESCRIPTION
### Summary

Updates docs for the new Status Page, including a change log, and new notifications system. Removes references to the now inaccessible maintenance calendar.

### Documentation checklist



- [X] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [X] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
