### PR TITLE
[Ruleset Engine] Clarify Access phase ordering

### DIFF
--- a/src/content/docs/ruleset-engine/reference/phases-list.mdx
+++ b/src/content/docs/ruleset-engine/reference/phases-list.mdx
@@ -32,30 +32,32 @@ The following tables list the [phases](/ruleset-engine/about/phases/) of Cloudfl
 
 The phases execute in the order they appear in the table.
 
-| Phase name                         | Used in product/feature                                                         |
-| ---------------------------------- | ------------------------------------------------------------------------------- |
-| `http_request_dynamic_redirect`    | [Single Redirects](/rules/url-forwarding/single-redirects/)                     |
-| `http_request_sanitize`            | [URL normalization](/rules/normalization/)                                      |
-| `http_request_transform`           | [URL Rewrite Rules](/rules/transform/url-rewrite/)                              |
-| _N/A_ (internal phase)             | [Waiting Room Rules](/waiting-room/additional-options/waiting-room-rules/)      |
-| `http_request_api_gateway_early`\* | [API Shield](/api-shield/)                                                      |
-| `http_config_settings`             | [Configuration Rules](/rules/configuration-rules/)                              |
-| `http_request_origin`              | [Origin Rules](/rules/origin-rules/)                                            |
-| `ddos_l7`\*                        | [HTTP DDoS Attack Protection](/ddos-protection/managed-rulesets/http/)          |
-| `http_request_firewall_custom`     | [Custom rules (Web Application Firewall)](/waf/custom-rules/)                   |
-| `http_ratelimit`                   | [Rate limiting rules (WAF)](/waf/rate-limiting-rules/)                          |
-| `http_request_api_gateway_late`    | [API Shield](/api-shield/)                                                      |
-| `http_request_firewall_managed`    | [WAF Managed Rules](/waf/managed-rules/)                                        |
-| `http_request_sbfm`                | [Super Bot Fight Mode](/bots/get-started/super-bot-fight-mode/)                 |
-| _N/A_ (internal phase)             | [Cloudflare Access](/cloudflare-one/access-controls/policies/)                  |
-| `http_request_redirect`            | [Bulk Redirects](/rules/url-forwarding/bulk-redirects/)                         |
-| _N/A_ (internal phase)             | [Managed Transforms](/rules/transform/managed-transforms/)                      |
-| `http_request_late_transform`      | [Request Header Transform Rules](/rules/transform/request-header-modification/) |
-| `http_request_cache_settings`      | [Cache Rules](/cache/how-to/cache-rules/)                                       |
-| `http_request_snippets`            | [Snippets](/rules/snippets/)                                                    |
-| `http_request_cloud_connector`     | [Cloud Connector](/rules/cloud-connector/)                                      |
+| Phase name                         | Used in product/feature                                                          |
+| ---------------------------------- | -------------------------------------------------------------------------------- |
+| `http_request_dynamic_redirect`    | [Single Redirects](/rules/url-forwarding/single-redirects/)                      |
+| `http_request_sanitize`            | [URL normalization](/rules/normalization/)                                       |
+| `http_request_transform`           | [URL Rewrite Rules](/rules/transform/url-rewrite/)                               |
+| _N/A_ (internal phase)             | [Waiting Room Rules](/waiting-room/additional-options/waiting-room-rules/)       |
+| `http_request_api_gateway_early`\* | [API Shield](/api-shield/)                                                       |
+| `http_config_settings`             | [Configuration Rules](/rules/configuration-rules/)                               |
+| `http_request_origin`              | [Origin Rules](/rules/origin-rules/)                                             |
+| `ddos_l7`\*                        | [HTTP DDoS Attack Protection](/ddos-protection/managed-rulesets/http/)           |
+| `http_request_firewall_custom`     | [Custom rules (Web Application Firewall)](/waf/custom-rules/)                    |
+| `http_ratelimit`                   | [Rate limiting rules (WAF)](/waf/rate-limiting-rules/)                           |
+| `http_request_api_gateway_late`    | [API Shield](/api-shield/)                                                       |
+| `http_request_firewall_managed`    | [WAF Managed Rules](/waf/managed-rules/)                                         |
+| `http_request_sbfm`                | [Super Bot Fight Mode](/bots/get-started/super-bot-fight-mode/)                  |
+| _N/A_ (internal phase)             | [Cloudflare Access](/cloudflare-one/access-controls/policies/) application check |
+| `http_request_redirect`            | [Bulk Redirects](/rules/url-forwarding/bulk-redirects/)                          |
+| _N/A_ (internal phase)             | [Managed Transforms](/rules/transform/managed-transforms/)                       |
+| `http_request_late_transform`      | [Request Header Transform Rules](/rules/transform/request-header-modification/)  |
+| `http_request_cache_settings`      | [Cache Rules](/cache/how-to/cache-rules/)                                        |
+| `http_request_snippets`            | [Snippets](/rules/snippets/)                                                     |
+| `http_request_cloud_connector`     | [Cloud Connector](/rules/cloud-connector/)                                       |
 
 \* _This phase is for configuration purposes only — the corresponding rules will not be executed at this stage in the request handling process._
+
+For Cloudflare Access, the `Cloudflare Access` row refers to Access application checking. Access enforcement and handling run in later internal phases, after Bulk Redirects.
 
 <Render file="bfm-change-notice" product="bots" />
 


### PR DESCRIPTION
### Summary

Clarifies the Ruleset Engine phases reference by specifying that the Cloudflare Access row refers to Access application checking. Also notes that Access enforcement and handling run in later internal phases, after Bulk Redirects.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
Remove the screenshots section because this is not a visual change.
Remove these checklist items because they do not apply:
- Changelog: this is a clarification/fix, not a new customer-facing feature.
- Issue: this is a small focused correction, not a larger restructuring.
- Redirects: no files were renamed, moved, or deleted.