### PR TITLE
[Observatory] Clarify metrics and traffic exclusions

### DIFF
--- a/src/content/docs/speed/observatory/index.mdx
+++ b/src/content/docs/speed/observatory/index.mdx
@@ -34,9 +34,9 @@ You can also compare network tests in Observatory by selecting any two completed
 
 ## Real user monitoring (RUM)
 
-Real user monitoring (also known as RUM), on the other hand, captures real metrics from real users accessing a website. This provides information that synthetic tests cannot capture, as users might access your website from different parts of the world, with different network conditions, ISPs, browsers and computer hardware. However, RUM data is only applied to your own website. Real user data also includes two user interaction metrics that synthetic tests do not offer - [First Input Delay (FID)](https://web.dev/fid/) and [Interaction to Next Paint (INP)](https://web.dev/inp/).
+Real user monitoring (also known as RUM), on the other hand, captures real metrics from real users accessing your own websites. This provides information that synthetic tests cannot capture, as users might access your website from different parts of the world, with different network conditions, ISPs, devices, browsers, browser extensions and other software competing for resources. Real user data also includes a user interaction metric that synthetic tests do not offer: [Interaction to Next Paint (INP)](https://web.dev/inp/).
 
-Free customers have RUM enabled automatically, with EU traffic excluded, and can switch it off if they prefer. Customers on other plans may enable RUM as needed.
+Free customers have RUM enabled automatically, with traffic from EEA/UK/CH excluded, and can switch it off if they prefer. Customers on other plans may enable RUM as needed.
 
 <LinkButton variant="primary" href="/speed/observatory/run-speed-test/">
 	Run test


### PR DESCRIPTION
Minor tweaks to the Observatory overview page to clarify the metrics captured (FID is no longer collected) and the exclusion of specific traffic regions.