### PR TITLE
[SSL] CT Monitoring GA: changelog + docs update

### DIFF
--- a/src/content/changelog/ssl/2026-08-13-ct-monitoring-ga.mdx
+++ b/src/content/changelog/ssl/2026-08-13-ct-monitoring-ga.mdx
@@ -1,0 +1,13 @@
+---
+title: Certificate Transparency Monitoring is now Generally Available
+description: CT Monitoring is now GA, with automatic filtering of Cloudflare-issued certificates to reduce noise and highlight alerts about certificates Cloudflare did not issue.
+date: 2026-08-13
+products:
+  - ssl
+---
+
+Certificate Transparency Monitoring is now [generally available](https://blog.cloudflare.com/certificate-transparency-monitoring-ga) across all Cloudflare plans.
+
+Alerts for certificates Cloudflare issues on your behalf (Universal SSL renewals, backup certificates, Advanced Certificate Manager, Total TLS) are now automatically filtered out. Alert emails are also clearer and more actionable, with structured certificate details and a direct link to manage CT Monitoring in the Cloudflare dashboard.
+
+Learn more in the [launch blog post](https://blog.cloudflare.com/certificate-transparency-monitoring-ga) or the [CT Monitoring docs](/ssl/edge-certificates/additional-options/certificate-transparency-monitoring/).

--- a/src/content/docs/ssl/edge-certificates/additional-options/certificate-transparency-monitoring.mdx
+++ b/src/content/docs/ssl/edge-certificates/additional-options/certificate-transparency-monitoring.mdx
@@ -6,20 +6,18 @@ title: Certificate Transparency Monitoring
 sidebar:
   order: 3
 head: []
-description: Certificate Transparency (CT) Monitoring is an opt-in feature in
-  public beta that aims at improving security by allowing you to double-check
-  any SSL/TLS certificates issued for your domain.
+description: Certificate Transparency (CT) Monitoring emails you when a new SSL/TLS certificate is issued for your domain, so you can spot unauthorized or mis-issued certificates.
 ---
 
 import { FeatureTable, GlossaryTooltip } from "~/components";
 
-Certificate Transparency (CT) Monitoring is an [opt-in](#opt-in-and-out) feature in public beta that aims at improving security by allowing you to double-check any SSL/TLS certificates issued for your domain.
+Certificate Transparency (CT) Monitoring is an [opt-in](#opt-in-and-out) feature that lets you double-check any SSL/TLS certificates issued for your domain.
 
-CT Monitoring alerts are triggered not only by Cloudflare processes - including [backup certificates](/ssl/edge-certificates/backup-certificates/) -, but whenever a certificate that covers your monitored domain is issued by a [Certificate Authority (CA)](/ssl/concepts/#certificate-authority-ca) and added to a public CT log. You can learn more about how this works in the [introductory blog post](https://blog.cloudflare.com/introducing-certificate-transparency-and-nimbus/).
+CT Monitoring alerts are triggered whenever a certificate that covers your monitored domain is issued by a [Certificate Authority (CA)](/ssl/reference/certificate-authorities/) and added to a public CT log. Alerts for certificates Cloudflare issues on your behalf, including backup certificates, are automatically filtered out. For more information, refer to [Certificate Transparency Monitoring filtering behavior](https://blog.cloudflare.com/certificate-transparency-monitoring-ga), or to the [introductory blog post](https://blog.cloudflare.com/introducing-certificate-transparency-monitoring/) to learn more about how CT Monitoring works.
 
 :::caution[Aspects to consider]
 
-- If you use Cloudflare or other services that automatically issue certificates for your domain or subdomains, this may trigger CT Monitoring emails as well.
+- Certificates that Cloudflare did not issue can still trigger CT Monitoring emails. This includes certificates issued by services outside Cloudflare, as well as custom certificates you upload yourself.
 - If your domain is included in a shared certificate, you may receive notifications for domains or subdomains that do not belong to you but are included as <GlossaryTooltip term="Subject Alternative Names (SANs)">subject alternative names (SANs)</GlossaryTooltip> together with your domain. You can use a tool like [Certificate Search](https://crt.sh/) to gather more information in such cases.
 - CT Monitoring does not detect phishing attempts. For example, for `cloudflare.com`, an alert would not trigger if a certificate was issued for `cloudf1are.com` or `cloud-flare.com`.
 
@@ -35,28 +33,29 @@ CT Monitoring alerts are triggered not only by Cloudflare processes - including 
 
 ## Opt in and out
 
-Alerts are turned off by default. If you want to receive alerts, go to the [**Edge Certificates**](https://dash.cloudflare.com/?to=/:account/:zone/ssl-tls/edge-certificates#ct-alerting-card) page and enable **Certificate Transparency Monitoring**. If you are in a Business or Enterprise zone, select **Add Email**.
+Alerts are turned off by default. If you want to receive alerts, go to the [**Edge Certificates**](https://dash.cloudflare.com/?to=/:account/:zone/ssl-tls/edge-certificates#ct-alerting-card) page and turn on **Certificate Transparency Monitoring**, then select **Add Email**.
 
-To stop receiving alerts, disable **Certificate Transparency Monitoring** or remove your email from the feature card.
+To stop receiving alerts, turn off **Certificate Transparency Monitoring** or remove your email from the feature card.
 
 ---
 
 ## Emails to be concerned about
 
-Most certificate alerts are routine. Cloudflare sends alerts whenever a certificate for your domain appears in a log. Certificates expire (and must be reissued), so it is completely normal to receive issuance emails. If your domain is listed in the email, along with reasonable ownership and certificate information, then **no action is required**.
+Cloudflare filters out the certificates it issues for you, so every alert you get is worth a quick look.
 
-Additionally, you should check whether the certificate was issued through Cloudflare. Cloudflare partners with [multiple CAs](/ssl/reference/certificate-authorities/) to provide certificates.
-To view all Cloudflare-issued certificates and backup certificates - which require no additional actions - visit the [Edge Certificates page](https://dash.cloudflare.com/?to=/:account/:zone/ssl-tls/edge-certificates) in the dashboard.
+Most alerts are routine. Open the email and check three things:
 
-You _should_ take action when something is clearly wrong, such as if you:
+1. **Your domain.** Does it match what you own?
+2. **The issuer.** Did you or your organization request this certificate, or was it requested by a service you use? The issuer is listed as the [Certificate Authority](/ssl/reference/certificate-authorities/) in the email.
+3. **The DNS names and validity dates.** Do they look reasonable?
 
-- Do not recognize the certificate issuer.
-  :::note
+If you can confirm that your organization or a service you use requested the certificate, no action is required. Otherwise, investigate the issuance with your security team or certificate provider. You can review certificates configured on Cloudflare from the [Edge Certificates page](https://dash.cloudflare.com/?to=/:account/:zone/ssl-tls/edge-certificates) in the dashboard. For external certificates, review the CT log entry or use [Certificate Search](https://crt.sh/).
 
-  Cloudflare provisions backup certificates, so you may see a certificate listed that is not in active use for your site. The [Edge Certificates page](https://dash.cloudflare.com/?to=/:account/:zone/ssl-tls/edge-certificates) will show all certificates requested for your site.
-  :::
+Take action if:
 
-- Have recently noticed problems with your website.
+- You do not recognize the issuer or did not request the certificate.
+- You do not recognize the DNS names.
+- Your website has been acting strangely.
 
 ---
 


### PR DESCRIPTION
### Summary

Adds the CT Monitoring GA changelog entry and revises the CT Monitoring docs page to reflect that alerts for Cloudflare-issued certificates are now automatically filtered out. Also removes the Business/Enterprise zone distinction from the opt-in instructions since CT Monitoring is now GA across all plans.

Based on changes in cloudflare/cloudflare-docs#32415.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
