### PR TITLE
docs(headers): list Cache-Tag as removed

### DIFF
--- a/src/content/docs/fundamentals/reference/http-headers.mdx
+++ b/src/content/docs/fundamentals/reference/http-headers.mdx
@@ -169,6 +169,7 @@ Cloudflare will remove some HTTP headers from the response sent back to the visi
 
 Cloudflare passes all HTTP headers in the response from the origin server back to the visitor with the exception of the following headers:
 
+- `Cache-Tag`
 - `X-Accel-Buffering`
 - `X-Accel-Charset`
 - `X-Accel-Limit-Rate`


### PR DESCRIPTION
## Summary

Add `Cache-Tag` to the reference list of response headers that Cloudflare removes before sending a response to a visitor.

The cache-tag documentation already describes this behavior, but the general HTTP header reference omits it. Listing the header in both places makes the two pages consistent.

Fixes #31818.

## Validation

- `astro check --minimumFailingSeverity=hint` — 442 files checked, 0 errors, warnings, or hints

## Documentation checklist

- [x] The change follows the documentation style guide.
- [x] No changelog is needed for a correction to an existing reference page.
