### PR TITLE
[Agents] Fix tracing output code block

### DIFF
--- a/src/content/agent-setup/tracing.md
+++ b/src/content/agent-setup/tracing.md
@@ -151,7 +151,7 @@ Run the validation commands for the selected framework. For non-Flue projects, r
 
 Once done, tell the user:
 
-```txt
+```
 ┌─ Cloudflare Agent Tracing Configured ─────────────────┐
 │ ✓ Tracing  <frameworks>                               │
 │ ✓ Sampling <rate and percentage>                      │


### PR DESCRIPTION
### Summary

Follow-up to #32710 that removes the unsupported language tag from the box-drawing output example in the agent tracing setup prompt.

### Documentation checklist

- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
