### PR TITLE
docs: clarify Workers route wildcard matching

### DIFF
--- a/src/content/docs/workers/configuration/routing/routes.mdx
+++ b/src/content/docs/workers/configuration/routing/routes.mdx
@@ -203,7 +203,7 @@ The following examples illustrate the difference between `*example.com/*` and `*
 
 :::note[Zone scope]
 
-A Workers route is scoped to the [zone](/dns/zone-setups/) where it was created. A route in the `example.com` zone is not evaluated for requests to `myexample.com` or `not-example.com`; those rows illustrate the wildcard's string-matching behavior.
+Cloudflare evaluates a Workers route only within the [zone](/dns/zone-setups/) where you create it. For example, Cloudflare does not evaluate a route in the `example.com` zone for requests to `myexample.com` or `not-example.com`. Those rows illustrate the wildcard's string-matching behavior.
 
 The distinction matters for subdomain patterns within a zone. For example, `*sub.example.com/*` in the `example.com` zone matches `sub.example.com`, `foo.sub.example.com`, and `notsub.example.com`.
 

--- a/src/content/docs/workers/configuration/routing/routes.mdx
+++ b/src/content/docs/workers/configuration/routing/routes.mdx
@@ -188,7 +188,7 @@ If a route pattern hostname begins with `*`, then it matches the host and all su
 
 :::caution
 
-Because `*` matches zero or more of **any character** (not just subdomains), `*example.com` will also match hostnames that are not subdomains of `example.com`. If you only want to match `example.com` and its subdomains, use two separate routes (`example.com/*` and `*.example.com/*`) instead.
+Because `*` matches zero or more of **any character** (not just subdomains), `*example.com` matches any hostname ending in `example.com`. This includes `myexample.com` and `not-example.com`. To match only `example.com` and its subdomains, use two separate routes: `example.com/*` and `*.example.com/*`.
 
 :::
 
@@ -199,7 +199,21 @@ The following examples illustrate the difference between `*example.com/*` and `*
 | `https://example.com/` | Matches | Does not match |
 | `https://www.example.com/path` | Matches | Matches |
 | `https://myexample.com/` | Matches | Does not match |
-| `https://not-example.com/` | Does not match | Does not match |
+| `https://not-example.com/` | Matches | Does not match |
+
+:::note[Zone scope]
+
+A Workers route is scoped to the [zone](/dns/zone-setups/) where it was created. A route in the `example.com` zone is not evaluated for requests to `myexample.com` or `not-example.com`; those rows illustrate the wildcard's string-matching behavior.
+
+The distinction matters for subdomain patterns within a zone. For example, `*sub.example.com/*` in the `example.com` zone matches `sub.example.com`, `foo.sub.example.com`, and `notsub.example.com`.
+
+| Request URL | `*sub.example.com/*` | `*.sub.example.com/*` |
+|---|---|---|
+| `https://sub.example.com/` | Matches | Does not match |
+| `https://foo.sub.example.com/path` | Matches | Matches |
+| `https://notsub.example.com/` | Matches | Does not match |
+
+:::
 
 #### Paths may optionally end with `*`
 


### PR DESCRIPTION
## Summary

- Correct the wildcard table: `*example.com/*` matches `not-example.com` as a string pattern.
- Explain that Workers routes are still scoped to the zone where they were created.
- Add a within-zone example showing the difference between `*sub.example.com/*` and `*.sub.example.com/*`.

Closes #30885.

## Validation

Ran the docs Astro check across 441 files: 0 errors, warnings, or hints.
