### PR TITLE
[Workers] Update RPC error serialization docs

### DIFF
--- a/src/content/docs/workers/runtime-apis/rpc/error-handling.mdx
+++ b/src/content/docs/workers/runtime-apis/rpc/error-handling.mdx
@@ -6,7 +6,7 @@ sidebar:
 head:
   - tag: title
     content: Workers RPC — Error Handling
-description: How exceptions, stack traces, and logging works with the Workers RPC system.
+description: How exceptions, error properties, and stack traces work with the Workers RPC system.
 
 products:
   - workers
@@ -14,14 +14,22 @@ products:
 
 ## Exceptions
 
-An exception thrown by an RPC method implementation will propagate to the caller. If it is one of the standard JavaScript Error types, the `message` and prototype's `name` will be retained, though the stack trace is not.
+An error thrown by an RPC method, or used to reject the method's returned Promise, propagates to the caller as a new error object. With enhanced error serialization, Workers preserves the effective `name` and `message` and serializable own properties, including non-enumerable properties such as [`cause`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause).
 
-### Unsupported error types
+[Enhanced error serialization](/workers/configuration/compatibility-flags/#enhanced-error-serialization) uses the `enhanced_error_serialization` compatibility flag. It is on by default for compatibility dates on or after `2026-04-21`. For earlier compatibility dates, add the flag to both the RPC provider and consumer. A Worker can opt out with `legacy_error_serialization`. Without enhanced error serialization, RPC uses legacy error reconstruction and does not preserve custom own properties.
 
-* If an [`AggregateError`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AggregateError) is thrown by an RPC method, it is not propagated back to the caller.
-* The [`SuppressedError`](https://github.com/tc39/proposal-explicit-resource-management?tab=readme-ov-file#the-suppressederror-error) type from the Explicit Resource Management proposal is not currently implemented or supported in Workers.
-* Own properties of error objects, such as the [`cause`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause) property, are not propagated back to the caller
+The provider must be able to serialize the error and its own property values. Keep public error properties small and serializable. If an own property contains a non-serializable value, Workers does not guarantee that the enhanced error details will reach the consumer.
+
+On the consumer, treat the error's serializable fields as the RPC contract. Workers does not preserve or guarantee:
+
+- The source object's identity, custom prototype, or constructor.
+- The results of `instanceof` checks, especially for custom error classes.
+- Prototype methods or property descriptors.
+- The provider's original stack trace. The consumer may see a new stack from error reconstruction instead.
+- Non-serializable property values.
+
+For example, an instance of `ProviderError extends Error` can arrive with `name` set to `"ProviderError"` and with serializable own fields such as `code`, but it is not an instance of a consumer-side `ProviderError` class. Check documented fields such as `name` and `code` instead of relying on class identity.
 
 ## Additional properties
 
-For some remote exceptions, the runtime may set properties on the propagated exception to provide more information about the error; see [Durable Object error handling](/durable-objects/best-practices/error-handling) for more details.
+For some remote exceptions, the runtime may add properties to the propagated exception, such as retry or Durable Object metadata. These properties are separate from the provider's custom properties. Refer to [Durable Object error handling](/durable-objects/best-practices/error-handling) for more details.


### PR DESCRIPTION
### Summary

- document `enhanced_error_serialization` and its `2026-04-21` default compatibility date
- clarify how thrown and rejected JSRPC errors preserve serializable own properties
- document provider/consumer requirements and identity, stack, descriptor, and serialization non-guarantees

### Validation

- `pnpm exec prettier --check src/content/docs/workers/runtime-apis/rpc/error-handling.mdx`
- `pnpm run check:astro`

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
