### PR TITLE
WAF Release - August 17th

### DIFF
--- a/src/content/changelog/waf/2026-08-17-waf-release.mdx
+++ b/src/content/changelog/waf/2026-08-17-waf-release.mdx
@@ -1,0 +1,55 @@
+---
+title: "WAF Release - 2026-08-17"
+description: Cloudflare WAF managed rulesets 2026-08-17 release
+date: 2026-08-17
+---
+
+import { RuleID } from "~/components";
+
+This release updates WordPress remote code execution rule metadata in the Cloudflare Managed Ruleset and Cloudflare Free Ruleset to identify CVE-2026-65640.
+
+**Key Findings**
+
+- CVE-2026-65640: A remote code execution vulnerability affecting WordPress core and plugin components. Remote, unauthenticated attackers can execute arbitrary system commands to gain unauthorized access or establish backdoors on host servers.
+
+**Impact**
+
+The WordPress changes update rule metadata only; detection behavior and actions remain unchanged.
+
+<table style="width: 100%">
+	<thead>
+		<tr>
+			<th>Ruleset</th>
+			<th>Rule ID</th>
+			<th>Legacy Rule ID</th>
+			<th>Description</th>
+			<th>Previous Action</th>
+			<th>New Action</th>
+			<th>Comments</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>Cloudflare Managed Ruleset</td>
+			<td>
+				<RuleID id="dcf635ab2e744e1a994443973590a4ad" />
+			</td>
+			<td>N/A</td>
+			<td>Wordpress - Remote Code Execution - CVE:CVE-2026-65640</td>
+			<td>Block</td>
+			<td>N/A</td>
+			<td>Rule metadata description refined. Detection unchanged.</td>
+		</tr>
+		<tr>
+			<td>Cloudflare Free Ruleset</td>
+			<td>
+				<RuleID id="6ad9f2049b094c608be0f8adcfe1a93c" />
+			</td>
+			<td>N/A</td>
+			<td>Wordpress - Remote Code Execution - CVE:CVE-2026-65640</td>
+			<td>Block</td>
+			<td>N/A</td>
+			<td>Rule metadata description refined. Detection unchanged.</td>
+		</tr>
+	</tbody>
+</table>

--- a/src/content/changelog/waf/scheduled-waf-release.mdx
+++ b/src/content/changelog/waf/scheduled-waf-release.mdx
@@ -1,7 +1,89 @@
 ---
-title: WAF Release - Scheduled changes for 2026-08-18
-description: WAF managed ruleset changes scheduled for 2026-8-18
-date: 2026-08-11
+title: WAF Release - Scheduled changes for 2026-08-24
+description: WAF managed ruleset changes scheduled for 2026-08-24
+date: 2026-08-17
 publish_future_dated_entry: true
-hidden: true
 ---
+
+import { RuleID } from "~/components";
+
+<table style="width: 100%">
+	<thead>
+		<tr>
+			<th>Announcement Date</th>
+			<th>Release Date</th>
+			<th>Release Behavior</th>
+			<th>Legacy Rule ID</th>
+			<th>Rule ID</th>
+			<th>Description</th>
+			<th>Comments</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>2026-08-17</td>
+			<td>2026-08-24</td>
+			<td>Log</td>
+			<td>N/A</td>
+			<td>
+				<RuleID id="a80f214f0947435dabb2ba2d1489d892" />
+			</td>
+			<td>HTTP/2 Request Smuggling - Request Body Anomaly</td>
+			<td>
+				This is a new detection.
+			</td>
+		</tr>
+		<tr>
+			<td>2026-08-17</td>
+			<td>2026-08-24</td>
+			<td>Log</td>
+			<td>N/A</td>
+			<td>
+				<RuleID id="58a184412d2b4113bca6379b20646260" />
+			</td>
+			<td>XSS - JavaScript Event Handler Coercion - Headers</td>
+			<td>
+				This is a new detection.
+			</td>
+		</tr>
+		<tr>
+			<td>2026-08-17</td>
+			<td>2026-08-24</td>
+			<td>Log</td>
+			<td>N/A</td>
+			<td>
+				<RuleID id="e79cb939d6aa41db984e6db3d706d517" />
+			</td>
+			<td>XSS - JavaScript Event Handler Coercion - Body</td>
+			<td>
+				This is a new detection.
+			</td>
+		</tr>
+		<tr>
+			<td>2026-08-17</td>
+			<td>2026-08-24</td>
+			<td>Log</td>
+			<td>N/A</td>
+			<td>
+				<RuleID id="7e3249c7a5d8469697478746660886c8" />
+			</td>
+			<td>XSS - JavaScript Event Handler Coercion - URI</td>
+			<td>
+				This is a new detection.
+			</td>
+		</tr>
+		<tr>
+			<td>2026-08-17</td>
+			<td>2026-08-24</td>
+			<td>Log</td>
+			<td>N/A</td>
+			<td>
+				<RuleID id="d34bc5db8cbc4e18a44ed115c293b926" />
+			</td>
+			<td>XSS, HTML Injection - Script Tag - Beta</td>
+			<td>
+				This rule will be merged into the original rule "XSS, HTML Injection - Script Tag" (ID:{" "}<RuleID id="9c8dda9708cc4452ac76e7be7b58420b" />).
+			</td>
+		</tr>
+	</tbody>
+</table>


### PR DESCRIPTION
Announces five new detections in Log mode for the 2026-08-24 scheduled release, and adds the 2026-08-17 release entry covering WordPress remote code execution rule metadata updates in the Cloudflare Managed Ruleset and Cloudflare Free Ruleset.

- `scheduled-waf-release.mdx` - five rules announced in Log mode, release date 2026-08-24.
- `2026-08-17-waf-release.mdx` - rule metadata description updates only; detection behavior and actions unchanged.