### PR TITLE
fix(dlp): document high confidence threshold

### DIFF
--- a/src/content/docs/cloudflare-one/data-loss-prevention/dlp-profiles/advanced-settings.mdx
+++ b/src/content/docs/cloudflare-one/data-loss-prevention/dlp-profiles/advanced-settings.mdx
@@ -67,9 +67,9 @@ Confidence thresholds indicate how confident Cloudflare DLP is in a detection. D
 
 When you set a confidence threshold on a profile, DLP only triggers on detections at that level or higher:
 
-- **Low** (default) — Based on regular expressions with few proximity keywords. This is the most inclusive setting, with high tolerance for false positives
-- **Medium** — Applies additional validations, to filter out low confidence detections. This setting has a medium tolerance for false positives.
-- **Medium** — Applies additional validations to filter out low confidence detections. This setting has a medium tolerance for false positives.
+- **Low** (default) — Uses regular expressions with few proximity keywords. This is the most inclusive setting and has the highest tolerance for false positives.
+- **Medium** — Applies additional validation to filter out low-confidence detections. This setting has a medium tolerance for false positives.
+- **High** — Applies the strictest validation to filter out low- and medium-confidence detections. This setting has the lowest tolerance for false positives.
 
 Confidence threshold is set on the DLP profile. Not all detection entries support confidence thresholds — when you select a threshold in the dashboard, entries that support confidence scoring display their current level. Entries without a displayed confidence level either do not support this feature or use detection methods (such as exact match) where confidence scoring does not apply.
 

--- a/src/content/docs/cloudflare-one/data-loss-prevention/dlp-profiles/advanced-settings.mdx
+++ b/src/content/docs/cloudflare-one/data-loss-prevention/dlp-profiles/advanced-settings.mdx
@@ -69,7 +69,7 @@ When you set a confidence threshold on a profile, DLP only triggers on detection
 
 - **Low** (default) — Uses regular expressions with few proximity keywords. This is the most inclusive setting and has the highest tolerance for false positives.
 - **Medium** — Applies additional validation to filter out low-confidence detections. This setting has a medium tolerance for false positives.
-- **High** — Applies the strictest validation to filter out low- and medium-confidence detections. This setting has the lowest tolerance for false positives.
+- **High** — Triggers only on detections classified as high confidence.
 
 Confidence threshold is set on the DLP profile. Not all detection entries support confidence thresholds — when you select a threshold in the dashboard, entries that support confidence scoring display their current level. Entries without a displayed confidence level either do not support this feature or use detection methods (such as exact match) where confidence scoring does not apply.
 


### PR DESCRIPTION
## Summary

Correct the duplicated **Medium** entry in the DLP confidence-threshold list to **High**. The High description is limited to the behavior already established on the page: only detections classified as high confidence meet that threshold.

This avoids adding claims about DLP's internal validation steps that are not documented publicly.

Fixes #31733.

## Evidence

- The existing section states that DLP triggers on detections at the configured confidence level or higher.
- The later Gateway example distinguishes Low, Medium, and High confidence profiles.
- Issue #31733 identifies the duplicated Medium entry.

## Validation

- `astro check --minimumFailingSeverity=hint` — 442 files checked, 0 errors, warnings, or hints
- `git diff --check`

## Documentation checklist

- [x] The change follows the documentation style guide.
- [x] No changelog is needed for a correction to an existing page.
