### PR TITLE
[Workers AI] Fix IndicTrans2 translation examples

### DIFF
--- a/src/components/models/code/TranslationCode.astro
+++ b/src/components/models/code/TranslationCode.astro
@@ -11,6 +11,26 @@ const props = z.object({
 
 const { name } = props.parse(Astro.props);
 
+const isIndicTrans2 = name === "@cf/ai4bharat/indictrans2-en-indic-1B";
+
+const workerInput = isIndicTrans2
+	? `        text: "Hello, how are you?",
+        target_language: "hin_Deva",`
+	: `        text: "I'll have an order of the moule frites",
+        source_lang: "english", // defaults to english
+        target_lang: "french",`;
+
+const pythonInput = isIndicTrans2
+	? `  "text": "Hello, how are you?",
+  "target_language": "hin_Deva"`
+	: `  "text": "I'll have an order of the moule frites",
+  "source_lang": "english",
+  "target_lang": "french"`;
+
+const curlInput = isIndicTrans2
+	? `{ "text": "Hello, how are you?", "target_language": "hin_Deva" }`
+	: `{ "text": "Ill have an order of the moule frites", "source_lang": "english", "target_lang": "french" }`;
+
 const worker = `
 export interface Env {
   AI: Ai;
@@ -22,9 +42,7 @@ export default {
     const response = await env.AI.run(
       "${name}",
       {
-        text: "I'll have an order of the moule frites",
-        source_lang: "english", // defaults to english
-        target_lang: "french",
+${workerInput}
       }
     );
 
@@ -44,9 +62,7 @@ def run(model, input):
     return response.json()
 
 output = run('${name}', {
-  "text": "I'll have an order of the moule frites",
-  "source_lang": "english",
-  "target_lang": "french"
+${pythonInput}
 })
 
 print(output)
@@ -56,7 +72,7 @@ const curl = `
 curl https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/run/${name}  \\
     -X POST  \\
     -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN"  \\
-    -d '{ "text": "Ill have an order of the moule frites", "source_lang": "english", "target_lang": "french" }'
+    -d '${curlInput}'
 `;
 ---
 

--- a/src/components/models/code/TranslationCode.astro
+++ b/src/components/models/code/TranslationCode.astro
@@ -11,7 +11,8 @@ const props = z.object({
 
 const { name } = props.parse(Astro.props);
 
-const isIndicTrans2 = name === "@cf/ai4bharat/indictrans2-en-indic-1B";
+const INDIC_TRANS2_MODELS = new Set(["@cf/ai4bharat/indictrans2-en-indic-1B"]);
+const isIndicTrans2 = INDIC_TRANS2_MODELS.has(name);
 
 const workerInput = isIndicTrans2
 	? `        text: "Hello, how are you?",


### PR DESCRIPTION
### Summary

Fixes the TypeScript, Python, and cURL examples for `@cf/ai4bharat/indictrans2-en-indic-1B` to use the model's `target_language` input instead of the M2M100-specific `source_lang` and `target_lang` inputs. The M2M100 examples remain unchanged.

Fixes https://github.com/cloudflare/cloudflare-docs/issues/28787

Validated with `pnpm run check`, `pnpm run lint`, `pnpm run format:check`, `pnpm run build`, and `pnpm run test`.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [x] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
