### PR TITLE
[WAF] Fix custom topics API endpoint in AI Security for Apps

### DIFF
--- a/src/content/docs/waf/detections/ai-security-for-apps/unsafe-topics.mdx
+++ b/src/content/docs/waf/detections/ai-security-for-apps/unsafe-topics.mdx
@@ -106,7 +106,7 @@ Both methods will update the same underlying topic list. Changes made in one are
 Update your custom topics list using a `PUT` request:
 
 ```bash
-curl "https://api.cloudflare.com/client/v4/zones/$ZONE_ID/firewall-for-ai/custom-topics" \
+curl "https://api.cloudflare.com/client/v4/zones/$ZONE_ID/ai-security/custom-topics" \
   --request PUT \
   --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
   --json '{
@@ -134,7 +134,7 @@ This request replaces your entire topic list. Include all topics you want to kee
 To retrieve your current topics, use a `GET` request:
 
 ```bash
-curl "https://api.cloudflare.com/client/v4/zones/$ZONE_ID/firewall-for-ai/custom-topics" \
+curl "https://api.cloudflare.com/client/v4/zones/$ZONE_ID/ai-security/custom-topics" \
   --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN"
 ```
 


### PR DESCRIPTION
### Summary

The GET and PUT examples on the unsafe topics page pointed at `/zones/{zone_id}/firewall-for-ai/custom-topics`, which does not exist.

The Cloudflare OpenAPI spec (cloudflare/api-schemas, openapi.json v4) defines the custom topics list under
`/zones/{zone_id}/ai-security/custom-topics`, with get and put operations. There is no `firewall-for-ai` path in the spec; the only related zone paths are `/zones/{zone_id}/ai-security/custom-topics` and `/zones/{zone_id}/ai-security/settings`.

Update both curl examples to use the `ai-security` path so the documented requests match the API.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
