### PR TITLE
[Analytics] Add WebSocket data transfer changelog

### DIFF
--- a/src/content/changelog/analytics/2026-08-14-websocket-data-transfer-reporting.mdx
+++ b/src/content/changelog/analytics/2026-08-14-websocket-data-transfer-reporting.mdx
@@ -1,0 +1,13 @@
+---
+title: WebSocket reporting now includes full connection data transfer
+description: HTTP Traffic Analytics and HTTP request logs now count data transferred throughout WebSocket connections, not only the initial handshake.
+date: 2026-08-14
+---
+
+Cloudflare has fixed an issue affecting WebSocket data transfer reporting. HTTP Traffic Analytics and HTTP request logs now correctly count data transferred throughout a WebSocket connection, restoring the correct behavior. During the affected period, reporting captured only the initial `101 Switching Protocols` handshake for some WebSocket connections, which could underreport their data transfer.
+
+Customers with WebSocket traffic will see the correct **Data Transfer** in the dashboard and `EdgeResponseBytes` in analytics and HTTP request logs. The change reflects restored accounting of existing WebSocket traffic, not an increase in traffic caused by this change. WebSocket connection behavior is unaffected.
+
+The separate [WebSocket Analytics Logpush dataset](/logs/logpush/logpush-job/datasets/zone/websocket_analytics/) continues to provide per-connection directional byte counts, timestamps, and close details.
+
+For more information about HTTP Traffic Analytics, refer to [Zone Analytics](/analytics/account-and-zone-analytics/zone-analytics/#http-traffic).


### PR DESCRIPTION
### Summary

Adds an Analytics changelog entry for the WebSocket data transfer reporting fix. HTTP Traffic Analytics and HTTP request logs now count data transferred throughout a WebSocket connection rather than only the initial handshake. The entry clarifies that corrected reporting may increase displayed data transfer without affecting WebSocket traffic or connection behavior.

### Documentation checklist

- [x] This PR adds a changelog entry.
- [x] The change adheres to the documentation style guide.