### PR TITLE
docs(markdown): clarify hostname base URL

### DIFF
--- a/src/content/docs/workers-ai/features/markdown-conversion/conversion-options.mdx
+++ b/src/content/docs/workers-ai/features/markdown-conversion/conversion-options.mdx
@@ -57,7 +57,7 @@ This option works on a _best-effort_ basis: it is not guaranteed that the result
 }
 ```
 
-- `hostname`: string to use as a host when resolving relative links inside the HTML.
+- `hostname`: absolute base URL used to resolve relative links in the HTML. Include the scheme and, when applicable, the page path — for example, `https://example.com/docs/page`. A bare hostname such as `example.com` is not sufficient.
 
 - `cssSelector`: string containing a CSS selector pattern to pick specific elements from your HTML. Refer to [how HTML is processed](/workers-ai/features/markdown-conversion/how-it-works/#html) for more details.
 

--- a/src/content/docs/workers-ai/features/markdown-conversion/how-it-works.mdx
+++ b/src/content/docs/workers-ai/features/markdown-conversion/how-it-works.mdx
@@ -23,12 +23,9 @@ When we detect an HTML file, a series of things happen to the HTML content befor
 - If the `cssSelector` option is:
   - present, then only those elements that match the selector are kept for further processing;
   - missing, then elements such as `<header>`, `<footer>` and `<head>` are removed from the text.
-- If a base URL was obtained previously, relative links in the remaining HTML are resolved to fully qualified URLs
+- If a base URL was obtained previously, relative links in the remaining HTML are resolved to fully qualified URLs.
 
-<sup>1</sup> The host can also be set per request, using the HTML conversion
-options. Refer to [Conversion
-Options](/workers-ai/features/markdown-conversion/conversion-options/#html) for
-more details.
+<sup>1</sup> You can also set the base URL for each request with the HTML conversion options. Refer to [Conversion Options](/workers-ai/features/markdown-conversion/conversion-options/#html) for more details.
 
 ### Images
 


### PR DESCRIPTION
## Summary

Describe the HTML `hostname` conversion option as the absolute base URL used to resolve relative links. The updated reference tells readers to include the scheme and relevant page path, and notes that a bare hostname is insufficient.

The related "How it works" footnote now uses the same base-URL terminology.

Fixes #31303.

## Validation

- `astro check --minimumFailingSeverity=hint` — 442 files checked, 0 errors, warnings, or hints

## Documentation checklist

- [x] The change follows the documentation style guide.
- [x] No changelog is needed for a clarification to an existing reference page.
