### PR TITLE
fix: correct TLS client ciphers field name

### DIFF
--- a/public/__redirects
+++ b/public/__redirects
@@ -1645,6 +1645,7 @@
 /ruleset-engine/rules-language/fields/http-request-header/ /ruleset-engine/rules-language/fields/reference/ 301
 /ruleset-engine/rules-language/fields/http-request-body/ /ruleset-engine/rules-language/fields/reference/ 301
 /ruleset-engine/rules-language/fields/http-request-response/ /ruleset-engine/rules-language/fields/reference/ 301
+/ruleset-engine/rules-language/fields/reference/cf.tls_ciphers_sha1/ /ruleset-engine/rules-language/fields/reference/cf.tls_client_ciphers_sha1/ 301
 /ruleset-engine/rules-language/fields/magic-firewall/ /cloudflare-network-firewall/reference/network-firewall-fields/ 301
 # security center
 /security-center/indicator-feeds/getting-started/ /security-center/indicator-feeds/ 301

--- a/src/content/fields/index.yaml
+++ b/src/content/fields/index.yaml
@@ -953,7 +953,7 @@ entries:
     example_value: |-
       "7zIpdDU5pvFPPBI2/PCzqbaXnRA="
 
-  - name: cf.tls_ciphers_sha1
+  - name: cf.tls_client_ciphers_sha1
     data_type: String
     categories: [Request, SSL/TLS]
     keywords: [request, ssl, tls, client, visitor]


### PR DESCRIPTION
## Summary

- Rename `cf.tls_ciphers_sha1` to the supported field name, `cf.tls_client_ciphers_sha1`.
- Redirect the old generated reference URL to the corrected URL.

Closes #31014.

## Validation

- Confirmed that both Transform Rules field lists use `cf.tls_client_ciphers_sha1`.
- Ran the docs Astro check across 441 files: 0 errors, warnings, or hints.
- Built all 8,851 pages and confirmed that the corrected reference page and the 301 redirect are present in the output.
