### PR TITLE
Clarify MASQUE requirement across Cloudflare Mesh docs

### DIFF
--- a/src/content/docs/cloudflare-one/networks/connectors/cloudflare-mesh/client-devices.mdx
+++ b/src/content/docs/cloudflare-one/networks/connectors/cloudflare-mesh/client-devices.mdx
@@ -72,7 +72,7 @@ Depending on your Cloudflare networking configuration, you may need to remove ad
 In Include mode, add the following to your include list:
 
 - `100.96.0.0/12` — Mesh IPs (device IPs)
-- `172.64.128.0/20` and `2606:4700:0cf1:4000::/64` — Hostname routing (if used)
+- `172.64.128.0/20` and `2606:4700:0cf1:4000::/64` — [Hostname routing](/cloudflare-one/networks/connectors/cloudflare-mesh/routes/#hostname-routes) (if used; requires MASQUE)
 - Any CIDR routes you have [configured for your Mesh nodes](/cloudflare-one/networks/connectors/cloudflare-mesh/routes/)
 
 ## Firewall considerations

--- a/src/content/docs/cloudflare-one/networks/connectors/cloudflare-mesh/containers.mdx
+++ b/src/content/docs/cloudflare-one/networks/connectors/cloudflare-mesh/containers.mdx
@@ -16,7 +16,7 @@ head:
     content: Run Cloudflare Mesh in containers
 ---
 
-import { DashButton, Details, Tabs, TabItem } from "~/components";
+import { DashButton, Details, Tabs, TabItem, Render } from "~/components";
 
 The [`cloudflare/mesh`](https://hub.docker.com/r/cloudflare/mesh) Docker image packages a Cloudflare Mesh node for Linux containers. It runs the Cloudflare One Client's `warp-svc` daemon headlessly in a minimal [Wolfi](https://wolfi.dev/)-based runtime.
 
@@ -368,6 +368,8 @@ Set `SRCNAT_ENABLED=false` only if the attached networks already have return rou
 
 ## High availability on Kubernetes
 
+<Render file="mesh/masque-required" product="cloudflare-one" />
+
 For [high availability](/cloudflare-one/networks/connectors/cloudflare-mesh/high-availability/) with CIDR routes:
 
 1. Use the same Mesh node token across multiple replicas.
@@ -378,6 +380,8 @@ Cloudflare operates replicas in active-passive mode. If the active replica goes 
 ## Hostname routes
 
 Containers support [hostname routing](/cloudflare-one/networks/connectors/cloudflare-mesh/routes/#hostname-routes). To resolve Kubernetes Services through a hostname route, make sure the hostname matches the cluster's actual DNS suffix. The default is `cluster.local`, producing Service names like `service.namespace.svc.cluster.local`.
+
+<Render file="mesh/masque-required" product="cloudflare-one" />
 
 ## Site-to-site networking
 

--- a/src/content/docs/cloudflare-one/networks/connectors/cloudflare-mesh/get-started.mdx
+++ b/src/content/docs/cloudflare-one/networks/connectors/cloudflare-mesh/get-started.mdx
@@ -33,6 +33,8 @@ Set up Cloudflare Mesh so your devices and servers can reach each other by priva
 	Client-to-client connectivity works without any Mesh nodes. Two enrolled laptops can reach each other directly by Mesh IP. Mesh nodes are for running the client in headless mode on a server — either to make that server reachable by its Mesh IP, or to [route traffic to a private subnet](/cloudflare-one/networks/connectors/cloudflare-mesh/routes/) behind it. You still need to complete the setup wizard to configure your account — you can skip the Mesh node installation step and connect the node later.
 	:::
 
+	Cloudflare Mesh requires [MASQUE](/cloudflare-one/networks/connectors/cloudflare-mesh/#protocol-requirement), the default protocol for the Cloudflare One Client. Hostname routes, IPv6 CIDR routes, and high availability do not work if a node or device has been switched to WireGuard.
+
 ## 1. Run the setup wizard
 
 The setup wizard [configures your account for Mesh networking](#what-the-wizard-configures) and optionally guides you through creating a Mesh node. This is a one-time setup.

--- a/src/content/docs/cloudflare-one/networks/connectors/cloudflare-mesh/get-started.mdx
+++ b/src/content/docs/cloudflare-one/networks/connectors/cloudflare-mesh/get-started.mdx
@@ -33,7 +33,7 @@ Set up Cloudflare Mesh so your devices and servers can reach each other by priva
 	Client-to-client connectivity works without any Mesh nodes. Two enrolled laptops can reach each other directly by Mesh IP. Mesh nodes are for running the client in headless mode on a server — either to make that server reachable by its Mesh IP, or to [route traffic to a private subnet](/cloudflare-one/networks/connectors/cloudflare-mesh/routes/) behind it. You still need to complete the setup wizard to configure your account — you can skip the Mesh node installation step and connect the node later.
 	:::
 
-	Cloudflare Mesh requires [MASQUE](/cloudflare-one/networks/connectors/cloudflare-mesh/#protocol-requirement), the default protocol for the Cloudflare One Client. Hostname routes, IPv6 CIDR routes, and high availability do not work if a node or device has been switched to WireGuard.
+Cloudflare Mesh requires [MASQUE](/cloudflare-one/networks/connectors/cloudflare-mesh/#protocol-requirement), the default protocol for the Cloudflare One Client. Hostname routes, IPv6 CIDR routes, and high availability do not work if a Mesh node uses WireGuard.
 
 ## 1. Run the setup wizard
 

--- a/src/content/docs/cloudflare-one/networks/connectors/cloudflare-mesh/get-started.mdx
+++ b/src/content/docs/cloudflare-one/networks/connectors/cloudflare-mesh/get-started.mdx
@@ -33,7 +33,7 @@ Set up Cloudflare Mesh so your devices and servers can reach each other by priva
 	Client-to-client connectivity works without any Mesh nodes. Two enrolled laptops can reach each other directly by Mesh IP. Mesh nodes are for running the client in headless mode on a server — either to make that server reachable by its Mesh IP, or to [route traffic to a private subnet](/cloudflare-one/networks/connectors/cloudflare-mesh/routes/) behind it. You still need to complete the setup wizard to configure your account — you can skip the Mesh node installation step and connect the node later.
 	:::
 
-Cloudflare Mesh requires [MASQUE](/cloudflare-one/networks/connectors/cloudflare-mesh/#protocol-requirement), the default protocol for the Cloudflare One Client. Hostname routes, IPv6 CIDR routes, and high availability do not work if a Mesh node uses WireGuard.
+Cloudflare Mesh requires that the Mesh node's [device profile](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/device-profiles/) is configured to use [MASQUE](/cloudflare-one/networks/connectors/cloudflare-mesh/#protocol-requirement). Hostname routes, IPv6 CIDR routes, and high availability do not work if the device profile uses WireGuard instead.
 
 ## 1. Run the setup wizard
 

--- a/src/content/docs/cloudflare-one/networks/connectors/cloudflare-mesh/high-availability.mdx
+++ b/src/content/docs/cloudflare-one/networks/connectors/cloudflare-mesh/high-availability.mdx
@@ -219,7 +219,7 @@ Get the `client_id` from the [connections endpoint](#view-replicas). Use the `id
 
 - High availability is set at node creation time and cannot be changed afterward.
 - You must install the client on at least two hosts for failover to work. A single replica means no redundancy.
-- High availability requires the MASQUE transport protocol. WireGuard does not support HA. Mesh nodes use MASQUE by default.
+- High availability requires that the Mesh node's [device profile](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/device-profiles/) is configured to use [MASQUE](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/settings/#device-tunnel-protocol), the default protocol for the Cloudflare One Client. It does not work if the device profile uses WireGuard instead.
 
 ### Network configuration
 

--- a/src/content/docs/cloudflare-one/networks/connectors/cloudflare-mesh/high-availability.mdx
+++ b/src/content/docs/cloudflare-one/networks/connectors/cloudflare-mesh/high-availability.mdx
@@ -219,7 +219,7 @@ Get the `client_id` from the [connections endpoint](#view-replicas). Use the `id
 
 - High availability is set at node creation time and cannot be changed afterward.
 - You must install the client on at least two hosts for failover to work. A single replica means no redundancy.
-- High availability requires [MASQUE](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/settings/#device-tunnel-protocol), the default protocol for the Cloudflare One Client. It does not work if the node has been switched to WireGuard.
+- High availability requires MASQUE. See the note above.
 
 ### Network configuration
 

--- a/src/content/docs/cloudflare-one/networks/connectors/cloudflare-mesh/high-availability.mdx
+++ b/src/content/docs/cloudflare-one/networks/connectors/cloudflare-mesh/high-availability.mdx
@@ -17,6 +17,8 @@ import { DashButton, Tabs, TabItem, Render, Details } from "~/components";
 
 For production deployments, you can run multiple replicas of a Mesh node in active-passive mode. All replicas share the same node identity and advertise the same [routes](/cloudflare-one/networks/connectors/cloudflare-mesh/routes/). If the active replica goes down, Cloudflare automatically promotes a standby replica.
 
+<Render file="mesh/masque-required" product="cloudflare-one" />
+
 ## When to use high availability
 
 High availability provides resilience for CIDR route prefixes advertised by a Mesh node. When the active replica disconnects, Cloudflare promotes a standby so that traffic to the advertised subnets continues to flow.
@@ -217,7 +219,7 @@ Get the `client_id` from the [connections endpoint](#view-replicas). Use the `id
 
 - High availability is set at node creation time and cannot be changed afterward.
 - You must install the client on at least two hosts for failover to work. A single replica means no redundancy.
-- High availability requires the MASQUE transport protocol. WireGuard does not support HA. Mesh nodes use MASQUE by default.
+- High availability requires [MASQUE](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/settings/#device-tunnel-protocol), the default protocol for the Cloudflare One Client. It does not work if the node has been switched to WireGuard.
 
 ### Network configuration
 

--- a/src/content/docs/cloudflare-one/networks/connectors/cloudflare-mesh/high-availability.mdx
+++ b/src/content/docs/cloudflare-one/networks/connectors/cloudflare-mesh/high-availability.mdx
@@ -219,7 +219,7 @@ Get the `client_id` from the [connections endpoint](#view-replicas). Use the `id
 
 - High availability is set at node creation time and cannot be changed afterward.
 - You must install the client on at least two hosts for failover to work. A single replica means no redundancy.
-- High availability requires MASQUE. See the note above.
+- High availability requires the MASQUE transport protocol. WireGuard does not support HA. Mesh nodes use MASQUE by default.
 
 ### Network configuration
 

--- a/src/content/docs/cloudflare-one/networks/connectors/cloudflare-mesh/index.mdx
+++ b/src/content/docs/cloudflare-one/networks/connectors/cloudflare-mesh/index.mdx
@@ -62,6 +62,16 @@ flowchart LR
 
 All traffic passes through Cloudflare, so [Gateway network policies](/cloudflare-one/traffic-policies/network-policies/), [device posture checks](/cloudflare-one/reusable-components/posture-checks/), and access rules apply to every connection.
 
+## Protocol requirement
+
+Cloudflare Mesh requires MASQUE, the default protocol for the [Cloudflare One Client](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/settings/#device-tunnel-protocol). Most deployments do not need to change anything.
+
+If a Mesh node or client device has been switched to WireGuard, the following capabilities will not work:
+
+- [Hostname routes](/cloudflare-one/networks/connectors/cloudflare-mesh/routes/#hostname-routes)
+- [IPv6 CIDR routes](/cloudflare-one/networks/connectors/cloudflare-mesh/routes/#manage-cidr-routes)
+- [High availability](/cloudflare-one/networks/connectors/cloudflare-mesh/high-availability/)
+
 ## Mesh IPs
 
 Every participant is assigned a private IP from the `100.96.0.0/12` range. In other parts of the Cloudflare One documentation, these addresses are referred to as [device IPs](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/device-ips/).

--- a/src/content/docs/cloudflare-one/networks/connectors/cloudflare-mesh/index.mdx
+++ b/src/content/docs/cloudflare-one/networks/connectors/cloudflare-mesh/index.mdx
@@ -64,9 +64,9 @@ All traffic passes through Cloudflare, so [Gateway network policies](/cloudflare
 
 ## Protocol requirement
 
-Cloudflare Mesh requires MASQUE, the default protocol for the [Cloudflare One Client](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/settings/#device-tunnel-protocol). Most deployments do not need to change anything.
+Cloudflare Mesh requires that the [device profile](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/device-profiles/) of each Mesh node is configured to use [MASQUE](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/settings/#device-tunnel-protocol), the default protocol for the Cloudflare One Client. Most deployments do not need to change anything.
 
-If a Mesh node uses WireGuard, the following capabilities will not work:
+If a Mesh node's device profile uses WireGuard instead, the following capabilities will not work:
 
 - [Hostname routes](/cloudflare-one/networks/connectors/cloudflare-mesh/routes/#hostname-routes)
 - [IPv6 CIDR routes](/cloudflare-one/networks/connectors/cloudflare-mesh/routes/#manage-cidr-routes)

--- a/src/content/docs/cloudflare-one/networks/connectors/cloudflare-mesh/index.mdx
+++ b/src/content/docs/cloudflare-one/networks/connectors/cloudflare-mesh/index.mdx
@@ -66,7 +66,7 @@ All traffic passes through Cloudflare, so [Gateway network policies](/cloudflare
 
 Cloudflare Mesh requires MASQUE, the default protocol for the [Cloudflare One Client](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/settings/#device-tunnel-protocol). Most deployments do not need to change anything.
 
-If a Mesh node or client device has been switched to WireGuard, the following capabilities will not work:
+If a Mesh node uses WireGuard, the following capabilities will not work:
 
 - [Hostname routes](/cloudflare-one/networks/connectors/cloudflare-mesh/routes/#hostname-routes)
 - [IPv6 CIDR routes](/cloudflare-one/networks/connectors/cloudflare-mesh/routes/#manage-cidr-routes)

--- a/src/content/docs/cloudflare-one/networks/connectors/cloudflare-mesh/routes.mdx
+++ b/src/content/docs/cloudflare-one/networks/connectors/cloudflare-mesh/routes.mdx
@@ -22,7 +22,7 @@ By default, a Mesh node is reachable only by its own [Mesh IP](/cloudflare-one/n
 
 When you add a route, the Mesh node acts as a gateway: traffic destined for the advertised CIDR or hostname is forwarded to the node, which delivers it to the appropriate host on the local network (or egresses it to the public Internet).
 
-Both IPv4 and IPv6 CIDR routes are supported. IPv6 routes require [MASQUE](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/settings/#device-tunnel-protocol) and will not work if the node uses WireGuard.
+Both IPv4 and IPv6 CIDR routes are supported. IPv6 routes require that the Mesh node's [device profile](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/device-profiles/) is configured to use [MASQUE](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/settings/#device-tunnel-protocol); they will not work if the device profile uses WireGuard instead.
 
 ## When to use routes
 
@@ -223,7 +223,7 @@ For a deeper look at the packet flow behind hostname routing, refer to the [anno
 ### Prerequisites
 
 - **Run a supported Mesh node version.** Hostname routing requires the Mesh node to run Linux Cloudflare One Client version `2026.6.822.0` or newer.
-- **Use [MASQUE](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/settings/#device-tunnel-protocol)**, the default protocol for the Cloudflare One Client. Hostname routing does not work if the node uses WireGuard.
+- **Configure the Mesh node's [device profile](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/device-profiles/) to use [MASQUE](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/settings/#device-tunnel-protocol).** Hostname routing does not work if the device profile uses WireGuard instead.
 - **Enable the Gateway proxy** with TCP, UDP, and ICMP:
 
   <Render file="tunnel/enable-gateway-proxy" product="cloudflare-one" />

--- a/src/content/docs/cloudflare-one/networks/connectors/cloudflare-mesh/routes.mdx
+++ b/src/content/docs/cloudflare-one/networks/connectors/cloudflare-mesh/routes.mdx
@@ -22,7 +22,7 @@ By default, a Mesh node is reachable only by its own [Mesh IP](/cloudflare-one/n
 
 When you add a route, the Mesh node acts as a gateway: traffic destined for the advertised CIDR or hostname is forwarded to the node, which delivers it to the appropriate host on the local network (or egresses it to the public Internet).
 
-Both IPv4 and IPv6 CIDR routes are supported. IPv6 routes require [MASQUE](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/settings/#device-tunnel-protocol) and will not work if the node has been switched to WireGuard.
+Both IPv4 and IPv6 CIDR routes are supported. IPv6 routes require [MASQUE](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/settings/#device-tunnel-protocol) and will not work if the node uses WireGuard.
 
 ## When to use routes
 
@@ -223,7 +223,7 @@ For a deeper look at the packet flow behind hostname routing, refer to the [anno
 ### Prerequisites
 
 - **Run a supported Mesh node version.** Hostname routing requires the Mesh node to run Linux Cloudflare One Client version `2026.6.822.0` or newer.
-- **Use [MASQUE](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/settings/#device-tunnel-protocol)**, the default protocol for the Cloudflare One Client. Hostname routing does not work if the node has been switched to WireGuard.
+- **Use [MASQUE](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/settings/#device-tunnel-protocol)**, the default protocol for the Cloudflare One Client. Hostname routing does not work if the node uses WireGuard.
 - **Enable the Gateway proxy** with TCP, UDP, and ICMP:
 
   <Render file="tunnel/enable-gateway-proxy" product="cloudflare-one" />

--- a/src/content/docs/cloudflare-one/networks/connectors/cloudflare-mesh/routes.mdx
+++ b/src/content/docs/cloudflare-one/networks/connectors/cloudflare-mesh/routes.mdx
@@ -22,7 +22,7 @@ By default, a Mesh node is reachable only by its own [Mesh IP](/cloudflare-one/n
 
 When you add a route, the Mesh node acts as a gateway: traffic destined for the advertised CIDR or hostname is forwarded to the node, which delivers it to the appropriate host on the local network (or egresses it to the public Internet).
 
-Both IPv4 and IPv6 CIDR routes are supported.
+Both IPv4 and IPv6 CIDR routes are supported. IPv6 routes require [MASQUE](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/settings/#device-tunnel-protocol) and will not work if the node has been switched to WireGuard.
 
 ## When to use routes
 
@@ -223,6 +223,7 @@ For a deeper look at the packet flow behind hostname routing, refer to the [anno
 ### Prerequisites
 
 - **Run a supported Mesh node version.** Hostname routing requires the Mesh node to run Linux Cloudflare One Client version `2026.6.822.0` or newer.
+- **Use [MASQUE](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/settings/#device-tunnel-protocol)**, the default protocol for the Cloudflare One Client. Hostname routing does not work if the node has been switched to WireGuard.
 - **Enable the Gateway proxy** with TCP, UDP, and ICMP:
 
   <Render file="tunnel/enable-gateway-proxy" product="cloudflare-one" />

--- a/src/content/partials/cloudflare-one/mesh/masque-required.mdx
+++ b/src/content/partials/cloudflare-one/mesh/masque-required.mdx
@@ -3,5 +3,5 @@
 ---
 
 :::note[MASQUE required]
-This feature requires [MASQUE](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/settings/#device-tunnel-protocol), the default protocol for the Cloudflare One Client. It does not work if the Mesh node uses WireGuard.
+This feature requires that the [device profile](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/device-profiles/) of the Mesh node is configured to use [MASQUE](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/settings/#device-tunnel-protocol), the default protocol for the Cloudflare One Client. It does not work if the device profile uses WireGuard instead.
 :::

--- a/src/content/partials/cloudflare-one/mesh/masque-required.mdx
+++ b/src/content/partials/cloudflare-one/mesh/masque-required.mdx
@@ -1,0 +1,7 @@
+---
+{}
+---
+
+:::note[MASQUE required]
+This feature requires [MASQUE](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/settings/#device-tunnel-protocol), the default protocol for the Cloudflare One Client. It does not work if the node or device has been switched to WireGuard.
+:::

--- a/src/content/partials/cloudflare-one/mesh/masque-required.mdx
+++ b/src/content/partials/cloudflare-one/mesh/masque-required.mdx
@@ -3,5 +3,5 @@
 ---
 
 :::note[MASQUE required]
-This feature requires [MASQUE](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/settings/#device-tunnel-protocol), the default protocol for the Cloudflare One Client. It does not work if the node or device has been switched to WireGuard.
+This feature requires [MASQUE](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/settings/#device-tunnel-protocol), the default protocol for the Cloudflare One Client. It does not work if the Mesh node uses WireGuard.
 :::


### PR DESCRIPTION
## Summary

Hostname routes, IPv6 CIDR routes, and high availability all require the MASQUE protocol and do not work if a Mesh node or client device has been switched to WireGuard. Previously this was only documented as a single buried bullet in the high-availability page's Considerations section — this PR surfaces it clearly across the Mesh docs.

## Changes

- New **Protocol requirement** section on the [Cloudflare Mesh overview page](https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-mesh/), stating the requirement plainly with links to each affected capability.
- New shared partial (`partials/cloudflare-one/mesh/masque-required.mdx`), reused as a `:::note` callout in:
  - Hostname routes (`routes.mdx`)
  - High availability (`high-availability.mdx`)
  - Containers: Kubernetes HA and hostname routing sections (`containers.mdx`)
- Explicit MASQUE call-outs added to:
  - The Hostname routes prerequisites list (`routes.mdx`)
  - The IPv6 CIDR routes description (`routes.mdx`)
  - `get-started.mdx` (Prerequisites) and `client-devices.mdx` (Split Tunnel Include mode list)

## Notes

- Deliberately avoids calling this a "tunnel protocol" anywhere in Mesh docs, since that clashes with the separate Cloudflare Tunnel product name. Cross-references to the actual client setting (which is named "Device tunnel protocol") use MASQUE as the link text instead.
- Deliberately does not frame WireGuard as a supported alternative for Cloudflare Mesh — it's only ever mentioned as a limitation (i.e., what breaks if a device has been switched to it), not as a documented configuration path.

🤖 Generated with [opencode](https://opencode.ai)