### PR TITLE
[Workers] Update Astro Node.js requirements

### DIFF
--- a/src/content/docs/workers/framework-guides/web-apps/astro.mdx
+++ b/src/content/docs/workers/framework-guides/web-apps/astro.mdx
@@ -252,4 +252,4 @@ If you want to use Astro as a static site generator, you do not need the Astro C
 
 ## Node.js requirements
 
-Astro 5.x requires Node.js 18.17.1 or higher. Astro 6 (currently in beta) requires Node.js 22 or higher. If you're using [Workers Builds](/workers/ci-cd/builds/), ensure your build environment meets these requirements.
+Astro 5.x supports Node.js 18.20.8, Node.js 20.3.0 and later 20.x releases, or Node.js 22.0.0 or later. Astro 6.x and 7.x require Node.js 22.12.0 or later. If you use [Workers Builds](/workers/ci-cd/builds/), its default Node.js version meets these requirements. If you override the default, select a version that meets [Astro's Node.js requirements](https://docs.astro.build/en/install-and-setup/#prerequisites).


### PR DESCRIPTION
### Summary

Updates Node.js version requirements in the Astro framework guide for stable Astro 5, 6, and 7 releases. Recreates and expands https://github.com/cloudflare/cloudflare-docs/pull/32227 based on current Astro release and package metadata.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
