### PR TITLE
[DO, D1] Document SQLite R*Tree module support

### DIFF
--- a/src/content/changelog/durable-objects/2026-07-22-durable-objects-sqlite-rtree.mdx
+++ b/src/content/changelog/durable-objects/2026-07-22-durable-objects-sqlite-rtree.mdx
@@ -1,0 +1,66 @@
+---
+title: Spatial and range queries with the SQLite R*Tree module
+description: Durable Objects and D1 now support SQLite's R*Tree module, so you can create spatial indexes for fast bounding box and range queries.
+products:
+  - durable-objects
+  - d1
+  - workers
+date: 2026-07-22
+---
+
+import { TypeScriptExample } from "~/components";
+
+SQLite-backed Durable Objects and D1 databases now support the [R\*Tree module](https://www.sqlite.org/rtree.html). An R\*Tree is a specialized index for range queries. Given a query rectangle, it returns every entry that overlaps or falls inside that rectangle without scanning the whole table.
+
+The R\*Tree suits any query that filters on the minimum and maximum values of one to five dimensions: which delivery zones cover a coordinate, which events were active during a time window, or which objects a camera can see in 3D space. Previously, these queries required a full table scan or a manually maintained index such as a geohash column.
+
+Create the index as a virtual table, then query it with an ordinary `WHERE` clause:
+
+<TypeScriptExample filename="src/index.ts">
+
+```ts
+import { DurableObject } from "cloudflare:workers";
+
+export class DeliveryZones extends DurableObject {
+	constructor(ctx: DurableObjectState, env: Env) {
+		super(ctx, env);
+
+		// Two dimensions: five columns, plus an auxiliary column for the name.
+		ctx.storage.sql.exec(`
+			CREATE VIRTUAL TABLE IF NOT EXISTS delivery_zones USING rtree(
+				id, minLng, maxLng, minLat, maxLat, +name
+			);
+		`);
+	}
+
+	zonesCovering(lng: number, lat: number) {
+		return this.ctx.storage.sql
+			.exec(
+				`SELECT id, name FROM delivery_zones
+				 WHERE minLng <= ? AND maxLng >= ?
+					 AND minLat <= ? AND maxLat >= ?`,
+				lng,
+				lng,
+				lat,
+				lat,
+			)
+			.toArray();
+	}
+}
+```
+
+</TypeScriptExample>
+
+An R\*Tree stores coordinates as 32-bit floats and rounds bounding boxes outwards, so a query can return rows that do not truly match. Treat it as a fast pre-filter and confirm each result against exact coordinates. To store coordinates as 32-bit signed integers instead, use `rtree_i32`.
+
+**Limits:**
+
+- The primary key and coordinate columns must total an odd number between 3 and 11, so an R\*Tree indexes a maximum of five dimensions. Auxiliary columns, prefixed with `+`, are counted separately, up to 100 columns in total.
+- Each R\*Tree is backed by three shadow tables, so writes count more rows written than an equivalent ordinary table. Refer to [Durable Objects pricing](/durable-objects/platform/pricing/) and [D1 pricing](/d1/platform/pricing/).
+- Writing to an R\*Tree while a query against the same R\*Tree is still open fails with `SQLITE_LOCKED`.
+- Only `rtreecheck()` is available. Custom geometry callbacks and the Geopoly module are not supported, so you cannot `MATCH` against application-defined regions.
+- D1 cannot export a database containing a virtual table. This already applied to FTS5 tables and now applies to R\*Tree tables.
+
+This works the same way in local development with `wrangler dev` as it does in production. Run `npm update wrangler` to ensure you are on a version with this support.
+
+For more information, refer to [Spatial and range indexes with R\*Tree](/durable-objects/best-practices/access-durable-objects-storage/#spatial-and-range-indexes-with-rtree).

--- a/src/content/docs/d1/best-practices/import-export-data.mdx
+++ b/src/content/docs/d1/best-practices/import-export-data.mdx
@@ -150,7 +150,7 @@ npx wrangler d1 export <database_name> --remote --table=<table_name> --output=./
 
 ### Known limitations
 
-- Export is not supported for virtual tables, including databases with virtual tables. D1 supports virtual tables for full-text search using SQLite's [FTS5 module](https://www.sqlite.org/fts5.html). As a workaround, delete any virtual tables, export, and then recreate virtual tables.
+- Export is not supported for virtual tables, including databases with virtual tables. D1 supports virtual tables for full-text search using SQLite's [FTS5 module](https://www.sqlite.org/fts5.html), and for spatial and range indexes using the [R\*Tree module](https://www.sqlite.org/rtree.html). As a workaround, delete any virtual tables, export, and then recreate virtual tables.
 - A running export will block other database requests.
 - Any numeric value in a column is affected by JavaScript's 52-bit precision for numbers. If you store a very large number (in `int64`), then retrieve the same value, the returned value may be less precise than your original number.
 

--- a/src/content/docs/durable-objects/api/sqlite-storage-api.mdx
+++ b/src/content/docs/durable-objects/api/sqlite-storage-api.mdx
@@ -134,9 +134,13 @@ class MyDurableObject(DurableObject):
 
 - SQL API methods accessed with `ctx.storage.sql` are only allowed on [Durable Object classes with SQLite storage backend](/durable-objects/best-practices/access-durable-objects-storage/#create-sqlite-backed-durable-object-class) and will return an error if called on Durable Object classes with a KV-storage backend.
 - When writing data, every row update of an index counts as an additional row. However, indexes may be beneficial for read-heavy use cases. Refer to [Index for SQLite Durable Objects](/durable-objects/best-practices/access-durable-objects-storage/#indexes-in-sqlite).
-- Writing data to [SQLite virtual tables](https://www.sqlite.org/vtab.html) also counts towards rows written.
+- Writing data to [SQLite virtual tables](https://www.sqlite.org/vtab.html) also counts towards rows written. Some virtual tables are backed by more than one underlying table, so a single write can count as several rows written.
+
+### Supported SQLite extensions
 
 <Render file="d1-do-supported-sqlite-extensions" product="d1" params={{ product: "Durable Objects support" }}/>
+
+For guidance on using the R\*Tree module, refer to [Spatial and range indexes with R\*Tree](/durable-objects/best-practices/access-durable-objects-storage/#spatial-and-range-indexes-with-rtree).
 
 ### `exec`
 

--- a/src/content/docs/durable-objects/best-practices/access-durable-objects-storage.mdx
+++ b/src/content/docs/durable-objects/best-practices/access-durable-objects-storage.mdx
@@ -181,6 +181,65 @@ You can represent the shape of any result type you wish, including more complex 
 
 Creating indexes for your most queried tables and filtered columns reduces how much data is scanned and improves query performance at the same time. If you have a read-heavy workload (most common), this can be particularly advantageous. Writing to columns referenced in an index will add at least one (1) additional row written to account for updating the index, but this is typically offset by the reduction in rows read due to the benefits of an index.
 
+### Spatial and range indexes with R\*Tree
+
+A regular B-tree index cannot efficiently answer a query that filters on two or more independent ranges at once, such as finding every rectangle that contains a given point. SQLite's [R\*Tree module](https://www.sqlite.org/rtree.html) solves this. It indexes bounding boxes of one to five dimensions and returns the entries that overlap or contain a query box without scanning the table.
+
+Common uses are geospatial lookups, time interval overlap, and 3D visibility tests. Create an R\*Tree index as a virtual table. The first column is a 64-bit integer primary key, the next columns are minimum and maximum pairs, one pair per dimension, and any auxiliary columns come last:
+
+```ts
+this.ctx.storage.sql.exec(`
+	CREATE VIRTUAL TABLE IF NOT EXISTS delivery_zones USING rtree(
+		id,
+		minLng, maxLng,
+		minLat, maxLat,
+		+name
+	);
+`);
+```
+
+Prefixing a column name with `+`, as with the `name` column, adds an auxiliary column. Auxiliary columns store arbitrary data alongside the coordinates so you do not need to join against a separate table. They must follow all coordinate columns, and an R\*Tree table can have at most 100 columns in total.
+
+Insert rows as you would for an ordinary table. Refer to an auxiliary column by its bare name, without the `+` prefix:
+
+```ts
+this.ctx.storage.sql.exec(
+	`INSERT INTO delivery_zones (id, minLng, maxLng, minLat, maxLat, name)
+	 VALUES (?, ?, ?, ?, ?, ?)`,
+	1,
+	-0.51,
+	0.33,
+	51.29,
+	51.69,
+	"London",
+);
+```
+
+Query the index with an ordinary `WHERE` clause. The more coordinates you constrain and the smaller the query box, the faster the query returns:
+
+```ts
+const zones = this.ctx.storage.sql
+	.exec(
+		`SELECT id, name FROM delivery_zones
+		 WHERE minLng <= ? AND maxLng >= ?
+			 AND minLat <= ? AND maxLat >= ?`,
+		lng,
+		lng,
+		lat,
+		lat,
+	)
+	.toArray();
+```
+
+Keep the following limitations in mind:
+
+- The primary key and coordinate columns must total an odd number between 3 and 11, which caps an R\*Tree at five dimensions. Auxiliary columns do not count towards this limit.
+- Coordinates are stored as 32-bit floats. Lower bounds round down and upper bounds round up, so a stored box is never smaller than the box you inserted. To store coordinates as 32-bit signed integers instead, use `rtree_i32` in place of `rtree`.
+- Because stored boxes round outwards, an R\*Tree can return rows that do not truly match. Treat it as a fast pre-filter, then confirm each result against exact coordinates. For the same reason, expand contained-within query boxes slightly so that edge matches are not excluded.
+- Each R\*Tree table is backed by three shadow tables, named `<name>_node`, `<name>_rowid`, and `<name>_parent`. They appear when you list tables, and writes to the index count more rows written than an equivalent ordinary table. Refer to [Durable Objects pricing](/durable-objects/platform/pricing/).
+- Writing to an R\*Tree while a query against the same R\*Tree is still open fails with `SQLITE_LOCKED`. Read results into an array first, then write.
+- Of the functions the module provides, only `rtreecheck()` is available. `rtreenode()` and `rtreedepth()` are not. Custom geometry callbacks and the Geopoly module are also unsupported, so you cannot `MATCH` against application-defined regions.
+
 <Render file="durable-objects-vs-d1" product="durable-objects" />
 
 ## Related resources

--- a/src/content/partials/d1/d1-do-supported-sqlite-extensions.mdx
+++ b/src/content/partials/d1/d1-do-supported-sqlite-extensions.mdx
@@ -8,5 +8,8 @@ params:
 - [FTS5 module](https://www.sqlite.org/fts5.html) for full-text search (including `fts5vocab`).
 - [JSON extension](https://www.sqlite.org/json1.html) for JSON functions and operators.
 - [Math functions](https://sqlite.org/lang_mathfunc.html).
+- [R\*Tree module](https://www.sqlite.org/rtree.html) for spatial and range indexes, with the `rtree_i32` variant for integer coordinates.
 
-Refer to the [source code](https://github.com/cloudflare/workerd/blob/4c42a4a9d3390c88e9bd977091c9d3395a6cd665/src/workerd/util/sqlite.c%2B%2B#L269) for the full list of supported functions.
+Of the functions the R\*Tree module provides, only `rtreecheck()` is available. Custom geometry callbacks and the Geopoly module are not supported.
+
+Refer to the [source code](https://github.com/cloudflare/workerd/blob/343766b542f2fa30a08e6b31f50d6466710fa0e7/src/workerd/util/sqlite.c%2B%2B#L363) for the full list of supported functions.


### PR DESCRIPTION
### Summary

The SQLite [R\*Tree module](https://www.sqlite.org/rtree.html) is now enabled in the Workers runtime, so SQLite-backed Durable Objects and D1 databases can create `rtree` and `rtree_i32` virtual tables for spatial and range queries. Nothing in the docs mentioned R\*Tree before this PR.

| File | Change |
| --- | --- |
| `changelog/durable-objects/2026-07-22-durable-objects-sqlite-rtree.mdx` | New changelog entry, scoped to both products |
| `partials/d1/d1-do-supported-sqlite-extensions.mdx` | Adds R\*Tree to the extensions list shared by D1 and Durable Objects |
| `docs/durable-objects/best-practices/access-durable-objects-storage.mdx` | New "Spatial and range indexes with R\*Tree" section with worked examples |
| `docs/durable-objects/api/sqlite-storage-api.mdx` | Adds a heading above the extensions list, plus a cross-link |
| `docs/d1/best-practices/import-export-data.mdx` | Notes that R\*Tree tables hit the existing virtual table export limitation |

Two incidental fixes while in these files:

- The Durable Objects extensions list had no heading, so it had no anchor to link to. D1's equivalent page has had one. Added `### Supported SQLite extensions` to match.
- The "Refer to the source code" permalink in the shared partial pointed at a 2024 commit and line 269, which is now the middle of the JSON function list. Repointed at `ALLOWED_SQLITE_FUNCTIONS[]`.

**Two things to confirm before this leaves draft:**

1. **The D1 claim needs an empirical check.** The runtime change applies to both products, and D1 already ships FTS5 virtual tables through the same code path, so R\*Tree should work identically. But I have not run `CREATE VIRTUAL TABLE t USING rtree(id, minX, maxX, minY, maxY)` against a production D1 database to confirm. Worth doing before merging, since the shared partial renders this claim on a live D1 page.
2. **The date may want to move.** The entry is dated for when the change reached production. That places it below entries already published, so it will not appear near the top of the changelog. If visibility matters more than the historical date, redate it to the publication date and note the availability date in the body.

Only `rtree` and `rtree_i32` are enabled. Geopoly is not, and of the functions the module provides only `rtreecheck()` is available — the docs say so in each place the module is described.

### Documentation checklist

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
