### PR TITLE
Ewc eventhub notifs

### DIFF
--- a/src/content/changelog/queues/2026-08-13-workers-event-subscriptions.mdx
+++ b/src/content/changelog/queues/2026-08-13-workers-event-subscriptions.mdx
@@ -1,0 +1,22 @@
+---
+title: Subscribe to Workers events with Queues
+description: Workers is now an event source for Queues event subscriptions, publishing events when Workers, versions, and deployments are created, updated, or deleted.
+products:
+  - queues
+  - workers
+date: 2026-08-14
+---
+
+You can now subscribe to **Workers events** with [Queues event subscriptions](/queues/event-subscriptions/), joining existing sources like R2, Workers KV, and Workers AI.
+
+Cloudflare publishes a message to your queue whenever a Worker, version, or deployment changes, so you can build audit logging, deploy notifications, and automated post-deploy checks without polling the API.
+
+| Event                | Triggered when                               |
+| -------------------- | -------------------------------------------- |
+| `worker.created`     | A Worker is created                          |
+| `worker.updated`     | A Worker's unversioned configuration changes |
+| `worker.deleted`     | A Worker is deleted                          |
+| `version.created`    | A new version of the Worker is created       |
+| `version.deleted`    | A version is deleted                         |
+| `deployment.created` | A deployment is created and rolled out       |
+| `deployment.deleted` | A deployment is deleted                      |

--- a/src/content/docs/queues/event-subscriptions/events-schemas.mdx
+++ b/src/content/docs/queues/event-subscriptions/events-schemas.mdx
@@ -41,6 +41,10 @@ This page provides a comprehensive reference of available event sources and thei
 
 <Render file="event-subscriptions/vectorize-events" product="queues" />
 
+### Workers
+
+<Render file="event-subscriptions/workers-events" product="queues" />
+
 ### Workers AI
 
 <Render file="event-subscriptions/workers-ai-events" product="queues" />

--- a/src/content/partials/queues/event-subscriptions/workers-events.mdx
+++ b/src/content/partials/queues/event-subscriptions/workers-events.mdx
@@ -153,7 +153,17 @@ Triggered when a Worker's unversioned configuration changes.
   },
   "payload": {
     "name": "my-worker",
-    "changed": ["logpush", "tags"]
+    "changed": {
+      "tags": {
+        "added": ["prod"],
+        "removed": ["staging"]
+      },
+      "logpush": {
+        "from": false,
+        "to": true
+      },
+      "preview_defaults": {}
+    }
   },
   "metadata": {
     "accountId": "f9f79265f388666de8122cfb508d7776",
@@ -164,7 +174,13 @@ Triggered when a Worker's unversioned configuration changes.
 }
 ```
 
-The `changed` array lists which unversioned configuration fields changed. The possible values are `name`, `tags`, `subdomain`, `observability`, `logpush`, `tail_consumers`, `preview_defaults`, and `usage_model`. These values are snake_case because they are the literal Workers API field names, unlike the camelCase keys used elsewhere in the event. Values are sorted and de-duplicated. The event does not include the previous or new value of a changed field.
+The `changed` object is keyed by the unversioned configuration fields that changed, and only fields that changed are present. The possible keys are `name`, `tags`, `subdomain`, `observability`, `logpush`, `tail_consumers`, `preview_defaults`, and `usage_model`. These keys are snake_case because they are the literal Workers API field names, unlike the camelCase keys used elsewhere in the event.
+
+Each value describes how that field changed:
+
+- Scalar fields report `from` and `to`.
+- Set-valued fields, such as `tags` and `tail_consumers`, report `added` and `removed`. Either key is omitted when it would be empty. If the members stay the same but their order changes, the field reports `from` and `to` instead.
+- The `preview_defaults` field reports an empty object, which means the field changed but its values are not published.
 
 #### `worker.deleted`
 

--- a/src/content/partials/queues/event-subscriptions/workers-events.mdx
+++ b/src/content/partials/queues/event-subscriptions/workers-events.mdx
@@ -1,124 +1,3 @@
-#### `deployment.created`
-
-Triggered when a deployment is created and rolled out.
-
-**Example:**
-
-```json
-{
-  "type": "cf.workers.script.deployment.created",
-  "source": {
-    "type": "workers.script",
-    "id": "9a7c3f21b45e4d8a9c0f1e2d3b4a5c6d"
-  },
-  "payload": {
-    "workerName": "my-worker",
-    "id": "bcf48806-b317-4351-9ee7-36e7d557d4de",
-    "strategy": "percentage",
-    "versions": [
-      {
-        "versionId": "3f9e2c1a-7b4d-4e8f-9a01-2b3c4d5e6f70",
-        "percentage": 100
-      }
-    ],
-    "annotations": {
-      "workers/message": "Fix redirect handling",
-      "workers/triggered_by": "deployment"
-    },
-    "authorEmail": "developer@example.com",
-    "createdOn": "2025-05-01T02:48:57Z"
-  },
-  "metadata": {
-    "accountId": "f9f79265f388666de8122cfb508d7776",
-    "eventSubscriptionId": "1830c4bb612e43c3af7f4cada31fbf3f",
-    "eventSchemaVersion": 1,
-    "eventTimestamp": "2025-05-01T02:48:57.132Z"
-  }
-}
-```
-
-The `versions` array describes the default traffic split, and the `percentage` values always sum to 100.
-
-The `annotations` and `authorEmail` fields are omitted when they are empty.
-
-#### `deployment.deleted`
-
-Triggered when a deployment is deleted.
-
-**Example:**
-
-```json
-{
-  "type": "cf.workers.script.deployment.deleted",
-  "source": {
-    "type": "workers.script",
-    "id": "9a7c3f21b45e4d8a9c0f1e2d3b4a5c6d"
-  },
-  "payload": {
-    "name": "my-worker",
-    "id": "bcf48806-b317-4351-9ee7-36e7d557d4de"
-  },
-  "metadata": {
-    "accountId": "f9f79265f388666de8122cfb508d7776",
-    "eventSubscriptionId": "1830c4bb612e43c3af7f4cada31fbf3f",
-    "eventSchemaVersion": 1,
-    "eventTimestamp": "2025-05-01T02:48:57.132Z"
-  }
-}
-```
-
-#### `version.created`
-
-Triggered when a new version of the Worker is created.
-
-**Example:**
-
-```json
-{
-  "type": "cf.workers.script.version.created",
-  "source": {
-    "type": "workers.script",
-    "id": "9a7c3f21b45e4d8a9c0f1e2d3b4a5c6d"
-  },
-  "payload": {
-    "name": "my-worker",
-    "id": "3f9e2c1a-7b4d-4e8f-9a01-2b3c4d5e6f70"
-  },
-  "metadata": {
-    "accountId": "f9f79265f388666de8122cfb508d7776",
-    "eventSubscriptionId": "1830c4bb612e43c3af7f4cada31fbf3f",
-    "eventSchemaVersion": 1,
-    "eventTimestamp": "2025-05-01T02:48:57.132Z"
-  }
-}
-```
-
-#### `version.deleted`
-
-Triggered when a version is deleted.
-
-**Example:**
-
-```json
-{
-  "type": "cf.workers.script.version.deleted",
-  "source": {
-    "type": "workers.script",
-    "id": "9a7c3f21b45e4d8a9c0f1e2d3b4a5c6d"
-  },
-  "payload": {
-    "name": "my-worker",
-    "id": "3f9e2c1a-7b4d-4e8f-9a01-2b3c4d5e6f70"
-  },
-  "metadata": {
-    "accountId": "f9f79265f388666de8122cfb508d7776",
-    "eventSubscriptionId": "1830c4bb612e43c3af7f4cada31fbf3f",
-    "eventSchemaVersion": 1,
-    "eventTimestamp": "2025-05-01T02:48:57.132Z"
-  }
-}
-```
-
 #### `worker.created`
 
 Triggered when a Worker is created.
@@ -204,6 +83,127 @@ Triggered when a Worker is deleted.
   },
   "payload": {
     "name": "my-worker"
+  },
+  "metadata": {
+    "accountId": "f9f79265f388666de8122cfb508d7776",
+    "eventSubscriptionId": "1830c4bb612e43c3af7f4cada31fbf3f",
+    "eventSchemaVersion": 1,
+    "eventTimestamp": "2025-05-01T02:48:57.132Z"
+  }
+}
+```
+
+#### `version.created`
+
+Triggered when a new version of the Worker is created.
+
+**Example:**
+
+```json
+{
+  "type": "cf.workers.script.version.created",
+  "source": {
+    "type": "workers.script",
+    "id": "9a7c3f21b45e4d8a9c0f1e2d3b4a5c6d"
+  },
+  "payload": {
+    "name": "my-worker",
+    "id": "3f9e2c1a-7b4d-4e8f-9a01-2b3c4d5e6f70"
+  },
+  "metadata": {
+    "accountId": "f9f79265f388666de8122cfb508d7776",
+    "eventSubscriptionId": "1830c4bb612e43c3af7f4cada31fbf3f",
+    "eventSchemaVersion": 1,
+    "eventTimestamp": "2025-05-01T02:48:57.132Z"
+  }
+}
+```
+
+#### `version.deleted`
+
+Triggered when a version is deleted.
+
+**Example:**
+
+```json
+{
+  "type": "cf.workers.script.version.deleted",
+  "source": {
+    "type": "workers.script",
+    "id": "9a7c3f21b45e4d8a9c0f1e2d3b4a5c6d"
+  },
+  "payload": {
+    "name": "my-worker",
+    "id": "3f9e2c1a-7b4d-4e8f-9a01-2b3c4d5e6f70"
+  },
+  "metadata": {
+    "accountId": "f9f79265f388666de8122cfb508d7776",
+    "eventSubscriptionId": "1830c4bb612e43c3af7f4cada31fbf3f",
+    "eventSchemaVersion": 1,
+    "eventTimestamp": "2025-05-01T02:48:57.132Z"
+  }
+}
+```
+
+#### `deployment.created`
+
+Triggered when a deployment is created and rolled out.
+
+**Example:**
+
+```json
+{
+  "type": "cf.workers.script.deployment.created",
+  "source": {
+    "type": "workers.script",
+    "id": "9a7c3f21b45e4d8a9c0f1e2d3b4a5c6d"
+  },
+  "payload": {
+    "workerName": "my-worker",
+    "id": "bcf48806-b317-4351-9ee7-36e7d557d4de",
+    "strategy": "percentage",
+    "versions": [
+      {
+        "versionId": "3f9e2c1a-7b4d-4e8f-9a01-2b3c4d5e6f70",
+        "percentage": 100
+      }
+    ],
+    "annotations": {
+      "workers/message": "Fix redirect handling",
+      "workers/triggered_by": "deployment"
+    },
+    "authorEmail": "developer@example.com",
+    "createdOn": "2025-05-01T02:48:57Z"
+  },
+  "metadata": {
+    "accountId": "f9f79265f388666de8122cfb508d7776",
+    "eventSubscriptionId": "1830c4bb612e43c3af7f4cada31fbf3f",
+    "eventSchemaVersion": 1,
+    "eventTimestamp": "2025-05-01T02:48:57.132Z"
+  }
+}
+```
+
+The `versions` array describes the default traffic split, and the `percentage` values always sum to 100.
+
+The `annotations` and `authorEmail` fields are omitted when they are empty.
+
+#### `deployment.deleted`
+
+Triggered when a deployment is deleted.
+
+**Example:**
+
+```json
+{
+  "type": "cf.workers.script.deployment.deleted",
+  "source": {
+    "type": "workers.script",
+    "id": "9a7c3f21b45e4d8a9c0f1e2d3b4a5c6d"
+  },
+  "payload": {
+    "name": "my-worker",
+    "id": "bcf48806-b317-4351-9ee7-36e7d557d4de"
   },
   "metadata": {
     "accountId": "f9f79265f388666de8122cfb508d7776",

--- a/src/content/partials/queues/event-subscriptions/workers-events.mdx
+++ b/src/content/partials/queues/event-subscriptions/workers-events.mdx
@@ -39,8 +39,6 @@ Triggered when a deployment is created and rolled out.
 
 The `versions` array describes the default traffic split, and the `percentage` values always sum to 100.
 
-The `annotations` object uses two keys. `workers/message` is the optional deployment message, and `workers/triggered_by` records what caused the deployment. Deployments made through the deployments API always report `"workers/triggered_by": "deployment"`. Deployments recorded by older Workers APIs report the operation that created them, such as `upload`, `rollback`, or `secret`.
-
 The `annotations` and `authorEmail` fields are omitted when they are empty.
 
 #### `deployment.deleted`

--- a/src/content/partials/queues/event-subscriptions/workers-events.mdx
+++ b/src/content/partials/queues/event-subscriptions/workers-events.mdx
@@ -1,4 +1,4 @@
-The `name` field in each payload is the Worker name at the time the event fired, and that name can change. The stable identifier for a Worker is the script tag in `source.id`. When a Worker is renamed, the `worker.updated` event reports the new name, and the previous name is not included in the event.
+The `name` field in each payload is the Worker name at the time the event fired, and that name can change. The stable identifier for a Worker is the script tag in `source.id`. When a Worker is renamed, the `worker.updated` event reports the new name in `payload.name`, and reports both the previous and new names in `payload.changed.name`.
 
 #### `deployment.created`
 
@@ -39,6 +39,8 @@ Triggered when a deployment is created and rolled out.
 ```
 
 The `versions` array describes the default traffic split, and the `percentage` values always sum to 100. Deployments that use cohorts can route traffic to versions that do not appear in `versions`.
+
+The `annotations` and `authorEmail` fields are omitted when they are empty.
 
 #### `deployment.deleted`
 

--- a/src/content/partials/queues/event-subscriptions/workers-events.mdx
+++ b/src/content/partials/queues/event-subscriptions/workers-events.mdx
@@ -1,0 +1,192 @@
+The `name` field in each payload is the Worker name at the time the event fired, and that name can change. The stable identifier for a Worker is the script tag in `source.id`. When a Worker is renamed, the `worker.updated` event reports the new name, and the previous name is not included in the event.
+
+#### `deployment.created`
+
+Triggered when a deployment is created and rolled out.
+
+**Example:**
+
+```json
+{
+  "type": "cf.workers.script.deployment.created",
+  "source": {
+    "type": "workers.script",
+    "id": "9a7c3f21b45e4d8a9c0f1e2d3b4a5c6d"
+  },
+  "payload": {
+    "name": "my-worker",
+    "id": "bcf48806-b317-4351-9ee7-36e7d557d4de",
+    "strategy": "percentage",
+    "versions": [
+      {
+        "versionId": "3f9e2c1a-7b4d-4e8f-9a01-2b3c4d5e6f70",
+        "percentage": 100
+      }
+    ]
+  },
+  "metadata": {
+    "accountId": "f9f79265f388666de8122cfb508d7776",
+    "eventSubscriptionId": "1830c4bb612e43c3af7f4cada31fbf3f",
+    "eventSchemaVersion": 1,
+    "eventTimestamp": "2025-05-01T02:48:57.132Z"
+  }
+}
+```
+
+The `versions` array describes the default traffic split, and the `percentage` values always sum to 100. The `strategy` field is currently always `percentage`. Deployments that use cohorts can route traffic to versions that do not appear in `versions`.
+
+#### `deployment.deleted`
+
+Triggered when a deployment is deleted.
+
+**Example:**
+
+```json
+{
+  "type": "cf.workers.script.deployment.deleted",
+  "source": {
+    "type": "workers.script",
+    "id": "9a7c3f21b45e4d8a9c0f1e2d3b4a5c6d"
+  },
+  "payload": {
+    "name": "my-worker",
+    "id": "bcf48806-b317-4351-9ee7-36e7d557d4de"
+  },
+  "metadata": {
+    "accountId": "f9f79265f388666de8122cfb508d7776",
+    "eventSubscriptionId": "1830c4bb612e43c3af7f4cada31fbf3f",
+    "eventSchemaVersion": 1,
+    "eventTimestamp": "2025-05-01T02:48:57.132Z"
+  }
+}
+```
+
+#### `version.created`
+
+Triggered when a new version of the Worker is uploaded.
+
+**Example:**
+
+```json
+{
+  "type": "cf.workers.script.version.created",
+  "source": {
+    "type": "workers.script",
+    "id": "9a7c3f21b45e4d8a9c0f1e2d3b4a5c6d"
+  },
+  "payload": {
+    "name": "my-worker",
+    "id": "3f9e2c1a-7b4d-4e8f-9a01-2b3c4d5e6f70"
+  },
+  "metadata": {
+    "accountId": "f9f79265f388666de8122cfb508d7776",
+    "eventSubscriptionId": "1830c4bb612e43c3af7f4cada31fbf3f",
+    "eventSchemaVersion": 1,
+    "eventTimestamp": "2025-05-01T02:48:57.132Z"
+  }
+}
+```
+
+#### `version.deleted`
+
+Triggered when a version is deleted.
+
+**Example:**
+
+```json
+{
+  "type": "cf.workers.script.version.deleted",
+  "source": {
+    "type": "workers.script",
+    "id": "9a7c3f21b45e4d8a9c0f1e2d3b4a5c6d"
+  },
+  "payload": {
+    "name": "my-worker",
+    "id": "3f9e2c1a-7b4d-4e8f-9a01-2b3c4d5e6f70"
+  },
+  "metadata": {
+    "accountId": "f9f79265f388666de8122cfb508d7776",
+    "eventSubscriptionId": "1830c4bb612e43c3af7f4cada31fbf3f",
+    "eventSchemaVersion": 1,
+    "eventTimestamp": "2025-05-01T02:48:57.132Z"
+  }
+}
+```
+
+#### `worker.created`
+
+Triggered when a Worker is created.
+
+**Example:**
+
+```json
+{
+  "type": "cf.workers.script.worker.created",
+  "source": {
+    "type": "workers.script",
+    "id": "9a7c3f21b45e4d8a9c0f1e2d3b4a5c6d"
+  },
+  "payload": {
+    "name": "my-worker"
+  },
+  "metadata": {
+    "accountId": "f9f79265f388666de8122cfb508d7776",
+    "eventSubscriptionId": "1830c4bb612e43c3af7f4cada31fbf3f",
+    "eventSchemaVersion": 1,
+    "eventTimestamp": "2025-05-01T02:48:57.132Z"
+  }
+}
+```
+
+#### `worker.updated`
+
+Triggered when a Worker's unversioned configuration changes.
+
+**Example:**
+
+```json
+{
+  "type": "cf.workers.script.worker.updated",
+  "source": {
+    "type": "workers.script",
+    "id": "9a7c3f21b45e4d8a9c0f1e2d3b4a5c6d"
+  },
+  "payload": {
+    "name": "my-worker",
+    "changed": ["logpush", "tags"]
+  },
+  "metadata": {
+    "accountId": "f9f79265f388666de8122cfb508d7776",
+    "eventSubscriptionId": "1830c4bb612e43c3af7f4cada31fbf3f",
+    "eventSchemaVersion": 1,
+    "eventTimestamp": "2025-05-01T02:48:57.132Z"
+  }
+}
+```
+
+The `changed` array lists which unversioned configuration fields changed. The possible values are `name`, `tags`, `subdomain`, `observability`, `logpush`, `tail_consumers`, `preview_defaults`, and `usage_model`. These values are snake_case because they are the literal Workers API field names, unlike the camelCase keys used elsewhere in the event. Values are sorted and de-duplicated. The event does not include the previous or new value of a changed field.
+
+#### `worker.deleted`
+
+Triggered when a Worker is deleted.
+
+**Example:**
+
+```json
+{
+  "type": "cf.workers.script.worker.deleted",
+  "source": {
+    "type": "workers.script",
+    "id": "9a7c3f21b45e4d8a9c0f1e2d3b4a5c6d"
+  },
+  "payload": {
+    "name": "my-worker"
+  },
+  "metadata": {
+    "accountId": "f9f79265f388666de8122cfb508d7776",
+    "eventSubscriptionId": "1830c4bb612e43c3af7f4cada31fbf3f",
+    "eventSchemaVersion": 1,
+    "eventTimestamp": "2025-05-01T02:48:57.132Z"
+  }
+}
+```

--- a/src/content/partials/queues/event-subscriptions/workers-events.mdx
+++ b/src/content/partials/queues/event-subscriptions/workers-events.mdx
@@ -71,7 +71,7 @@ Triggered when a deployment is deleted.
 
 #### `version.created`
 
-Triggered when a new version of the Worker is created. Uploading a Worker creates a version, and so does any operation that copies an existing version, such as a rollback or a change to the Worker's secrets. Those operations emit `version.created` without an upload.
+Triggered when a new version of the Worker is created.
 
 **Example:**
 

--- a/src/content/partials/queues/event-subscriptions/workers-events.mdx
+++ b/src/content/partials/queues/event-subscriptions/workers-events.mdx
@@ -169,8 +169,7 @@ Triggered when a Worker's unversioned configuration changes.
       "logpush": {
         "from": false,
         "to": true
-      },
-      "previews_base_config": {}
+      }
     },
     "updatedOn": "2025-05-01T02:48:57Z"
   },

--- a/src/content/partials/queues/event-subscriptions/workers-events.mdx
+++ b/src/content/partials/queues/event-subscriptions/workers-events.mdx
@@ -185,7 +185,7 @@ Triggered when a Worker's unversioned configuration changes.
 
 `updatedOn` is an RFC 3339 UTC timestamp recording when the configuration changed.
 
-The `changed` object is keyed by the unversioned configuration fields that changed, and only fields that changed are present. The possible keys are `name`, `tags`, `subdomain`, `observability`, `logpush`, `tail_consumers`, `previews_base_config`, and `usage_model`.
+The `changed` object is keyed by the unversioned configuration fields that changed, and only fields that changed are present. The possible keys are `name`, `tags`, `subdomain`, `observability`, `logpush`, `tail_consumers`, and `usage_model`.
 
 Each value describes how that field changed:
 

--- a/src/content/partials/queues/event-subscriptions/workers-events.mdx
+++ b/src/content/partials/queues/event-subscriptions/workers-events.mdx
@@ -1,5 +1,3 @@
-The `name` field in each payload is the Worker name at the time the event fired, and that name can change. The stable identifier for a Worker is the script tag in `source.id`. When a Worker is renamed, the `worker.updated` event reports the new name in `payload.name`, and reports both the previous and new names in `payload.changed.name`.
-
 #### `deployment.created`
 
 Triggered when a deployment is created and rolled out.
@@ -24,7 +22,8 @@ Triggered when a deployment is created and rolled out.
       }
     ],
     "annotations": {
-      "workers/message": "Fix redirect handling"
+      "workers/message": "Fix redirect handling",
+      "workers/triggered_by": "deployment"
     },
     "authorEmail": "developer@example.com",
     "createdOn": "2025-05-01T02:48:57Z"
@@ -39,6 +38,8 @@ Triggered when a deployment is created and rolled out.
 ```
 
 The `versions` array describes the default traffic split, and the `percentage` values always sum to 100. Deployments that use cohorts can route traffic to versions that do not appear in `versions`.
+
+The `annotations` object uses two keys. `workers/message` is the optional deployment message, and `workers/triggered_by` records what caused the deployment. Deployments made through the deployments API always report `"workers/triggered_by": "deployment"`. Deployments recorded by older Workers APIs report the operation that created them, such as `upload`, `rollback`, or `secret`.
 
 The `annotations` and `authorEmail` fields are omitted when they are empty.
 
@@ -70,7 +71,7 @@ Triggered when a deployment is deleted.
 
 #### `version.created`
 
-Triggered when a new version of the Worker is uploaded.
+Triggered when a new version of the Worker is created. Uploading a Worker creates a version, and so does any operation that copies an existing version, such as a rollback or a change to the Worker's secrets. Those operations emit `version.created` without an upload.
 
 **Example:**
 

--- a/src/content/partials/queues/event-subscriptions/workers-events.mdx
+++ b/src/content/partials/queues/event-subscriptions/workers-events.mdx
@@ -14,7 +14,7 @@ Triggered when a deployment is created and rolled out.
     "id": "9a7c3f21b45e4d8a9c0f1e2d3b4a5c6d"
   },
   "payload": {
-    "name": "my-worker",
+    "workerName": "my-worker",
     "id": "bcf48806-b317-4351-9ee7-36e7d557d4de",
     "strategy": "percentage",
     "versions": [
@@ -22,7 +22,12 @@ Triggered when a deployment is created and rolled out.
         "versionId": "3f9e2c1a-7b4d-4e8f-9a01-2b3c4d5e6f70",
         "percentage": 100
       }
-    ]
+    ],
+    "annotations": {
+      "workers/message": "Fix redirect handling"
+    },
+    "authorEmail": "developer@example.com",
+    "createdOn": "2025-05-01T02:48:57Z"
   },
   "metadata": {
     "accountId": "f9f79265f388666de8122cfb508d7776",
@@ -33,7 +38,7 @@ Triggered when a deployment is created and rolled out.
 }
 ```
 
-The `versions` array describes the default traffic split, and the `percentage` values always sum to 100. The `strategy` field is currently always `percentage`. Deployments that use cohorts can route traffic to versions that do not appear in `versions`.
+The `versions` array describes the default traffic split, and the `percentage` values always sum to 100. Deployments that use cohorts can route traffic to versions that do not appear in `versions`.
 
 #### `deployment.deleted`
 
@@ -162,8 +167,9 @@ Triggered when a Worker's unversioned configuration changes.
         "from": false,
         "to": true
       },
-      "preview_defaults": {}
-    }
+      "previews_base_config": {}
+    },
+    "updatedOn": "2025-05-01T02:48:57Z"
   },
   "metadata": {
     "accountId": "f9f79265f388666de8122cfb508d7776",
@@ -174,13 +180,15 @@ Triggered when a Worker's unversioned configuration changes.
 }
 ```
 
-The `changed` object is keyed by the unversioned configuration fields that changed, and only fields that changed are present. The possible keys are `name`, `tags`, `subdomain`, `observability`, `logpush`, `tail_consumers`, `preview_defaults`, and `usage_model`. These keys are snake_case because they are the literal Workers API field names, unlike the camelCase keys used elsewhere in the event.
+`updatedOn` is an RFC 3339 UTC timestamp recording when the configuration changed.
+
+The `changed` object is keyed by the unversioned configuration fields that changed, and only fields that changed are present. The possible keys are `name`, `tags`, `subdomain`, `observability`, `logpush`, `tail_consumers`, `previews_base_config`, and `usage_model`.
 
 Each value describes how that field changed:
 
 - Scalar fields report `from` and `to`.
 - Set-valued fields, such as `tags` and `tail_consumers`, report `added` and `removed`. Either key is omitted when it would be empty. If the members stay the same but their order changes, the field reports `from` and `to` instead.
-- The `preview_defaults` field reports an empty object, which means the field changed but its values are not published.
+- The `previews_base_config` field reports an empty object, which means the field changed but its values are not published. This keeps preview secrets out of the event.
 
 #### `worker.deleted`
 

--- a/src/content/partials/queues/event-subscriptions/workers-events.mdx
+++ b/src/content/partials/queues/event-subscriptions/workers-events.mdx
@@ -191,7 +191,6 @@ Each value describes how that field changed:
 
 - Scalar fields report `from` and `to`.
 - Set-valued fields, such as `tags` and `tail_consumers`, report `added` and `removed`. Either key is omitted when it would be empty. If the members stay the same but their order changes, the field reports `from` and `to` instead.
-- The `previews_base_config` field reports an empty object, which means the field changed but its values are not published. This keeps preview secrets out of the event.
 
 #### `worker.deleted`
 

--- a/src/content/partials/queues/event-subscriptions/workers-events.mdx
+++ b/src/content/partials/queues/event-subscriptions/workers-events.mdx
@@ -37,7 +37,7 @@ Triggered when a deployment is created and rolled out.
 }
 ```
 
-The `versions` array describes the default traffic split, and the `percentage` values always sum to 100. Deployments that use cohorts can route traffic to versions that do not appear in `versions`.
+The `versions` array describes the default traffic split, and the `percentage` values always sum to 100.
 
 The `annotations` object uses two keys. `workers/message` is the optional deployment message, and `workers/triggered_by` records what caused the deployment. Deployments made through the deployments API always report `"workers/triggered_by": "deployment"`. Deployments recorded by older Workers APIs report the operation that created them, such as `upload`, `rollback`, or `secret`.
 


### PR DESCRIPTION
### Summary

Adds a Workers source to the [event subscriptions schema reference](https://developers.cloudflare.com/queues/event-subscriptions/events-schemas/), documenting the seven Worker lifecycle events that can be delivered to a queue: `deployment.created`, `deployment.deleted`, `version.created`, `version.deleted`, `worker.created`, `worker.updated`, and `worker.deleted`.

Each event gets a description and a full example payload. The reference also covers behavior that is easy to misread from the payloads alone:

- The Worker name in a payload is the name at the time the event fired, and that name can change. The stable identifier is the script tag in `source.id`. `deployment.created` reports the name in `workerName`, while every other event uses `name`.
- `version.created` fires whenever a version is created, not only on upload. Rollbacks and secret changes copy an existing version and emit the event with no upload.
- `deployment.created` annotations use two keys, `workers/message` and `workers/triggered_by`. Deployments made through the deployments API always report `"workers/triggered_by": "deployment"`.
- The `versions` array on `deployment.created` is the default traffic split and always sums to 100. Deployments that use cohorts can route traffic to versions that do not appear in `versions`.
- `changed` on `worker.updated` is keyed by the public Workers API field names rather than the camelCase JSON keys, and `previews_base_config` reports an empty object so preview secrets stay out of the event.
- Delivery is at-least-once and unordered, so subscribers should deduplicate on the payload `id` and sort on `metadata.eventTimestamp`.