### PR TITLE
[Agents] Fix tracing prompt review findings

### DIFF
--- a/src/content/agent-setup/tracing.md
+++ b/src/content/agent-setup/tracing.md
@@ -125,7 +125,7 @@ const tracedAI = wrapAISDK(ai);
 
 For payload recording, pass `{ storeMessages: true, storeTools: true }` to `wrapAISDK()`.
 
-Supply a shared agent name, stable agent ID, and opaque conversation ID on every call. For AI SDK v7, use `telemetry.functionId`, add the IDs to `runtimeContext`, and set both IDs to `true` in `telemetry.includeRuntimeContext`. For v6, use `experimental_telemetry.functionId` and `metadata`. Merge existing telemetry fields and include no credentials, user input, or personal data.
+Supply a shared agent name, stable agent ID, and opaque conversation ID on every call. For AI SDK v7, set `telemetry.functionId` to the shared agent name. Add only `agentId` and `conversationId` to `runtimeContext`, and set those two keys to `true` in `telemetry.includeRuntimeContext`. For v6, use `experimental_telemetry.functionId` and `metadata`. Merge existing telemetry fields and include no credentials, user input, or personal data.
 
 If identity sources are unclear, show the call sites and ask the user where each value comes from.
 

--- a/src/pages/agent-setup/tracing.md.ts
+++ b/src/pages/agent-setup/tracing.md.ts
@@ -1,0 +1,10 @@
+import type { APIRoute } from "astro";
+import tracingText from "~/content/agent-setup/tracing.md?raw";
+
+export const GET: APIRoute = () => {
+	return new Response(tracingText, {
+		headers: {
+			"Content-Type": "text/markdown; charset=utf-8",
+		},
+	});
+};


### PR DESCRIPTION
### Summary

Follow-up to #32653 that fixes the two review findings: clarifies AI SDK v7 telemetry identity field placement and adds the Astro route that publishes the tracing prompt as Markdown.

### Documentation checklist

- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
