### PR TITLE
[Workers] Correct Cron Trigger limit scope

### DIFF
--- a/src/content/docs/workers/configuration/cron-triggers.mdx
+++ b/src/content/docs/workers/configuration/cron-triggers.mdx
@@ -287,7 +287,7 @@ When deploying a Worker with Wrangler any previous Cron Triggers are replaced wi
 
 ## Limits
 
-Refer to [Limits](/workers/platform/limits/) to track the maximum number of Cron Triggers per Worker.
+Refer to [Workers limits](/workers/platform/limits/#account-plan-limits) for the maximum number of Cron Triggers per account.
 
 ## Green Compute
 


### PR DESCRIPTION
## Summary

- Corrects the Cron Triggers limits section to state that the maximum is per account, matching the Workers limits table.
- Links directly to the account plan limits section.

Closes #29326

## Validation

- Astro check: 442 files, 0 errors, warnings, or hints
- `git diff --check`
