### PR TITLE
[Style Guide] Allow deep imports for page-specific or one-off components

### DIFF
--- a/.agents/agents/docs.md
+++ b/.agents/agents/docs.md
@@ -98,7 +98,7 @@ Documentation should read as timeless. Do not use:
 | Package install/run commands | `PackageManagers`                         | Shows npm/yarn/pnpm tabs automatically                           |
 | Everything else              | Standard code fences with a language hint | Only when no named component fits                                |
 
-Import components from `~/components`:
+Import barrel-exported components from `~/components`. Page-specific wrapper components or one-off components not in the barrel may use deep paths:
 
 ```mdx
 import {

--- a/.agents/agents/docs.md
+++ b/.agents/agents/docs.md
@@ -98,7 +98,7 @@ Documentation should read as timeless. Do not use:
 | Package install/run commands | `PackageManagers`                         | Shows npm/yarn/pnpm tabs automatically                           |
 | Everything else              | Standard code fences with a language hint | Only when no named component fits                                |
 
-Import barrel-exported components from `~/components`. Page-specific wrapper components or one-off components not in the barrel may use deep paths:
+Add reusable components to the `~/components` barrel export (`src/components.ts`) and import them from `~/components`. Page-specific wrapper components or one-off components may use deep paths instead:
 
 ```mdx
 import {

--- a/.agents/references/components.md
+++ b/.agents/references/components.md
@@ -1,6 +1,6 @@
 # Cloudflare Docs — Component Reference
 
-Full usage details for MDX components available in this repository. All components are imported from `~/components`. Imports must appear after the frontmatter block.
+Full usage details for MDX components available in this repository. Components exported from the `~/components` barrel must be imported from `~/components`. Page-specific wrapper components or one-off components not in the barrel may use deep paths. Imports must appear after the frontmatter block.
 
 ---
 

--- a/.agents/references/components.md
+++ b/.agents/references/components.md
@@ -1,6 +1,6 @@
 # Cloudflare Docs — Component Reference
 
-Full usage details for MDX components available in this repository. Components exported from the `~/components` barrel must be imported from `~/components`. Page-specific wrapper components or one-off components not in the barrel may use deep paths. Imports must appear after the frontmatter block.
+Full usage details for MDX components available in this repository. Add reusable components to the `~/components` barrel export (`src/components.ts`) and import them from `~/components`. Page-specific wrapper components or one-off components may use deep paths instead of adding to the barrel. Imports must appear after the frontmatter block.
 
 ---
 

--- a/.agents/references/style-guide.md
+++ b/.agents/references/style-guide.md
@@ -277,7 +277,7 @@ Package install commands must use `PackageManagers`.
 
 ## Components
 
-Add reusable components to the `~/components` barrel export (`src/components.ts`) and import them from `~/components`. Page-specific wrapper components or one-off components may use deep paths (e.g. `~/components/models/AIModelCatalog.astro`) instead of adding to the barrel. Imports must appear after the frontmatter block.
+Add reusable components to the `~/components` barrel export (`src/components.ts`) and import them from `~/components`. Page-specific wrapper components or one-off components may use deep paths (e.g. `~/components/BaseSchemaProperties.astro`) instead of adding to the barrel. Imports must appear after the frontmatter block.
 
 **Mandatory component usage** — do not use bare fences for these:
 

--- a/.agents/references/style-guide.md
+++ b/.agents/references/style-guide.md
@@ -277,7 +277,7 @@ Package install commands must use `PackageManagers`.
 
 ## Components
 
-All components are imported from `~/components`. Imports must appear after the frontmatter block.
+Components exported from the `~/components` barrel must be imported from `~/components`. Page-specific wrapper components or one-off components not in the barrel may use deep paths (e.g. `~/components/models/AIModelCatalog.astro`). Imports must appear after the frontmatter block.
 
 **Mandatory component usage** — do not use bare fences for these:
 

--- a/.agents/references/style-guide.md
+++ b/.agents/references/style-guide.md
@@ -277,7 +277,7 @@ Package install commands must use `PackageManagers`.
 
 ## Components
 
-Components exported from the `~/components` barrel must be imported from `~/components`. Page-specific wrapper components or one-off components not in the barrel may use deep paths (e.g. `~/components/models/AIModelCatalog.astro`). Imports must appear after the frontmatter block.
+Add reusable components to the `~/components` barrel export (`src/components.ts`) and import them from `~/components`. Page-specific wrapper components or one-off components may use deep paths (e.g. `~/components/models/AIModelCatalog.astro`) instead of adding to the barrel. Imports must appear after the frontmatter block.
 
 **Mandatory component usage** — do not use bare fences for these:
 

--- a/.agents/skills/contributing/references/choosing-components.md
+++ b/.agents/skills/contributing/references/choosing-components.md
@@ -6,7 +6,7 @@ This covers the components in the synced catalog (`.agents/references/components
 
 Two rules first:
 
-- Import every component you use from `~/components`, after the frontmatter. A used-but-unimported component is a silent build failure.
+- Import every barrel-exported component you use from `~/components`, after the frontmatter. Page-specific wrapper components or one-off components not in the barrel may use deep paths. A used-but-unimported component is a silent build failure.
 - For the mandatory mappings below, never use a bare code fence.
 
 ## Reverse lookup: the data you have → the component

--- a/.agents/skills/contributing/references/choosing-components.md
+++ b/.agents/skills/contributing/references/choosing-components.md
@@ -6,7 +6,7 @@ This covers the components in the synced catalog (`.agents/references/components
 
 Two rules first:
 
-- Import every barrel-exported component you use from `~/components`, after the frontmatter. Page-specific wrapper components or one-off components not in the barrel may use deep paths. A used-but-unimported component is a silent build failure.
+- Add reusable components to the `~/components` barrel export (`src/components.ts`) and import them from `~/components`, after the frontmatter. Page-specific wrapper components or one-off components may use deep paths instead of adding to the barrel. A used-but-unimported component is a silent build failure.
 - For the mandatory mappings below, never use a bare code fence.
 
 ## Reverse lookup: the data you have → the component

--- a/.agents/skills/contributing/references/reviewing-docs.md
+++ b/.agents/skills/contributing/references/reviewing-docs.md
@@ -150,7 +150,7 @@ See `.agents/references/style-guide.md` for the full rules. Quick reference:
 | Rule                     | Detail                                                                                                            |
 | ------------------------ | ----------------------------------------------------------------------------------------------------------------- |
 | Unescaped MDX characters | `{`, `}`, `<`, `>` in prose must be escaped or in backticks                                                       |
-| Component imports        | Barrel-exported components must be imported from `~/components`; page-specific or one-off components may use deep paths |
+| Component imports        | Reusable components must be added to the `~/components` barrel and imported from `~/components`; page-specific or one-off components may use deep paths |
 | Workers code             | Must use `TypeScriptExample`, not bare `js`/`ts` fences                                                           |
 | Config blocks            | Must use `WranglerConfig`; use `$today` for `compatibility_date`                                                  |
 | Package install commands | Must use `PackageManagers`, not bare `sh` fences                                                                  |

--- a/.agents/skills/contributing/references/reviewing-docs.md
+++ b/.agents/skills/contributing/references/reviewing-docs.md
@@ -150,7 +150,7 @@ See `.agents/references/style-guide.md` for the full rules. Quick reference:
 | Rule                     | Detail                                                                                                            |
 | ------------------------ | ----------------------------------------------------------------------------------------------------------------- |
 | Unescaped MDX characters | `{`, `}`, `<`, `>` in prose must be escaped or in backticks                                                       |
-| Component imports        | Every component used must be imported from `~/components`                                                         |
+| Component imports        | Barrel-exported components must be imported from `~/components`; page-specific or one-off components may use deep paths |
 | Workers code             | Must use `TypeScriptExample`, not bare `js`/`ts` fences                                                           |
 | Config blocks            | Must use `WranglerConfig`; use `$today` for `compatibility_date`                                                  |
 | Package install commands | Must use `PackageManagers`, not bare `sh` fences                                                                  |

--- a/.agents/skills/contributing/references/writing-docs.md
+++ b/.agents/skills/contributing/references/writing-docs.md
@@ -47,7 +47,7 @@ Mandatory mappings (do not use bare fences for these):
 - Multi-step procedure → `Steps`
 - Dashboard navigation step → `DashButton`
 
-Remember to import every component you use from `~/components`, after the frontmatter block. Remove unused imports.
+Remember to import every barrel-exported component you use from `~/components`, after the frontmatter block. Page-specific wrapper components or one-off components not in the barrel may use deep paths. Remove unused imports.
 
 ## 6. Handle assets and related artifacts
 

--- a/.agents/skills/contributing/references/writing-docs.md
+++ b/.agents/skills/contributing/references/writing-docs.md
@@ -47,7 +47,7 @@ Mandatory mappings (do not use bare fences for these):
 - Multi-step procedure → `Steps`
 - Dashboard navigation step → `DashButton`
 
-Remember to import every barrel-exported component you use from `~/components`, after the frontmatter block. Page-specific wrapper components or one-off components not in the barrel may use deep paths. Remove unused imports.
+Remember to add reusable components to the `~/components` barrel export (`src/components.ts`) and import them from `~/components`, after the frontmatter block. Page-specific wrapper components or one-off components may use deep paths instead of adding to the barrel. Remove unused imports.
 
 ## 6. Handle assets and related artifacts
 

--- a/.flue/.agents/skills/style-guide-review/reference/conditional/imports.md
+++ b/.flue/.agents/skills/style-guide-review/reference/conditional/imports.md
@@ -6,7 +6,7 @@ description: Rules for importing and using MDX components.
 ## Rules
 
 - Reusable components must be added to the `~/components` barrel export (`src/components.ts`) and imported from `~/components`. If a reusable component is imported via a deep path instead of from the barrel → **warning**.
-- Page-specific wrapper components or one-off components may be imported via a deep path (e.g. `~/components/models/AIModelCatalog.astro`) instead of adding to the barrel. Deep imports for these components are allowed and should **not** be flagged.
+- Page-specific wrapper components or one-off components may be imported via a deep path (e.g. `~/components/BaseSchemaProperties.astro`) instead of adding to the barrel. Deep imports for these components are allowed and should **not** be flagged.
 - Exception: `SubtractIPCalculator` is exported from `~/components` and should be imported from there. The direct path `~/components/SubtractIPCalculator.tsx` is a legacy shim and should not be used in new content.
 
 ## Import Pattern
@@ -20,5 +20,5 @@ Multiple components can be imported in a single statement.
 For page-specific wrapper components not in the barrel:
 
 ```mdx
-import AIModelCatalog from "~/components/models/AIModelCatalog.astro";
+import BaseSchemaProperties from "~/components/BaseSchemaProperties.astro";
 ```

--- a/.flue/.agents/skills/style-guide-review/reference/conditional/imports.md
+++ b/.flue/.agents/skills/style-guide-review/reference/conditional/imports.md
@@ -5,7 +5,8 @@ description: Rules for importing and using MDX components.
 
 ## Rules
 
-- If an import uses any path other than `~/components` → **warning**: all components must import from `~/components`.
+- Components exported from the `~/components` barrel must be imported from `~/components`, not via a deep path (e.g. `~/components/ui/tabs.astro`). If a barrel-exported component is imported via a deep path → **warning**.
+- Page-specific wrapper components or one-off components that are **not** exported from the `~/components` barrel may be imported via a deep path (e.g. `~/components/models/AIModelCatalog.astro`). These do not belong in the barrel. Deep imports for non-barrel components are allowed and should **not** be flagged.
 - Exception: `SubtractIPCalculator` is exported from `~/components` and should be imported from there. The direct path `~/components/SubtractIPCalculator.tsx` is a legacy shim and should not be used in new content.
 
 ## Import Pattern
@@ -15,3 +16,9 @@ import { ComponentA, ComponentB } from "~/components";
 ```
 
 Multiple components can be imported in a single statement.
+
+For page-specific wrapper components not in the barrel:
+
+```mdx
+import AIModelCatalog from "~/components/models/AIModelCatalog.astro";
+```

--- a/.flue/.agents/skills/style-guide-review/reference/conditional/imports.md
+++ b/.flue/.agents/skills/style-guide-review/reference/conditional/imports.md
@@ -5,8 +5,8 @@ description: Rules for importing and using MDX components.
 
 ## Rules
 
-- Components exported from the `~/components` barrel must be imported from `~/components`, not via a deep path (e.g. `~/components/ui/tabs.astro`). If a barrel-exported component is imported via a deep path → **warning**.
-- Page-specific wrapper components or one-off components that are **not** exported from the `~/components` barrel may be imported via a deep path (e.g. `~/components/models/AIModelCatalog.astro`). These do not belong in the barrel. Deep imports for non-barrel components are allowed and should **not** be flagged.
+- Reusable components must be added to the `~/components` barrel export (`src/components.ts`) and imported from `~/components`. If a reusable component is imported via a deep path instead of from the barrel → **warning**.
+- Page-specific wrapper components or one-off components may be imported via a deep path (e.g. `~/components/models/AIModelCatalog.astro`) instead of adding to the barrel. Deep imports for these components are allowed and should **not** be flagged.
 - Exception: `SubtractIPCalculator` is exported from `~/components` and should be imported from there. The direct path `~/components/SubtractIPCalculator.tsx` is a legacy shim and should not be used in new content.
 
 ## Import Pattern

--- a/.flue/evals/style-guide.eval.ts
+++ b/.flue/evals/style-guide.eval.ts
@@ -341,7 +341,7 @@ describeEval("style-guide reviewer", { harness }, (it) => {
 			addedLines: [
 				{
 					line: 3,
-					content: 'import { Tabs } from "~/components/ui/tabs.astro";',
+					content: 'import Tabs from "~/components/ui/tabs/Tabs.astro";',
 				},
 			],
 		});
@@ -377,7 +377,7 @@ describeEval("style-guide reviewer", { harness }, (it) => {
 				{
 					line: 15,
 					content:
-						'import AIModelCatalog from "~/components/models/AIModelCatalog.astro";',
+						'import BaseSchemaProperties from "~/components/BaseSchemaProperties.astro";',
 				},
 			],
 		});
@@ -391,7 +391,7 @@ describeEval("style-guide reviewer", { harness }, (it) => {
 				(f.rule?.toLowerCase().includes("import") ||
 					f.rule?.toLowerCase().includes("component") ||
 					f.rule?.toLowerCase().includes("barrel") ||
-					f.evidence?.includes("~/components/models/")),
+					f.evidence?.includes("~/components/BaseSchemaProperties")),
 		);
 		expect(importWarnings).toHaveLength(0);
 

--- a/.flue/evals/style-guide.eval.ts
+++ b/.flue/evals/style-guide.eval.ts
@@ -330,4 +330,73 @@ describeEval("style-guide reviewer", { harness }, (it) => {
 			"submit_style_guide",
 		);
 	});
+
+	it("flags a barrel-exported component imported via a deep path", async ({
+		run,
+	}) => {
+		const result = await run({
+			pullRequest: PR,
+			headSha: HEAD_SHA,
+			filename: "src/content/docs/workers/example.mdx",
+			addedLines: [
+				{
+					line: 3,
+					content: 'import { Tabs } from "~/components/ui/tabs.astro";',
+				},
+			],
+		});
+
+		const findings = (result.output as { findings?: Finding[] })?.findings;
+		expect(findings).toBeDefined();
+
+		const importFinding = (findings ?? []).find(
+			(f) =>
+				f.rule?.toLowerCase().includes("import") ||
+				f.rule?.toLowerCase().includes("component") ||
+				f.rule?.toLowerCase().includes("barrel") ||
+				f.evidence?.includes("~/components/ui/"),
+		);
+		expect(importFinding).toBeDefined();
+		expect(importFinding!.severity).toBe("warning");
+		expect(importFinding!.path).toBe("src/content/docs/workers/example.mdx");
+		expect(importFinding!.line).toBe(3);
+
+		expect(toolCalls(result).map((c) => c.name)).toContain(
+			"submit_style_guide",
+		);
+	});
+
+	it("does not flag a page-specific wrapper component imported via a deep path", async ({
+		run,
+	}) => {
+		const result = await run({
+			pullRequest: PR,
+			headSha: HEAD_SHA,
+			filename: "src/content/docs/ai/models/index.mdx",
+			addedLines: [
+				{
+					line: 15,
+					content:
+						'import AIModelCatalog from "~/components/models/AIModelCatalog.astro";',
+				},
+			],
+		});
+
+		const findings = (result.output as { findings?: Finding[] })?.findings;
+		expect(findings).toBeDefined();
+
+		const importWarnings = (findings ?? []).filter(
+			(f) =>
+				f.severity === "warning" &&
+				(f.rule?.toLowerCase().includes("import") ||
+					f.rule?.toLowerCase().includes("component") ||
+					f.rule?.toLowerCase().includes("barrel") ||
+					f.evidence?.includes("~/components/models/")),
+		);
+		expect(importWarnings).toHaveLength(0);
+
+		expect(toolCalls(result).map((c) => c.name)).toContain(
+			"submit_style_guide",
+		);
+	});
 });

--- a/src/content/docs/style-guide/components/index.mdx
+++ b/src/content/docs/style-guide/components/index.mdx
@@ -47,7 +47,7 @@ To add a component to a page:
    Page-specific wrapper components or one-off components do not need to be added to the barrel — import them via a deep path:
 
    ```mdx
-   import AIModelCatalog from "~/components/models/AIModelCatalog.astro";
+   import BaseSchemaProperties from "~/components/BaseSchemaProperties.astro";
    ```
 
 2. Add the component to the page by adding this text anywhere on the page you want the component to appear:

--- a/src/content/docs/style-guide/components/index.mdx
+++ b/src/content/docs/style-guide/components/index.mdx
@@ -44,7 +44,7 @@ To add a component to a page:
    ;
    ```
 
-   Page-specific wrapper components or one-off components not exported from the `~/components` barrel may be imported via a deep path:
+   Page-specific wrapper components or one-off components do not need to be added to the barrel — import them via a deep path:
 
    ```mdx
    import AIModelCatalog from "~/components/models/AIModelCatalog.astro";

--- a/src/content/docs/style-guide/components/index.mdx
+++ b/src/content/docs/style-guide/components/index.mdx
@@ -44,6 +44,12 @@ To add a component to a page:
    ;
    ```
 
+   Page-specific wrapper components or one-off components not exported from the `~/components` barrel may be imported via a deep path:
+
+   ```mdx
+   import AIModelCatalog from "~/components/models/AIModelCatalog.astro";
+   ```
+
 2. Add the component to the page by adding this text anywhere on the page you want the component to appear:
 
    ```mdx


### PR DESCRIPTION
### Summary

Updates the component import style guide rule in all 8 places it is stated to allow deep imports for page-specific wrapper components or one-off components that are not exported from the `~/components` barrel.

Previously, the rule required **all** component imports to use `~/components`. This is correct for reusable barrel-exported components, but page-specific wrapper components (e.g. `BaseSchemaProperties.astro`, `FieldCatalogPage.astro`) that encapsulate build-time data fetching for a single content page should not be added to the barrel. The rule now explicitly allows deep paths for these components.

| File | Role |
| --- | --- |
| `.flue/.agents/skills/style-guide-review/reference/conditional/imports.md` | Bot enforcement rule |
| `.agents/references/style-guide.md` | Agent reference |
| `.agents/references/components.md` | Agent component catalog |
| `.agents/skills/contributing/references/writing-docs.md` | Contributing skill |
| `.agents/skills/contributing/references/choosing-components.md` | Contributing skill |
| `.agents/skills/contributing/references/reviewing-docs.md` | Contributing skill |
| `.agents/agents/docs.md` | Agent definition |
| `src/content/docs/style-guide/components/index.mdx` | Live style guide |
| `.flue/evals/style-guide.eval.ts` | Eval tests for the updated rule (2 new cases: flags barrel component via deep path, passes on page-specific wrapper via deep path) |

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
