### PR TITLE
[Workers AI] Use an active model in the Wrangler starter guide

### DIFF
--- a/src/content/docs/workers-ai/get-started/workers-wrangler.mdx
+++ b/src/content/docs/workers-ai/get-started/workers-wrangler.mdx
@@ -74,7 +74,7 @@ You can also bind Workers AI to a Pages Function. For more information, refer to
 
 ## 3. Run an inference task in your Worker
 
-You are now ready to run an inference task in your Worker. In this case, you will use an LLM, [`llama-3.1-8b-instruct`](/workers-ai/models/llama-3.1-8b-instruct/), to answer a question.
+You are now ready to run an inference task in your Worker. In this case, you will use an LLM, [`llama-3.1-8b-instruct-fast`](/workers-ai/models/llama-3.1-8b-instruct-fast/), to answer a question.
 
 Update the `index.ts` file in your `hello-ai` application directory with the following code:
 
@@ -89,7 +89,7 @@ export interface Env {
 
 export default {
 	async fetch(request, env): Promise<Response> {
-		const response = await env.AI.run("@cf/meta/llama-3.1-8b-instruct", {
+		const response = await env.AI.run("@cf/meta/llama-3.1-8b-instruct-fast", {
 			prompt: "What is the origin of the phrase Hello, World",
 		});
 


### PR DESCRIPTION
## Summary

Replace the deprecated `@cf/meta/llama-3.1-8b-instruct` model in the Workers AI Wrangler starter guide with `@cf/meta/llama-3.1-8b-instruct-fast`.

The replacement is present in the current model catalog and is listed among the variants that remain active in the May 2026 model-deprecation changelog. The model link and runnable example now use the same active identifier.

Fixes #32501.

## Validation

- Confirmed the replacement model exists in the current Workers AI model catalog
- `astro check --minimumFailingSeverity=hint` — 441 files checked, 0 errors, warnings, or hints

## Documentation checklist

- [x] The change follows the documentation style guide.
- [x] No changelog is needed because the model deprecation already has a changelog entry.
