### PR TITLE
[Cloudflare Tunnel] Include metrics address in Docker diagnostics

### DIFF
--- a/src/content/partials/cloudflare-one/tunnel/diagnostics/docker.mdx
+++ b/src/content/partials/cloudflare-one/tunnel/diagnostics/docker.mdx
@@ -36,17 +36,19 @@ params:
    }
    ```
 
-4. Run the diagnostic using the Docker container ID:
+4. Run the diagnostic using the local metrics address and Docker container ID:
 
    ```sh
-   cloudflared tunnel diag --diag-container-id=<containerID>
+   cloudflared tunnel diag --metrics localhost:20241 --diag-container-id=<containerID>
    ```
 
    Alternatively, you can specify the container's name instead of its ID:
 
    ```sh
-   cloudflared tunnel diag --diag-container-id=<containerName>
+   cloudflared tunnel diag --metrics localhost:20241 --diag-container-id=<containerName>
    ```
+
+   If you forwarded a different local port in Step 2, replace `20241` with that port.
 
    Running the diagnostic command with the container ID allows `cloudflared` to collect information from the Docker environment such as logs and container details.
 


### PR DESCRIPTION
## Summary

- Pass the forwarded metrics address to the Docker diagnostic commands for both container IDs and names.
- Explain how to substitute a different local forwarding port.

The [`cloudflared tunnel diag` implementation](https://github.com/cloudflare/cloudflared/blob/aba66df755b17b8e46c0b716ea69796b9b570758/cmd/cloudflared/tunnel/subcommands.go#L199-L203) defines `--metrics` as the way to target a specific metrics server, including one forwarded from Docker or Kubernetes.

## Validation

- `astro check --minimumFailingSeverity=hint` — 441 files, 0 errors, warnings, or hints
- `tsc --noEmit -p ./worker/tsconfig.json`
- `astro build` — 8,848 pages built

Closes #28798
