### PR TITLE
[Workers] Add latest changelog entries

### DIFF
--- a/src/content/release-notes/workers.yaml
+++ b/src/content/release-notes/workers.yaml
@@ -3,6 +3,12 @@ link: "/workers/platform/changelog/"
 productName: Workers
 productLink: "/workers/"
 entries:
+  - publish_date: "2026-08-18"
+    description: |-
+      - Updated v8 to version 15.2.
+  - publish_date: "2026-07-16"
+    description: |-
+      - Updated v8 to version 15.1.
   - publish_date: "2026-06-04"
     description: |-
       - Updated v8 to version 15.0.


### PR DESCRIPTION
### Summary

Updating the release notes for the Workers Runtime as part of on-call.

### Documentation checklist

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).