### PR TITLE
docs(redirects): define static and dynamic rules

### DIFF
--- a/src/content/partials/workers/redirects.mdx
+++ b/src/content/partials/workers/redirects.mdx
@@ -46,12 +46,18 @@ Lines starting with a `#` will be treated as comments.
 
 ### Per file
 
+Redirects are classified by their source and position in the file:
+
+- A **static redirect** has an exact source path and appears before any dynamic redirects.
+- A **dynamic redirect** has a splat (`*`) or placeholder (`:name`) in its source path. After the first dynamic redirect, every subsequent redirect is also counted as dynamic, even if its source path is exact.
+
+The destination does not affect this classification. For example, a source containing `*` is dynamic even if its destination does not use `:splat`.
+
 A `_redirects` file is limited to 2,000 static redirects and 100 dynamic redirects, for a combined total of 2,100 redirects. Each redirect declaration has a 1,000-character limit.
 
 In your `_redirects` file:
 
-- The order of your redirects matter. If there are multiple redirects for the same `source` path, the top-most redirect is applied.
-- Static redirects should appear before dynamic redirects.
+- The order of your redirects matters. If there are multiple redirects for the same `source` path, the top-most redirect is applied.
 - Redirects are always followed, regardless of whether or not an asset matches the incoming request.
 
 A complete example with multiple redirects may look like the following:


### PR DESCRIPTION
## Summary

Define how `_redirects` rules are classified as static or dynamic:

- An exact source before any dynamic rules is static.
- A source containing a splat or placeholder is dynamic.
- Rules after the first dynamic rule count as dynamic, even when their source is exact.
- Placeholders in the destination do not determine the classification.

These definitions mirror the current `parseRedirects` behavior in `workers-sdk` and answer whether a source wildcard remains dynamic when its destination does not use `:splat`.

Fixes #31285.

## Validation

- `astro check --minimumFailingSeverity=hint` — 442 files checked, 0 errors, warnings, or hints

## Documentation checklist

- [x] The change follows the documentation style guide.
- [x] No changelog is needed for a clarification to existing documentation.
