### PR TITLE
Update China Network Available Products

### DIFF
--- a/src/content/docs/china-network/reference/available-products.mdx
+++ b/src/content/docs/china-network/reference/available-products.mdx
@@ -28,6 +28,10 @@ The following products and features are available on the Cloudflare China Networ
 | [Rules](/rules/)[^2]                                                       | Make adjustments to requests and responses, configure Cloudflare settings, and trigger specific actions for matching requests.                           |
 | [Load Balancing](/load-balancing/additional-options/load-balancing-china/) | Maximize application performance and availability.                                                                                                       |
 
+[^1]: [Turnstile](/turnstile/) is not available within Mainland China.
+
+[^2]: [Origin Rules](/rules/origin-rules/) require that China Network is enabled on the original zone (the one visitors are accessing). The target zone does not need to be on the China Network, but it must be accessible from Mainland China. Otherwise, visitors will receive a [1016 error](/support/troubleshooting/http-status-codes/cloudflare-1xxx-errors/error-1016/) along with an [HTTP 530 status code](/support/troubleshooting/http-status-codes/cloudflare-5xx-errors/error-530/).
+
 ## Developer Services
 
 | Product/Feature                                                           | Description                                                                                                                                        |
@@ -37,18 +41,13 @@ The following products and features are available on the Cloudflare China Networ
 | [R2](/r2/)[^3]                                                            | Object storage for all your data.                                                                                                                  |
 | [Assets](/workers/static-assets/)                                         | Upload static assets (HTML, CSS, images and other files) as part of your Worker — Cloudflare will handle caching and serving them to web browsers. |
 | [Environment variables](/workers/configuration/environment-variables/)    | Attach text strings or JSON values to your Worker.                                                                                                 |
-| [Images](/images/optimization/binding/)[^4]                          | Store, transform, optimize, and deliver images at scale.                                                                                           |
-| [mTLS](/workers/runtime-apis/bindings/mtls/)                              | Securely connect to backend servers over [mTLS](https://www.cloudflare.com/learning/access-management/what-is-mutual-tls/).                        |
+| [Images](/images/optimization/binding/)[^4]                               | Store, transform, optimize, and deliver images at scale.                                                                                           |
 | [Rate Limiting](/workers/runtime-apis/bindings/rate-limit/)               | Define rate limits and write code around them in your Worker.                                                                                      |
 | [Secrets](/workers/configuration/secrets/)                                | Attach encrypted text values to your Worker.                                                                                                       |
 | [Service bindings](/workers/runtime-apis/bindings/service-bindings/)      | Service bindings allow one Worker to call into another, without going through a publicly-accessible URL.                                           |
 | [Tail Workers](/workers/observability/logs/tail-workers/)                 | Receives information about the execution of other Workers.                                                                                         |
 | [Version metadata](/workers/runtime-apis/bindings/version-metadata/)      | Access metadata associated with a version from inside the Workers runtime.                                                                         |
 | [Workers for Platforms](/cloudflare-for-platforms/workers-for-platforms/) | Deploy custom code on behalf of your users or let your users directly deploy their own code to your platform, managing infrastructure.             |
-
-[^1]: [Turnstile](/turnstile/) is not available within Mainland China.
-
-[^2]: [Origin Rules](/rules/origin-rules/) require that China Network is enabled on both the original zone (the one visitors are accessing) and the target zone. Otherwise, visitors will receive a [1016 error](/support/troubleshooting/http-status-codes/cloudflare-1xxx-errors/error-1016/) along with an [HTTP 530 status code](/support/troubleshooting/http-status-codes/cloudflare-5xx-errors/error-530/).
 
 [^3]: R2 buckets cannot be created within Mainland China and [custom domains](/r2/buckets/public-buckets/#add-your-domain-to-cloudflare) are not supported within Mainland China. However, R2 can be extended into Mainland China through [Global Acceleration](/china-network/concepts/global-acceleration/).
 
@@ -60,8 +59,11 @@ The following products and features are available on the Cloudflare China Networ
 | ------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
 | [IPv6](/network/ipv6-compatibility/)                                            | All data centers have IPv6 support by default.                                                              |
 | [SSL/TLS](/ssl/)                                                                | Customer Certificate, Dedicated Certificate, Universal Certificate, Custom, ACM (Dedicated), Universal SSL. |
+| mTLS[^5]                                                                        | Mutual TLS authentication between clients and the Cloudflare edge, and between the Cloudflare edge and your origin.                                 |
 | [HTTP/3 (QUIC)](https://www.cloudflare.com/learning/performance/what-is-http3/) | The latest version of the HTTP protocol to optimize page loading performance.                               |
 | [WebSockets](/workers/runtime-apis/websockets/)                                 | Real-time communication with Cloudflare Workers serverless functions.                                       |
+
+[^5]: mTLS on the China Network is supported in two configurations: client-to-edge, using [mTLS with Cloudflare Access](/cloudflare-one/access-controls/service-credentials/mutual-tls-authentication/) (including Client Certificate Forwarding); and edge-to-origin, using [Authenticated Origin Pulls](/ssl/origin-configuration/authenticated-origin-pull/).
 
 ## Zero Trust Services
 


### PR DESCRIPTION
### Summary

Updates `china-network/reference/available-products.mdx` to correct inaccurate product listings and footnotes:

- **Origin Rules footnote**: Corrects the requirement that China Network must be enabled on both zones. The target zone does not need to be on the China Network — it only needs to be accessible from Mainland China.
- **mTLS**: Removes the Workers mTLS binding row (support unconfirmed). Adds mTLS as a Network Services entry alongside SSL/TLS, with a footnote clarifying the two supported configurations: client-to-edge via Cloudflare Access (including Client Certificate Forwarding), and edge-to-origin via Authenticated Origin Pulls.
- **Footnote ordering**: Moved footnote definitions to follow their respective section tables for readability.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).