### PR TITLE
[D1] Add changelog entry for free tier daily query limit enforcement

### DIFF
--- a/src/content/changelog/d1/2026-09-01-d1-free-tier-limit-enforcement.mdx
+++ b/src/content/changelog/d1/2026-09-01-d1-free-tier-limit-enforcement.mdx
@@ -1,0 +1,20 @@
+---
+title: D1 enforces free tier daily query limits
+description: Beginning September 1, 2026, D1 queries on Workers Free accounts that exceed daily row read or row write limits will fail and return errors.
+products:
+  - d1
+date: 2026-09-01
+---
+
+Beginning September 1, 2026, D1 queries on the [Workers Free plan](/workers/platform/pricing/#workers) will fail when an account exceeds the daily [row read or row write limits](/d1/platform/pricing/). Queries via the [Workers Binding API](/d1/worker-api/) and the [REST API](/d1/rest-api/) will return errors until the limit resets at midnight UTC. Stored data is not affected.
+
+Users will receive email alerts when the daily limit is reached. The following errors indicate that a limit has been exceeded:
+
+| Error | Description |
+|-------|-------------|
+| Your account has exceeded D1's free tier daily row read limit. Upgrade to a paid plan or wait until tomorrow (midnight UTC) to continue. | The account has reached its daily row read limit. |
+| Your account has exceeded D1's free tier daily row write limit. Upgrade to a paid plan or wait until tomorrow (midnight UTC) to continue. | The account has reached its daily row write limit. |
+
+Inspect database query activity before the enforcement date to identify queries that may exceed these limits. To reduce row reads, add [indexes](/d1/best-practices/use-indexes/) to tables and review queries that perform full table scans. If usage requires higher limits after optimization, upgrade to a [Workers Paid plan](/workers/platform/pricing/#workers).
+
+For more information on D1 errors and how to handle them, refer to the [D1 error list](/d1/observability/debug-d1/#error-list).

--- a/src/content/changelog/d1/2026-09-01-d1-free-tier-limit-enforcement.mdx
+++ b/src/content/changelog/d1/2026-09-01-d1-free-tier-limit-enforcement.mdx
@@ -8,7 +8,7 @@ date: 2026-09-01
 
 Beginning September 1, 2026, D1 queries on the [Workers Free plan](/workers/platform/pricing/#workers) will fail when an account exceeds the daily [row read or row write limits](/d1/platform/pricing/). Queries via the [Workers Binding API](/d1/worker-api/) and the [REST API](/d1/rest-api/) will return errors until the limit resets at midnight UTC. Stored data is not affected.
 
-Users will receive email alerts when the daily limit is reached. The following errors indicate that a limit has been exceeded:
+You will receive email alerts when the daily limit is reached. The following errors indicate that a limit has been exceeded:
 
 | Error | Description |
 |-------|-------------|


### PR DESCRIPTION
### Summary

Adds a changelog entry to announce that D1 will begin enforcing free tier daily query limits on September 1, 2026. This informs users that queries exceeding the daily row read or row write limits on the Workers Free plan will fail and return errors until the limit resets at midnight UTC.

- Includes the exact error messages users will see when limits are exceeded
- Links to existing D1 pricing, limits, indexes best practices, and debug error list documentation

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
