### PR TITLE
docs: remove stale local warning from DurableObjectState.abort

### DIFF
--- a/src/content/docs/durable-objects/api/state.mdx
+++ b/src/content/docs/durable-objects/api/state.mdx
@@ -340,12 +340,6 @@ class MyDurableObject(DurableObject):
 
 </Tabs>
 
-:::caution[Not available in local development]
-
-`abort` is not available in local development with the `wrangler dev` CLI command.
-
-:::
-
 #### Parameters
 
 - An optional `string` .


### PR DESCRIPTION
## Summary

Remove the warning that says `DurableObjectState.abort()` is unavailable in local development. Current Wrangler and workerd releases support it in local mode.

Closes #31659.

## Validation

- Ran the docs Astro check across 441 files: 0 errors, warnings, or hints.
- Called `ctx.abort("abort-local-smoke")` from a local Durable Object with Wrangler 4.114.0. The runtime raised the expected error and returned HTTP 500.
