### PR TITLE
[Rules] Fix Cache Rules changelog bot field list

### DIFF
--- a/src/content/changelog/rules/2026-07-16-cache-rules-bot-fields-asn.mdx
+++ b/src/content/changelog/rules/2026-07-16-cache-rules-bot-fields-asn.mdx
@@ -22,10 +22,10 @@ The following fields are now available in Cache Rules expressions:
 | `cf.bot_management.verified_bot` | Boolean | Whether the request originates from a verified bot, such as a search engine crawler. |
 | `cf.bot_management.static_resource` | Boolean | Whether the request is for a static resource and therefore exempt from bot detection. |
 | `cf.bot_management.js_detection.passed` | Boolean | Whether the browser passed JavaScript detection when the feature is enabled. |
-| `cf.bot_management.attack_score` | Number | Classifies the request by attack score, from `1` (likely automated) to `99` (likely human). |
-| `cf.bot_management.api_score` | Number | Classifies the request by API score, from `1` (likely automated) to `99` (likely human). |
-| `cf.bot_management.bot_tags["<TAG>"]` | Boolean | Whether the bot traffic matches the specified tag, such as `google` or `bing`. |
+| `cf.bot_management.tags` | Array | Bot tags associated with the request. |
 | `cf.bot_management.corporate_proxy` | Boolean | Whether the request originates from a known corporate proxy. |
+| `cf.bot_management.detection_ids` | Array | Detection IDs for Bot Management heuristic detections on the request. |
+| `cf.bot_management.signed_agent` | Boolean | Whether the request originates from a known agent that self-identifies with Web Bot Auth. |
 | `ip.src.asnum` | Number | The autonomous system number (ASN) of the incoming request's IP address. |
 
 :::note
@@ -42,4 +42,4 @@ or
 (http.request.uri.path contains "/api/" and not ip.src.asnum in {12345 67890})
 ```
 
-To learn more, refer to the [Cache Rules documentation](/cache/how-to/cache-rules/) and the [Fields reference](/ruleset-engine/rules-language/fields/).
+To learn more, refer to the [Cache Rules documentation](/cache/how-to/cache-rules/), [Bot Management variables](/bots/reference/bot-management-variables/), and the [Fields reference](/ruleset-engine/rules-language/fields/).

--- a/src/content/changelog/rules/2026-07-16-cache-rules-bot-fields-asn.mdx
+++ b/src/content/changelog/rules/2026-07-16-cache-rules-bot-fields-asn.mdx
@@ -22,7 +22,6 @@ The following fields are now available in Cache Rules expressions:
 | `cf.bot_management.verified_bot` | Boolean | Whether the request originates from a verified bot, such as a search engine crawler. |
 | `cf.bot_management.static_resource` | Boolean | Whether the request is for a static resource and therefore exempt from bot detection. |
 | `cf.bot_management.js_detection.passed` | Boolean | Whether the browser passed JavaScript detection when the feature is enabled. |
-| `cf.bot_management.tags` | Array | Bot tags associated with the request. |
 | `cf.bot_management.corporate_proxy` | Boolean | Whether the request originates from a known corporate proxy. |
 | `cf.bot_management.detection_ids` | Array | Detection IDs for Bot Management heuristic detections on the request. |
 | `cf.bot_management.signed_agent` | Boolean | Whether the request originates from a known agent that self-identifies with Web Bot Auth. |


### PR DESCRIPTION
## What

Correct the 2026-07-16 Cache Rules changelog field table.

## Why

Three listed fields are not valid Rules language fields:

- `cf.bot_management.api_score` — does not exist
- `cf.bot_management.attack_score` — does not exist (WAF attack score is `cf.waf.score`)
- `cf.bot_management.bot_tags["<TAG>"]` — does not exist (and bot tags are documented as log-only today)

Also list Bot Management fields that are already documented and available in rules: `detection_ids`, `signed_agent`.

## Changes

- Remove `api_score`, `attack_score`, and `bot_tags["…"]`
- Add `detection_ids` and `signed_agent`
- Link [Bot Management variables](/bots/reference/bot-management-variables/)

## Page

- `/changelog/2026-07-16-cache-rules-bot-fields-asn/`
