### PR TITLE
[Hyperdrive] Document creating PlanetScale databases with Wrangler

### DIFF
--- a/src/content/docs/hyperdrive/planetscale.mdx
+++ b/src/content/docs/hyperdrive/planetscale.mdx
@@ -23,6 +23,51 @@ Get the best of both products, build for Workers global distribution and optimiz
 
 <DashButton url="/?to=/:account/workers/hyperdrive?modal=1&type=planetscale&step=1" />
 
+## Create a database from the command line
+
+:::note
+
+The `wrangler hyperdrive planetscale signature` command is experimental, and its interface may change.
+
+:::
+
+You can also create a Cloudflare-billed PlanetScale database from the command line with the [PlanetScale CLI](https://planetscale.com/docs/reference/planetscale-cli) (`pscale`), using [Wrangler](/workers/wrangler/) to authorize the Cloudflare billing side of the request. This requires `pscale` v0.313.0 or newer.
+
+Generate the billing authorization:
+
+```sh
+npx wrangler hyperdrive planetscale signature
+```
+
+This prints a JSON payload:
+
+```json
+{
+	"account_id": "<ACCOUNT_ID>",
+	"timestamp": "<TIMESTAMP>",
+	"signature": "<SIGNATURE>"
+}
+```
+
+`pscale database create` accepts this payload through its `--cloudflare-billing` flag. Passing `@-` makes the PlanetScale CLI read it from standard input, which we recommend over passing the signature as a command line argument:
+
+```sh
+npx wrangler hyperdrive planetscale signature | \
+  pscale database create <DATABASE_NAME> \
+    --org <PLANETSCALE_ORG> \
+    --engine postgresql \
+    --cloudflare-billing @- \
+    --format json
+```
+
+`pscale database create` defaults to Vitess, so pass `--engine postgresql` for a Postgres database, and `--format json` is recommended when the output is consumed by an agent.
+
+Your PlanetScale credentials stay between you and `pscale`. Wrangler authorizes the Cloudflare billing side only.
+
+The signature is a cryptographically signed token that authorizes creating a database billed to your Cloudflare account. Treat it as a credential and do not share it.
+
+Refer to [PlanetScale's documentation](https://planetscale.com/docs/reference/database#create-a-database) for the options `pscale database create` supports.
+
 ## Workers + PlanetScale
 
 With Workers, build your application to deploy anywhere across Cloudflare’s global network spanning 330+ cities. You can deploy with a single step, and users in new locations can reach your application without deploying regional infrastructure.


### PR DESCRIPTION
### Summary

Adds relevant documentation for the new `wrangler` commands being added to support the PlanetScale partnership. https://github.com/cloudflare/workers-sdk/pull/15065

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
