### PR TITLE
Load Balancing Changelog - Analytics UI pool name filter

### DIFF
--- a/src/content/changelog/load-balancing/2026-08-17-pool-name-analytics-filter.mdx
+++ b/src/content/changelog/load-balancing/2026-08-17-pool-name-analytics-filter.mdx
@@ -1,0 +1,24 @@
+---
+title: Load balancing analytics now filters by pool name
+description: The pool filter in load balancing analytics now queries by pool name instead of pool ID, matching what you see in the UI dropdown.
+products:
+  - load-balancing
+date: 2026-08-17
+---
+
+Load balancing analytics now filters traffic data by pool name instead of pool ID, aligning the query behavior with the pool names displayed in the filter dropdown.
+
+Previously, the analytics pool filter queried by internal pool ID while displaying pool names in the UI dropdown. This mismatch caused filtering issues when pools shared similar names or when you expected results based on the visible pool name. Because the underlying query used a different identifier than what appeared on screen, the displayed data could be confusing or incorrect.
+
+The pool filter now queries by the same pool name shown in the dropdown. When you select a pool from the filter, the analytics graphs and tables display data for that specific pool as you would expect. This change affects:
+
+- **Requests over time**, filtering the chart series to the selected pool.
+- **Pool distribution**, showing only the selected pool segment.
+- **Top endpoints**, displaying cards for origins in the selected pool.
+- **Latency**, showing latency data for the selected pool.
+
+The **Logs** view and health event filtering are unchanged.
+
+To use this, go to **Traffic** > **Load Balancing Analytics** for a zone. The same pool filter appears in the analytics view for an individual load balancer under **Load Balancing** at the account level.
+
+For more information about analytics filters and metrics, refer to [Load Balancing Analytics](/load-balancing/reference/load-balancing-analytics/).


### PR DESCRIPTION
### Summary

The pool filter in load balancing analytics now queries by pool name instead of pool ID, matching what you see in the UI dropdown.

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [x] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [x] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
