### PR TITLE
[Cloudflare Tunnel] Correct Domain DNS role name

### DIFF
--- a/src/content/partials/cloudflare-one/tunnel/account-scoped-roles.mdx
+++ b/src/content/partials/cloudflare-one/tunnel/account-scoped-roles.mdx
@@ -7,5 +7,5 @@ Minimum permissions needed to create, delete, and configure tunnels for an accou
 - [Cloudflare Access](/cloudflare-one/roles-permissions/)
 
 Additional permissions needed to [route traffic to a public hostname](/cloudflare-one/networks/connectors/cloudflare-tunnel/routing-to-tunnel/) and to be able to perform `cloudflared login`:
-- [DNS](/fundamentals/manage-members/roles/)
+- [Domain DNS](/fundamentals/manage-members/roles/)
 - [Load Balancer](/fundamentals/manage-members/roles/)


### PR DESCRIPTION
## Summary

Updates the Cloudflare Tunnel account role requirement from the former **DNS** name to the current **Domain DNS** name. The existing link still points to the account-scoped role table, which already uses the current name.

Closes #32067

## Validation

- Astro check: 442 files, 0 errors, warnings, or hints
- Worker TypeScript check
- Full Astro build: 8,850 pages
- `git diff --check`
