### PR TITLE
[AI Gateway] Document setting spend limits by user

### DIFF
--- a/src/content/docs/ai-gateway/features/spend-limits.mdx
+++ b/src/content/docs/ai-gateway/features/spend-limits.mdx
@@ -9,6 +9,8 @@ products:
   - ai-gateway
 ---
 
+import { Steps } from "~/components";
+
 Spend limits let you set cost-based budgets on your AI Gateway. When cumulative spend reaches the limit within a time window, AI Gateway blocks further requests with a `429` response until the window resets.
 
 Unlike [rate limiting](/ai-gateway/features/rate-limiting/), which caps the number of requests, spend limits track actual dollar cost per request based on model pricing. You can scope limits to any combination of model, provider, or [custom metadata](/ai-gateway/observability/custom-metadata/) dimensions like user ID, team, or application.
@@ -27,26 +29,32 @@ Spend limits are eventually consistent. The current request's cost is recorded a
 
 ## Scoping with dimensions
 
-Each rule can be scoped by model, provider, or custom metadata dimensions. Each dimension can be configured in one of two modes:
+Each rule can be scoped by one or more dimensions:
 
-| Mode                | Behavior                                                          | Example                                                                                    |
-| ------------------- | ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
-| **Split by value**  | Each distinct value gets its own independent budget bucket.       | Splitting by `metadata.user_id` gives every user their own budget.                         |
-| **Filter by value** | The rule applies only when the dimension equals a specific value. | Filtering `metadata.team` to `engineering` limits only requests from the engineering team. |
+- **Limit by provider** — the provider used for the request.
+- **Limit by model** — the model used for the request.
+- **Limit by metadata** — a [custom metadata](/ai-gateway/observability/custom-metadata/) key you attach to requests. Enter the metadata key name (for example, `agent_id` or `environment`).
+
+Each dimension can be configured in one of two modes:
+
+| Mode                | Behavior                                                          | Example                                                                                                        |
+| ------------------- | ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| **Split by value**  | Each distinct value gets its own independent budget bucket.       | For example, if you pass in `agent_id`, splitting by `agent_id` gives every agent its own budget.             |
+| **Filter by value** | The rule applies only when the dimension equals a specific value. | For example, if you pass in `agent_id`, filtering `agent_id` to `agent_42` limits only that agent's requests. |
 
 If a dimension is not configured on a rule, all values share one budget bucket. For example, a rule without a `provider` dimension tracks spend across all providers together.
 
 ### Dimension examples
 
-Given a request with `model=openai/gpt-5.5` and `metadata.user_id=u_42`:
+Given a request with model `openai/gpt-5.5` and an `agent_id` metadata value of `agent_42`:
 
-| Scenario                   | Dimensions                                                     | Budget bucket                                 |
-| -------------------------- | -------------------------------------------------------------- | --------------------------------------------- |
-| Global budget for everyone | None                                                           | One shared bucket                             |
-| Per-user budget            | `metadata.user_id`: split by value                             | Separate bucket per user                      |
-| Per-provider, per-user     | `metadata.user_id`: split by value, `provider`: split by value | Separate bucket per user+provider combination |
-| Specific model only        | `model`: filter by value `openai/gpt-5.5`                      | Only applies to `openai/gpt-5.5` requests     |
-| Per-user, per-model        | `metadata.user_id`: split by value, `model`: split by value    | Separate bucket per user+model combination    |
+| Scenario                   | Dimensions                                                       | Budget bucket                                  |
+| -------------------------- | ---------------------------------------------------------------- | ---------------------------------------------- |
+| Global budget for everyone | None                                                             | One shared bucket                              |
+| Per-agent budget           | `agent_id` metadata: split by value                              | Separate bucket per agent                      |
+| Per-provider, per-agent    | `agent_id` metadata: split by value, `provider`: split by value  | Separate bucket per agent+provider combination |
+| Specific model only        | `model`: filter by value `openai/gpt-5.5`                        | Only applies to `openai/gpt-5.5` requests      |
+| Per-agent, per-model       | `agent_id` metadata: split by value, `model`: split by value     | Separate bucket per agent+model combination    |
 
 ## Configure spend limits
 
@@ -55,6 +63,38 @@ Spend limits are configured on the gateway via the dashboard or the API. You can
 ![Add spend limit rule form](~/assets/images/ai-gateway/spend-limits-add-rule.png)
 
 To scope spend limits by custom dimensions like user ID or team, attach [custom metadata](/ai-gateway/observability/custom-metadata/) to your requests.
+
+### Set spend limits by user
+
+You can give every user their own budget by scoping a rule to a user identifier. How you get that identifier depends on how your gateway is authenticated.
+
+#### With Cloudflare Access
+
+If your gateway is protected by [Cloudflare Access](/ai-gateway/configuration/cloudflare-access/), AI Gateway automatically adds the authenticated Access user ID to each request as the reserved [`cf.user_id`](/ai-gateway/observability/custom-metadata/#reserved-metadata) metadata key. You do not need to pass user IDs from your client application.
+
+To set a per-user budget:
+
+<Steps>
+
+1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **AI** > **AI Gateway** and select your gateway.
+2. Go to the spend limits settings and add a rule.
+3. Under **Limit by metadata**, select **Add metadata dimension** and enter `cf.user_id` as the key.
+4. Set the dimension to **Split by value**.
+5. Set the budget amount and time window, then save.
+
+</Steps>
+
+Each authenticated Access user now gets an independent budget. To instead limit a single user, set the dimension to **Filter by value** and enter that user's Access JWT `sub` claim.
+
+:::note
+
+`cf.user_id` is only present on requests that arrive through an Access-protected [custom domain](/ai-gateway/configuration/custom-domains/) with a valid Access user subject. Service-token requests do not include `cf.user_id`.
+
+:::
+
+#### Without Cloudflare Access
+
+If your gateway is not behind Access, pass your own user identifier as [custom metadata](/ai-gateway/observability/custom-metadata/) (for example, a `user_id` key). Then, under **Limit by metadata**, add a dimension with the key `user_id` and set it to **Split by value**.
 
 ## Behavior when a limit is reached
 


### PR DESCRIPTION
### Summary

Updates the [AI Gateway spend limits](https://developers.cloudflare.com/ai-gateway/features/spend-limits/) page to document how to scope spend limits per user now that the [Cloudflare Access integration](https://developers.cloudflare.com/ai-gateway/configuration/cloudflare-access/) automatically adds the authenticated user to request metadata as the reserved `cf.user_id` key.

- Adds a "Set spend limits by user" section covering both the Access path (using the auto-added `cf.user_id` metadata) and the non-Access path (passing your own user identifier).
- Aligns the dimension descriptions with the dashboard UI (**Limit by provider/model/metadata**) and drops an invented `metadata.<key>` notation in favor of plain metadata key names, which was previously confusing.

### Documentation checklist

- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
