### PR TITLE
[1.1.1.1] Add EDE 33 (Negative Trust Anchor) to extended DNS error codes

### DIFF
--- a/src/content/docs/1.1.1.1/infrastructure/extended-dns-error-codes.mdx
+++ b/src/content/docs/1.1.1.1/infrastructure/extended-dns-error-codes.mdx
@@ -118,11 +118,11 @@ dig @1.1.1.1 example.com A
             <td><code>EDE: 30 (Invalid Query Type): Invalid Query Type</code></td>
             <td>The record type in the request cannot give a valid answer. If this is returned for standard query types, such as A or AAAA records, please reach out to the <a href="https://community.cloudflare.com/c/reliability/dns-1111/47">community forum</a>.</td>
         </tr>
-				<tr>
+        <tr>
             <td>33</td>
             <td>Negative Trust Anchor</td>
             <td><code>EDE: 33 (Negative Trust Anchor): (a Negative Trust Anchor has been applied for this query (see RFC 7646))</code></td>
-            <td>A <a href="https://www.rfc-editor.org/rfc/rfc7646">Negative Trust Anchor</a> was applied to this query, bypassing DNSSEC validation. Check the <a href="https://www.cloudflarestatus.com/">Cloudflare status page</a> for any details, and read our <a href="https://blog.cloudflare.com/dnssec-nta-ede-33/">blog post</a> on EDE 33 for more information.</td>
+            <td>A <a href="https://www.rfc-editor.org/rfc/rfc7646">Negative Trust Anchor</a> was applied to this query, bypassing DNSSEC validation. Check the <a href="https://www.cloudflarestatus.com/">Cloudflare status page</a> for any details, and read our <a href="https://blog.cloudflare.com/dnssec-nta-ede-33/">blog post on EDE 33</a> for more information.</td>
         </tr>
     </tbody>
 </table>

--- a/src/content/docs/1.1.1.1/infrastructure/extended-dns-error-codes.mdx
+++ b/src/content/docs/1.1.1.1/infrastructure/extended-dns-error-codes.mdx
@@ -118,5 +118,11 @@ dig @1.1.1.1 example.com A
             <td><code>EDE: 30 (Invalid Query Type): Invalid Query Type</code></td>
             <td>The record type in the request cannot give a valid answer. If this is returned for standard query types, such as A or AAAA records, please reach out to the <a href="https://community.cloudflare.com/c/reliability/dns-1111/47">community forum</a>.</td>
         </tr>
+				<tr>
+            <td>33</td>
+            <td>Negative Trust Anchor</td>
+            <td><code>EDE: 33 (Negative Trust Anchor): (a Negative Trust Anchor has been applied for this query (see RFC 7646))</code></td>
+            <td>A <a href="https://www.rfc-editor.org/rfc/rfc7646">Negative Trust Anchor</a> was applied to this query, bypassing DNSSEC validation. Check the <a href="https://www.cloudflarestatus.com/">Cloudflare status page</a> for any details, and read our <a href="https://blog.cloudflare.com/dnssec-nta-ede-33/">blog post</a> on EDE 33 for more information.</td>
+        </tr>
     </tbody>
 </table>


### PR DESCRIPTION
### Summary

Adds EDE 33 (Negative Trust Anchor) to the 1.1.1.1 [extended DNS error codes](https://developers.cloudflare.com/1.1.1.1/infrastructure/extended-dns-error-codes/) table. 1.1.1.1 already returns this code when an NTA is in effect; the page had not been updated.

Links RFC 7646, the Cloudflare status page, and the [EDE 33 blog post](https://blog.cloudflare.com/dnssec-nta-ede-33/).

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).