### PR TITLE
[Workers AI] Add DeepSeek V4 Flash and Pro models

### DIFF
--- a/src/content/changelog/workers-ai/2026-08-14-deepseek-v4-workers-ai.mdx
+++ b/src/content/changelog/workers-ai/2026-08-14-deepseek-v4-workers-ai.mdx
@@ -1,6 +1,6 @@
 ---
 title: "DeepSeek V4 Flash and Pro now available on Workers AI"
-description: DeepSeek's latest reasoning models are now on Workers AI, with DeepSeek V4 Pro bringing the first full one million token context window to the platform.
+description: DeepSeek's latest reasoning models are now on Workers AI, the first models on the platform with a full one million token context window.
 products:
   - workers-ai
 date: 2026-08-14
@@ -8,15 +8,15 @@ date: 2026-08-14
 
 [`@cf/deepseek-ai/deepseek-v4-pro-0813`](/workers-ai/models/deepseek-v4-pro-0813/) and [`@cf/deepseek-ai/deepseek-v4-flash-0731`](/workers-ai/models/deepseek-v4-flash-0731/) are now available on Workers AI.
 
-DeepSeek V4 Pro is the first Workers AI model with a full **one million (1,048,576) token context window**. Use it for long-horizon agentic workflows, large codebases, and multi-step reasoning that exceed the context limits of every other model hosted on the platform.
+DeepSeek V4 Flash and DeepSeek V4 Pro are the first Workers AI models with a full **one million (1,048,576) token context window**. Use them for long-horizon agentic workflows, large codebases, and multi-step reasoning that exceed the context limits of every other model hosted on the platform.
 
-DeepSeek V4 Flash is the faster, lower-cost sibling with a **384,000 token context window**. This release supersedes the preview version with substantially enhanced agentic capabilities.
+DeepSeek V4 Flash is the faster, lower-cost sibling. This release supersedes the preview version with substantially enhanced agentic capabilities.
 
 **Key capabilities:**
 
 - **Reasoning**: Both models support thinking mode for complex, step-by-step problem-solving.
 - **Function calling**: Build agents that invoke tools and APIs across multiple conversation turns.
-- **Long context**: DeepSeek V4 Pro supports 1,048,576 tokens, and DeepSeek V4 Flash supports 384,000 tokens.
+- **Long context**: Both models support a full 1,048,576 token context window.
 
 Both models require the [Workers Paid plan](/workers/platform/pricing/#workers) or prepaid [AI Gateway credits](/ai-gateway/features/unified-billing/).
 

--- a/src/content/changelog/workers-ai/2026-08-14-deepseek-v4-workers-ai.mdx
+++ b/src/content/changelog/workers-ai/2026-08-14-deepseek-v4-workers-ai.mdx
@@ -1,0 +1,25 @@
+---
+title: "DeepSeek V4 Flash and Pro now available on Workers AI"
+description: DeepSeek's latest reasoning models are now on Workers AI, with DeepSeek V4 Pro bringing the first full one million token context window to the platform.
+products:
+  - workers-ai
+date: 2026-08-14
+---
+
+[`@cf/deepseek-ai/deepseek-v4-pro-0813`](/workers-ai/models/deepseek-v4-pro-0813/) and [`@cf/deepseek-ai/deepseek-v4-flash-0731`](/workers-ai/models/deepseek-v4-flash-0731/) are now available on Workers AI.
+
+DeepSeek V4 Pro is the first Workers AI model with a full **one million (1,048,576) token context window**. Use it for long-horizon agentic workflows, large codebases, and multi-step reasoning that exceed the context limits of every other model hosted on the platform.
+
+DeepSeek V4 Flash is the faster, lower-cost sibling with a **384,000 token context window**. This release supersedes the preview version with substantially enhanced agentic capabilities.
+
+**Key capabilities:**
+
+- **Reasoning**: Both models support thinking mode for complex, step-by-step problem-solving.
+- **Function calling**: Build agents that invoke tools and APIs across multiple conversation turns.
+- **Long context**: DeepSeek V4 Pro supports 1,048,576 tokens, and DeepSeek V4 Flash supports 384,000 tokens.
+
+Both models require the [Workers Paid plan](/workers/platform/pricing/#workers) or prepaid [AI Gateway credits](/ai-gateway/features/unified-billing/).
+
+Use these models through the [Workers AI binding](/workers-ai/configuration/bindings/) (`env.AI.run()`), the REST API, the [OpenAI-compatible endpoint](/workers-ai/configuration/open-ai-compatibility/), or [AI Gateway](/ai-gateway/).
+
+For more information, refer to the [DeepSeek V4 Pro model page](/workers-ai/models/deepseek-v4-pro-0813/), the [DeepSeek V4 Flash model page](/workers-ai/models/deepseek-v4-flash-0731/), and [pricing](/workers-ai/platform/pricing/).

--- a/src/content/docs/workers-ai/platform/pricing.mdx
+++ b/src/content/docs/workers-ai/platform/pricing.mdx
@@ -26,7 +26,7 @@ All limits reset daily at 00:00 UTC. If you exceed any one of the above limits, 
 | Workers Paid | 10,000 Neurons per day | $0.011 / 1,000 Neurons        |
 
 :::note
-Some models require a paid billing method. This applies to `@cf/moonshotai/kimi-k2.6`, `@cf/moonshotai/kimi-k2.7-code`, and `@cf/zai-org/glm-5.2`. You can access these models with either the [Workers Paid plan](/workers/platform/pricing/#workers) or prepaid [AI Gateway credits](/ai-gateway/features/unified-billing/).
+Some models require a paid billing method. This applies to `@cf/moonshotai/kimi-k2.6`, `@cf/moonshotai/kimi-k2.7-code`, `@cf/zai-org/glm-5.2`, `@cf/deepseek-ai/deepseek-v4-flash-0731`, and `@cf/deepseek-ai/deepseek-v4-pro-0813`. You can access these models with either the [Workers Paid plan](/workers/platform/pricing/#workers) or prepaid [AI Gateway credits](/ai-gateway/features/unified-billing/).
 :::
 
 ## Pay with AI Gateway credits
@@ -54,6 +54,8 @@ The Price in Tokens column is equivalent to the Price in Neurons column - the di
 | @cf/meta/llama-3.1-70b-instruct-fp8-fast     | $0.293 per M input tokens <br/> $2.253 per M output tokens                                        | 26668 neurons per M input tokens <br/> 204805 neurons per M output tokens                                                |
 | @cf/meta/llama-3.3-70b-instruct-fp8-fast     | $0.293 per M input tokens <br/> $2.253 per M output tokens                                        | 26668 neurons per M input tokens <br/> 204805 neurons per M output tokens                                                |
 | @cf/deepseek-ai/deepseek-r1-distill-qwen-32b | $0.497 per M input tokens <br/> $4.881 per M output tokens                                        | 45170 neurons per M input tokens <br/> 443756 neurons per M output tokens                                                |
+| @cf/deepseek-ai/deepseek-v4-flash-0731       | $0.440 per M input tokens <br/> $0.014 per M cached input tokens <br/> $1.320 per M output tokens | 40000 neurons per M input tokens <br/> 1273 neurons per M cached input tokens <br/> 120000 neurons per M output tokens    |
+| @cf/deepseek-ai/deepseek-v4-pro-0813         | $1.320 per M input tokens <br/> $0.044 per M cached input tokens <br/> $3.960 per M output tokens | 120000 neurons per M input tokens <br/> 4000 neurons per M cached input tokens <br/> 360000 neurons per M output tokens   |
 | @cf/mistral/mistral-7b-instruct-v0.1         | $0.110 per M input tokens <br/> $0.190 per M output tokens                                        | 10000 neurons per M input tokens <br/> 17300 neurons per M output tokens                                                 |
 | @cf/mistralai/mistral-small-3.1-24b-instruct | $0.351 per M input tokens <br/> $0.555 per M output tokens                                        | 31876 neurons per M input tokens <br/> 50488 neurons per M output tokens                                                 |
 | @cf/meta/llama-3.1-8b-instruct               | $0.282 per M input tokens <br/> $0.827 per M output tokens                                        | 25608 neurons per M input tokens <br/> 75147 neurons per M output tokens                                                 |

--- a/src/content/workers-ai-models/deepseek-v4-flash-0731.json
+++ b/src/content/workers-ai-models/deepseek-v4-flash-0731.json
@@ -7,7 +7,7 @@
         },
         {
             "property_id": "context_window",
-            "value": "384000"
+            "value": "1048576"
         },
         {
             "property_id": "function_calling",

--- a/src/content/workers-ai-models/deepseek-v4-flash-0731.json
+++ b/src/content/workers-ai-models/deepseek-v4-flash-0731.json
@@ -1,0 +1,4770 @@
+{
+    "name": "@cf/deepseek-ai/deepseek-v4-flash-0731",
+    "properties": [
+        {
+            "property_id": "require_workers_paid",
+            "value": "true"
+        },
+        {
+            "property_id": "context_window",
+            "value": "384000"
+        },
+        {
+            "property_id": "function_calling",
+            "value": "true"
+        },
+        {
+            "property_id": "reasoning",
+            "value": "true"
+        },
+        {
+            "property_id": "price",
+            "value": [
+                {
+                    "unit": "per M input tokens",
+                    "price": 0.44,
+                    "currency": "USD"
+                },
+                {
+                    "unit": "per M output tokens",
+                    "price": 1.32,
+                    "currency": "USD"
+                },
+                {
+                    "unit": "per M cached input tokens",
+                    "price": 0.014,
+                    "currency": "USD"
+                }
+            ]
+        }
+    ],
+    "id": "7276b330-b4ae-4662-81d1-3a8bea8368f8",
+    "source": 1,
+    "description": "DeepSeek-V4-Flash-0731 is the official release of DeepSeek-V4-Flash, superseding the preview version, with substantially enhanced agentic capabilities. ",
+    "task": {
+        "id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+        "name": "Text Generation",
+        "description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+    },
+    "created_at": "2026-07-31 14:10:43.440",
+    "tags": [],
+    "schema": {
+        "input": {
+            "anyOf": [
+                {
+                    "type": "object",
+                    "oneOf": [
+                        {
+                            "title": "Prompt",
+                            "properties": {
+                                "prompt": {
+                                    "type": "string",
+                                    "minLength": 1,
+                                    "description": "The input text prompt for the model to generate a response."
+                                },
+                                "model": {
+                                    "type": "string",
+                                    "description": "ID of the model to use (e.g. '@cf/zai-org/glm-4.7-flash, etc')."
+                                },
+                                "audio": {
+                                    "anyOf": [
+                                        {
+                                            "type": "object",
+                                            "description": "Parameters for audio output. Required when modalities includes 'audio'.",
+                                            "properties": {
+                                                "voice": {
+                                                    "oneOf": [
+                                                        {
+                                                            "type": "string"
+                                                        },
+                                                        {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "id": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "id"
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                "format": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "wav",
+                                                        "aac",
+                                                        "mp3",
+                                                        "flac",
+                                                        "opus",
+                                                        "pcm16"
+                                                    ]
+                                                }
+                                            },
+                                            "required": [
+                                                "voice",
+                                                "format"
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "frequency_penalty": {
+                                    "anyOf": [
+                                        {
+                                            "type": "number",
+                                            "minimum": -2,
+                                            "maximum": 2
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": 0,
+                                    "description": "Penalizes new tokens based on their existing frequency in the text so far."
+                                },
+                                "logit_bias": {
+                                    "anyOf": [
+                                        {
+                                            "type": "object"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "Modify the likelihood of specified tokens appearing in the completion. Maps token IDs to bias values from -100 to 100."
+                                },
+                                "logprobs": {
+                                    "anyOf": [
+                                        {
+                                            "type": "boolean"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": false,
+                                    "description": "Whether to return log probabilities of the output tokens."
+                                },
+                                "top_logprobs": {
+                                    "anyOf": [
+                                        {
+                                            "type": "integer",
+                                            "minimum": 0,
+                                            "maximum": 20
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "How many top log probabilities to return at each token position (0-20). Requires logprobs=true."
+                                },
+                                "max_tokens": {
+                                    "anyOf": [
+                                        {
+                                            "type": "integer"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "Deprecated in favor of max_completion_tokens. The maximum number of tokens to generate."
+                                },
+                                "max_completion_tokens": {
+                                    "anyOf": [
+                                        {
+                                            "type": "integer"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "An upper bound for the number of tokens that can be generated for a completion."
+                                },
+                                "metadata": {
+                                    "anyOf": [
+                                        {
+                                            "type": "object"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "Set of 16 key-value pairs that can be attached to the object."
+                                },
+                                "modalities": {
+                                    "anyOf": [
+                                        {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "text",
+                                                    "audio"
+                                                ]
+                                            }
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "Output types requested from the model (e.g. ['text'] or ['text', 'audio'])."
+                                },
+                                "n": {
+                                    "anyOf": [
+                                        {
+                                            "type": "integer",
+                                            "minimum": 1,
+                                            "maximum": 128
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": 1,
+                                    "description": "How many chat completion choices to generate for each input message."
+                                },
+                                "parallel_tool_calls": {
+                                    "type": "boolean",
+                                    "default": true,
+                                    "description": "Whether to enable parallel function calling during tool use."
+                                },
+                                "prediction": {
+                                    "anyOf": [
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "type": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "content"
+                                                    ]
+                                                },
+                                                "content": {
+                                                    "anyOf": [
+                                                        {
+                                                            "type": "string"
+                                                        },
+                                                        {
+                                                            "type": "array",
+                                                            "items": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "type": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "text"
+                                                                        ]
+                                                                    },
+                                                                    "text": {
+                                                                        "type": "string"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "type",
+                                                                    "text"
+                                                                ]
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "required": [
+                                                "type",
+                                                "content"
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "presence_penalty": {
+                                    "anyOf": [
+                                        {
+                                            "type": "number",
+                                            "minimum": -2,
+                                            "maximum": 2
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": 0,
+                                    "description": "Penalizes new tokens based on whether they appear in the text so far."
+                                },
+                                "reasoning_effort": {
+                                    "anyOf": [
+                                        {
+                                            "type": "string",
+                                            "enum": [
+                                                "low",
+                                                "medium",
+                                                "high"
+                                            ]
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "Constrains effort on reasoning for reasoning models (o1, o3-mini, etc.)."
+                                },
+                                "chat_template_kwargs": {
+                                    "type": "object",
+                                    "properties": {
+                                        "enable_thinking": {
+                                            "type": "boolean",
+                                            "default": true,
+                                            "description": "Whether to enable reasoning, enabled by default."
+                                        },
+                                        "clear_thinking": {
+                                            "type": "boolean",
+                                            "default": false,
+                                            "description": "If false, preserves reasoning context between turns."
+                                        }
+                                    }
+                                },
+                                "response_format": {
+                                    "anyOf": [
+                                        {
+                                            "description": "Specifies the format the model must output.",
+                                            "oneOf": [
+                                                {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "text"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "type"
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "json_object"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "type"
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "json_schema"
+                                                            ]
+                                                        },
+                                                        "json_schema": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "name": {
+                                                                    "type": "string"
+                                                                },
+                                                                "description": {
+                                                                    "type": "string"
+                                                                },
+                                                                "schema": {
+                                                                    "type": "object"
+                                                                },
+                                                                "strict": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "boolean"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "name"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "type",
+                                                        "json_schema"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "seed": {
+                                    "anyOf": [
+                                        {
+                                            "type": "integer"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "If specified, the system will make a best effort to sample deterministically."
+                                },
+                                "service_tier": {
+                                    "anyOf": [
+                                        {
+                                            "type": "string",
+                                            "enum": [
+                                                "auto",
+                                                "default",
+                                                "flex",
+                                                "scale",
+                                                "priority"
+                                            ]
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": "auto",
+                                    "description": "Specifies the processing type used for serving the request."
+                                },
+                                "stop": {
+                                    "description": "Up to 4 sequences where the API will stop generating further tokens.",
+                                    "anyOf": [
+                                        {
+                                            "type": "null"
+                                        },
+                                        {
+                                            "type": "string"
+                                        },
+                                        {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            },
+                                            "minItems": 1,
+                                            "maxItems": 4
+                                        }
+                                    ]
+                                },
+                                "store": {
+                                    "anyOf": [
+                                        {
+                                            "type": "boolean"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": false,
+                                    "description": "Whether to store the output for model distillation / evals."
+                                },
+                                "stream": {
+                                    "anyOf": [
+                                        {
+                                            "type": "boolean"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": false,
+                                    "description": "If true, partial message deltas will be sent as server-sent events."
+                                },
+                                "stream_options": {
+                                    "anyOf": [
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "include_usage": {
+                                                    "type": "boolean"
+                                                },
+                                                "include_obfuscation": {
+                                                    "type": "boolean"
+                                                }
+                                            }
+                                        }
+                                    ]
+                                },
+                                "temperature": {
+                                    "anyOf": [
+                                        {
+                                            "type": "number",
+                                            "minimum": 0,
+                                            "maximum": 2
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": 1,
+                                    "description": "Sampling temperature between 0 and 2."
+                                },
+                                "tool_choice": {
+                                    "anyOf": [
+                                        {
+                                            "description": "Controls which (if any) tool is called by the model. 'none' = no tools, 'auto' = model decides, 'required' = must call a tool.",
+                                            "oneOf": [
+                                                {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "none",
+                                                        "auto",
+                                                        "required"
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "description": "Force a specific function tool.",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "function"
+                                                            ]
+                                                        },
+                                                        "function": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "name": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "name"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "type",
+                                                        "function"
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "description": "Force a specific custom tool.",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "custom"
+                                                            ]
+                                                        },
+                                                        "custom": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "name": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "name"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "type",
+                                                        "custom"
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "description": "Constrain to an allowed subset of tools.",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "allowed_tools"
+                                                            ]
+                                                        },
+                                                        "allowed_tools": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "mode": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "auto",
+                                                                        "required"
+                                                                    ]
+                                                                },
+                                                                "tools": {
+                                                                    "type": "array",
+                                                                    "items": {
+                                                                        "type": "object"
+                                                                    }
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "mode",
+                                                                "tools"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "type",
+                                                        "allowed_tools"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "tools": {
+                                    "type": "array",
+                                    "description": "A list of tools the model may call.",
+                                    "items": {
+                                        "oneOf": [
+                                            {
+                                                "type": "object",
+                                                "properties": {
+                                                    "type": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "function"
+                                                        ]
+                                                    },
+                                                    "function": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "name": {
+                                                                "type": "string",
+                                                                "description": "The name of the function to be called."
+                                                            },
+                                                            "description": {
+                                                                "type": "string",
+                                                                "description": "A description of what the function does."
+                                                            },
+                                                            "parameters": {
+                                                                "type": "object",
+                                                                "description": "The parameters the function accepts, described as a JSON Schema object."
+                                                            },
+                                                            "strict": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "boolean"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ],
+                                                                "default": false,
+                                                                "description": "Whether to enable strict schema adherence."
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "name"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type",
+                                                    "function"
+                                                ]
+                                            },
+                                            {
+                                                "type": "object",
+                                                "properties": {
+                                                    "type": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "custom"
+                                                        ]
+                                                    },
+                                                    "custom": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "name": {
+                                                                "type": "string"
+                                                            },
+                                                            "description": {
+                                                                "type": "string"
+                                                            },
+                                                            "format": {
+                                                                "oneOf": [
+                                                                    {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "type": {
+                                                                                "type": "string",
+                                                                                "enum": [
+                                                                                    "text"
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "type"
+                                                                        ]
+                                                                    },
+                                                                    {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "type": {
+                                                                                "type": "string",
+                                                                                "enum": [
+                                                                                    "grammar"
+                                                                                ]
+                                                                            },
+                                                                            "grammar": {
+                                                                                "type": "object",
+                                                                                "properties": {
+                                                                                    "definition": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "syntax": {
+                                                                                        "type": "string",
+                                                                                        "enum": [
+                                                                                            "lark",
+                                                                                            "regex"
+                                                                                        ]
+                                                                                    }
+                                                                                },
+                                                                                "required": [
+                                                                                    "definition",
+                                                                                    "syntax"
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "type",
+                                                                            "grammar"
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "name"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type",
+                                                    "custom"
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                },
+                                "top_p": {
+                                    "anyOf": [
+                                        {
+                                            "type": "number",
+                                            "minimum": 0,
+                                            "maximum": 1
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": 1,
+                                    "description": "Nucleus sampling: considers the results of the tokens with top_p probability mass."
+                                },
+                                "user": {
+                                    "type": "string",
+                                    "description": "A unique identifier representing your end-user, for abuse monitoring."
+                                },
+                                "web_search_options": {
+                                    "anyOf": [
+                                        {
+                                            "type": "object",
+                                            "description": "Options for the web search tool (when using built-in web search).",
+                                            "properties": {
+                                                "search_context_size": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "low",
+                                                        "medium",
+                                                        "high"
+                                                    ],
+                                                    "default": "medium"
+                                                },
+                                                "user_location": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "approximate"
+                                                            ]
+                                                        },
+                                                        "approximate": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "city": {
+                                                                    "type": "string"
+                                                                },
+                                                                "country": {
+                                                                    "type": "string"
+                                                                },
+                                                                "region": {
+                                                                    "type": "string"
+                                                                },
+                                                                "timezone": {
+                                                                    "type": "string"
+                                                                }
+                                                            }
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "type",
+                                                        "approximate"
+                                                    ]
+                                                }
+                                            }
+                                        }
+                                    ]
+                                },
+                                "function_call": {
+                                    "anyOf": [
+                                        {
+                                            "type": "string",
+                                            "enum": [
+                                                "none",
+                                                "auto"
+                                            ]
+                                        },
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "name": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "name"
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "functions": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "name": {
+                                                "type": "string",
+                                                "description": "The name of the function to be called."
+                                            },
+                                            "description": {
+                                                "type": "string",
+                                                "description": "A description of what the function does."
+                                            },
+                                            "parameters": {
+                                                "type": "object",
+                                                "description": "The parameters the function accepts, described as a JSON Schema object."
+                                            },
+                                            "strict": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "boolean"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": false,
+                                                "description": "Whether to enable strict schema adherence."
+                                            }
+                                        },
+                                        "required": [
+                                            "name"
+                                        ]
+                                    },
+                                    "minItems": 1,
+                                    "maxItems": 128
+                                }
+                            },
+                            "required": [
+                                "prompt"
+                            ]
+                        },
+                        {
+                            "title": "Messages",
+                            "properties": {
+                                "messages": {
+                                    "type": "array",
+                                    "description": "A list of messages comprising the conversation so far.",
+                                    "items": {
+                                        "oneOf": [
+                                            {
+                                                "type": "object",
+                                                "properties": {
+                                                    "role": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "developer"
+                                                        ]
+                                                    },
+                                                    "content": {
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "string"
+                                                            },
+                                                            {
+                                                                "type": "array",
+                                                                "items": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "enum": [
+                                                                                "text"
+                                                                            ]
+                                                                        },
+                                                                        "text": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "type",
+                                                                        "text"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
+                                                    },
+                                                    "name": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "role",
+                                                    "content"
+                                                ]
+                                            },
+                                            {
+                                                "type": "object",
+                                                "properties": {
+                                                    "role": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "system"
+                                                        ]
+                                                    },
+                                                    "content": {
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "string"
+                                                            },
+                                                            {
+                                                                "type": "array",
+                                                                "items": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "enum": [
+                                                                                "text"
+                                                                            ]
+                                                                        },
+                                                                        "text": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "type",
+                                                                        "text"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
+                                                    },
+                                                    "name": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "role",
+                                                    "content"
+                                                ]
+                                            },
+                                            {
+                                                "type": "object",
+                                                "properties": {
+                                                    "role": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "user"
+                                                        ]
+                                                    },
+                                                    "content": {
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "string"
+                                                            },
+                                                            {
+                                                                "type": "array",
+                                                                "items": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "enum": [
+                                                                                "text",
+                                                                                "image_url",
+                                                                                "video_url",
+                                                                                "input_audio",
+                                                                                "file"
+                                                                            ]
+                                                                        },
+                                                                        "text": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "image_url": {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "url": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "detail": {
+                                                                                    "type": "string",
+                                                                                    "enum": [
+                                                                                        "auto",
+                                                                                        "low",
+                                                                                        "high"
+                                                                                    ],
+                                                                                    "default": "auto"
+                                                                                }
+                                                                            }
+                                                                        },
+                                                                        "video_url": {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "url": {
+                                                                                    "type": "string"
+                                                                                }
+                                                                            }
+                                                                        },
+                                                                        "input_audio": {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "data": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "format": {
+                                                                                    "type": "string",
+                                                                                    "enum": [
+                                                                                        "wav",
+                                                                                        "mp3"
+                                                                                    ]
+                                                                                }
+                                                                            }
+                                                                        },
+                                                                        "file": {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "file_data": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "file_id": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "filename": {
+                                                                                    "type": "string"
+                                                                                }
+                                                                            }
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "type"
+                                                                    ]
+                                                                },
+                                                                "minItems": 1
+                                                            }
+                                                        ]
+                                                    },
+                                                    "name": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "role",
+                                                    "content"
+                                                ]
+                                            },
+                                            {
+                                                "type": "object",
+                                                "properties": {
+                                                    "role": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "assistant"
+                                                        ]
+                                                    },
+                                                    "content": {
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "string"
+                                                            },
+                                                            {
+                                                                "type": "null"
+                                                            },
+                                                            {
+                                                                "type": "array",
+                                                                "items": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "enum": [
+                                                                                "text",
+                                                                                "refusal"
+                                                                            ]
+                                                                        },
+                                                                        "text": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "refusal": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "type"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
+                                                    },
+                                                    "refusal": {
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "string"
+                                                            },
+                                                            {
+                                                                "type": "null"
+                                                            }
+                                                        ]
+                                                    },
+                                                    "name": {
+                                                        "type": "string"
+                                                    },
+                                                    "audio": {
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "id": {
+                                                                        "type": "string"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "id"
+                                                                ]
+                                                            }
+                                                        ]
+                                                    },
+                                                    "tool_calls": {
+                                                        "type": "array",
+                                                        "items": {
+                                                            "oneOf": [
+                                                                {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "id": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "enum": [
+                                                                                "function"
+                                                                            ]
+                                                                        },
+                                                                        "function": {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "name": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "arguments": {
+                                                                                    "type": "string",
+                                                                                    "description": "JSON-encoded arguments string."
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "name",
+                                                                                "arguments"
+                                                                            ]
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "id",
+                                                                        "type",
+                                                                        "function"
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "id": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "enum": [
+                                                                                "custom"
+                                                                            ]
+                                                                        },
+                                                                        "custom": {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "name": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "input": {
+                                                                                    "type": "string"
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "name",
+                                                                                "input"
+                                                                            ]
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "id",
+                                                                        "type",
+                                                                        "custom"
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        }
+                                                    },
+                                                    "function_call": {
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "name": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "arguments": {
+                                                                        "type": "string"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "name",
+                                                                    "arguments"
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                "required": [
+                                                    "role"
+                                                ]
+                                            },
+                                            {
+                                                "type": "object",
+                                                "properties": {
+                                                    "role": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "tool"
+                                                        ]
+                                                    },
+                                                    "content": {
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "string"
+                                                            },
+                                                            {
+                                                                "type": "array",
+                                                                "items": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "enum": [
+                                                                                "text"
+                                                                            ]
+                                                                        },
+                                                                        "text": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "type",
+                                                                        "text"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
+                                                    },
+                                                    "tool_call_id": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "role",
+                                                    "content",
+                                                    "tool_call_id"
+                                                ]
+                                            },
+                                            {
+                                                "type": "object",
+                                                "properties": {
+                                                    "role": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "function"
+                                                        ]
+                                                    },
+                                                    "content": {
+                                                        "type": "string"
+                                                    },
+                                                    "name": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "role",
+                                                    "content",
+                                                    "name"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "minItems": 1
+                                },
+                                "model": {
+                                    "type": "string",
+                                    "description": "ID of the model to use (e.g. '@cf/zai-org/glm-4.7-flash, etc')."
+                                },
+                                "audio": {
+                                    "anyOf": [
+                                        {
+                                            "type": "object",
+                                            "description": "Parameters for audio output. Required when modalities includes 'audio'.",
+                                            "properties": {
+                                                "voice": {
+                                                    "oneOf": [
+                                                        {
+                                                            "type": "string"
+                                                        },
+                                                        {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "id": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "id"
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                "format": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "wav",
+                                                        "aac",
+                                                        "mp3",
+                                                        "flac",
+                                                        "opus",
+                                                        "pcm16"
+                                                    ]
+                                                }
+                                            },
+                                            "required": [
+                                                "voice",
+                                                "format"
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "frequency_penalty": {
+                                    "anyOf": [
+                                        {
+                                            "type": "number",
+                                            "minimum": -2,
+                                            "maximum": 2
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": 0,
+                                    "description": "Penalizes new tokens based on their existing frequency in the text so far."
+                                },
+                                "logit_bias": {
+                                    "anyOf": [
+                                        {
+                                            "type": "object"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "Modify the likelihood of specified tokens appearing in the completion. Maps token IDs to bias values from -100 to 100."
+                                },
+                                "logprobs": {
+                                    "anyOf": [
+                                        {
+                                            "type": "boolean"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": false,
+                                    "description": "Whether to return log probabilities of the output tokens."
+                                },
+                                "top_logprobs": {
+                                    "anyOf": [
+                                        {
+                                            "type": "integer",
+                                            "minimum": 0,
+                                            "maximum": 20
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "How many top log probabilities to return at each token position (0-20). Requires logprobs=true."
+                                },
+                                "max_tokens": {
+                                    "anyOf": [
+                                        {
+                                            "type": "integer"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "Deprecated in favor of max_completion_tokens. The maximum number of tokens to generate."
+                                },
+                                "max_completion_tokens": {
+                                    "anyOf": [
+                                        {
+                                            "type": "integer"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "An upper bound for the number of tokens that can be generated for a completion."
+                                },
+                                "metadata": {
+                                    "anyOf": [
+                                        {
+                                            "type": "object"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "Set of 16 key-value pairs that can be attached to the object."
+                                },
+                                "modalities": {
+                                    "anyOf": [
+                                        {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "text",
+                                                    "audio"
+                                                ]
+                                            }
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "Output types requested from the model (e.g. ['text'] or ['text', 'audio'])."
+                                },
+                                "n": {
+                                    "anyOf": [
+                                        {
+                                            "type": "integer",
+                                            "minimum": 1,
+                                            "maximum": 128
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": 1,
+                                    "description": "How many chat completion choices to generate for each input message."
+                                },
+                                "parallel_tool_calls": {
+                                    "type": "boolean",
+                                    "default": true,
+                                    "description": "Whether to enable parallel function calling during tool use."
+                                },
+                                "prediction": {
+                                    "anyOf": [
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "type": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "content"
+                                                    ]
+                                                },
+                                                "content": {
+                                                    "anyOf": [
+                                                        {
+                                                            "type": "string"
+                                                        },
+                                                        {
+                                                            "type": "array",
+                                                            "items": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "type": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "text"
+                                                                        ]
+                                                                    },
+                                                                    "text": {
+                                                                        "type": "string"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "type",
+                                                                    "text"
+                                                                ]
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "required": [
+                                                "type",
+                                                "content"
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "presence_penalty": {
+                                    "anyOf": [
+                                        {
+                                            "type": "number",
+                                            "minimum": -2,
+                                            "maximum": 2
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": 0,
+                                    "description": "Penalizes new tokens based on whether they appear in the text so far."
+                                },
+                                "reasoning_effort": {
+                                    "anyOf": [
+                                        {
+                                            "type": "string",
+                                            "enum": [
+                                                "low",
+                                                "medium",
+                                                "high"
+                                            ]
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "Constrains effort on reasoning for reasoning models (o1, o3-mini, etc.)."
+                                },
+                                "chat_template_kwargs": {
+                                    "type": "object",
+                                    "properties": {
+                                        "enable_thinking": {
+                                            "type": "boolean",
+                                            "default": true,
+                                            "description": "Whether to enable reasoning, enabled by default."
+                                        },
+                                        "clear_thinking": {
+                                            "type": "boolean",
+                                            "default": false,
+                                            "description": "If false, preserves reasoning context between turns."
+                                        }
+                                    }
+                                },
+                                "response_format": {
+                                    "anyOf": [
+                                        {
+                                            "description": "Specifies the format the model must output.",
+                                            "oneOf": [
+                                                {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "text"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "type"
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "json_object"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "type"
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "json_schema"
+                                                            ]
+                                                        },
+                                                        "json_schema": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "name": {
+                                                                    "type": "string"
+                                                                },
+                                                                "description": {
+                                                                    "type": "string"
+                                                                },
+                                                                "schema": {
+                                                                    "type": "object"
+                                                                },
+                                                                "strict": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "boolean"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "name"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "type",
+                                                        "json_schema"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "seed": {
+                                    "anyOf": [
+                                        {
+                                            "type": "integer"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "If specified, the system will make a best effort to sample deterministically."
+                                },
+                                "service_tier": {
+                                    "anyOf": [
+                                        {
+                                            "type": "string",
+                                            "enum": [
+                                                "auto",
+                                                "default",
+                                                "flex",
+                                                "scale",
+                                                "priority"
+                                            ]
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": "auto",
+                                    "description": "Specifies the processing type used for serving the request."
+                                },
+                                "stop": {
+                                    "description": "Up to 4 sequences where the API will stop generating further tokens.",
+                                    "anyOf": [
+                                        {
+                                            "type": "null"
+                                        },
+                                        {
+                                            "type": "string"
+                                        },
+                                        {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            },
+                                            "minItems": 1,
+                                            "maxItems": 4
+                                        }
+                                    ]
+                                },
+                                "store": {
+                                    "anyOf": [
+                                        {
+                                            "type": "boolean"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": false,
+                                    "description": "Whether to store the output for model distillation / evals."
+                                },
+                                "stream": {
+                                    "anyOf": [
+                                        {
+                                            "type": "boolean"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": false,
+                                    "description": "If true, partial message deltas will be sent as server-sent events."
+                                },
+                                "stream_options": {
+                                    "anyOf": [
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "include_usage": {
+                                                    "type": "boolean"
+                                                },
+                                                "include_obfuscation": {
+                                                    "type": "boolean"
+                                                }
+                                            }
+                                        }
+                                    ]
+                                },
+                                "temperature": {
+                                    "anyOf": [
+                                        {
+                                            "type": "number",
+                                            "minimum": 0,
+                                            "maximum": 2
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": 1,
+                                    "description": "Sampling temperature between 0 and 2."
+                                },
+                                "tool_choice": {
+                                    "anyOf": [
+                                        {
+                                            "description": "Controls which (if any) tool is called by the model. 'none' = no tools, 'auto' = model decides, 'required' = must call a tool.",
+                                            "oneOf": [
+                                                {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "none",
+                                                        "auto",
+                                                        "required"
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "description": "Force a specific function tool.",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "function"
+                                                            ]
+                                                        },
+                                                        "function": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "name": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "name"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "type",
+                                                        "function"
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "description": "Force a specific custom tool.",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "custom"
+                                                            ]
+                                                        },
+                                                        "custom": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "name": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "name"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "type",
+                                                        "custom"
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "description": "Constrain to an allowed subset of tools.",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "allowed_tools"
+                                                            ]
+                                                        },
+                                                        "allowed_tools": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "mode": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "auto",
+                                                                        "required"
+                                                                    ]
+                                                                },
+                                                                "tools": {
+                                                                    "type": "array",
+                                                                    "items": {
+                                                                        "type": "object"
+                                                                    }
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "mode",
+                                                                "tools"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "type",
+                                                        "allowed_tools"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "tools": {
+                                    "type": "array",
+                                    "description": "A list of tools the model may call.",
+                                    "items": {
+                                        "oneOf": [
+                                            {
+                                                "type": "object",
+                                                "properties": {
+                                                    "type": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "function"
+                                                        ]
+                                                    },
+                                                    "function": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "name": {
+                                                                "type": "string",
+                                                                "description": "The name of the function to be called."
+                                                            },
+                                                            "description": {
+                                                                "type": "string",
+                                                                "description": "A description of what the function does."
+                                                            },
+                                                            "parameters": {
+                                                                "type": "object",
+                                                                "description": "The parameters the function accepts, described as a JSON Schema object."
+                                                            },
+                                                            "strict": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "boolean"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ],
+                                                                "default": false,
+                                                                "description": "Whether to enable strict schema adherence."
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "name"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type",
+                                                    "function"
+                                                ]
+                                            },
+                                            {
+                                                "type": "object",
+                                                "properties": {
+                                                    "type": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "custom"
+                                                        ]
+                                                    },
+                                                    "custom": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "name": {
+                                                                "type": "string"
+                                                            },
+                                                            "description": {
+                                                                "type": "string"
+                                                            },
+                                                            "format": {
+                                                                "oneOf": [
+                                                                    {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "type": {
+                                                                                "type": "string",
+                                                                                "enum": [
+                                                                                    "text"
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "type"
+                                                                        ]
+                                                                    },
+                                                                    {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "type": {
+                                                                                "type": "string",
+                                                                                "enum": [
+                                                                                    "grammar"
+                                                                                ]
+                                                                            },
+                                                                            "grammar": {
+                                                                                "type": "object",
+                                                                                "properties": {
+                                                                                    "definition": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "syntax": {
+                                                                                        "type": "string",
+                                                                                        "enum": [
+                                                                                            "lark",
+                                                                                            "regex"
+                                                                                        ]
+                                                                                    }
+                                                                                },
+                                                                                "required": [
+                                                                                    "definition",
+                                                                                    "syntax"
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "type",
+                                                                            "grammar"
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "name"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type",
+                                                    "custom"
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                },
+                                "top_p": {
+                                    "anyOf": [
+                                        {
+                                            "type": "number",
+                                            "minimum": 0,
+                                            "maximum": 1
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": 1,
+                                    "description": "Nucleus sampling: considers the results of the tokens with top_p probability mass."
+                                },
+                                "user": {
+                                    "type": "string",
+                                    "description": "A unique identifier representing your end-user, for abuse monitoring."
+                                },
+                                "web_search_options": {
+                                    "anyOf": [
+                                        {
+                                            "type": "object",
+                                            "description": "Options for the web search tool (when using built-in web search).",
+                                            "properties": {
+                                                "search_context_size": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "low",
+                                                        "medium",
+                                                        "high"
+                                                    ],
+                                                    "default": "medium"
+                                                },
+                                                "user_location": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "approximate"
+                                                            ]
+                                                        },
+                                                        "approximate": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "city": {
+                                                                    "type": "string"
+                                                                },
+                                                                "country": {
+                                                                    "type": "string"
+                                                                },
+                                                                "region": {
+                                                                    "type": "string"
+                                                                },
+                                                                "timezone": {
+                                                                    "type": "string"
+                                                                }
+                                                            }
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "type",
+                                                        "approximate"
+                                                    ]
+                                                }
+                                            }
+                                        }
+                                    ]
+                                },
+                                "function_call": {
+                                    "anyOf": [
+                                        {
+                                            "type": "string",
+                                            "enum": [
+                                                "none",
+                                                "auto"
+                                            ]
+                                        },
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "name": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "name"
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "functions": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "name": {
+                                                "type": "string",
+                                                "description": "The name of the function to be called."
+                                            },
+                                            "description": {
+                                                "type": "string",
+                                                "description": "A description of what the function does."
+                                            },
+                                            "parameters": {
+                                                "type": "object",
+                                                "description": "The parameters the function accepts, described as a JSON Schema object."
+                                            },
+                                            "strict": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "boolean"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": false,
+                                                "description": "Whether to enable strict schema adherence."
+                                            }
+                                        },
+                                        "required": [
+                                            "name"
+                                        ]
+                                    },
+                                    "minItems": 1,
+                                    "maxItems": 128
+                                }
+                            },
+                            "required": [
+                                "messages"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "requests": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "oneOf": [
+                                    {
+                                        "title": "Prompt",
+                                        "properties": {
+                                            "prompt": {
+                                                "type": "string",
+                                                "minLength": 1,
+                                                "description": "The input text prompt for the model to generate a response."
+                                            },
+                                            "model": {
+                                                "type": "string",
+                                                "description": "ID of the model to use (e.g. '@cf/zai-org/glm-4.7-flash, etc')."
+                                            },
+                                            "audio": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "object",
+                                                        "description": "Parameters for audio output. Required when modalities includes 'audio'.",
+                                                        "properties": {
+                                                            "voice": {
+                                                                "oneOf": [
+                                                                    {
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "id": {
+                                                                                "type": "string"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "id"
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "format": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                    "wav",
+                                                                    "aac",
+                                                                    "mp3",
+                                                                    "flac",
+                                                                    "opus",
+                                                                    "pcm16"
+                                                                ]
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "voice",
+                                                            "format"
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            "frequency_penalty": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "number",
+                                                        "minimum": -2,
+                                                        "maximum": 2
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": 0,
+                                                "description": "Penalizes new tokens based on their existing frequency in the text so far."
+                                            },
+                                            "logit_bias": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "Modify the likelihood of specified tokens appearing in the completion. Maps token IDs to bias values from -100 to 100."
+                                            },
+                                            "logprobs": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "boolean"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": false,
+                                                "description": "Whether to return log probabilities of the output tokens."
+                                            },
+                                            "top_logprobs": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "integer",
+                                                        "minimum": 0,
+                                                        "maximum": 20
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "How many top log probabilities to return at each token position (0-20). Requires logprobs=true."
+                                            },
+                                            "max_tokens": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "integer"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "Deprecated in favor of max_completion_tokens. The maximum number of tokens to generate."
+                                            },
+                                            "max_completion_tokens": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "integer"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "An upper bound for the number of tokens that can be generated for a completion."
+                                            },
+                                            "metadata": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "Set of 16 key-value pairs that can be attached to the object."
+                                            },
+                                            "modalities": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "array",
+                                                        "items": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "text",
+                                                                "audio"
+                                                            ]
+                                                        }
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "Output types requested from the model (e.g. ['text'] or ['text', 'audio'])."
+                                            },
+                                            "n": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "integer",
+                                                        "minimum": 1,
+                                                        "maximum": 128
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": 1,
+                                                "description": "How many chat completion choices to generate for each input message."
+                                            },
+                                            "parallel_tool_calls": {
+                                                "type": "boolean",
+                                                "default": true,
+                                                "description": "Whether to enable parallel function calling during tool use."
+                                            },
+                                            "prediction": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "type": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                    "content"
+                                                                ]
+                                                            },
+                                                            "content": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "type": "array",
+                                                                        "items": {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "type": {
+                                                                                    "type": "string",
+                                                                                    "enum": [
+                                                                                        "text"
+                                                                                    ]
+                                                                                },
+                                                                                "text": {
+                                                                                    "type": "string"
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "type",
+                                                                                "text"
+                                                                            ]
+                                                                        }
+                                                                    }
+                                                                ]
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "type",
+                                                            "content"
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            "presence_penalty": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "number",
+                                                        "minimum": -2,
+                                                        "maximum": 2
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": 0,
+                                                "description": "Penalizes new tokens based on whether they appear in the text so far."
+                                            },
+                                            "reasoning_effort": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "low",
+                                                            "medium",
+                                                            "high"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "Constrains effort on reasoning for reasoning models (o1, o3-mini, etc.)."
+                                            },
+                                            "chat_template_kwargs": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "enable_thinking": {
+                                                        "type": "boolean",
+                                                        "default": true,
+                                                        "description": "Whether to enable reasoning, enabled by default."
+                                                    },
+                                                    "clear_thinking": {
+                                                        "type": "boolean",
+                                                        "default": false,
+                                                        "description": "If false, preserves reasoning context between turns."
+                                                    }
+                                                }
+                                            },
+                                            "response_format": {
+                                                "anyOf": [
+                                                    {
+                                                        "description": "Specifies the format the model must output.",
+                                                        "oneOf": [
+                                                            {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "type": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "text"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "type"
+                                                                ]
+                                                            },
+                                                            {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "type": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "json_object"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "type"
+                                                                ]
+                                                            },
+                                                            {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "type": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "json_schema"
+                                                                        ]
+                                                                    },
+                                                                    "json_schema": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "name": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "description": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "schema": {
+                                                                                "type": "object"
+                                                                            },
+                                                                            "strict": {
+                                                                                "anyOf": [
+                                                                                    {
+                                                                                        "type": "boolean"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "null"
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "name"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "type",
+                                                                    "json_schema"
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            "seed": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "integer"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "If specified, the system will make a best effort to sample deterministically."
+                                            },
+                                            "service_tier": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "auto",
+                                                            "default",
+                                                            "flex",
+                                                            "scale",
+                                                            "priority"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": "auto",
+                                                "description": "Specifies the processing type used for serving the request."
+                                            },
+                                            "stop": {
+                                                "description": "Up to 4 sequences where the API will stop generating further tokens.",
+                                                "anyOf": [
+                                                    {
+                                                        "type": "null"
+                                                    },
+                                                    {
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "array",
+                                                        "items": {
+                                                            "type": "string"
+                                                        },
+                                                        "minItems": 1,
+                                                        "maxItems": 4
+                                                    }
+                                                ]
+                                            },
+                                            "store": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "boolean"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": false,
+                                                "description": "Whether to store the output for model distillation / evals."
+                                            },
+                                            "stream": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "boolean"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": false,
+                                                "description": "If true, partial message deltas will be sent as server-sent events."
+                                            },
+                                            "stream_options": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "include_usage": {
+                                                                "type": "boolean"
+                                                            },
+                                                            "include_obfuscation": {
+                                                                "type": "boolean"
+                                                            }
+                                                        }
+                                                    }
+                                                ]
+                                            },
+                                            "temperature": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "number",
+                                                        "minimum": 0,
+                                                        "maximum": 2
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": 1,
+                                                "description": "Sampling temperature between 0 and 2."
+                                            },
+                                            "tool_choice": {
+                                                "anyOf": [
+                                                    {
+                                                        "description": "Controls which (if any) tool is called by the model. 'none' = no tools, 'auto' = model decides, 'required' = must call a tool.",
+                                                        "oneOf": [
+                                                            {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                    "none",
+                                                                    "auto",
+                                                                    "required"
+                                                                ]
+                                                            },
+                                                            {
+                                                                "type": "object",
+                                                                "description": "Force a specific function tool.",
+                                                                "properties": {
+                                                                    "type": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "function"
+                                                                        ]
+                                                                    },
+                                                                    "function": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "name": {
+                                                                                "type": "string"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "name"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "type",
+                                                                    "function"
+                                                                ]
+                                                            },
+                                                            {
+                                                                "type": "object",
+                                                                "description": "Force a specific custom tool.",
+                                                                "properties": {
+                                                                    "type": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "custom"
+                                                                        ]
+                                                                    },
+                                                                    "custom": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "name": {
+                                                                                "type": "string"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "name"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "type",
+                                                                    "custom"
+                                                                ]
+                                                            },
+                                                            {
+                                                                "type": "object",
+                                                                "description": "Constrain to an allowed subset of tools.",
+                                                                "properties": {
+                                                                    "type": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "allowed_tools"
+                                                                        ]
+                                                                    },
+                                                                    "allowed_tools": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "mode": {
+                                                                                "type": "string",
+                                                                                "enum": [
+                                                                                    "auto",
+                                                                                    "required"
+                                                                                ]
+                                                                            },
+                                                                            "tools": {
+                                                                                "type": "array",
+                                                                                "items": {
+                                                                                    "type": "object"
+                                                                                }
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "mode",
+                                                                            "tools"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "type",
+                                                                    "allowed_tools"
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            "tools": {
+                                                "type": "array",
+                                                "description": "A list of tools the model may call.",
+                                                "items": {
+                                                    "oneOf": [
+                                                        {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "type": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "function"
+                                                                    ]
+                                                                },
+                                                                "function": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "name": {
+                                                                            "type": "string",
+                                                                            "description": "The name of the function to be called."
+                                                                        },
+                                                                        "description": {
+                                                                            "type": "string",
+                                                                            "description": "A description of what the function does."
+                                                                        },
+                                                                        "parameters": {
+                                                                            "type": "object",
+                                                                            "description": "The parameters the function accepts, described as a JSON Schema object."
+                                                                        },
+                                                                        "strict": {
+                                                                            "anyOf": [
+                                                                                {
+                                                                                    "type": "boolean"
+                                                                                },
+                                                                                {
+                                                                                    "type": "null"
+                                                                                }
+                                                                            ],
+                                                                            "default": false,
+                                                                            "description": "Whether to enable strict schema adherence."
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "name"
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "type",
+                                                                "function"
+                                                            ]
+                                                        },
+                                                        {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "type": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "custom"
+                                                                    ]
+                                                                },
+                                                                "custom": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "name": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "description": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "format": {
+                                                                            "oneOf": [
+                                                                                {
+                                                                                    "type": "object",
+                                                                                    "properties": {
+                                                                                        "type": {
+                                                                                            "type": "string",
+                                                                                            "enum": [
+                                                                                                "text"
+                                                                                            ]
+                                                                                        }
+                                                                                    },
+                                                                                    "required": [
+                                                                                        "type"
+                                                                                    ]
+                                                                                },
+                                                                                {
+                                                                                    "type": "object",
+                                                                                    "properties": {
+                                                                                        "type": {
+                                                                                            "type": "string",
+                                                                                            "enum": [
+                                                                                                "grammar"
+                                                                                            ]
+                                                                                        },
+                                                                                        "grammar": {
+                                                                                            "type": "object",
+                                                                                            "properties": {
+                                                                                                "definition": {
+                                                                                                    "type": "string"
+                                                                                                },
+                                                                                                "syntax": {
+                                                                                                    "type": "string",
+                                                                                                    "enum": [
+                                                                                                        "lark",
+                                                                                                        "regex"
+                                                                                                    ]
+                                                                                                }
+                                                                                            },
+                                                                                            "required": [
+                                                                                                "definition",
+                                                                                                "syntax"
+                                                                                            ]
+                                                                                        }
+                                                                                    },
+                                                                                    "required": [
+                                                                                        "type",
+                                                                                        "grammar"
+                                                                                    ]
+                                                                                }
+                                                                            ]
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "name"
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "type",
+                                                                "custom"
+                                                            ]
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "top_p": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "number",
+                                                        "minimum": 0,
+                                                        "maximum": 1
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": 1,
+                                                "description": "Nucleus sampling: considers the results of the tokens with top_p probability mass."
+                                            },
+                                            "user": {
+                                                "type": "string",
+                                                "description": "A unique identifier representing your end-user, for abuse monitoring."
+                                            },
+                                            "web_search_options": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "object",
+                                                        "description": "Options for the web search tool (when using built-in web search).",
+                                                        "properties": {
+                                                            "search_context_size": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                    "low",
+                                                                    "medium",
+                                                                    "high"
+                                                                ],
+                                                                "default": "medium"
+                                                            },
+                                                            "user_location": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "type": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "approximate"
+                                                                        ]
+                                                                    },
+                                                                    "approximate": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "city": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "country": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "region": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "timezone": {
+                                                                                "type": "string"
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "type",
+                                                                    "approximate"
+                                                                ]
+                                                            }
+                                                        }
+                                                    }
+                                                ]
+                                            },
+                                            "function_call": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "none",
+                                                            "auto"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "name": {
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "name"
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            "functions": {
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "name": {
+                                                            "type": "string",
+                                                            "description": "The name of the function to be called."
+                                                        },
+                                                        "description": {
+                                                            "type": "string",
+                                                            "description": "A description of what the function does."
+                                                        },
+                                                        "parameters": {
+                                                            "type": "object",
+                                                            "description": "The parameters the function accepts, described as a JSON Schema object."
+                                                        },
+                                                        "strict": {
+                                                            "anyOf": [
+                                                                {
+                                                                    "type": "boolean"
+                                                                },
+                                                                {
+                                                                    "type": "null"
+                                                                }
+                                                            ],
+                                                            "default": false,
+                                                            "description": "Whether to enable strict schema adherence."
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "name"
+                                                    ]
+                                                },
+                                                "minItems": 1,
+                                                "maxItems": 128
+                                            }
+                                        },
+                                        "required": [
+                                            "prompt"
+                                        ]
+                                    },
+                                    {
+                                        "title": "Messages",
+                                        "properties": {
+                                            "messages": {
+                                                "type": "array",
+                                                "description": "A list of messages comprising the conversation so far.",
+                                                "items": {
+                                                    "oneOf": [
+                                                        {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "role": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "developer"
+                                                                    ]
+                                                                },
+                                                                "content": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "array",
+                                                                            "items": {
+                                                                                "type": "object",
+                                                                                "properties": {
+                                                                                    "type": {
+                                                                                        "type": "string",
+                                                                                        "enum": [
+                                                                                            "text"
+                                                                                        ]
+                                                                                    },
+                                                                                    "text": {
+                                                                                        "type": "string"
+                                                                                    }
+                                                                                },
+                                                                                "required": [
+                                                                                    "type",
+                                                                                    "text"
+                                                                                ]
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "name": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "role",
+                                                                "content"
+                                                            ]
+                                                        },
+                                                        {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "role": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "system"
+                                                                    ]
+                                                                },
+                                                                "content": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "array",
+                                                                            "items": {
+                                                                                "type": "object",
+                                                                                "properties": {
+                                                                                    "type": {
+                                                                                        "type": "string",
+                                                                                        "enum": [
+                                                                                            "text"
+                                                                                        ]
+                                                                                    },
+                                                                                    "text": {
+                                                                                        "type": "string"
+                                                                                    }
+                                                                                },
+                                                                                "required": [
+                                                                                    "type",
+                                                                                    "text"
+                                                                                ]
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "name": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "role",
+                                                                "content"
+                                                            ]
+                                                        },
+                                                        {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "role": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "user"
+                                                                    ]
+                                                                },
+                                                                "content": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "array",
+                                                                            "items": {
+                                                                                "type": "object",
+                                                                                "properties": {
+                                                                                    "type": {
+                                                                                        "type": "string",
+                                                                                        "enum": [
+                                                                                            "text",
+                                                                                            "image_url",
+                                                                                            "video_url",
+                                                                                            "input_audio",
+                                                                                            "file"
+                                                                                        ]
+                                                                                    },
+                                                                                    "text": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "image_url": {
+                                                                                        "type": "object",
+                                                                                        "properties": {
+                                                                                            "url": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "detail": {
+                                                                                                "type": "string",
+                                                                                                "enum": [
+                                                                                                    "auto",
+                                                                                                    "low",
+                                                                                                    "high"
+                                                                                                ],
+                                                                                                "default": "auto"
+                                                                                            }
+                                                                                        }
+                                                                                    },
+                                                                                    "video_url": {
+                                                                                        "type": "object",
+                                                                                        "properties": {
+                                                                                            "url": {
+                                                                                                "type": "string"
+                                                                                            }
+                                                                                        }
+                                                                                    },
+                                                                                    "input_audio": {
+                                                                                        "type": "object",
+                                                                                        "properties": {
+                                                                                            "data": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "format": {
+                                                                                                "type": "string",
+                                                                                                "enum": [
+                                                                                                    "wav",
+                                                                                                    "mp3"
+                                                                                                ]
+                                                                                            }
+                                                                                        }
+                                                                                    },
+                                                                                    "file": {
+                                                                                        "type": "object",
+                                                                                        "properties": {
+                                                                                            "file_data": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "file_id": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "filename": {
+                                                                                                "type": "string"
+                                                                                            }
+                                                                                        }
+                                                                                    }
+                                                                                },
+                                                                                "required": [
+                                                                                    "type"
+                                                                                ]
+                                                                            },
+                                                                            "minItems": 1
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "name": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "role",
+                                                                "content"
+                                                            ]
+                                                        },
+                                                        {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "role": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "assistant"
+                                                                    ]
+                                                                },
+                                                                "content": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        },
+                                                                        {
+                                                                            "type": "array",
+                                                                            "items": {
+                                                                                "type": "object",
+                                                                                "properties": {
+                                                                                    "type": {
+                                                                                        "type": "string",
+                                                                                        "enum": [
+                                                                                            "text",
+                                                                                            "refusal"
+                                                                                        ]
+                                                                                    },
+                                                                                    "text": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "refusal": {
+                                                                                        "type": "string"
+                                                                                    }
+                                                                                },
+                                                                                "required": [
+                                                                                    "type"
+                                                                                ]
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "refusal": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "name": {
+                                                                    "type": "string"
+                                                                },
+                                                                "audio": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "id": {
+                                                                                    "type": "string"
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "id"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "tool_calls": {
+                                                                    "type": "array",
+                                                                    "items": {
+                                                                        "oneOf": [
+                                                                            {
+                                                                                "type": "object",
+                                                                                "properties": {
+                                                                                    "id": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "type": {
+                                                                                        "type": "string",
+                                                                                        "enum": [
+                                                                                            "function"
+                                                                                        ]
+                                                                                    },
+                                                                                    "function": {
+                                                                                        "type": "object",
+                                                                                        "properties": {
+                                                                                            "name": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "arguments": {
+                                                                                                "type": "string",
+                                                                                                "description": "JSON-encoded arguments string."
+                                                                                            }
+                                                                                        },
+                                                                                        "required": [
+                                                                                            "name",
+                                                                                            "arguments"
+                                                                                        ]
+                                                                                    }
+                                                                                },
+                                                                                "required": [
+                                                                                    "id",
+                                                                                    "type",
+                                                                                    "function"
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "type": "object",
+                                                                                "properties": {
+                                                                                    "id": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "type": {
+                                                                                        "type": "string",
+                                                                                        "enum": [
+                                                                                            "custom"
+                                                                                        ]
+                                                                                    },
+                                                                                    "custom": {
+                                                                                        "type": "object",
+                                                                                        "properties": {
+                                                                                            "name": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "input": {
+                                                                                                "type": "string"
+                                                                                            }
+                                                                                        },
+                                                                                        "required": [
+                                                                                            "name",
+                                                                                            "input"
+                                                                                        ]
+                                                                                    }
+                                                                                },
+                                                                                "required": [
+                                                                                    "id",
+                                                                                    "type",
+                                                                                    "custom"
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "function_call": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "name": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "arguments": {
+                                                                                    "type": "string"
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "name",
+                                                                                "arguments"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "role"
+                                                            ]
+                                                        },
+                                                        {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "role": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "tool"
+                                                                    ]
+                                                                },
+                                                                "content": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "array",
+                                                                            "items": {
+                                                                                "type": "object",
+                                                                                "properties": {
+                                                                                    "type": {
+                                                                                        "type": "string",
+                                                                                        "enum": [
+                                                                                            "text"
+                                                                                        ]
+                                                                                    },
+                                                                                    "text": {
+                                                                                        "type": "string"
+                                                                                    }
+                                                                                },
+                                                                                "required": [
+                                                                                    "type",
+                                                                                    "text"
+                                                                                ]
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "tool_call_id": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "role",
+                                                                "content",
+                                                                "tool_call_id"
+                                                            ]
+                                                        },
+                                                        {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "role": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "function"
+                                                                    ]
+                                                                },
+                                                                "content": {
+                                                                    "type": "string"
+                                                                },
+                                                                "name": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "role",
+                                                                "content",
+                                                                "name"
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                "minItems": 1
+                                            },
+                                            "model": {
+                                                "type": "string",
+                                                "description": "ID of the model to use (e.g. '@cf/zai-org/glm-4.7-flash, etc')."
+                                            },
+                                            "audio": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "object",
+                                                        "description": "Parameters for audio output. Required when modalities includes 'audio'.",
+                                                        "properties": {
+                                                            "voice": {
+                                                                "oneOf": [
+                                                                    {
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "id": {
+                                                                                "type": "string"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "id"
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "format": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                    "wav",
+                                                                    "aac",
+                                                                    "mp3",
+                                                                    "flac",
+                                                                    "opus",
+                                                                    "pcm16"
+                                                                ]
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "voice",
+                                                            "format"
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            "frequency_penalty": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "number",
+                                                        "minimum": -2,
+                                                        "maximum": 2
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": 0,
+                                                "description": "Penalizes new tokens based on their existing frequency in the text so far."
+                                            },
+                                            "logit_bias": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "Modify the likelihood of specified tokens appearing in the completion. Maps token IDs to bias values from -100 to 100."
+                                            },
+                                            "logprobs": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "boolean"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": false,
+                                                "description": "Whether to return log probabilities of the output tokens."
+                                            },
+                                            "top_logprobs": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "integer",
+                                                        "minimum": 0,
+                                                        "maximum": 20
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "How many top log probabilities to return at each token position (0-20). Requires logprobs=true."
+                                            },
+                                            "max_tokens": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "integer"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "Deprecated in favor of max_completion_tokens. The maximum number of tokens to generate."
+                                            },
+                                            "max_completion_tokens": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "integer"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "An upper bound for the number of tokens that can be generated for a completion."
+                                            },
+                                            "metadata": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "Set of 16 key-value pairs that can be attached to the object."
+                                            },
+                                            "modalities": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "array",
+                                                        "items": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "text",
+                                                                "audio"
+                                                            ]
+                                                        }
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "Output types requested from the model (e.g. ['text'] or ['text', 'audio'])."
+                                            },
+                                            "n": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "integer",
+                                                        "minimum": 1,
+                                                        "maximum": 128
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": 1,
+                                                "description": "How many chat completion choices to generate for each input message."
+                                            },
+                                            "parallel_tool_calls": {
+                                                "type": "boolean",
+                                                "default": true,
+                                                "description": "Whether to enable parallel function calling during tool use."
+                                            },
+                                            "prediction": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "type": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                    "content"
+                                                                ]
+                                                            },
+                                                            "content": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "type": "array",
+                                                                        "items": {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "type": {
+                                                                                    "type": "string",
+                                                                                    "enum": [
+                                                                                        "text"
+                                                                                    ]
+                                                                                },
+                                                                                "text": {
+                                                                                    "type": "string"
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "type",
+                                                                                "text"
+                                                                            ]
+                                                                        }
+                                                                    }
+                                                                ]
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "type",
+                                                            "content"
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            "presence_penalty": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "number",
+                                                        "minimum": -2,
+                                                        "maximum": 2
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": 0,
+                                                "description": "Penalizes new tokens based on whether they appear in the text so far."
+                                            },
+                                            "reasoning_effort": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "low",
+                                                            "medium",
+                                                            "high"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "Constrains effort on reasoning for reasoning models (o1, o3-mini, etc.)."
+                                            },
+                                            "chat_template_kwargs": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "enable_thinking": {
+                                                        "type": "boolean",
+                                                        "default": true,
+                                                        "description": "Whether to enable reasoning, enabled by default."
+                                                    },
+                                                    "clear_thinking": {
+                                                        "type": "boolean",
+                                                        "default": false,
+                                                        "description": "If false, preserves reasoning context between turns."
+                                                    }
+                                                }
+                                            },
+                                            "response_format": {
+                                                "anyOf": [
+                                                    {
+                                                        "description": "Specifies the format the model must output.",
+                                                        "oneOf": [
+                                                            {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "type": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "text"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "type"
+                                                                ]
+                                                            },
+                                                            {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "type": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "json_object"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "type"
+                                                                ]
+                                                            },
+                                                            {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "type": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "json_schema"
+                                                                        ]
+                                                                    },
+                                                                    "json_schema": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "name": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "description": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "schema": {
+                                                                                "type": "object"
+                                                                            },
+                                                                            "strict": {
+                                                                                "anyOf": [
+                                                                                    {
+                                                                                        "type": "boolean"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "null"
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "name"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "type",
+                                                                    "json_schema"
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            "seed": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "integer"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "If specified, the system will make a best effort to sample deterministically."
+                                            },
+                                            "service_tier": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "auto",
+                                                            "default",
+                                                            "flex",
+                                                            "scale",
+                                                            "priority"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": "auto",
+                                                "description": "Specifies the processing type used for serving the request."
+                                            },
+                                            "stop": {
+                                                "description": "Up to 4 sequences where the API will stop generating further tokens.",
+                                                "anyOf": [
+                                                    {
+                                                        "type": "null"
+                                                    },
+                                                    {
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "array",
+                                                        "items": {
+                                                            "type": "string"
+                                                        },
+                                                        "minItems": 1,
+                                                        "maxItems": 4
+                                                    }
+                                                ]
+                                            },
+                                            "store": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "boolean"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": false,
+                                                "description": "Whether to store the output for model distillation / evals."
+                                            },
+                                            "stream": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "boolean"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": false,
+                                                "description": "If true, partial message deltas will be sent as server-sent events."
+                                            },
+                                            "stream_options": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "include_usage": {
+                                                                "type": "boolean"
+                                                            },
+                                                            "include_obfuscation": {
+                                                                "type": "boolean"
+                                                            }
+                                                        }
+                                                    }
+                                                ]
+                                            },
+                                            "temperature": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "number",
+                                                        "minimum": 0,
+                                                        "maximum": 2
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": 1,
+                                                "description": "Sampling temperature between 0 and 2."
+                                            },
+                                            "tool_choice": {
+                                                "anyOf": [
+                                                    {
+                                                        "description": "Controls which (if any) tool is called by the model. 'none' = no tools, 'auto' = model decides, 'required' = must call a tool.",
+                                                        "oneOf": [
+                                                            {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                    "none",
+                                                                    "auto",
+                                                                    "required"
+                                                                ]
+                                                            },
+                                                            {
+                                                                "type": "object",
+                                                                "description": "Force a specific function tool.",
+                                                                "properties": {
+                                                                    "type": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "function"
+                                                                        ]
+                                                                    },
+                                                                    "function": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "name": {
+                                                                                "type": "string"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "name"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "type",
+                                                                    "function"
+                                                                ]
+                                                            },
+                                                            {
+                                                                "type": "object",
+                                                                "description": "Force a specific custom tool.",
+                                                                "properties": {
+                                                                    "type": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "custom"
+                                                                        ]
+                                                                    },
+                                                                    "custom": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "name": {
+                                                                                "type": "string"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "name"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "type",
+                                                                    "custom"
+                                                                ]
+                                                            },
+                                                            {
+                                                                "type": "object",
+                                                                "description": "Constrain to an allowed subset of tools.",
+                                                                "properties": {
+                                                                    "type": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "allowed_tools"
+                                                                        ]
+                                                                    },
+                                                                    "allowed_tools": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "mode": {
+                                                                                "type": "string",
+                                                                                "enum": [
+                                                                                    "auto",
+                                                                                    "required"
+                                                                                ]
+                                                                            },
+                                                                            "tools": {
+                                                                                "type": "array",
+                                                                                "items": {
+                                                                                    "type": "object"
+                                                                                }
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "mode",
+                                                                            "tools"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "type",
+                                                                    "allowed_tools"
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            "tools": {
+                                                "type": "array",
+                                                "description": "A list of tools the model may call.",
+                                                "items": {
+                                                    "oneOf": [
+                                                        {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "type": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "function"
+                                                                    ]
+                                                                },
+                                                                "function": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "name": {
+                                                                            "type": "string",
+                                                                            "description": "The name of the function to be called."
+                                                                        },
+                                                                        "description": {
+                                                                            "type": "string",
+                                                                            "description": "A description of what the function does."
+                                                                        },
+                                                                        "parameters": {
+                                                                            "type": "object",
+                                                                            "description": "The parameters the function accepts, described as a JSON Schema object."
+                                                                        },
+                                                                        "strict": {
+                                                                            "anyOf": [
+                                                                                {
+                                                                                    "type": "boolean"
+                                                                                },
+                                                                                {
+                                                                                    "type": "null"
+                                                                                }
+                                                                            ],
+                                                                            "default": false,
+                                                                            "description": "Whether to enable strict schema adherence."
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "name"
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "type",
+                                                                "function"
+                                                            ]
+                                                        },
+                                                        {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "type": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "custom"
+                                                                    ]
+                                                                },
+                                                                "custom": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "name": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "description": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "format": {
+                                                                            "oneOf": [
+                                                                                {
+                                                                                    "type": "object",
+                                                                                    "properties": {
+                                                                                        "type": {
+                                                                                            "type": "string",
+                                                                                            "enum": [
+                                                                                                "text"
+                                                                                            ]
+                                                                                        }
+                                                                                    },
+                                                                                    "required": [
+                                                                                        "type"
+                                                                                    ]
+                                                                                },
+                                                                                {
+                                                                                    "type": "object",
+                                                                                    "properties": {
+                                                                                        "type": {
+                                                                                            "type": "string",
+                                                                                            "enum": [
+                                                                                                "grammar"
+                                                                                            ]
+                                                                                        },
+                                                                                        "grammar": {
+                                                                                            "type": "object",
+                                                                                            "properties": {
+                                                                                                "definition": {
+                                                                                                    "type": "string"
+                                                                                                },
+                                                                                                "syntax": {
+                                                                                                    "type": "string",
+                                                                                                    "enum": [
+                                                                                                        "lark",
+                                                                                                        "regex"
+                                                                                                    ]
+                                                                                                }
+                                                                                            },
+                                                                                            "required": [
+                                                                                                "definition",
+                                                                                                "syntax"
+                                                                                            ]
+                                                                                        }
+                                                                                    },
+                                                                                    "required": [
+                                                                                        "type",
+                                                                                        "grammar"
+                                                                                    ]
+                                                                                }
+                                                                            ]
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "name"
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "type",
+                                                                "custom"
+                                                            ]
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "top_p": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "number",
+                                                        "minimum": 0,
+                                                        "maximum": 1
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": 1,
+                                                "description": "Nucleus sampling: considers the results of the tokens with top_p probability mass."
+                                            },
+                                            "user": {
+                                                "type": "string",
+                                                "description": "A unique identifier representing your end-user, for abuse monitoring."
+                                            },
+                                            "web_search_options": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "object",
+                                                        "description": "Options for the web search tool (when using built-in web search).",
+                                                        "properties": {
+                                                            "search_context_size": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                    "low",
+                                                                    "medium",
+                                                                    "high"
+                                                                ],
+                                                                "default": "medium"
+                                                            },
+                                                            "user_location": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "type": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "approximate"
+                                                                        ]
+                                                                    },
+                                                                    "approximate": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "city": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "country": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "region": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "timezone": {
+                                                                                "type": "string"
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "type",
+                                                                    "approximate"
+                                                                ]
+                                                            }
+                                                        }
+                                                    }
+                                                ]
+                                            },
+                                            "function_call": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "none",
+                                                            "auto"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "name": {
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "name"
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            "functions": {
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "name": {
+                                                            "type": "string",
+                                                            "description": "The name of the function to be called."
+                                                        },
+                                                        "description": {
+                                                            "type": "string",
+                                                            "description": "A description of what the function does."
+                                                        },
+                                                        "parameters": {
+                                                            "type": "object",
+                                                            "description": "The parameters the function accepts, described as a JSON Schema object."
+                                                        },
+                                                        "strict": {
+                                                            "anyOf": [
+                                                                {
+                                                                    "type": "boolean"
+                                                                },
+                                                                {
+                                                                    "type": "null"
+                                                                }
+                                                            ],
+                                                            "default": false,
+                                                            "description": "Whether to enable strict schema adherence."
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "name"
+                                                    ]
+                                                },
+                                                "minItems": 1,
+                                                "maxItems": 128
+                                            }
+                                        },
+                                        "required": [
+                                            "messages"
+                                        ]
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "output": {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "contentType": "application/json",
+                    "properties": {
+                        "id": {
+                            "type": "string",
+                            "description": "A unique identifier for the chat completion."
+                        },
+                        "object": {
+                            "type": "string"
+                        },
+                        "created": {
+                            "type": "integer",
+                            "description": "Unix timestamp (seconds) of when the completion was created."
+                        },
+                        "model": {
+                            "type": "string",
+                            "description": "The model used for the chat completion."
+                        },
+                        "choices": {
+                            "type": "array",
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "object",
+                                        "properties": {
+                                            "index": {
+                                                "type": "integer"
+                                            },
+                                            "message": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "role": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                    "assistant"
+                                                                ]
+                                                            },
+                                                            "content": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "refusal": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "annotations": {
+                                                                "type": "array",
+                                                                "items": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "enum": [
+                                                                                "url_citation"
+                                                                            ]
+                                                                        },
+                                                                        "url_citation": {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "url": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "title": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "start_index": {
+                                                                                    "type": "integer"
+                                                                                },
+                                                                                "end_index": {
+                                                                                    "type": "integer"
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "url",
+                                                                                "title",
+                                                                                "start_index",
+                                                                                "end_index"
+                                                                            ]
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "type",
+                                                                        "url_citation"
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "audio": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "id": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "data": {
+                                                                                "type": "string",
+                                                                                "description": "Base64 encoded audio bytes."
+                                                                            },
+                                                                            "expires_at": {
+                                                                                "type": "integer"
+                                                                            },
+                                                                            "transcript": {
+                                                                                "type": "string"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "id",
+                                                                            "data",
+                                                                            "expires_at",
+                                                                            "transcript"
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "tool_calls": {
+                                                                "type": "array",
+                                                                "items": {
+                                                                    "oneOf": [
+                                                                        {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "id": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "type": {
+                                                                                    "type": "string",
+                                                                                    "enum": [
+                                                                                        "function"
+                                                                                    ]
+                                                                                },
+                                                                                "function": {
+                                                                                    "type": "object",
+                                                                                    "properties": {
+                                                                                        "name": {
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "arguments": {
+                                                                                            "type": "string",
+                                                                                            "description": "JSON-encoded arguments string."
+                                                                                        }
+                                                                                    },
+                                                                                    "required": [
+                                                                                        "name",
+                                                                                        "arguments"
+                                                                                    ]
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "id",
+                                                                                "type",
+                                                                                "function"
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "id": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "type": {
+                                                                                    "type": "string",
+                                                                                    "enum": [
+                                                                                        "custom"
+                                                                                    ]
+                                                                                },
+                                                                                "custom": {
+                                                                                    "type": "object",
+                                                                                    "properties": {
+                                                                                        "name": {
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "input": {
+                                                                                            "type": "string"
+                                                                                        }
+                                                                                    },
+                                                                                    "required": [
+                                                                                        "name",
+                                                                                        "input"
+                                                                                    ]
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "id",
+                                                                                "type",
+                                                                                "custom"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "function_call": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "name": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "arguments": {
+                                                                                "type": "string"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "name",
+                                                                            "arguments"
+                                                                        ]
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ]
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "role",
+                                                            "content",
+                                                            "refusal"
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            "finish_reason": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "stop",
+                                                    "length",
+                                                    "tool_calls",
+                                                    "content_filter",
+                                                    "function_call"
+                                                ]
+                                            },
+                                            "logprobs": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "content": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "array",
+                                                                        "items": {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "token": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "logprob": {
+                                                                                    "type": "number"
+                                                                                },
+                                                                                "bytes": {
+                                                                                    "anyOf": [
+                                                                                        {
+                                                                                            "type": "array",
+                                                                                            "items": {
+                                                                                                "type": "integer"
+                                                                                            }
+                                                                                        },
+                                                                                        {
+                                                                                            "type": "null"
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                "top_logprobs": {
+                                                                                    "type": "array",
+                                                                                    "items": {
+                                                                                        "type": "object",
+                                                                                        "properties": {
+                                                                                            "token": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "logprob": {
+                                                                                                "type": "number"
+                                                                                            },
+                                                                                            "bytes": {
+                                                                                                "anyOf": [
+                                                                                                    {
+                                                                                                        "type": "array",
+                                                                                                        "items": {
+                                                                                                            "type": "integer"
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "null"
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        },
+                                                                                        "required": [
+                                                                                            "token",
+                                                                                            "logprob",
+                                                                                            "bytes"
+                                                                                        ]
+                                                                                    }
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "token",
+                                                                                "logprob",
+                                                                                "bytes",
+                                                                                "top_logprobs"
+                                                                            ]
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "refusal": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "array",
+                                                                        "items": {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "token": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "logprob": {
+                                                                                    "type": "number"
+                                                                                },
+                                                                                "bytes": {
+                                                                                    "anyOf": [
+                                                                                        {
+                                                                                            "type": "array",
+                                                                                            "items": {
+                                                                                                "type": "integer"
+                                                                                            }
+                                                                                        },
+                                                                                        {
+                                                                                            "type": "null"
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                "top_logprobs": {
+                                                                                    "type": "array",
+                                                                                    "items": {
+                                                                                        "type": "object",
+                                                                                        "properties": {
+                                                                                            "token": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "logprob": {
+                                                                                                "type": "number"
+                                                                                            },
+                                                                                            "bytes": {
+                                                                                                "anyOf": [
+                                                                                                    {
+                                                                                                        "type": "array",
+                                                                                                        "items": {
+                                                                                                            "type": "integer"
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "null"
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        },
+                                                                                        "required": [
+                                                                                            "token",
+                                                                                            "logprob",
+                                                                                            "bytes"
+                                                                                        ]
+                                                                                    }
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "token",
+                                                                                "logprob",
+                                                                                "bytes",
+                                                                                "top_logprobs"
+                                                                            ]
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ]
+                                                            }
+                                                        }
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "index",
+                                            "message",
+                                            "finish_reason",
+                                            "logprobs"
+                                        ]
+                                    }
+                                ]
+                            },
+                            "minItems": 1
+                        },
+                        "usage": {
+                            "anyOf": [
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "prompt_tokens": {
+                                            "type": "integer"
+                                        },
+                                        "completion_tokens": {
+                                            "type": "integer"
+                                        },
+                                        "total_tokens": {
+                                            "type": "integer"
+                                        },
+                                        "prompt_tokens_details": {
+                                            "type": "object",
+                                            "properties": {
+                                                "cached_tokens": {
+                                                    "type": "integer"
+                                                },
+                                                "audio_tokens": {
+                                                    "type": "integer"
+                                                }
+                                            }
+                                        },
+                                        "completion_tokens_details": {
+                                            "type": "object",
+                                            "properties": {
+                                                "reasoning_tokens": {
+                                                    "type": "integer"
+                                                },
+                                                "audio_tokens": {
+                                                    "type": "integer"
+                                                },
+                                                "accepted_prediction_tokens": {
+                                                    "type": "integer"
+                                                },
+                                                "rejected_prediction_tokens": {
+                                                    "type": "integer"
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "required": [
+                                        "prompt_tokens",
+                                        "completion_tokens",
+                                        "total_tokens"
+                                    ]
+                                }
+                            ]
+                        },
+                        "system_fingerprint": {
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ]
+                        },
+                        "service_tier": {
+                            "anyOf": [
+                                {
+                                    "type": "string",
+                                    "enum": [
+                                        "auto",
+                                        "default",
+                                        "flex",
+                                        "scale",
+                                        "priority"
+                                    ]
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ]
+                        }
+                    },
+                    "required": [
+                        "id",
+                        "object",
+                        "created",
+                        "model",
+                        "choices"
+                    ]
+                },
+                {
+                    "type": "string",
+                    "contentType": "text/event-stream",
+                    "format": "binary"
+                }
+            ]
+        }
+    },
+    "deprecated": false
+}

--- a/src/content/workers-ai-models/deepseek-v4-pro-0813.json
+++ b/src/content/workers-ai-models/deepseek-v4-pro-0813.json
@@ -1,0 +1,4778 @@
+{
+    "name": "@cf/deepseek-ai/deepseek-v4-pro-0813",
+    "properties": [
+        {
+            "property_id": "beta",
+            "value": "false"
+        },
+        {
+            "property_id": "require_workers_paid",
+            "value": "true"
+        },
+        {
+            "property_id": "context_window",
+            "value": "1048576"
+        },
+        {
+            "property_id": "function_calling",
+            "value": "true"
+        },
+        {
+            "property_id": "reasoning",
+            "value": "true"
+        },
+        {
+            "property_id": "vision",
+            "value": "false"
+        },
+        {
+            "property_id": "price",
+            "value": [
+                {
+                    "unit": "per M input tokens",
+                    "price": 1.32,
+                    "currency": "USD"
+                },
+                {
+                    "unit": "per M output tokens",
+                    "price": 3.96,
+                    "currency": "USD"
+                },
+                {
+                    "unit": "per M cached input tokens",
+                    "price": 0.044,
+                    "currency": "USD"
+                }
+            ]
+        }
+    ],
+    "id": "2d50837b-2dc7-4994-a690-a38e25c16d74",
+    "source": 1,
+    "description": "deepseek-ai/deepseek-v4-pro-0813",
+    "task": {
+        "id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+        "name": "Text Generation",
+        "description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+    },
+    "created_at": "2026-08-13 17:15:08.489",
+    "tags": [],
+    "schema": {
+        "input": {
+            "anyOf": [
+                {
+                    "type": "object",
+                    "oneOf": [
+                        {
+                            "title": "Prompt",
+                            "properties": {
+                                "prompt": {
+                                    "type": "string",
+                                    "minLength": 1,
+                                    "description": "The input text prompt for the model to generate a response."
+                                },
+                                "model": {
+                                    "type": "string",
+                                    "description": "ID of the model to use (e.g. '@cf/zai-org/glm-4.7-flash, etc')."
+                                },
+                                "audio": {
+                                    "anyOf": [
+                                        {
+                                            "type": "object",
+                                            "description": "Parameters for audio output. Required when modalities includes 'audio'.",
+                                            "properties": {
+                                                "voice": {
+                                                    "oneOf": [
+                                                        {
+                                                            "type": "string"
+                                                        },
+                                                        {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "id": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "id"
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                "format": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "wav",
+                                                        "aac",
+                                                        "mp3",
+                                                        "flac",
+                                                        "opus",
+                                                        "pcm16"
+                                                    ]
+                                                }
+                                            },
+                                            "required": [
+                                                "voice",
+                                                "format"
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "frequency_penalty": {
+                                    "anyOf": [
+                                        {
+                                            "type": "number",
+                                            "minimum": -2,
+                                            "maximum": 2
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": 0,
+                                    "description": "Penalizes new tokens based on their existing frequency in the text so far."
+                                },
+                                "logit_bias": {
+                                    "anyOf": [
+                                        {
+                                            "type": "object"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "Modify the likelihood of specified tokens appearing in the completion. Maps token IDs to bias values from -100 to 100."
+                                },
+                                "logprobs": {
+                                    "anyOf": [
+                                        {
+                                            "type": "boolean"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": false,
+                                    "description": "Whether to return log probabilities of the output tokens."
+                                },
+                                "top_logprobs": {
+                                    "anyOf": [
+                                        {
+                                            "type": "integer",
+                                            "minimum": 0,
+                                            "maximum": 20
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "How many top log probabilities to return at each token position (0-20). Requires logprobs=true."
+                                },
+                                "max_tokens": {
+                                    "anyOf": [
+                                        {
+                                            "type": "integer"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "Deprecated in favor of max_completion_tokens. The maximum number of tokens to generate."
+                                },
+                                "max_completion_tokens": {
+                                    "anyOf": [
+                                        {
+                                            "type": "integer"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "An upper bound for the number of tokens that can be generated for a completion."
+                                },
+                                "metadata": {
+                                    "anyOf": [
+                                        {
+                                            "type": "object"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "Set of 16 key-value pairs that can be attached to the object."
+                                },
+                                "modalities": {
+                                    "anyOf": [
+                                        {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "text",
+                                                    "audio"
+                                                ]
+                                            }
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "Output types requested from the model (e.g. ['text'] or ['text', 'audio'])."
+                                },
+                                "n": {
+                                    "anyOf": [
+                                        {
+                                            "type": "integer",
+                                            "minimum": 1,
+                                            "maximum": 128
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": 1,
+                                    "description": "How many chat completion choices to generate for each input message."
+                                },
+                                "parallel_tool_calls": {
+                                    "type": "boolean",
+                                    "default": true,
+                                    "description": "Whether to enable parallel function calling during tool use."
+                                },
+                                "prediction": {
+                                    "anyOf": [
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "type": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "content"
+                                                    ]
+                                                },
+                                                "content": {
+                                                    "anyOf": [
+                                                        {
+                                                            "type": "string"
+                                                        },
+                                                        {
+                                                            "type": "array",
+                                                            "items": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "type": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "text"
+                                                                        ]
+                                                                    },
+                                                                    "text": {
+                                                                        "type": "string"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "type",
+                                                                    "text"
+                                                                ]
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "required": [
+                                                "type",
+                                                "content"
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "presence_penalty": {
+                                    "anyOf": [
+                                        {
+                                            "type": "number",
+                                            "minimum": -2,
+                                            "maximum": 2
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": 0,
+                                    "description": "Penalizes new tokens based on whether they appear in the text so far."
+                                },
+                                "reasoning_effort": {
+                                    "anyOf": [
+                                        {
+                                            "type": "string",
+                                            "enum": [
+                                                "low",
+                                                "medium",
+                                                "high"
+                                            ]
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "Constrains effort on reasoning for reasoning models (o1, o3-mini, etc.)."
+                                },
+                                "chat_template_kwargs": {
+                                    "type": "object",
+                                    "properties": {
+                                        "enable_thinking": {
+                                            "type": "boolean",
+                                            "default": true,
+                                            "description": "Whether to enable reasoning, enabled by default."
+                                        },
+                                        "clear_thinking": {
+                                            "type": "boolean",
+                                            "default": false,
+                                            "description": "If false, preserves reasoning context between turns."
+                                        }
+                                    }
+                                },
+                                "response_format": {
+                                    "anyOf": [
+                                        {
+                                            "description": "Specifies the format the model must output.",
+                                            "oneOf": [
+                                                {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "text"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "type"
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "json_object"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "type"
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "json_schema"
+                                                            ]
+                                                        },
+                                                        "json_schema": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "name": {
+                                                                    "type": "string"
+                                                                },
+                                                                "description": {
+                                                                    "type": "string"
+                                                                },
+                                                                "schema": {
+                                                                    "type": "object"
+                                                                },
+                                                                "strict": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "boolean"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "name"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "type",
+                                                        "json_schema"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "seed": {
+                                    "anyOf": [
+                                        {
+                                            "type": "integer"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "If specified, the system will make a best effort to sample deterministically."
+                                },
+                                "service_tier": {
+                                    "anyOf": [
+                                        {
+                                            "type": "string",
+                                            "enum": [
+                                                "auto",
+                                                "default",
+                                                "flex",
+                                                "scale",
+                                                "priority"
+                                            ]
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": "auto",
+                                    "description": "Specifies the processing type used for serving the request."
+                                },
+                                "stop": {
+                                    "description": "Up to 4 sequences where the API will stop generating further tokens.",
+                                    "anyOf": [
+                                        {
+                                            "type": "null"
+                                        },
+                                        {
+                                            "type": "string"
+                                        },
+                                        {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            },
+                                            "minItems": 1,
+                                            "maxItems": 4
+                                        }
+                                    ]
+                                },
+                                "store": {
+                                    "anyOf": [
+                                        {
+                                            "type": "boolean"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": false,
+                                    "description": "Whether to store the output for model distillation / evals."
+                                },
+                                "stream": {
+                                    "anyOf": [
+                                        {
+                                            "type": "boolean"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": false,
+                                    "description": "If true, partial message deltas will be sent as server-sent events."
+                                },
+                                "stream_options": {
+                                    "anyOf": [
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "include_usage": {
+                                                    "type": "boolean"
+                                                },
+                                                "include_obfuscation": {
+                                                    "type": "boolean"
+                                                }
+                                            }
+                                        }
+                                    ]
+                                },
+                                "temperature": {
+                                    "anyOf": [
+                                        {
+                                            "type": "number",
+                                            "minimum": 0,
+                                            "maximum": 2
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": 1,
+                                    "description": "Sampling temperature between 0 and 2."
+                                },
+                                "tool_choice": {
+                                    "anyOf": [
+                                        {
+                                            "description": "Controls which (if any) tool is called by the model. 'none' = no tools, 'auto' = model decides, 'required' = must call a tool.",
+                                            "oneOf": [
+                                                {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "none",
+                                                        "auto",
+                                                        "required"
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "description": "Force a specific function tool.",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "function"
+                                                            ]
+                                                        },
+                                                        "function": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "name": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "name"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "type",
+                                                        "function"
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "description": "Force a specific custom tool.",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "custom"
+                                                            ]
+                                                        },
+                                                        "custom": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "name": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "name"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "type",
+                                                        "custom"
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "description": "Constrain to an allowed subset of tools.",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "allowed_tools"
+                                                            ]
+                                                        },
+                                                        "allowed_tools": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "mode": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "auto",
+                                                                        "required"
+                                                                    ]
+                                                                },
+                                                                "tools": {
+                                                                    "type": "array",
+                                                                    "items": {
+                                                                        "type": "object"
+                                                                    }
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "mode",
+                                                                "tools"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "type",
+                                                        "allowed_tools"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "tools": {
+                                    "type": "array",
+                                    "description": "A list of tools the model may call.",
+                                    "items": {
+                                        "oneOf": [
+                                            {
+                                                "type": "object",
+                                                "properties": {
+                                                    "type": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "function"
+                                                        ]
+                                                    },
+                                                    "function": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "name": {
+                                                                "type": "string",
+                                                                "description": "The name of the function to be called."
+                                                            },
+                                                            "description": {
+                                                                "type": "string",
+                                                                "description": "A description of what the function does."
+                                                            },
+                                                            "parameters": {
+                                                                "type": "object",
+                                                                "description": "The parameters the function accepts, described as a JSON Schema object."
+                                                            },
+                                                            "strict": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "boolean"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ],
+                                                                "default": false,
+                                                                "description": "Whether to enable strict schema adherence."
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "name"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type",
+                                                    "function"
+                                                ]
+                                            },
+                                            {
+                                                "type": "object",
+                                                "properties": {
+                                                    "type": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "custom"
+                                                        ]
+                                                    },
+                                                    "custom": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "name": {
+                                                                "type": "string"
+                                                            },
+                                                            "description": {
+                                                                "type": "string"
+                                                            },
+                                                            "format": {
+                                                                "oneOf": [
+                                                                    {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "type": {
+                                                                                "type": "string",
+                                                                                "enum": [
+                                                                                    "text"
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "type"
+                                                                        ]
+                                                                    },
+                                                                    {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "type": {
+                                                                                "type": "string",
+                                                                                "enum": [
+                                                                                    "grammar"
+                                                                                ]
+                                                                            },
+                                                                            "grammar": {
+                                                                                "type": "object",
+                                                                                "properties": {
+                                                                                    "definition": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "syntax": {
+                                                                                        "type": "string",
+                                                                                        "enum": [
+                                                                                            "lark",
+                                                                                            "regex"
+                                                                                        ]
+                                                                                    }
+                                                                                },
+                                                                                "required": [
+                                                                                    "definition",
+                                                                                    "syntax"
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "type",
+                                                                            "grammar"
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "name"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type",
+                                                    "custom"
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                },
+                                "top_p": {
+                                    "anyOf": [
+                                        {
+                                            "type": "number",
+                                            "minimum": 0,
+                                            "maximum": 1
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": 1,
+                                    "description": "Nucleus sampling: considers the results of the tokens with top_p probability mass."
+                                },
+                                "user": {
+                                    "type": "string",
+                                    "description": "A unique identifier representing your end-user, for abuse monitoring."
+                                },
+                                "web_search_options": {
+                                    "anyOf": [
+                                        {
+                                            "type": "object",
+                                            "description": "Options for the web search tool (when using built-in web search).",
+                                            "properties": {
+                                                "search_context_size": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "low",
+                                                        "medium",
+                                                        "high"
+                                                    ],
+                                                    "default": "medium"
+                                                },
+                                                "user_location": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "approximate"
+                                                            ]
+                                                        },
+                                                        "approximate": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "city": {
+                                                                    "type": "string"
+                                                                },
+                                                                "country": {
+                                                                    "type": "string"
+                                                                },
+                                                                "region": {
+                                                                    "type": "string"
+                                                                },
+                                                                "timezone": {
+                                                                    "type": "string"
+                                                                }
+                                                            }
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "type",
+                                                        "approximate"
+                                                    ]
+                                                }
+                                            }
+                                        }
+                                    ]
+                                },
+                                "function_call": {
+                                    "anyOf": [
+                                        {
+                                            "type": "string",
+                                            "enum": [
+                                                "none",
+                                                "auto"
+                                            ]
+                                        },
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "name": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "name"
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "functions": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "name": {
+                                                "type": "string",
+                                                "description": "The name of the function to be called."
+                                            },
+                                            "description": {
+                                                "type": "string",
+                                                "description": "A description of what the function does."
+                                            },
+                                            "parameters": {
+                                                "type": "object",
+                                                "description": "The parameters the function accepts, described as a JSON Schema object."
+                                            },
+                                            "strict": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "boolean"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": false,
+                                                "description": "Whether to enable strict schema adherence."
+                                            }
+                                        },
+                                        "required": [
+                                            "name"
+                                        ]
+                                    },
+                                    "minItems": 1,
+                                    "maxItems": 128
+                                }
+                            },
+                            "required": [
+                                "prompt"
+                            ]
+                        },
+                        {
+                            "title": "Messages",
+                            "properties": {
+                                "messages": {
+                                    "type": "array",
+                                    "description": "A list of messages comprising the conversation so far.",
+                                    "items": {
+                                        "oneOf": [
+                                            {
+                                                "type": "object",
+                                                "properties": {
+                                                    "role": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "developer"
+                                                        ]
+                                                    },
+                                                    "content": {
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "string"
+                                                            },
+                                                            {
+                                                                "type": "array",
+                                                                "items": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "enum": [
+                                                                                "text"
+                                                                            ]
+                                                                        },
+                                                                        "text": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "type",
+                                                                        "text"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
+                                                    },
+                                                    "name": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "role",
+                                                    "content"
+                                                ]
+                                            },
+                                            {
+                                                "type": "object",
+                                                "properties": {
+                                                    "role": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "system"
+                                                        ]
+                                                    },
+                                                    "content": {
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "string"
+                                                            },
+                                                            {
+                                                                "type": "array",
+                                                                "items": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "enum": [
+                                                                                "text"
+                                                                            ]
+                                                                        },
+                                                                        "text": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "type",
+                                                                        "text"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
+                                                    },
+                                                    "name": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "role",
+                                                    "content"
+                                                ]
+                                            },
+                                            {
+                                                "type": "object",
+                                                "properties": {
+                                                    "role": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "user"
+                                                        ]
+                                                    },
+                                                    "content": {
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "string"
+                                                            },
+                                                            {
+                                                                "type": "array",
+                                                                "items": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "enum": [
+                                                                                "text",
+                                                                                "image_url",
+                                                                                "video_url",
+                                                                                "input_audio",
+                                                                                "file"
+                                                                            ]
+                                                                        },
+                                                                        "text": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "image_url": {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "url": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "detail": {
+                                                                                    "type": "string",
+                                                                                    "enum": [
+                                                                                        "auto",
+                                                                                        "low",
+                                                                                        "high"
+                                                                                    ],
+                                                                                    "default": "auto"
+                                                                                }
+                                                                            }
+                                                                        },
+                                                                        "video_url": {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "url": {
+                                                                                    "type": "string"
+                                                                                }
+                                                                            }
+                                                                        },
+                                                                        "input_audio": {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "data": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "format": {
+                                                                                    "type": "string",
+                                                                                    "enum": [
+                                                                                        "wav",
+                                                                                        "mp3"
+                                                                                    ]
+                                                                                }
+                                                                            }
+                                                                        },
+                                                                        "file": {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "file_data": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "file_id": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "filename": {
+                                                                                    "type": "string"
+                                                                                }
+                                                                            }
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "type"
+                                                                    ]
+                                                                },
+                                                                "minItems": 1
+                                                            }
+                                                        ]
+                                                    },
+                                                    "name": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "role",
+                                                    "content"
+                                                ]
+                                            },
+                                            {
+                                                "type": "object",
+                                                "properties": {
+                                                    "role": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "assistant"
+                                                        ]
+                                                    },
+                                                    "content": {
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "string"
+                                                            },
+                                                            {
+                                                                "type": "null"
+                                                            },
+                                                            {
+                                                                "type": "array",
+                                                                "items": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "enum": [
+                                                                                "text",
+                                                                                "refusal"
+                                                                            ]
+                                                                        },
+                                                                        "text": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "refusal": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "type"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
+                                                    },
+                                                    "refusal": {
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "string"
+                                                            },
+                                                            {
+                                                                "type": "null"
+                                                            }
+                                                        ]
+                                                    },
+                                                    "name": {
+                                                        "type": "string"
+                                                    },
+                                                    "audio": {
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "id": {
+                                                                        "type": "string"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "id"
+                                                                ]
+                                                            }
+                                                        ]
+                                                    },
+                                                    "tool_calls": {
+                                                        "type": "array",
+                                                        "items": {
+                                                            "oneOf": [
+                                                                {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "id": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "enum": [
+                                                                                "function"
+                                                                            ]
+                                                                        },
+                                                                        "function": {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "name": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "arguments": {
+                                                                                    "type": "string",
+                                                                                    "description": "JSON-encoded arguments string."
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "name",
+                                                                                "arguments"
+                                                                            ]
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "id",
+                                                                        "type",
+                                                                        "function"
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "id": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "enum": [
+                                                                                "custom"
+                                                                            ]
+                                                                        },
+                                                                        "custom": {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "name": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "input": {
+                                                                                    "type": "string"
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "name",
+                                                                                "input"
+                                                                            ]
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "id",
+                                                                        "type",
+                                                                        "custom"
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        }
+                                                    },
+                                                    "function_call": {
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "name": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "arguments": {
+                                                                        "type": "string"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "name",
+                                                                    "arguments"
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                "required": [
+                                                    "role"
+                                                ]
+                                            },
+                                            {
+                                                "type": "object",
+                                                "properties": {
+                                                    "role": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "tool"
+                                                        ]
+                                                    },
+                                                    "content": {
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "string"
+                                                            },
+                                                            {
+                                                                "type": "array",
+                                                                "items": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "enum": [
+                                                                                "text"
+                                                                            ]
+                                                                        },
+                                                                        "text": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "type",
+                                                                        "text"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
+                                                    },
+                                                    "tool_call_id": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "role",
+                                                    "content",
+                                                    "tool_call_id"
+                                                ]
+                                            },
+                                            {
+                                                "type": "object",
+                                                "properties": {
+                                                    "role": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "function"
+                                                        ]
+                                                    },
+                                                    "content": {
+                                                        "type": "string"
+                                                    },
+                                                    "name": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "role",
+                                                    "content",
+                                                    "name"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "minItems": 1
+                                },
+                                "model": {
+                                    "type": "string",
+                                    "description": "ID of the model to use (e.g. '@cf/zai-org/glm-4.7-flash, etc')."
+                                },
+                                "audio": {
+                                    "anyOf": [
+                                        {
+                                            "type": "object",
+                                            "description": "Parameters for audio output. Required when modalities includes 'audio'.",
+                                            "properties": {
+                                                "voice": {
+                                                    "oneOf": [
+                                                        {
+                                                            "type": "string"
+                                                        },
+                                                        {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "id": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "id"
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                "format": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "wav",
+                                                        "aac",
+                                                        "mp3",
+                                                        "flac",
+                                                        "opus",
+                                                        "pcm16"
+                                                    ]
+                                                }
+                                            },
+                                            "required": [
+                                                "voice",
+                                                "format"
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "frequency_penalty": {
+                                    "anyOf": [
+                                        {
+                                            "type": "number",
+                                            "minimum": -2,
+                                            "maximum": 2
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": 0,
+                                    "description": "Penalizes new tokens based on their existing frequency in the text so far."
+                                },
+                                "logit_bias": {
+                                    "anyOf": [
+                                        {
+                                            "type": "object"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "Modify the likelihood of specified tokens appearing in the completion. Maps token IDs to bias values from -100 to 100."
+                                },
+                                "logprobs": {
+                                    "anyOf": [
+                                        {
+                                            "type": "boolean"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": false,
+                                    "description": "Whether to return log probabilities of the output tokens."
+                                },
+                                "top_logprobs": {
+                                    "anyOf": [
+                                        {
+                                            "type": "integer",
+                                            "minimum": 0,
+                                            "maximum": 20
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "How many top log probabilities to return at each token position (0-20). Requires logprobs=true."
+                                },
+                                "max_tokens": {
+                                    "anyOf": [
+                                        {
+                                            "type": "integer"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "Deprecated in favor of max_completion_tokens. The maximum number of tokens to generate."
+                                },
+                                "max_completion_tokens": {
+                                    "anyOf": [
+                                        {
+                                            "type": "integer"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "An upper bound for the number of tokens that can be generated for a completion."
+                                },
+                                "metadata": {
+                                    "anyOf": [
+                                        {
+                                            "type": "object"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "Set of 16 key-value pairs that can be attached to the object."
+                                },
+                                "modalities": {
+                                    "anyOf": [
+                                        {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "text",
+                                                    "audio"
+                                                ]
+                                            }
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "Output types requested from the model (e.g. ['text'] or ['text', 'audio'])."
+                                },
+                                "n": {
+                                    "anyOf": [
+                                        {
+                                            "type": "integer",
+                                            "minimum": 1,
+                                            "maximum": 128
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": 1,
+                                    "description": "How many chat completion choices to generate for each input message."
+                                },
+                                "parallel_tool_calls": {
+                                    "type": "boolean",
+                                    "default": true,
+                                    "description": "Whether to enable parallel function calling during tool use."
+                                },
+                                "prediction": {
+                                    "anyOf": [
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "type": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "content"
+                                                    ]
+                                                },
+                                                "content": {
+                                                    "anyOf": [
+                                                        {
+                                                            "type": "string"
+                                                        },
+                                                        {
+                                                            "type": "array",
+                                                            "items": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "type": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "text"
+                                                                        ]
+                                                                    },
+                                                                    "text": {
+                                                                        "type": "string"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "type",
+                                                                    "text"
+                                                                ]
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "required": [
+                                                "type",
+                                                "content"
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "presence_penalty": {
+                                    "anyOf": [
+                                        {
+                                            "type": "number",
+                                            "minimum": -2,
+                                            "maximum": 2
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": 0,
+                                    "description": "Penalizes new tokens based on whether they appear in the text so far."
+                                },
+                                "reasoning_effort": {
+                                    "anyOf": [
+                                        {
+                                            "type": "string",
+                                            "enum": [
+                                                "low",
+                                                "medium",
+                                                "high"
+                                            ]
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "Constrains effort on reasoning for reasoning models (o1, o3-mini, etc.)."
+                                },
+                                "chat_template_kwargs": {
+                                    "type": "object",
+                                    "properties": {
+                                        "enable_thinking": {
+                                            "type": "boolean",
+                                            "default": true,
+                                            "description": "Whether to enable reasoning, enabled by default."
+                                        },
+                                        "clear_thinking": {
+                                            "type": "boolean",
+                                            "default": false,
+                                            "description": "If false, preserves reasoning context between turns."
+                                        }
+                                    }
+                                },
+                                "response_format": {
+                                    "anyOf": [
+                                        {
+                                            "description": "Specifies the format the model must output.",
+                                            "oneOf": [
+                                                {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "text"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "type"
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "json_object"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "type"
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "json_schema"
+                                                            ]
+                                                        },
+                                                        "json_schema": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "name": {
+                                                                    "type": "string"
+                                                                },
+                                                                "description": {
+                                                                    "type": "string"
+                                                                },
+                                                                "schema": {
+                                                                    "type": "object"
+                                                                },
+                                                                "strict": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "boolean"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "name"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "type",
+                                                        "json_schema"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "seed": {
+                                    "anyOf": [
+                                        {
+                                            "type": "integer"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "If specified, the system will make a best effort to sample deterministically."
+                                },
+                                "service_tier": {
+                                    "anyOf": [
+                                        {
+                                            "type": "string",
+                                            "enum": [
+                                                "auto",
+                                                "default",
+                                                "flex",
+                                                "scale",
+                                                "priority"
+                                            ]
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": "auto",
+                                    "description": "Specifies the processing type used for serving the request."
+                                },
+                                "stop": {
+                                    "description": "Up to 4 sequences where the API will stop generating further tokens.",
+                                    "anyOf": [
+                                        {
+                                            "type": "null"
+                                        },
+                                        {
+                                            "type": "string"
+                                        },
+                                        {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            },
+                                            "minItems": 1,
+                                            "maxItems": 4
+                                        }
+                                    ]
+                                },
+                                "store": {
+                                    "anyOf": [
+                                        {
+                                            "type": "boolean"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": false,
+                                    "description": "Whether to store the output for model distillation / evals."
+                                },
+                                "stream": {
+                                    "anyOf": [
+                                        {
+                                            "type": "boolean"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": false,
+                                    "description": "If true, partial message deltas will be sent as server-sent events."
+                                },
+                                "stream_options": {
+                                    "anyOf": [
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "include_usage": {
+                                                    "type": "boolean"
+                                                },
+                                                "include_obfuscation": {
+                                                    "type": "boolean"
+                                                }
+                                            }
+                                        }
+                                    ]
+                                },
+                                "temperature": {
+                                    "anyOf": [
+                                        {
+                                            "type": "number",
+                                            "minimum": 0,
+                                            "maximum": 2
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": 1,
+                                    "description": "Sampling temperature between 0 and 2."
+                                },
+                                "tool_choice": {
+                                    "anyOf": [
+                                        {
+                                            "description": "Controls which (if any) tool is called by the model. 'none' = no tools, 'auto' = model decides, 'required' = must call a tool.",
+                                            "oneOf": [
+                                                {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "none",
+                                                        "auto",
+                                                        "required"
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "description": "Force a specific function tool.",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "function"
+                                                            ]
+                                                        },
+                                                        "function": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "name": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "name"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "type",
+                                                        "function"
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "description": "Force a specific custom tool.",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "custom"
+                                                            ]
+                                                        },
+                                                        "custom": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "name": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "name"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "type",
+                                                        "custom"
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "description": "Constrain to an allowed subset of tools.",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "allowed_tools"
+                                                            ]
+                                                        },
+                                                        "allowed_tools": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "mode": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "auto",
+                                                                        "required"
+                                                                    ]
+                                                                },
+                                                                "tools": {
+                                                                    "type": "array",
+                                                                    "items": {
+                                                                        "type": "object"
+                                                                    }
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "mode",
+                                                                "tools"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "type",
+                                                        "allowed_tools"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "tools": {
+                                    "type": "array",
+                                    "description": "A list of tools the model may call.",
+                                    "items": {
+                                        "oneOf": [
+                                            {
+                                                "type": "object",
+                                                "properties": {
+                                                    "type": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "function"
+                                                        ]
+                                                    },
+                                                    "function": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "name": {
+                                                                "type": "string",
+                                                                "description": "The name of the function to be called."
+                                                            },
+                                                            "description": {
+                                                                "type": "string",
+                                                                "description": "A description of what the function does."
+                                                            },
+                                                            "parameters": {
+                                                                "type": "object",
+                                                                "description": "The parameters the function accepts, described as a JSON Schema object."
+                                                            },
+                                                            "strict": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "boolean"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ],
+                                                                "default": false,
+                                                                "description": "Whether to enable strict schema adherence."
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "name"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type",
+                                                    "function"
+                                                ]
+                                            },
+                                            {
+                                                "type": "object",
+                                                "properties": {
+                                                    "type": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "custom"
+                                                        ]
+                                                    },
+                                                    "custom": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "name": {
+                                                                "type": "string"
+                                                            },
+                                                            "description": {
+                                                                "type": "string"
+                                                            },
+                                                            "format": {
+                                                                "oneOf": [
+                                                                    {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "type": {
+                                                                                "type": "string",
+                                                                                "enum": [
+                                                                                    "text"
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "type"
+                                                                        ]
+                                                                    },
+                                                                    {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "type": {
+                                                                                "type": "string",
+                                                                                "enum": [
+                                                                                    "grammar"
+                                                                                ]
+                                                                            },
+                                                                            "grammar": {
+                                                                                "type": "object",
+                                                                                "properties": {
+                                                                                    "definition": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "syntax": {
+                                                                                        "type": "string",
+                                                                                        "enum": [
+                                                                                            "lark",
+                                                                                            "regex"
+                                                                                        ]
+                                                                                    }
+                                                                                },
+                                                                                "required": [
+                                                                                    "definition",
+                                                                                    "syntax"
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "type",
+                                                                            "grammar"
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "name"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type",
+                                                    "custom"
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                },
+                                "top_p": {
+                                    "anyOf": [
+                                        {
+                                            "type": "number",
+                                            "minimum": 0,
+                                            "maximum": 1
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": 1,
+                                    "description": "Nucleus sampling: considers the results of the tokens with top_p probability mass."
+                                },
+                                "user": {
+                                    "type": "string",
+                                    "description": "A unique identifier representing your end-user, for abuse monitoring."
+                                },
+                                "web_search_options": {
+                                    "anyOf": [
+                                        {
+                                            "type": "object",
+                                            "description": "Options for the web search tool (when using built-in web search).",
+                                            "properties": {
+                                                "search_context_size": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "low",
+                                                        "medium",
+                                                        "high"
+                                                    ],
+                                                    "default": "medium"
+                                                },
+                                                "user_location": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "approximate"
+                                                            ]
+                                                        },
+                                                        "approximate": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "city": {
+                                                                    "type": "string"
+                                                                },
+                                                                "country": {
+                                                                    "type": "string"
+                                                                },
+                                                                "region": {
+                                                                    "type": "string"
+                                                                },
+                                                                "timezone": {
+                                                                    "type": "string"
+                                                                }
+                                                            }
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "type",
+                                                        "approximate"
+                                                    ]
+                                                }
+                                            }
+                                        }
+                                    ]
+                                },
+                                "function_call": {
+                                    "anyOf": [
+                                        {
+                                            "type": "string",
+                                            "enum": [
+                                                "none",
+                                                "auto"
+                                            ]
+                                        },
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "name": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "name"
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "functions": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "name": {
+                                                "type": "string",
+                                                "description": "The name of the function to be called."
+                                            },
+                                            "description": {
+                                                "type": "string",
+                                                "description": "A description of what the function does."
+                                            },
+                                            "parameters": {
+                                                "type": "object",
+                                                "description": "The parameters the function accepts, described as a JSON Schema object."
+                                            },
+                                            "strict": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "boolean"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": false,
+                                                "description": "Whether to enable strict schema adherence."
+                                            }
+                                        },
+                                        "required": [
+                                            "name"
+                                        ]
+                                    },
+                                    "minItems": 1,
+                                    "maxItems": 128
+                                }
+                            },
+                            "required": [
+                                "messages"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "requests": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "oneOf": [
+                                    {
+                                        "title": "Prompt",
+                                        "properties": {
+                                            "prompt": {
+                                                "type": "string",
+                                                "minLength": 1,
+                                                "description": "The input text prompt for the model to generate a response."
+                                            },
+                                            "model": {
+                                                "type": "string",
+                                                "description": "ID of the model to use (e.g. '@cf/zai-org/glm-4.7-flash, etc')."
+                                            },
+                                            "audio": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "object",
+                                                        "description": "Parameters for audio output. Required when modalities includes 'audio'.",
+                                                        "properties": {
+                                                            "voice": {
+                                                                "oneOf": [
+                                                                    {
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "id": {
+                                                                                "type": "string"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "id"
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "format": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                    "wav",
+                                                                    "aac",
+                                                                    "mp3",
+                                                                    "flac",
+                                                                    "opus",
+                                                                    "pcm16"
+                                                                ]
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "voice",
+                                                            "format"
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            "frequency_penalty": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "number",
+                                                        "minimum": -2,
+                                                        "maximum": 2
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": 0,
+                                                "description": "Penalizes new tokens based on their existing frequency in the text so far."
+                                            },
+                                            "logit_bias": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "Modify the likelihood of specified tokens appearing in the completion. Maps token IDs to bias values from -100 to 100."
+                                            },
+                                            "logprobs": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "boolean"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": false,
+                                                "description": "Whether to return log probabilities of the output tokens."
+                                            },
+                                            "top_logprobs": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "integer",
+                                                        "minimum": 0,
+                                                        "maximum": 20
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "How many top log probabilities to return at each token position (0-20). Requires logprobs=true."
+                                            },
+                                            "max_tokens": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "integer"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "Deprecated in favor of max_completion_tokens. The maximum number of tokens to generate."
+                                            },
+                                            "max_completion_tokens": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "integer"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "An upper bound for the number of tokens that can be generated for a completion."
+                                            },
+                                            "metadata": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "Set of 16 key-value pairs that can be attached to the object."
+                                            },
+                                            "modalities": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "array",
+                                                        "items": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "text",
+                                                                "audio"
+                                                            ]
+                                                        }
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "Output types requested from the model (e.g. ['text'] or ['text', 'audio'])."
+                                            },
+                                            "n": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "integer",
+                                                        "minimum": 1,
+                                                        "maximum": 128
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": 1,
+                                                "description": "How many chat completion choices to generate for each input message."
+                                            },
+                                            "parallel_tool_calls": {
+                                                "type": "boolean",
+                                                "default": true,
+                                                "description": "Whether to enable parallel function calling during tool use."
+                                            },
+                                            "prediction": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "type": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                    "content"
+                                                                ]
+                                                            },
+                                                            "content": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "type": "array",
+                                                                        "items": {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "type": {
+                                                                                    "type": "string",
+                                                                                    "enum": [
+                                                                                        "text"
+                                                                                    ]
+                                                                                },
+                                                                                "text": {
+                                                                                    "type": "string"
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "type",
+                                                                                "text"
+                                                                            ]
+                                                                        }
+                                                                    }
+                                                                ]
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "type",
+                                                            "content"
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            "presence_penalty": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "number",
+                                                        "minimum": -2,
+                                                        "maximum": 2
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": 0,
+                                                "description": "Penalizes new tokens based on whether they appear in the text so far."
+                                            },
+                                            "reasoning_effort": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "low",
+                                                            "medium",
+                                                            "high"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "Constrains effort on reasoning for reasoning models (o1, o3-mini, etc.)."
+                                            },
+                                            "chat_template_kwargs": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "enable_thinking": {
+                                                        "type": "boolean",
+                                                        "default": true,
+                                                        "description": "Whether to enable reasoning, enabled by default."
+                                                    },
+                                                    "clear_thinking": {
+                                                        "type": "boolean",
+                                                        "default": false,
+                                                        "description": "If false, preserves reasoning context between turns."
+                                                    }
+                                                }
+                                            },
+                                            "response_format": {
+                                                "anyOf": [
+                                                    {
+                                                        "description": "Specifies the format the model must output.",
+                                                        "oneOf": [
+                                                            {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "type": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "text"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "type"
+                                                                ]
+                                                            },
+                                                            {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "type": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "json_object"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "type"
+                                                                ]
+                                                            },
+                                                            {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "type": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "json_schema"
+                                                                        ]
+                                                                    },
+                                                                    "json_schema": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "name": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "description": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "schema": {
+                                                                                "type": "object"
+                                                                            },
+                                                                            "strict": {
+                                                                                "anyOf": [
+                                                                                    {
+                                                                                        "type": "boolean"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "null"
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "name"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "type",
+                                                                    "json_schema"
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            "seed": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "integer"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "If specified, the system will make a best effort to sample deterministically."
+                                            },
+                                            "service_tier": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "auto",
+                                                            "default",
+                                                            "flex",
+                                                            "scale",
+                                                            "priority"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": "auto",
+                                                "description": "Specifies the processing type used for serving the request."
+                                            },
+                                            "stop": {
+                                                "description": "Up to 4 sequences where the API will stop generating further tokens.",
+                                                "anyOf": [
+                                                    {
+                                                        "type": "null"
+                                                    },
+                                                    {
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "array",
+                                                        "items": {
+                                                            "type": "string"
+                                                        },
+                                                        "minItems": 1,
+                                                        "maxItems": 4
+                                                    }
+                                                ]
+                                            },
+                                            "store": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "boolean"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": false,
+                                                "description": "Whether to store the output for model distillation / evals."
+                                            },
+                                            "stream": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "boolean"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": false,
+                                                "description": "If true, partial message deltas will be sent as server-sent events."
+                                            },
+                                            "stream_options": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "include_usage": {
+                                                                "type": "boolean"
+                                                            },
+                                                            "include_obfuscation": {
+                                                                "type": "boolean"
+                                                            }
+                                                        }
+                                                    }
+                                                ]
+                                            },
+                                            "temperature": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "number",
+                                                        "minimum": 0,
+                                                        "maximum": 2
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": 1,
+                                                "description": "Sampling temperature between 0 and 2."
+                                            },
+                                            "tool_choice": {
+                                                "anyOf": [
+                                                    {
+                                                        "description": "Controls which (if any) tool is called by the model. 'none' = no tools, 'auto' = model decides, 'required' = must call a tool.",
+                                                        "oneOf": [
+                                                            {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                    "none",
+                                                                    "auto",
+                                                                    "required"
+                                                                ]
+                                                            },
+                                                            {
+                                                                "type": "object",
+                                                                "description": "Force a specific function tool.",
+                                                                "properties": {
+                                                                    "type": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "function"
+                                                                        ]
+                                                                    },
+                                                                    "function": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "name": {
+                                                                                "type": "string"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "name"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "type",
+                                                                    "function"
+                                                                ]
+                                                            },
+                                                            {
+                                                                "type": "object",
+                                                                "description": "Force a specific custom tool.",
+                                                                "properties": {
+                                                                    "type": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "custom"
+                                                                        ]
+                                                                    },
+                                                                    "custom": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "name": {
+                                                                                "type": "string"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "name"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "type",
+                                                                    "custom"
+                                                                ]
+                                                            },
+                                                            {
+                                                                "type": "object",
+                                                                "description": "Constrain to an allowed subset of tools.",
+                                                                "properties": {
+                                                                    "type": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "allowed_tools"
+                                                                        ]
+                                                                    },
+                                                                    "allowed_tools": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "mode": {
+                                                                                "type": "string",
+                                                                                "enum": [
+                                                                                    "auto",
+                                                                                    "required"
+                                                                                ]
+                                                                            },
+                                                                            "tools": {
+                                                                                "type": "array",
+                                                                                "items": {
+                                                                                    "type": "object"
+                                                                                }
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "mode",
+                                                                            "tools"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "type",
+                                                                    "allowed_tools"
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            "tools": {
+                                                "type": "array",
+                                                "description": "A list of tools the model may call.",
+                                                "items": {
+                                                    "oneOf": [
+                                                        {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "type": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "function"
+                                                                    ]
+                                                                },
+                                                                "function": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "name": {
+                                                                            "type": "string",
+                                                                            "description": "The name of the function to be called."
+                                                                        },
+                                                                        "description": {
+                                                                            "type": "string",
+                                                                            "description": "A description of what the function does."
+                                                                        },
+                                                                        "parameters": {
+                                                                            "type": "object",
+                                                                            "description": "The parameters the function accepts, described as a JSON Schema object."
+                                                                        },
+                                                                        "strict": {
+                                                                            "anyOf": [
+                                                                                {
+                                                                                    "type": "boolean"
+                                                                                },
+                                                                                {
+                                                                                    "type": "null"
+                                                                                }
+                                                                            ],
+                                                                            "default": false,
+                                                                            "description": "Whether to enable strict schema adherence."
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "name"
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "type",
+                                                                "function"
+                                                            ]
+                                                        },
+                                                        {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "type": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "custom"
+                                                                    ]
+                                                                },
+                                                                "custom": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "name": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "description": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "format": {
+                                                                            "oneOf": [
+                                                                                {
+                                                                                    "type": "object",
+                                                                                    "properties": {
+                                                                                        "type": {
+                                                                                            "type": "string",
+                                                                                            "enum": [
+                                                                                                "text"
+                                                                                            ]
+                                                                                        }
+                                                                                    },
+                                                                                    "required": [
+                                                                                        "type"
+                                                                                    ]
+                                                                                },
+                                                                                {
+                                                                                    "type": "object",
+                                                                                    "properties": {
+                                                                                        "type": {
+                                                                                            "type": "string",
+                                                                                            "enum": [
+                                                                                                "grammar"
+                                                                                            ]
+                                                                                        },
+                                                                                        "grammar": {
+                                                                                            "type": "object",
+                                                                                            "properties": {
+                                                                                                "definition": {
+                                                                                                    "type": "string"
+                                                                                                },
+                                                                                                "syntax": {
+                                                                                                    "type": "string",
+                                                                                                    "enum": [
+                                                                                                        "lark",
+                                                                                                        "regex"
+                                                                                                    ]
+                                                                                                }
+                                                                                            },
+                                                                                            "required": [
+                                                                                                "definition",
+                                                                                                "syntax"
+                                                                                            ]
+                                                                                        }
+                                                                                    },
+                                                                                    "required": [
+                                                                                        "type",
+                                                                                        "grammar"
+                                                                                    ]
+                                                                                }
+                                                                            ]
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "name"
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "type",
+                                                                "custom"
+                                                            ]
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "top_p": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "number",
+                                                        "minimum": 0,
+                                                        "maximum": 1
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": 1,
+                                                "description": "Nucleus sampling: considers the results of the tokens with top_p probability mass."
+                                            },
+                                            "user": {
+                                                "type": "string",
+                                                "description": "A unique identifier representing your end-user, for abuse monitoring."
+                                            },
+                                            "web_search_options": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "object",
+                                                        "description": "Options for the web search tool (when using built-in web search).",
+                                                        "properties": {
+                                                            "search_context_size": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                    "low",
+                                                                    "medium",
+                                                                    "high"
+                                                                ],
+                                                                "default": "medium"
+                                                            },
+                                                            "user_location": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "type": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "approximate"
+                                                                        ]
+                                                                    },
+                                                                    "approximate": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "city": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "country": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "region": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "timezone": {
+                                                                                "type": "string"
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "type",
+                                                                    "approximate"
+                                                                ]
+                                                            }
+                                                        }
+                                                    }
+                                                ]
+                                            },
+                                            "function_call": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "none",
+                                                            "auto"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "name": {
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "name"
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            "functions": {
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "name": {
+                                                            "type": "string",
+                                                            "description": "The name of the function to be called."
+                                                        },
+                                                        "description": {
+                                                            "type": "string",
+                                                            "description": "A description of what the function does."
+                                                        },
+                                                        "parameters": {
+                                                            "type": "object",
+                                                            "description": "The parameters the function accepts, described as a JSON Schema object."
+                                                        },
+                                                        "strict": {
+                                                            "anyOf": [
+                                                                {
+                                                                    "type": "boolean"
+                                                                },
+                                                                {
+                                                                    "type": "null"
+                                                                }
+                                                            ],
+                                                            "default": false,
+                                                            "description": "Whether to enable strict schema adherence."
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "name"
+                                                    ]
+                                                },
+                                                "minItems": 1,
+                                                "maxItems": 128
+                                            }
+                                        },
+                                        "required": [
+                                            "prompt"
+                                        ]
+                                    },
+                                    {
+                                        "title": "Messages",
+                                        "properties": {
+                                            "messages": {
+                                                "type": "array",
+                                                "description": "A list of messages comprising the conversation so far.",
+                                                "items": {
+                                                    "oneOf": [
+                                                        {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "role": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "developer"
+                                                                    ]
+                                                                },
+                                                                "content": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "array",
+                                                                            "items": {
+                                                                                "type": "object",
+                                                                                "properties": {
+                                                                                    "type": {
+                                                                                        "type": "string",
+                                                                                        "enum": [
+                                                                                            "text"
+                                                                                        ]
+                                                                                    },
+                                                                                    "text": {
+                                                                                        "type": "string"
+                                                                                    }
+                                                                                },
+                                                                                "required": [
+                                                                                    "type",
+                                                                                    "text"
+                                                                                ]
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "name": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "role",
+                                                                "content"
+                                                            ]
+                                                        },
+                                                        {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "role": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "system"
+                                                                    ]
+                                                                },
+                                                                "content": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "array",
+                                                                            "items": {
+                                                                                "type": "object",
+                                                                                "properties": {
+                                                                                    "type": {
+                                                                                        "type": "string",
+                                                                                        "enum": [
+                                                                                            "text"
+                                                                                        ]
+                                                                                    },
+                                                                                    "text": {
+                                                                                        "type": "string"
+                                                                                    }
+                                                                                },
+                                                                                "required": [
+                                                                                    "type",
+                                                                                    "text"
+                                                                                ]
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "name": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "role",
+                                                                "content"
+                                                            ]
+                                                        },
+                                                        {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "role": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "user"
+                                                                    ]
+                                                                },
+                                                                "content": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "array",
+                                                                            "items": {
+                                                                                "type": "object",
+                                                                                "properties": {
+                                                                                    "type": {
+                                                                                        "type": "string",
+                                                                                        "enum": [
+                                                                                            "text",
+                                                                                            "image_url",
+                                                                                            "video_url",
+                                                                                            "input_audio",
+                                                                                            "file"
+                                                                                        ]
+                                                                                    },
+                                                                                    "text": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "image_url": {
+                                                                                        "type": "object",
+                                                                                        "properties": {
+                                                                                            "url": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "detail": {
+                                                                                                "type": "string",
+                                                                                                "enum": [
+                                                                                                    "auto",
+                                                                                                    "low",
+                                                                                                    "high"
+                                                                                                ],
+                                                                                                "default": "auto"
+                                                                                            }
+                                                                                        }
+                                                                                    },
+                                                                                    "video_url": {
+                                                                                        "type": "object",
+                                                                                        "properties": {
+                                                                                            "url": {
+                                                                                                "type": "string"
+                                                                                            }
+                                                                                        }
+                                                                                    },
+                                                                                    "input_audio": {
+                                                                                        "type": "object",
+                                                                                        "properties": {
+                                                                                            "data": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "format": {
+                                                                                                "type": "string",
+                                                                                                "enum": [
+                                                                                                    "wav",
+                                                                                                    "mp3"
+                                                                                                ]
+                                                                                            }
+                                                                                        }
+                                                                                    },
+                                                                                    "file": {
+                                                                                        "type": "object",
+                                                                                        "properties": {
+                                                                                            "file_data": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "file_id": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "filename": {
+                                                                                                "type": "string"
+                                                                                            }
+                                                                                        }
+                                                                                    }
+                                                                                },
+                                                                                "required": [
+                                                                                    "type"
+                                                                                ]
+                                                                            },
+                                                                            "minItems": 1
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "name": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "role",
+                                                                "content"
+                                                            ]
+                                                        },
+                                                        {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "role": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "assistant"
+                                                                    ]
+                                                                },
+                                                                "content": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        },
+                                                                        {
+                                                                            "type": "array",
+                                                                            "items": {
+                                                                                "type": "object",
+                                                                                "properties": {
+                                                                                    "type": {
+                                                                                        "type": "string",
+                                                                                        "enum": [
+                                                                                            "text",
+                                                                                            "refusal"
+                                                                                        ]
+                                                                                    },
+                                                                                    "text": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "refusal": {
+                                                                                        "type": "string"
+                                                                                    }
+                                                                                },
+                                                                                "required": [
+                                                                                    "type"
+                                                                                ]
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "refusal": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "name": {
+                                                                    "type": "string"
+                                                                },
+                                                                "audio": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "id": {
+                                                                                    "type": "string"
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "id"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "tool_calls": {
+                                                                    "type": "array",
+                                                                    "items": {
+                                                                        "oneOf": [
+                                                                            {
+                                                                                "type": "object",
+                                                                                "properties": {
+                                                                                    "id": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "type": {
+                                                                                        "type": "string",
+                                                                                        "enum": [
+                                                                                            "function"
+                                                                                        ]
+                                                                                    },
+                                                                                    "function": {
+                                                                                        "type": "object",
+                                                                                        "properties": {
+                                                                                            "name": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "arguments": {
+                                                                                                "type": "string",
+                                                                                                "description": "JSON-encoded arguments string."
+                                                                                            }
+                                                                                        },
+                                                                                        "required": [
+                                                                                            "name",
+                                                                                            "arguments"
+                                                                                        ]
+                                                                                    }
+                                                                                },
+                                                                                "required": [
+                                                                                    "id",
+                                                                                    "type",
+                                                                                    "function"
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "type": "object",
+                                                                                "properties": {
+                                                                                    "id": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "type": {
+                                                                                        "type": "string",
+                                                                                        "enum": [
+                                                                                            "custom"
+                                                                                        ]
+                                                                                    },
+                                                                                    "custom": {
+                                                                                        "type": "object",
+                                                                                        "properties": {
+                                                                                            "name": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "input": {
+                                                                                                "type": "string"
+                                                                                            }
+                                                                                        },
+                                                                                        "required": [
+                                                                                            "name",
+                                                                                            "input"
+                                                                                        ]
+                                                                                    }
+                                                                                },
+                                                                                "required": [
+                                                                                    "id",
+                                                                                    "type",
+                                                                                    "custom"
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "function_call": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "name": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "arguments": {
+                                                                                    "type": "string"
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "name",
+                                                                                "arguments"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "role"
+                                                            ]
+                                                        },
+                                                        {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "role": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "tool"
+                                                                    ]
+                                                                },
+                                                                "content": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "array",
+                                                                            "items": {
+                                                                                "type": "object",
+                                                                                "properties": {
+                                                                                    "type": {
+                                                                                        "type": "string",
+                                                                                        "enum": [
+                                                                                            "text"
+                                                                                        ]
+                                                                                    },
+                                                                                    "text": {
+                                                                                        "type": "string"
+                                                                                    }
+                                                                                },
+                                                                                "required": [
+                                                                                    "type",
+                                                                                    "text"
+                                                                                ]
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "tool_call_id": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "role",
+                                                                "content",
+                                                                "tool_call_id"
+                                                            ]
+                                                        },
+                                                        {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "role": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "function"
+                                                                    ]
+                                                                },
+                                                                "content": {
+                                                                    "type": "string"
+                                                                },
+                                                                "name": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "role",
+                                                                "content",
+                                                                "name"
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                "minItems": 1
+                                            },
+                                            "model": {
+                                                "type": "string",
+                                                "description": "ID of the model to use (e.g. '@cf/zai-org/glm-4.7-flash, etc')."
+                                            },
+                                            "audio": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "object",
+                                                        "description": "Parameters for audio output. Required when modalities includes 'audio'.",
+                                                        "properties": {
+                                                            "voice": {
+                                                                "oneOf": [
+                                                                    {
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "id": {
+                                                                                "type": "string"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "id"
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "format": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                    "wav",
+                                                                    "aac",
+                                                                    "mp3",
+                                                                    "flac",
+                                                                    "opus",
+                                                                    "pcm16"
+                                                                ]
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "voice",
+                                                            "format"
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            "frequency_penalty": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "number",
+                                                        "minimum": -2,
+                                                        "maximum": 2
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": 0,
+                                                "description": "Penalizes new tokens based on their existing frequency in the text so far."
+                                            },
+                                            "logit_bias": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "Modify the likelihood of specified tokens appearing in the completion. Maps token IDs to bias values from -100 to 100."
+                                            },
+                                            "logprobs": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "boolean"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": false,
+                                                "description": "Whether to return log probabilities of the output tokens."
+                                            },
+                                            "top_logprobs": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "integer",
+                                                        "minimum": 0,
+                                                        "maximum": 20
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "How many top log probabilities to return at each token position (0-20). Requires logprobs=true."
+                                            },
+                                            "max_tokens": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "integer"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "Deprecated in favor of max_completion_tokens. The maximum number of tokens to generate."
+                                            },
+                                            "max_completion_tokens": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "integer"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "An upper bound for the number of tokens that can be generated for a completion."
+                                            },
+                                            "metadata": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "Set of 16 key-value pairs that can be attached to the object."
+                                            },
+                                            "modalities": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "array",
+                                                        "items": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "text",
+                                                                "audio"
+                                                            ]
+                                                        }
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "Output types requested from the model (e.g. ['text'] or ['text', 'audio'])."
+                                            },
+                                            "n": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "integer",
+                                                        "minimum": 1,
+                                                        "maximum": 128
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": 1,
+                                                "description": "How many chat completion choices to generate for each input message."
+                                            },
+                                            "parallel_tool_calls": {
+                                                "type": "boolean",
+                                                "default": true,
+                                                "description": "Whether to enable parallel function calling during tool use."
+                                            },
+                                            "prediction": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "type": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                    "content"
+                                                                ]
+                                                            },
+                                                            "content": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "type": "array",
+                                                                        "items": {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "type": {
+                                                                                    "type": "string",
+                                                                                    "enum": [
+                                                                                        "text"
+                                                                                    ]
+                                                                                },
+                                                                                "text": {
+                                                                                    "type": "string"
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "type",
+                                                                                "text"
+                                                                            ]
+                                                                        }
+                                                                    }
+                                                                ]
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "type",
+                                                            "content"
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            "presence_penalty": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "number",
+                                                        "minimum": -2,
+                                                        "maximum": 2
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": 0,
+                                                "description": "Penalizes new tokens based on whether they appear in the text so far."
+                                            },
+                                            "reasoning_effort": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "low",
+                                                            "medium",
+                                                            "high"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "Constrains effort on reasoning for reasoning models (o1, o3-mini, etc.)."
+                                            },
+                                            "chat_template_kwargs": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "enable_thinking": {
+                                                        "type": "boolean",
+                                                        "default": true,
+                                                        "description": "Whether to enable reasoning, enabled by default."
+                                                    },
+                                                    "clear_thinking": {
+                                                        "type": "boolean",
+                                                        "default": false,
+                                                        "description": "If false, preserves reasoning context between turns."
+                                                    }
+                                                }
+                                            },
+                                            "response_format": {
+                                                "anyOf": [
+                                                    {
+                                                        "description": "Specifies the format the model must output.",
+                                                        "oneOf": [
+                                                            {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "type": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "text"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "type"
+                                                                ]
+                                                            },
+                                                            {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "type": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "json_object"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "type"
+                                                                ]
+                                                            },
+                                                            {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "type": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "json_schema"
+                                                                        ]
+                                                                    },
+                                                                    "json_schema": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "name": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "description": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "schema": {
+                                                                                "type": "object"
+                                                                            },
+                                                                            "strict": {
+                                                                                "anyOf": [
+                                                                                    {
+                                                                                        "type": "boolean"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "null"
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "name"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "type",
+                                                                    "json_schema"
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            "seed": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "integer"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "If specified, the system will make a best effort to sample deterministically."
+                                            },
+                                            "service_tier": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "auto",
+                                                            "default",
+                                                            "flex",
+                                                            "scale",
+                                                            "priority"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": "auto",
+                                                "description": "Specifies the processing type used for serving the request."
+                                            },
+                                            "stop": {
+                                                "description": "Up to 4 sequences where the API will stop generating further tokens.",
+                                                "anyOf": [
+                                                    {
+                                                        "type": "null"
+                                                    },
+                                                    {
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "array",
+                                                        "items": {
+                                                            "type": "string"
+                                                        },
+                                                        "minItems": 1,
+                                                        "maxItems": 4
+                                                    }
+                                                ]
+                                            },
+                                            "store": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "boolean"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": false,
+                                                "description": "Whether to store the output for model distillation / evals."
+                                            },
+                                            "stream": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "boolean"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": false,
+                                                "description": "If true, partial message deltas will be sent as server-sent events."
+                                            },
+                                            "stream_options": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "include_usage": {
+                                                                "type": "boolean"
+                                                            },
+                                                            "include_obfuscation": {
+                                                                "type": "boolean"
+                                                            }
+                                                        }
+                                                    }
+                                                ]
+                                            },
+                                            "temperature": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "number",
+                                                        "minimum": 0,
+                                                        "maximum": 2
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": 1,
+                                                "description": "Sampling temperature between 0 and 2."
+                                            },
+                                            "tool_choice": {
+                                                "anyOf": [
+                                                    {
+                                                        "description": "Controls which (if any) tool is called by the model. 'none' = no tools, 'auto' = model decides, 'required' = must call a tool.",
+                                                        "oneOf": [
+                                                            {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                    "none",
+                                                                    "auto",
+                                                                    "required"
+                                                                ]
+                                                            },
+                                                            {
+                                                                "type": "object",
+                                                                "description": "Force a specific function tool.",
+                                                                "properties": {
+                                                                    "type": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "function"
+                                                                        ]
+                                                                    },
+                                                                    "function": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "name": {
+                                                                                "type": "string"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "name"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "type",
+                                                                    "function"
+                                                                ]
+                                                            },
+                                                            {
+                                                                "type": "object",
+                                                                "description": "Force a specific custom tool.",
+                                                                "properties": {
+                                                                    "type": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "custom"
+                                                                        ]
+                                                                    },
+                                                                    "custom": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "name": {
+                                                                                "type": "string"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "name"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "type",
+                                                                    "custom"
+                                                                ]
+                                                            },
+                                                            {
+                                                                "type": "object",
+                                                                "description": "Constrain to an allowed subset of tools.",
+                                                                "properties": {
+                                                                    "type": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "allowed_tools"
+                                                                        ]
+                                                                    },
+                                                                    "allowed_tools": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "mode": {
+                                                                                "type": "string",
+                                                                                "enum": [
+                                                                                    "auto",
+                                                                                    "required"
+                                                                                ]
+                                                                            },
+                                                                            "tools": {
+                                                                                "type": "array",
+                                                                                "items": {
+                                                                                    "type": "object"
+                                                                                }
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "mode",
+                                                                            "tools"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "type",
+                                                                    "allowed_tools"
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            "tools": {
+                                                "type": "array",
+                                                "description": "A list of tools the model may call.",
+                                                "items": {
+                                                    "oneOf": [
+                                                        {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "type": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "function"
+                                                                    ]
+                                                                },
+                                                                "function": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "name": {
+                                                                            "type": "string",
+                                                                            "description": "The name of the function to be called."
+                                                                        },
+                                                                        "description": {
+                                                                            "type": "string",
+                                                                            "description": "A description of what the function does."
+                                                                        },
+                                                                        "parameters": {
+                                                                            "type": "object",
+                                                                            "description": "The parameters the function accepts, described as a JSON Schema object."
+                                                                        },
+                                                                        "strict": {
+                                                                            "anyOf": [
+                                                                                {
+                                                                                    "type": "boolean"
+                                                                                },
+                                                                                {
+                                                                                    "type": "null"
+                                                                                }
+                                                                            ],
+                                                                            "default": false,
+                                                                            "description": "Whether to enable strict schema adherence."
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "name"
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "type",
+                                                                "function"
+                                                            ]
+                                                        },
+                                                        {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "type": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "custom"
+                                                                    ]
+                                                                },
+                                                                "custom": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "name": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "description": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "format": {
+                                                                            "oneOf": [
+                                                                                {
+                                                                                    "type": "object",
+                                                                                    "properties": {
+                                                                                        "type": {
+                                                                                            "type": "string",
+                                                                                            "enum": [
+                                                                                                "text"
+                                                                                            ]
+                                                                                        }
+                                                                                    },
+                                                                                    "required": [
+                                                                                        "type"
+                                                                                    ]
+                                                                                },
+                                                                                {
+                                                                                    "type": "object",
+                                                                                    "properties": {
+                                                                                        "type": {
+                                                                                            "type": "string",
+                                                                                            "enum": [
+                                                                                                "grammar"
+                                                                                            ]
+                                                                                        },
+                                                                                        "grammar": {
+                                                                                            "type": "object",
+                                                                                            "properties": {
+                                                                                                "definition": {
+                                                                                                    "type": "string"
+                                                                                                },
+                                                                                                "syntax": {
+                                                                                                    "type": "string",
+                                                                                                    "enum": [
+                                                                                                        "lark",
+                                                                                                        "regex"
+                                                                                                    ]
+                                                                                                }
+                                                                                            },
+                                                                                            "required": [
+                                                                                                "definition",
+                                                                                                "syntax"
+                                                                                            ]
+                                                                                        }
+                                                                                    },
+                                                                                    "required": [
+                                                                                        "type",
+                                                                                        "grammar"
+                                                                                    ]
+                                                                                }
+                                                                            ]
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "name"
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "type",
+                                                                "custom"
+                                                            ]
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "top_p": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "number",
+                                                        "minimum": 0,
+                                                        "maximum": 1
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": 1,
+                                                "description": "Nucleus sampling: considers the results of the tokens with top_p probability mass."
+                                            },
+                                            "user": {
+                                                "type": "string",
+                                                "description": "A unique identifier representing your end-user, for abuse monitoring."
+                                            },
+                                            "web_search_options": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "object",
+                                                        "description": "Options for the web search tool (when using built-in web search).",
+                                                        "properties": {
+                                                            "search_context_size": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                    "low",
+                                                                    "medium",
+                                                                    "high"
+                                                                ],
+                                                                "default": "medium"
+                                                            },
+                                                            "user_location": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "type": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "approximate"
+                                                                        ]
+                                                                    },
+                                                                    "approximate": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "city": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "country": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "region": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "timezone": {
+                                                                                "type": "string"
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "type",
+                                                                    "approximate"
+                                                                ]
+                                                            }
+                                                        }
+                                                    }
+                                                ]
+                                            },
+                                            "function_call": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "none",
+                                                            "auto"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "name": {
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "name"
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            "functions": {
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "name": {
+                                                            "type": "string",
+                                                            "description": "The name of the function to be called."
+                                                        },
+                                                        "description": {
+                                                            "type": "string",
+                                                            "description": "A description of what the function does."
+                                                        },
+                                                        "parameters": {
+                                                            "type": "object",
+                                                            "description": "The parameters the function accepts, described as a JSON Schema object."
+                                                        },
+                                                        "strict": {
+                                                            "anyOf": [
+                                                                {
+                                                                    "type": "boolean"
+                                                                },
+                                                                {
+                                                                    "type": "null"
+                                                                }
+                                                            ],
+                                                            "default": false,
+                                                            "description": "Whether to enable strict schema adherence."
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "name"
+                                                    ]
+                                                },
+                                                "minItems": 1,
+                                                "maxItems": 128
+                                            }
+                                        },
+                                        "required": [
+                                            "messages"
+                                        ]
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "output": {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "contentType": "application/json",
+                    "properties": {
+                        "id": {
+                            "type": "string",
+                            "description": "A unique identifier for the chat completion."
+                        },
+                        "object": {
+                            "type": "string"
+                        },
+                        "created": {
+                            "type": "integer",
+                            "description": "Unix timestamp (seconds) of when the completion was created."
+                        },
+                        "model": {
+                            "type": "string",
+                            "description": "The model used for the chat completion."
+                        },
+                        "choices": {
+                            "type": "array",
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "object",
+                                        "properties": {
+                                            "index": {
+                                                "type": "integer"
+                                            },
+                                            "message": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "role": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                    "assistant"
+                                                                ]
+                                                            },
+                                                            "content": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "refusal": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "annotations": {
+                                                                "type": "array",
+                                                                "items": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "enum": [
+                                                                                "url_citation"
+                                                                            ]
+                                                                        },
+                                                                        "url_citation": {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "url": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "title": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "start_index": {
+                                                                                    "type": "integer"
+                                                                                },
+                                                                                "end_index": {
+                                                                                    "type": "integer"
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "url",
+                                                                                "title",
+                                                                                "start_index",
+                                                                                "end_index"
+                                                                            ]
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "type",
+                                                                        "url_citation"
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "audio": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "id": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "data": {
+                                                                                "type": "string",
+                                                                                "description": "Base64 encoded audio bytes."
+                                                                            },
+                                                                            "expires_at": {
+                                                                                "type": "integer"
+                                                                            },
+                                                                            "transcript": {
+                                                                                "type": "string"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "id",
+                                                                            "data",
+                                                                            "expires_at",
+                                                                            "transcript"
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "tool_calls": {
+                                                                "type": "array",
+                                                                "items": {
+                                                                    "oneOf": [
+                                                                        {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "id": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "type": {
+                                                                                    "type": "string",
+                                                                                    "enum": [
+                                                                                        "function"
+                                                                                    ]
+                                                                                },
+                                                                                "function": {
+                                                                                    "type": "object",
+                                                                                    "properties": {
+                                                                                        "name": {
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "arguments": {
+                                                                                            "type": "string",
+                                                                                            "description": "JSON-encoded arguments string."
+                                                                                        }
+                                                                                    },
+                                                                                    "required": [
+                                                                                        "name",
+                                                                                        "arguments"
+                                                                                    ]
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "id",
+                                                                                "type",
+                                                                                "function"
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "id": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "type": {
+                                                                                    "type": "string",
+                                                                                    "enum": [
+                                                                                        "custom"
+                                                                                    ]
+                                                                                },
+                                                                                "custom": {
+                                                                                    "type": "object",
+                                                                                    "properties": {
+                                                                                        "name": {
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "input": {
+                                                                                            "type": "string"
+                                                                                        }
+                                                                                    },
+                                                                                    "required": [
+                                                                                        "name",
+                                                                                        "input"
+                                                                                    ]
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "id",
+                                                                                "type",
+                                                                                "custom"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "function_call": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "name": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "arguments": {
+                                                                                "type": "string"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "name",
+                                                                            "arguments"
+                                                                        ]
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ]
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "role",
+                                                            "content",
+                                                            "refusal"
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            "finish_reason": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "stop",
+                                                    "length",
+                                                    "tool_calls",
+                                                    "content_filter",
+                                                    "function_call"
+                                                ]
+                                            },
+                                            "logprobs": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "content": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "array",
+                                                                        "items": {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "token": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "logprob": {
+                                                                                    "type": "number"
+                                                                                },
+                                                                                "bytes": {
+                                                                                    "anyOf": [
+                                                                                        {
+                                                                                            "type": "array",
+                                                                                            "items": {
+                                                                                                "type": "integer"
+                                                                                            }
+                                                                                        },
+                                                                                        {
+                                                                                            "type": "null"
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                "top_logprobs": {
+                                                                                    "type": "array",
+                                                                                    "items": {
+                                                                                        "type": "object",
+                                                                                        "properties": {
+                                                                                            "token": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "logprob": {
+                                                                                                "type": "number"
+                                                                                            },
+                                                                                            "bytes": {
+                                                                                                "anyOf": [
+                                                                                                    {
+                                                                                                        "type": "array",
+                                                                                                        "items": {
+                                                                                                            "type": "integer"
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "null"
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        },
+                                                                                        "required": [
+                                                                                            "token",
+                                                                                            "logprob",
+                                                                                            "bytes"
+                                                                                        ]
+                                                                                    }
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "token",
+                                                                                "logprob",
+                                                                                "bytes",
+                                                                                "top_logprobs"
+                                                                            ]
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "refusal": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "array",
+                                                                        "items": {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "token": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "logprob": {
+                                                                                    "type": "number"
+                                                                                },
+                                                                                "bytes": {
+                                                                                    "anyOf": [
+                                                                                        {
+                                                                                            "type": "array",
+                                                                                            "items": {
+                                                                                                "type": "integer"
+                                                                                            }
+                                                                                        },
+                                                                                        {
+                                                                                            "type": "null"
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                "top_logprobs": {
+                                                                                    "type": "array",
+                                                                                    "items": {
+                                                                                        "type": "object",
+                                                                                        "properties": {
+                                                                                            "token": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "logprob": {
+                                                                                                "type": "number"
+                                                                                            },
+                                                                                            "bytes": {
+                                                                                                "anyOf": [
+                                                                                                    {
+                                                                                                        "type": "array",
+                                                                                                        "items": {
+                                                                                                            "type": "integer"
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "null"
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        },
+                                                                                        "required": [
+                                                                                            "token",
+                                                                                            "logprob",
+                                                                                            "bytes"
+                                                                                        ]
+                                                                                    }
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "token",
+                                                                                "logprob",
+                                                                                "bytes",
+                                                                                "top_logprobs"
+                                                                            ]
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ]
+                                                            }
+                                                        }
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "index",
+                                            "message",
+                                            "finish_reason",
+                                            "logprobs"
+                                        ]
+                                    }
+                                ]
+                            },
+                            "minItems": 1
+                        },
+                        "usage": {
+                            "anyOf": [
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "prompt_tokens": {
+                                            "type": "integer"
+                                        },
+                                        "completion_tokens": {
+                                            "type": "integer"
+                                        },
+                                        "total_tokens": {
+                                            "type": "integer"
+                                        },
+                                        "prompt_tokens_details": {
+                                            "type": "object",
+                                            "properties": {
+                                                "cached_tokens": {
+                                                    "type": "integer"
+                                                },
+                                                "audio_tokens": {
+                                                    "type": "integer"
+                                                }
+                                            }
+                                        },
+                                        "completion_tokens_details": {
+                                            "type": "object",
+                                            "properties": {
+                                                "reasoning_tokens": {
+                                                    "type": "integer"
+                                                },
+                                                "audio_tokens": {
+                                                    "type": "integer"
+                                                },
+                                                "accepted_prediction_tokens": {
+                                                    "type": "integer"
+                                                },
+                                                "rejected_prediction_tokens": {
+                                                    "type": "integer"
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "required": [
+                                        "prompt_tokens",
+                                        "completion_tokens",
+                                        "total_tokens"
+                                    ]
+                                }
+                            ]
+                        },
+                        "system_fingerprint": {
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ]
+                        },
+                        "service_tier": {
+                            "anyOf": [
+                                {
+                                    "type": "string",
+                                    "enum": [
+                                        "auto",
+                                        "default",
+                                        "flex",
+                                        "scale",
+                                        "priority"
+                                    ]
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ]
+                        }
+                    },
+                    "required": [
+                        "id",
+                        "object",
+                        "created",
+                        "model",
+                        "choices"
+                    ]
+                },
+                {
+                    "type": "string",
+                    "contentType": "text/event-stream",
+                    "format": "binary"
+                }
+            ]
+        }
+    },
+    "deprecated": false
+}


### PR DESCRIPTION
### Summary

Adds DeepSeek V4 Flash and DeepSeek V4 Pro to the Workers AI model catalog — the first Workers AI models with a full 1M (1,048,576) token context window.

- Syncs the two model definitions: `@cf/deepseek-ai/deepseek-v4-flash-0731` and `@cf/deepseek-ai/deepseek-v4-pro-0813`
- Both models require the Workers Paid plan (`require_workers_paid: true`)
- Adds a Workers AI changelog entry announcing the models
- Updates the Workers AI pricing page with both models, and adds them to the paid-billing note

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).