### PR TITLE
[Fundamentals] Clarify API token quota scopes

### DIFF
--- a/src/content/partials/fundamentals/api-rate-limits.mdx
+++ b/src/content/partials/fundamentals/api-rate-limits.mdx
@@ -9,13 +9,13 @@ import { AnchorHeading } from "~/components";
 	<AnchorHeading title="API token limits" depth={2} />
 )}
 
-| Type                    | Limit                               |
-| ----------------------- | ----------------------------------- |
-| Client API per user/account token     | 1200/5 minutes        |
-| Client API per IP       | 200/second                          |
-| GraphQL                 | Varies by query cost. Max 320/5 min |
-| User API token quota    | 50                                  |
-| Account API token quota | 500                                 |
+| Type                              | Limit                               |
+| --------------------------------- | ----------------------------------- |
+| Client API per user/account token | 1200/5 minutes                      |
+| Client API per IP                 | 200/second                          |
+| GraphQL                           | Varies by query cost. Max 320/5 min |
+| User API tokens per user          | 50                                  |
+| Account API tokens per account    | 500                                 |
 
 :::note
 The global rate limit for the Cloudflare API is 1,200 requests per five minute period per user, and applies cumulatively regardless of whether the request is made via the dashboard, API key, or API token.


### PR DESCRIPTION
## Summary

Clarify that the quota is 50 user API tokens for each user and 500 account API tokens for each account.

Closes #31023.

## Evidence

- The existing limits table separately identifies the limits as the **User API token quota** and **Account API token quota**.
- [Account API tokens](https://developers.cloudflare.com/fundamentals/api/get-started/account-owned-tokens/) describes account API tokens as service principals owned by an account rather than a user.
- The API lists user tokens under `/user/tokens` and account-owned tokens under `/accounts/{account_id}/tokens`. The account endpoint describes its result as the account-owned tokens created for that account.

These sources agree on the ownership boundary used by each quota.

## Validation

- `astro check --minimumFailingSeverity=hint` — 442 files checked, 0 errors, warnings, or hints
- Worker TypeScript check
- Full Astro build: 8,850 pages
- `git diff --check`
