### PR TITLE
docs: make Workers RPC example reproducible

### DIFF
--- a/src/content/partials/workers/service-binding-rpc-example.mdx
+++ b/src/content/partials/workers/service-binding-rpc-example.mdx
@@ -2,17 +2,30 @@
 {}
 ---
 
-import { WranglerConfig, TypeScriptExample, TabItem, Tabs } from "~/components";
+import { PackageManagers, WranglerConfig, TypeScriptExample, TabItem, Tabs } from "~/components";
 
-For example, if Worker B implements the public method `add(a, b)`:
+The TypeScript example below uses a separate directory for each Worker:
+
+```txt
+rpc-example/
+├── worker-a/
+│   ├── src/index.ts
+│   └── wrangler.jsonc
+└── worker-b/
+    ├── src/index.ts
+    └── wrangler.jsonc
+```
+
+Worker B implements the public method `add(a, b)`:
 
 <WranglerConfig>
 
 ```jsonc
 {
 	"$schema": "./node_modules/wrangler/config-schema.json",
-	"name": "worker_b",
-	"main": "./src/workerB.js"
+	"name": "worker-b",
+	"main": "./src/index.ts",
+	"compatibility_date": "$today"
 }
 ```
 
@@ -26,10 +39,6 @@ For example, if Worker B implements the public method `add(a, b)`:
 import { WorkerEntrypoint } from "cloudflare:workers";
 
 export default class extends WorkerEntrypoint {
-	async fetch() {
-		return new Response("Hello from Worker B");
-	}
-
 	add(a: number, b: number) {
 		return a + b;
 	}
@@ -41,12 +50,9 @@ export default class extends WorkerEntrypoint {
 <TabItem label="Python" icon="seti:python">
 
 ```python
-from workers import WorkerEntrypoint, Response
+from workers import WorkerEntrypoint
 
 class Default(WorkerEntrypoint):
-    async def fetch(self, request):
-        return Response("Hello from Worker B")
-
     def add(self, a: int, b: int) -> int:
         return a + b
 ```
@@ -62,12 +68,13 @@ Worker A can declare a [binding](/workers/runtime-apis/bindings) to Worker B:
 ```jsonc
 {
 	"$schema": "./node_modules/wrangler/config-schema.json",
-	"name": "worker_a",
-	"main": "./src/workerA.js",
+	"name": "worker-a",
+	"main": "./src/index.ts",
+	"compatibility_date": "$today",
 	"services": [
 		{
 			"binding": "WORKER_B",
-			"service": "worker_b"
+			"service": "worker-b"
 		}
 	]
 }
@@ -75,7 +82,17 @@ Worker A can declare a [binding](/workers/runtime-apis/bindings) to Worker B:
 
 </WranglerConfig>
 
-Making it possible for Worker A to call the `add()` method from Worker B:
+For TypeScript, generate Worker A's binding types from both configuration files. Run the following command from the `worker-a` directory:
+
+<PackageManagers
+	type="exec"
+	pkg="wrangler"
+	args="types -c ./wrangler.jsonc -c ../worker-b/wrangler.jsonc"
+/>
+
+Passing both files lets Wrangler resolve Worker B's default export. The generated `Env` interface types `WORKER_B` as a `Service` with the `add()` method. Do not set `entrypoint` to `default`; omitting `entrypoint` selects the default export.
+
+Worker A can then call `add()`:
 
 
 <Tabs syncKey="workersExamples">
@@ -84,11 +101,11 @@ Making it possible for Worker A to call the `add()` method from Worker B:
 
 ```ts
 export default {
-	async fetch(request, env) {
+	async fetch(_request, env): Promise<Response> {
 		const result = await env.WORKER_B.add(1, 2);
-		return new Response(result);
+		return new Response(result.toString());
 	},
-};
+} satisfies ExportedHandler<Env>;
 ```
 
 </TypeScriptExample>
@@ -108,3 +125,11 @@ class Default(WorkerEntrypoint):
 </TabItem>
 
 </Tabs>
+
+To run both Workers locally, run the following command from the `rpc-example` directory. The first configuration is the primary Worker and is available at `http://localhost:8787`.
+
+<PackageManagers
+	type="exec"
+	pkg="wrangler"
+	args="dev -c ./worker-a/wrangler.jsonc -c ./worker-b/wrangler.jsonc"
+/>


### PR DESCRIPTION
## Summary

- Show a two-directory layout for the Worker A and Worker B projects.
- Add compatibility dates and use TypeScript entrypoint paths in both Wrangler configurations.
- Generate Worker A's binding types from both configurations, which exposes Worker B's `add()` RPC method without a handwritten `Env` interface.
- Convert the numeric result to a string before constructing the response, remove Worker B's unused `fetch()` method, and include the multi-Worker local development command.

Closes #31154.

## Validation

- Ran `wrangler types -c ./wrangler.jsonc -c ../worker-b/wrangler.jsonc` with Wrangler 4.114.0. It generated `WORKER_B: Service<typeof import("../worker-b/src/index").default>`.
- Type-checked both Workers in strict mode with TypeScript 5.9.3.
- Started both Workers with the documented multi-config command. Worker A called Worker B over RPC and returned `3` with HTTP 200.
- Ran the docs Astro check across 441 files: 0 errors, warnings, or hints.
