### PR TITLE
[Agents] Mention Valibot schema support for tools and actions

### DIFF
--- a/src/content/docs/agents/harnesses/think/actions.mdx
+++ b/src/content/docs/agents/harnesses/think/actions.mdx
@@ -242,7 +242,7 @@ A built-in `ReplyAttachment` covers `email_draft`, `card`, and `voice_note`; any
 | Field             | Type                                                         | Required | Default       | Description                                                                             |
 | ----------------- | ------------------------------------------------------------ | -------- | ------------- | --------------------------------------------------------------------------------------- |
 | `description`     | `string`                                                     | Yes      | —             | Tool description shown to the model.                                                    |
-| `inputSchema`     | `FlexibleSchema` (Zod or AI SDK `jsonSchema`)                | Yes      | —             | Validates and types the `execute` input.                                                |
+| `inputSchema`     | `FlexibleSchema` (Zod, Valibot or AI SDK `jsonSchema`)       | Yes      | —             | Validates and types the `execute` input.                                                |
 | `execute`         | `(input, ctx) => Output \| Promise<Output>`                  | Yes      | —             | The action body. Receives validated input and an `ActionContext`.                       |
 | `name`            | `string`                                                     | No       | map key       | Overrides the tool name.                                                                |
 | `idempotencyKey`  | `string \| ({ input, ctx }) => string`                       | No       | per tool call | Stable key for ledger replay. Use a domain identifier.                                  |

--- a/src/content/docs/agents/harnesses/think/tools.mdx
+++ b/src/content/docs/agents/harnesses/think/tools.mdx
@@ -100,7 +100,7 @@ bucket_name = "agent-files"
 
 ## Custom tools
 
-Override `getTools()` to add your own tools. These are standard AI SDK `tool()` definitions with Zod schemas:
+Override `getTools()` to add your own tools. These are standard AI SDK `tool()` definitions with schemas from a library like Zod or Valibot:
 
 <TypeScriptExample>
 

--- a/src/content/docs/agents/model-context-protocol/protocol/tools.mdx
+++ b/src/content/docs/agents/model-context-protocol/protocol/tools.mdx
@@ -30,7 +30,7 @@ The Agents SDK also includes the experimental `agents/experimental/webmcp` adapt
 
 ## Defining tools
 
-Use `server.registerTool()` to register a tool on a stateless `McpServer` instance. Each tool has a name, a description, an input schema defined with [Zod](https://zod.dev), and a handler function.
+Use `server.registerTool()` to register a tool on a stateless `McpServer` instance. Each tool has a name, a description, an input schema defined with a schema library like [Zod](https://zod.dev) or [Valibot](https://valibot.dev), and a handler function.
 
 <TypeScriptExample>
 


### PR DESCRIPTION
### Summary

The Agents SDK accepts the AI SDK's flexible schema format since cloudflare/agents#2091, so tool and action schemas are not limited to Zod. This updates the wording in the Think tools and actions pages to mention that schema libraries like Valibot work as well. It also updates the MCP tools page, since the MCP TypeScript SDK v2 accepts these libraries too. I'm the author of Valibot.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
