### PR TITLE
[Cloudflare One] Add Duo identity provider setup

### DIFF
--- a/src/content/docs/cloudflare-one/integrations/identity-providers/duo.mdx
+++ b/src/content/docs/cloudflare-one/integrations/identity-providers/duo.mdx
@@ -1,0 +1,165 @@
+---
+pcx_content_type: how-to
+description: Configure Cisco Duo as an OpenID Connect identity provider in Cloudflare One.
+products:
+  - cloudflare-one
+title: Duo
+tags:
+  - OIDC
+  - SSO
+---
+
+import {
+	APIRequest,
+	DashButton,
+	Render,
+	Steps,
+	TabItem,
+	Tabs,
+} from "~/components";
+
+Cloudflare Access supports Cisco Duo Single Sign-On as an OpenID Connect (OIDC) identity provider.
+
+## Prerequisites
+
+- A commercial Duo plan that includes Duo Single Sign-On
+- A working Duo Single Sign-On authentication source
+- A Duo user with access to the application
+- A Cloudflare Zero Trust organization
+
+## 1. Create an application in Duo
+
+<Steps>
+1. Log in to the Duo Admin Panel and go to **Applications** > **Application Catalog**.
+
+2. Find **Generic OIDC Relying Party** with the **SSO** label, then select **Add**.
+
+3. Under **User access**, grant access to selected Duo groups or all users.
+
+4. In the **Metadata** tab, copy these values:
+
+   - **Client ID**
+   - **Client Secret**
+   - **Discovery URL**
+
+5. In the **General** tab, turn on the **Authorization Code** grant type.
+
+6. Under **Sign-In Redirect URLs**, enter your Cloudflare Access callback URL:
+
+   ```txt
+   https://<YOUR_TEAM_NAME>.cloudflareaccess.com/cdn-cgi/access/callback
+   ```
+
+   <Render file="find-team-name" product="cloudflare-one" />
+
+7. In the **Scopes** tab, turn on the `email` and `profile` scopes. The `openid` scope is always enabled.
+
+8. Confirm that the `email` claim maps to the user's email attribute.
+
+9. Select **Save**.
+</Steps>
+
+## 2. Add Duo to Cloudflare One
+
+<Tabs syncKey="dashPlusAPI">
+<TabItem label="Dashboard">
+
+<Steps>
+1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Integrations** > **Identity providers**.
+
+   <DashButton url="/?to=/:account/integrations/identity-providers" zeroTrust />
+
+2. Under **Your identity providers**, select **Add new identity provider**.
+
+3. Select **Duo**.
+
+4. Enter the **Client ID**, **Client Secret**, and **Discovery URL** copied from Duo.
+
+5. (Optional) Turn on Proof Key for Code Exchange (PKCE) if you configured PKCE in Duo.
+
+6. (Optional) Under **Optional configurations**, configure a different email claim, custom OIDC claims, or additional scopes.
+
+7. Select **Save**.
+</Steps>
+
+</TabItem>
+<TabItem label="API">
+
+Make a `POST` request to the [Identity Providers](/api/resources/zero_trust/subresources/identity_providers/methods/create/) endpoint:
+
+<APIRequest
+	path="/accounts/{account_id}/access/identity_providers"
+	method="POST"
+	json={{
+		name: "Duo",
+		type: "duo",
+		config: {
+			client_id: "$DUO_CLIENT_ID",
+			client_secret: "$DUO_CLIENT_SECRET",
+			discovery_url: "$DUO_DISCOVERY_URL",
+			email_claim_name: "email",
+			pkce_enabled: false,
+			claims: [],
+			scopes: ["openid", "email", "profile"],
+		},
+	}}
+/>
+
+</TabItem>
+</Tabs>
+
+## 3. Test the connection
+
+In **Zero Trust** > **Integrations** > **Identity providers**, select **Test** next to Duo. Complete authentication through Duo and confirm that Cloudflare returns the expected email address.
+
+<DashButton url="/?to=/:account/integrations/identity-providers" zeroTrust />
+
+## Custom OIDC claims
+
+Duo does not send group membership as an OIDC claim by default. If you map group membership to a custom claim, use **Duo OIDC Claims** in Access policies. Do not use **Identity provider group** for Duo.
+
+To use another Duo claim in an Access policy:
+
+<Steps>
+1. In the Duo application's **Scopes** tab, add the claim to an enabled scope.
+
+2. In **Zero Trust** > **Integrations** > **Identity providers**, edit Duo.
+
+   <DashButton url="/?to=/:account/integrations/identity-providers" zeroTrust />
+
+3. Under **OIDC Claims**, enter the exact claim name.
+
+4. Select **Save**, then test the identity provider.
+
+5. In an Access policy, use the **Duo OIDC Claims** selector.
+</Steps>
+
+An empty `oidc_fields` object means Duo returned none of the configured custom claims. Confirm each claim is mapped in Duo and listed under **OIDC Claims** in Cloudflare.
+
+## Troubleshooting
+
+### Relying Party is not configured
+
+Confirm that the Cloudflare callback URL is present in Duo's **Sign-In Redirect URLs**. Save the Duo application after adding the URL.
+
+### Invalid credentials
+
+Confirm that Duo Single Sign-On uses the expected authentication source. If Duo looks up users by email, confirm that the user's email attribute is populated.
+
+### User email was not returned
+
+Confirm that the Duo application enables the `email` scope and maps the `email` claim to a populated user attribute.
+
+### User cannot access the application
+
+Under **User access** in Duo, grant access to the user's Duo group or all users.
+
+### Discovery metadata cannot be loaded
+
+Copy the exact **Discovery URL** from the Duo application's **Metadata** tab. Do not enter a Duo Admin API hostname, email domain, or custom login domain.
+
+Confirm that the Client ID and Discovery URL came from the same Duo application.
+
+### Duo passcode does not arrive
+
+Select another enrolled Duo authentication method, or contact your Duo administrator to confirm telephony availability.

--- a/src/content/docs/cloudflare-one/integrations/identity-providers/duo.mdx
+++ b/src/content/docs/cloudflare-one/integrations/identity-providers/duo.mdx
@@ -77,9 +77,11 @@ Cloudflare Access supports Cisco Duo Single Sign-On as an OpenID Connect (OIDC) 
 
 5. (Optional) Turn on Proof Key for Code Exchange (PKCE) if you configured PKCE in Duo.
 
-6. (Optional) Under **Optional configurations**, configure a different email claim, custom OIDC claims, or additional scopes.
+6. To use group membership in Access policies, under **Optional configurations** > **OIDC Claims**, enter `groups`.
 
-7. Select **Save**.
+7. (Optional) Configure a different email claim, other custom OIDC claims, or additional scopes.
+
+8. Select **Save**.
 </Steps>
 
 </TabItem>
@@ -99,7 +101,7 @@ Make a `POST` request to the [Identity Providers](/api/resources/zero_trust/subr
 			discovery_url: "$DUO_DISCOVERY_URL",
 			email_claim_name: "email",
 			pkce_enabled: false,
-			claims: [],
+			claims: ["groups"],
 			scopes: ["openid", "email", "profile"],
 		},
 	}}
@@ -114,9 +116,31 @@ In **Zero Trust** > **Integrations** > **Identity providers**, select **Test** n
 
 <DashButton url="/?to=/:account/integrations/identity-providers" zeroTrust />
 
-## Custom OIDC claims
+## Group membership
 
-Duo does not send group membership as an OIDC claim by default. If you map group membership to a custom claim, use **Duo OIDC Claims** in Access policies. Do not use **Identity provider group** for Duo.
+Duo's **User access** setting controls which Duo users can open the application, but it does not send those Duo group memberships to Cloudflare. To use groups in Access policies, configure Duo to return a `groups` claim from your SSO authentication source.
+
+<Steps>
+1. In the Duo application's **Scopes** tab, add a `groups` claim to an enabled scope such as `profile`.
+
+2. Map the claim to the group membership attribute from your Duo SSO authentication source.
+
+3. If your Active Directory returns group distinguished names, use Duo's [`format_ad_groups` claim transformation](https://duo.com/docs/sso-oidc-generic#claim-transformations) to return group names.
+
+4. Use Duo's **Preview Response** tool to confirm that `groups` is a string or an array of strings.
+
+5. In **Zero Trust** > **Integrations** > **Identity providers**, edit Duo. Under **OIDC Claims**, enter `groups`, then select **Save**.
+
+   <DashButton url="/?to=/:account/integrations/identity-providers" zeroTrust />
+
+6. Test the identity provider and confirm that `oidc_fields.groups` contains the expected group names.
+
+7. In an Access policy, use the **Duo OIDC Claims** selector. Enter `groups` as the claim name and the exact group name as the claim value.
+</Steps>
+
+The **Identity provider group** selector requires a group integration that can list groups, such as SCIM. Duo group matching in this integration uses the OIDC claim instead.
+
+## Other custom OIDC claims
 
 To use another Duo claim in an Access policy:
 
@@ -153,6 +177,10 @@ Confirm that the Duo application enables the `email` scope and maps the `email` 
 ### User cannot access the application
 
 Under **User access** in Duo, grant access to the user's Duo group or all users.
+
+### Group policy does not match
+
+Use Duo's **Preview Response** tool to confirm that the `groups` claim contains the expected group name. Confirm that `groups` is listed under **OIDC Claims** in Cloudflare and that the Access policy uses the **Duo OIDC Claims** selector.
 
 ### Discovery metadata cannot be loaded
 


### PR DESCRIPTION
## Summary

Adds setup documentation for Cisco Duo as a first-class Cloudflare Access OIDC identity provider.

## Scope

- Duo Generic OIDC Relying Party setup
- Client ID, Client Secret, and Discovery URL configuration
- Dashboard and API examples
- Authentication-source group mapping through the OIDC `groups` claim
- Other custom OIDC claim guidance
- Troubleshooting based on the validated end-to-end flow

The page documents group policy matching through **Duo OIDC Claims**. It does not advertise native Duo group discovery or customer-facing SCIM support.

## Dependencies

Draft only. Do not merge until the product rollout is approved and these implementation MRs are ready in rollout order:

1. Heimtor: https://gitlab.cfdata.org/cloudflare/ea/heimtor/-/merge_requests/2581
2. Edgeauth: https://gitlab.cfdata.org/cloudflare/ea/edgeauth/-/merge_requests/5371
3. ztx-frontend: https://gitlab.cfdata.org/cloudflare/ztx/ztx-frontend/-/merge_requests/11349

## Validation

- `pnpm run check`
- `pnpm run build` (8,839 pages)
- Prettier formatting
- Cloudflare Docs style and technical review

## Handoff for Kenny

Final implementation state captured on 2026-08-14. The linked branches, MRs, commits, and pipelines are authoritative. No merge or production deployment is authorized by this handoff.

### Customer contract

- Customers enter only **Client ID**, **Client Secret**, and the exact Duo **Discovery URL**.
- Edgeauth resolves and validates discovery metadata on IdP create/update. Heimtor performs no runtime discovery.
- The persisted provider type remains `duo`; it is never rewritten to generic `oidc`.
- Missing or blank Duo configuration versions fail closed before authorization.
- Duo state binds provider ID, provider type, and configuration version before token exchange.
- ID tokens require the exact issuer, valid audience and authorized party, and a finite future expiry.
- Token and JWKS redirects are rejected. JWKS cache entries are scoped by Duo configuration version.
- Generic OIDC behavior remains unchanged.

### Group support

- Duo **User access** groups control who may launch the application. They are not automatically sent to Cloudflare.
- Access policy matching uses an authentication-source group attribute emitted as a custom OIDC claim named `groups`.
- Add `groups` to an enabled Duo scope such as `profile`. For Active Directory distinguished names, use Duo's `format_ad_groups` transformation.
- Use Duo's **Preview Response** tool to verify that `groups` is a string or array of strings.
- Add `groups` under Cloudflare **OIDC Claims**.
- In policies, use **Duo OIDC Claims**, claim name `groups`, and the exact group name as the value.
- Heimtor retains the claim in `oidc_fields.groups` and promotes valid values to `identity.groups` unless the existing OIDC group kill switch is enabled.
- Native Duo group discovery, the **Identity provider group** picker, and Duo SCIM are not included.

### Final repository state

| Surface | Ticket | Branch and head | Review artifact | Verified state |
| --- | --- | --- | --- | --- |
| Heimtor | AUTH-9007 | `bhavya/AUTH-9007` at `89b3de2e` | [MR !2581](https://gitlab.cfdata.org/cloudflare/ea/heimtor/-/merge_requests/2581) | Ready, pipeline [4166647](https://gitlab.cfdata.org/cloudflare/ea/heimtor/-/pipelines/4166647) green, no unresolved resolvable discussions |
| Edgeauth | AUTH-9010 | `bhavya/AUTH-9010` at `18bece6d` | [MR !5371](https://gitlab.cfdata.org/cloudflare/ea/edgeauth/-/merge_requests/5371) | Ready, pipeline [4172674](https://gitlab.cfdata.org/cloudflare/ea/edgeauth/-/pipelines/4172674) green, no unresolved resolvable discussions |
| ztx-frontend | AUTH-9009 | `bhavya/AUTH-9009` at `38f32ae4` | [MR !11349](https://gitlab.cfdata.org/cloudflare/ztx/ztx-frontend/-/merge_requests/11349) | Ready, pipeline [4137154](https://gitlab.cfdata.org/cloudflare/ztx/ztx-frontend/-/pipelines/4137154) green, no unresolved resolvable discussions |
| Cloudflare Docs | AUTH-9008 | `bhavya559/AUTH-9008` at `626b3058` | This Draft PR | Content validated locally; refresh from current `production` before publication |

The three implementation MRs are non-draft and their exact-head required pipelines pass. Normal human, code-owner, and security-policy approvals remain.

### Heimtor architecture

The provider-encapsulation review is resolved in `89b3de2e`, following the established Azure/Okta pattern:

- `src/lib/providers/duo.ts` owns login URL generation, PKCE/shared callback behavior, state/version binding, callback response issuer validation, token exchange policy, JWKS policy, ID-token validation, identity/custom claims, and groups.
- Login, refresh, and test-IdP handlers call provider-neutral state hooks.
- Callback dispatch calls a provider-neutral context-validation hook before token exchange.
- Generic OIDC contains no Duo branches.
- Shared OAuth exposes only generic redirect and cache options.
- Duplicate and empty RFC 9207 `iss` parameters survive the shared callback router for Duo validation.

Key files: `src/lib/providers/duo.ts`, `src/lib/providers/oidc_claims.ts`, `src/lib/providers/shared_oauth.ts`, `src/lib/providers/index.ts`, and the login/callback/test-IdP/refresh handlers.

### Edgeauth discovery decisions

- The removed capacity-eight channel limited only simultaneous administrative discovery calls per process. It never limited users or authentication. Each discovery request remains bounded by a 10-second timeout.
- Resolver initialization now occurs once before `AdminServer` construction. Tests may inject a resolver; production receives the default.
- Go's standard HTTP transport handles transparent gzip. `io.LimitReader` enforces the 64 KiB limit on decoded content, with a transport-backed regression test.
- Discovery uses no proxy, follows no redirects, requires TLS 1.2+, caps response headers/body, and validates the exact Duo hostname, client-ID path, issuer, endpoints, grants, algorithms, scopes, token auth, and PKCE support.
- RFC-042 requires more than hostname allowlisting. Every DNS answer is validated as public and the transport dials the validated IP directly to prevent DNS rebinding.
- The unrelated SAML certificate endpoint guard and its Duo test were removed from this MR.

Key files: `connector/duo.go`, `connector/duo_discovery.go`, `admin/connection.go`, and the account/zone identity-provider schemas.

### Verification evidence

- Heimtor: 321 focused tests across ten files, `npm run type`, and `git diff --check` passed. Required pipeline `4166647` passed at `89b3de2e`.
- Edgeauth: discovery tests, transparent-gzip/decoded-size tests, schema client tests, `go vet ./connector ./admin`, `gofmt`, and diff checks passed. Required pipeline `4172674` passed at `18bece6d`.
- ztx-frontend: 21 focused tests, `yarn type`, formatting, scoped lint, Playwright/E2E, and pipeline `4137154` passed at `38f32ae4`.
- Docs: Prettier, `pnpm run check`, and the full 8,839-page build passed at `626b3058`.

### Known CI noise

- Heimtor's old Vitest 3 shards intermittently hit the upstream `.sqlite-shm`/`.sqlite-wal` isolated-storage race in unrelated suites. The new `js-next-test` lane passes. Retry only the affected old shard unless a Duo assertion fails.
- Edgeauth has intermittently failed before or outside Duo tests due Docker build-tag generation and integration setup timeouts. Retry the affected shard; do not patch Duo without a Duo failure.

### Frontend preview and screenshots

Review app for `38f32ae4`:

https://dash.cloudflare.com/api/preview/service?servicePreview=zt-dash%3A4bf89845&redirect=%2Fone

After choosing a test account, copy the account ID from the URL and navigate to:

- Duo tile: `/one/<ACCOUNT_ID>/integrations/identity-providers/add`
- Duo form: `/one/<ACCOUNT_ID>/integrations/identity-providers/add/duo`
- Policy builder: `/one/<ACCOUNT_ID>/access-controls/policies/add`

The tile and unsaved form work in the frontend-only preview. **Duo OIDC Claims** requires the account API to return a Duo IdP, so use backend-enabled staging or clearly disclose a local fixture. Never enter or capture real secrets or customer identifiers.

### Rollout order

1. Obtain product, human, code-owner, and security-policy approvals.
2. Deploy Heimtor !2581.
3. Deploy Edgeauth !5371.
4. Refresh this docs branch from current `production`, rerun docs checks/build, and publish the page.
5. Expose ztx-frontend !11349 only after the docs URL is live.
6. Smoke-test create, edit, login, test-IdP, email, custom claims, and `groups` matching with a non-production Duo app.

The safest immediate rollback is frontend first while leaving backend Duo support in place. Do not remove Heimtor support while persisted Duo configurations may exist.

### Remaining checklist

- [ ] Obtain required product/human/code-owner/security approvals.
- [ ] Add frontend screenshots to !11349 without secrets or customer identifiers.
- [ ] Refresh this Draft PR from current `production`; the Outdated PR check is currently failing because the branch is stale.
- [ ] Re-run `pnpm run check` and `pnpm run build` after the docs base refresh.
- [ ] Confirm all exact-head pipelines immediately before rollout.
- [ ] Follow the backend -> docs -> frontend order above.
- [ ] Do not merge or deploy solely from this handoff.

### Explicit non-goals

- Native Duo group discovery or group catalog browsing
- Customer-facing Duo SCIM provisioning
- Generic OIDC discovery
- A fabricated Duo logo before an approved brand asset exists
- Merge or production deployment authorization

Related: AUTH-9008, AUTH-9007, AUTH-9010, AUTH-9009.
