### PR TITLE
[Workers] Warn that deploy button inputs become production secrets

### DIFF
--- a/src/content/docs/workers/platform/deploy-buttons.mdx
+++ b/src/content/docs/workers/platform/deploy-buttons.mdx
@@ -86,8 +86,16 @@ Cloudflare will read the Wrangler configuration file of your source repo to dete
 [Worker secrets](/workers/configuration/secrets/) can be defined in a `.dev.vars.example` or `.env.example` file with a [dotenv](https://www.npmjs.com/package/dotenv) format:
 
 ```ini title=".dev.vars.example"
-COOKIE_SIGNING_KEY=my-secret # comment
+COOKIE_SIGNING_KEY=
 ```
+
+:::caution[Production secrets]
+
+Deploy to Cloudflare treats every uncommented entry in `.dev.vars.example` or `.env.example` as a required setup input. The value supplied during setup is stored as a secret on the deployed Worker.
+
+Use these files to list the secrets required for a production deployment, not as a collection of local development defaults. Comment out local-only or optional entries, and do not include defaults such as authentication bypass flags or localhost URLs that would be unsafe in production.
+
+:::
 
 [Secrets Store](/secrets-store/) secrets can be configured in the Wrangler configuration file as normal:
 

--- a/src/content/docs/workers/platform/deploy-buttons.mdx
+++ b/src/content/docs/workers/platform/deploy-buttons.mdx
@@ -91,9 +91,9 @@ COOKIE_SIGNING_KEY=
 
 :::caution[Production secrets]
 
-Deploy to Cloudflare treats every uncommented entry in `.dev.vars.example` or `.env.example` as a required setup input. The value supplied during setup is stored as a secret on the deployed Worker.
+Entries in `.dev.vars.example` or `.env.example` define Worker secrets that users configure during deployment.
 
-Use these files to list the secrets required for a production deployment, not as a collection of local development defaults. Comment out local-only or optional entries, and do not include defaults such as authentication bypass flags or localhost URLs that would be unsafe in production.
+Use these files for secrets needed by the deployed Worker, not for local development defaults. Comment out local-only or optional entries, and do not include defaults such as authentication bypass flags or localhost URLs that would be unsafe in production.
 
 :::
 


### PR DESCRIPTION
## Summary

Add a production-safety warning for `.dev.vars.example` and `.env.example` files. The warning explains that entries in these files define Worker secrets that users configure during deployment.

It advises template authors to keep local-only and optional settings commented out, and not to include defaults such as authentication bypass flags or localhost URLs that would be unsafe in production. The example no longer supplies `my-secret` as a default value.

Fixes #31988.

## Evidence

- The Deploy to Cloudflare documentation identifies `.dev.vars.example` and `.env.example` as sources for Worker secrets.
- The Cloudflare templates contribution guide states that users configure these Worker secrets during deployment.
- Issue #31988 documents the production risk of treating the example file as a local-development scratchpad.

## Validation

- `astro check --minimumFailingSeverity=hint` — 441 files checked, 0 errors, warnings, or hints
- `git diff --check`

## Documentation checklist

- [x] The change follows the documentation style guide.
- [x] No changelog is needed for a safety clarification to existing documentation.
