### PR TITLE
[Artifacts] Document data localization

### DIFF
--- a/src/content/changelog/artifacts/2026-08-13-artifacts-jurisdictions.mdx
+++ b/src/content/changelog/artifacts/2026-08-13-artifacts-jurisdictions.mdx
@@ -1,0 +1,26 @@
+---
+title: Data localization support for Artifacts
+description: Ensure Artifacts stores and processes repo data only within a selected jurisdiction.
+products:
+  - artifacts
+date: 2026-08-13
+---
+
+Artifacts now supports jurisdictions, allowing you to select the European Union or the United States as the only location where repo data is stored and processed.
+
+Select a jurisdiction when you create a namespace. Every repo in that namespace automatically uses the selected jurisdiction.
+
+```bash
+curl --request POST \
+  "https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/artifacts/namespaces" \
+  --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "namespace": "my-eu-namespace",
+    "jurisdiction": "eu"
+  }'
+```
+
+Jurisdictions cannot be changed after namespace creation. If you omit the jurisdiction, Artifacts creates an unrestricted namespace.
+
+For supported jurisdictions and usage details, refer to [Data localization](/artifacts/guides/data-localization/).

--- a/src/content/docs/artifacts/api/rest-api.mdx
+++ b/src/content/docs/artifacts/api/rest-api.mdx
@@ -81,6 +81,7 @@ Returned repo tokens are secrets. Do not log them or store them in long-lived re
 
 ```ts
 export type NamespaceName = string;
+export type Jurisdiction = "eu" | "us";
 export type RepoName = string;
 export type BranchName = string;
 export type Scope = "read" | "write";
@@ -153,6 +154,31 @@ export interface TokenInfo {
 ```
 
 ## Namespaces
+
+### Create a namespace
+
+Route: `POST /artifacts/namespaces`
+
+Use the account-level base URL.
+
+Request body:
+
+- `namespace` <Type text="NamespaceName" /> <MetaInfo text="required" />
+- `jurisdiction` <Type text='"eu" | "us"' /> <MetaInfo text="optional (default: unrestricted)" />
+
+```bash
+curl --request POST "$ARTIFACTS_ACCOUNT_BASE_URL/namespaces" \
+  --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "namespace": "my-eu-namespace",
+    "jurisdiction": "eu"
+  }'
+```
+
+The jurisdiction applies to every repo in the namespace and cannot be changed after creation. If you omit `jurisdiction`, Artifacts creates an unrestricted namespace.
+
+For more information, refer to [Data localization](/artifacts/guides/data-localization/).
 
 ### List namespaces
 

--- a/src/content/docs/artifacts/concepts/how-artifacts-works.mdx
+++ b/src/content/docs/artifacts/concepts/how-artifacts-works.mdx
@@ -14,7 +14,7 @@ Artifacts creates Git repos on demand. Each repo is an isolated Git service with
 
 Namespaces are the top-level container for repos. A repo lives inside one namespace, and its name is unique within that namespace.
 
-Artifacts does not provision namespaces separately. When you create the first repo with a new namespace name, Artifacts creates that namespace implicitly.
+You can create a namespace explicitly to select a [jurisdiction](/artifacts/guides/data-localization/). When you create the first repo with a new namespace name, Artifacts creates an unrestricted namespace implicitly.
 
 A namespace provides the naming and routing boundary for repos. Together, the namespace and repo name form the repo's stable address, and API responses also return a repo ID.
 

--- a/src/content/docs/artifacts/concepts/how-artifacts-works.mdx
+++ b/src/content/docs/artifacts/concepts/how-artifacts-works.mdx
@@ -14,7 +14,7 @@ Artifacts creates Git repos on demand. Each repo is an isolated Git service with
 
 Namespaces are the top-level container for repos. A repo lives inside one namespace, and its name is unique within that namespace.
 
-You can create a namespace explicitly to select a [jurisdiction](/artifacts/guides/data-localization/). When you create the first repo with a new namespace name, Artifacts creates an unrestricted namespace implicitly.
+Artifacts does not provision namespaces separately. When you create the first repo with a new namespace name, Artifacts creates that namespace implicitly.
 
 A namespace provides the naming and routing boundary for repos. Together, the namespace and repo name form the repo's stable address, and API responses also return a repo ID.
 

--- a/src/content/docs/artifacts/concepts/index.mdx
+++ b/src/content/docs/artifacts/concepts/index.mdx
@@ -12,6 +12,6 @@ products:
 
 import { DirectoryListing } from "~/components";
 
-Use these concepts to understand namespaces, repositories, versioning behavior, and the operating model for Artifacts.
+Use these concepts to understand namespaces, repos, versioning behavior, and the operating model for Artifacts.
 
 <DirectoryListing />

--- a/src/content/docs/artifacts/concepts/namespaces.mdx
+++ b/src/content/docs/artifacts/concepts/namespaces.mdx
@@ -12,7 +12,7 @@ import { WranglerConfig } from "~/components";
 
 Artifacts uses namespaces as top-level containers for repositories. Use them to separate repositories by environment, such as `prod`, `staging`, and `dev`, by tenant, or shard.
 
-You can create a namespace explicitly or let Artifacts create one automatically. Create a namespace explicitly when you need to select a [jurisdiction](/artifacts/guides/data-localization/). If you create a repo under a namespace name that does not exist, Artifacts creates an unrestricted namespace automatically.
+You can create a namespace explicitly or let Artifacts create one automatically. If you create a repo under a namespace name that does not exist, Artifacts creates the namespace automatically.
 
 ## Use namespaces as containers
 

--- a/src/content/docs/artifacts/concepts/namespaces.mdx
+++ b/src/content/docs/artifacts/concepts/namespaces.mdx
@@ -12,7 +12,7 @@ import { WranglerConfig } from "~/components";
 
 Artifacts uses namespaces as top-level containers for repositories. Use them to separate repositories by environment, such as `prod`, `staging`, and `dev`, by tenant, or shard.
 
-Namespaces are created implicitly — there is no separate step to create one. You choose a namespace name, then reference it in your Wrangler config or REST API path. The first time you create a repository under that name, Artifacts creates the namespace for you automatically.
+You can create a namespace explicitly or let Artifacts create one automatically. Create a namespace explicitly when you need to select a [jurisdiction](/artifacts/guides/data-localization/). If you create a repo under a namespace name that does not exist, Artifacts creates an unrestricted namespace automatically.
 
 ## Use namespaces as containers
 
@@ -33,6 +33,12 @@ Namespace names follow the same public naming rules as repo names:
 - keep the name stable across your Workers, API clients, and Git workflows
 
 If you have not chosen a namespace strategy yet, use `default` in the examples throughout this docset.
+
+## Choose a data location
+
+Select a jurisdiction when you create a namespace to restrict where Artifacts stores and processes repo data. Every repo in that namespace uses the selected jurisdiction.
+
+You cannot change a namespace jurisdiction after creation. For supported jurisdictions and creation instructions, refer to [Data localization](/artifacts/guides/data-localization/).
 
 ## Use the same namespace everywhere
 

--- a/src/content/docs/artifacts/concepts/repositories.mdx
+++ b/src/content/docs/artifacts/concepts/repositories.mdx
@@ -10,7 +10,7 @@ products:
 
 Artifacts stores work in repositories. A repository is one isolated Git service with its own history, refs, remote URL, tokens, and durable state.
 
-Every repository lives inside one namespace. If the namespace does not exist yet, Artifacts creates it when you create the first repo in it.
+Every repo lives inside one namespace. If the namespace does not exist yet, Artifacts creates an unrestricted namespace when you create the first repo in it.
 
 The namespace groups related repositories, and the repository name identifies one repository inside that group.
 

--- a/src/content/docs/artifacts/concepts/repositories.mdx
+++ b/src/content/docs/artifacts/concepts/repositories.mdx
@@ -10,7 +10,7 @@ products:
 
 Artifacts stores work in repositories. A repository is one isolated Git service with its own history, refs, remote URL, tokens, and durable state.
 
-Every repo lives inside one namespace. If the namespace does not exist yet, Artifacts creates an unrestricted namespace when you create the first repo in it.
+Every repo lives inside one namespace. If the namespace does not exist yet, Artifacts creates it when you create the first repo in it.
 
 The namespace groups related repositories, and the repository name identifies one repository inside that group.
 

--- a/src/content/docs/artifacts/guides/data-localization.mdx
+++ b/src/content/docs/artifacts/guides/data-localization.mdx
@@ -1,0 +1,39 @@
+---
+title: Data localization
+description: Ensure Artifacts stores and processes repo data only within a selected jurisdiction.
+pcx_content_type: how-to
+sidebar:
+  order: 6
+products:
+  - artifacts
+---
+
+Artifacts jurisdictions ensure repo data is stored and processed only within a selected location. Set a jurisdiction when you create a namespace to apply the restriction to every repo in that namespace.
+
+## Supported jurisdictions
+
+Artifacts supports the following jurisdictions:
+
+| Jurisdiction | Location       |
+| ------------ | -------------- |
+| `eu`         | European Union |
+| `us`         | United States  |
+
+## Create a namespace with a jurisdiction
+
+To restrict a namespace to the European Union, set `jurisdiction` to `eu` when you create the namespace:
+
+```bash
+curl --request POST \
+  "https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/artifacts/namespaces" \
+  --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "namespace": "my-eu-namespace",
+    "jurisdiction": "eu"
+  }'
+```
+
+The selected jurisdiction applies to every repo in the namespace. You cannot change the jurisdiction after creating the namespace. The `jurisdiction` parameter is optional. If you omit it, the namespace remains unrestricted.
+
+For endpoint details, refer to the [Artifacts REST API reference](/artifacts/api/rest-api/#create-a-namespace).

--- a/src/content/docs/artifacts/guides/index.mdx
+++ b/src/content/docs/artifacts/guides/index.mdx
@@ -12,6 +12,6 @@ products:
 
 import { DirectoryListing } from "~/components";
 
-In-depth guides for using Artifacts in production, including how Artifacts authenticates clients, controls data localization, imports existing Git repos, and mounts large repos within sandboxes.
+In-depth guides for using Artifacts in production, including how Artifacts authenticates clients, imports existing Git repos, and mounts large repos within sandboxes.
 
 <DirectoryListing />

--- a/src/content/docs/artifacts/guides/index.mdx
+++ b/src/content/docs/artifacts/guides/index.mdx
@@ -12,6 +12,6 @@ products:
 
 import { DirectoryListing } from "~/components";
 
-In-depth guides for using Artifacts in production, including how Artifacts authenticates clients, how to import existing Git repositories, and how to mount large repositories within sandboxes.
+In-depth guides for using Artifacts in production, including how Artifacts authenticates clients, controls data localization, imports existing Git repos, and mounts large repos within sandboxes.
 
 <DirectoryListing />


### PR DESCRIPTION
### Summary

Adds Artifacts data localization documentation for restricting repo storage and processing to the European Union or the United States. Documents namespace creation through the REST API, including the unrestricted behavior when the optional jurisdiction is omitted, and adds a changelog entry.

### Screenshots (optional)

<!-- TODO: add screenshots before requesting review -->

### Documentation checklist

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) - how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page - an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
