### PR TITLE
[Workers] Correct cloudflare:test type path

### DIFF
--- a/src/content/docs/workers/testing/vitest-integration/write-your-first-test.mdx
+++ b/src/content/docs/workers/testing/vitest-integration/write-your-first-test.mdx
@@ -84,7 +84,7 @@ If you are not using Typescript, you can skip this section.
 
 First make sure you have run [`wrangler types`](/workers/wrangler/commands/), which generates [types for the Cloudflare Workers runtime](/workers/languages/typescript/) and an `Env` type based on your Worker's bindings.
 
-Then add a `tsconfig.json` in your tests folder and add `"@cloudflare/vitest-plugin"` to your types array to define types for `cloudflare:test`.
+Then add a `tsconfig.json` in your tests folder and add `"@cloudflare/vitest-plugin/types"` to your types array to define types for `cloudflare:test`.
 You should also add the output of `wrangler types` to the `include` array so that the types for the Cloudflare Workers runtime are available.
 
 <Details header="Example test/tsconfig.json">


### PR DESCRIPTION
### Summary

The Workers Vitest setup text referenced the package root, which does not export the ambient `cloudflare:test` declarations. It now uses `@cloudflare/vitest-pool-workers/types`, matching the `tsconfig.json` example and current package exports.

Fixes https://github.com/cloudflare/cloudflare-docs/issues/30069

Validated with `pnpm run check`, `pnpm run format:check`, `pnpm run build`, and `pnpm run test`.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [x] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
