### PR TITLE
Remove availability table for plans in CT Monitoring

### DIFF
--- a/src/content/docs/ssl/edge-certificates/additional-options/certificate-transparency-monitoring.mdx
+++ b/src/content/docs/ssl/edge-certificates/additional-options/certificate-transparency-monitoring.mdx
@@ -9,7 +9,7 @@ head: []
 description: Certificate Transparency (CT) Monitoring emails you when a new SSL/TLS certificate is issued for your domain, so you can spot unauthorized or mis-issued certificates.
 ---
 
-import { FeatureTable, GlossaryTooltip } from "~/components";
+import { GlossaryTooltip } from "~/components";
 
 Certificate Transparency (CT) Monitoring is an [opt-in](#opt-in-and-out) feature that lets you double-check any SSL/TLS certificates issued for your domain.
 
@@ -22,12 +22,6 @@ CT Monitoring alerts are triggered whenever a certificate that covers your monit
 - CT Monitoring does not detect phishing attempts. For example, for `cloudflare.com`, an alert would not trigger if a certificate was issued for `cloudf1are.com` or `cloud-flare.com`.
 
 :::
-
----
-
-## Availability
-
-<FeatureTable id="ssl.cert_transparency" />
 
 ---
 

--- a/src/content/plans/index.json
+++ b/src/content/plans/index.json
@@ -2653,27 +2653,6 @@
 				}
 			}
 		},
-		"cert_transparency": {
-			"title": "Certificate Transparency Monitoring",
-			"link": "/ssl/edge-certificates/additional-options/certificate-transparency-monitoring/",
-			"properties": {
-				"availability": {
-					"title": "Availability",
-					"summary": "Available on all plans.",
-					"free": "Yes",
-					"pro": "Yes",
-					"biz": "Yes",
-					"ent": "Yes"
-				},
-				"email_recipients": {
-					"title": "Email Recipients",
-					"free": "All account members",
-					"pro": "All account members",
-					"biz": "Specified email addresses",
-					"ent": "Specified email addresses"
-				}
-			}
-		},
 		"opportunistic_encryption": {
 			"title": "Opportunistic Encryption",
 			"link": "/ssl/edge-certificates/additional-options/opportunistic-encryption/",


### PR DESCRIPTION
### Summary

Now that Certificate Transparency Monitoring is GA on all plans (Free, Pro, Business, Enterprise) with all plans able to configure specified email addresses, the plan-comparison Availability table on this page no longer conveys useful differentiation. This PR removes it.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ X] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
