### PR TITLE
fix(turnstile): correct PHP server variables

### DIFF
--- a/src/content/docs/turnstile/get-started/server-side-validation.mdx
+++ b/src/content/docs/turnstile/get-started/server-side-validation.mdx
@@ -190,9 +190,9 @@ function validateTurnstile($token, $secret, $remoteip = null) {
 // Usage
 $secret_key = 'your-secret-key';
 $token = $_POST['cf-turnstile-response'] ?? '';
-$remoteip = $\_SERVER['HTTP_CF_CONNECTING_IP'] ??
-$\_SERVER['HTTP_X_FORWARDED_FOR'] ??
-$\_SERVER['REMOTE_ADDR'];
+$remoteip = $_SERVER['HTTP_CF_CONNECTING_IP'] ??
+$_SERVER['HTTP_X_FORWARDED_FOR'] ??
+$_SERVER['REMOTE_ADDR'];
 
 $validation = validateTurnstile($token, $secret_key, $remoteip);
 


### PR DESCRIPTION
## Summary

Replace the escaped `$\_SERVER` references in the Turnstile PHP example with PHP's valid `$_SERVER` superglobal.

The backslashes are part of the rendered code block, so copying the current example produces invalid PHP. This restores the three-line fix originally proposed in #30873, which was closed automatically after becoming stale.

Fixes #31872.

## Validation

- `astro check --minimumFailingSeverity=hint` — 442 files checked, 0 errors, warnings, or hints

## Documentation checklist

- [x] The change follows the documentation style guide.
- [x] No changelog is needed for a correction to an existing example.
