### PR TITLE
[Rules] Correct Cache Rules bot fields changelog

### DIFF
--- a/src/content/changelog/rules/2026-07-16-cache-rules-bot-fields-asn.mdx
+++ b/src/content/changelog/rules/2026-07-16-cache-rules-bot-fields-asn.mdx
@@ -22,9 +22,9 @@ The following fields are now available in Cache Rules expressions:
 | `cf.bot_management.verified_bot` | Boolean | Whether the request originates from a verified bot, such as a search engine crawler. |
 | `cf.bot_management.static_resource` | Boolean | Whether the request is for a static resource and therefore exempt from bot detection. |
 | `cf.bot_management.js_detection.passed` | Boolean | Whether the browser passed JavaScript detection when the feature is enabled. |
-| `cf.bot_management.attack_score` | Number | Classifies the request by attack score, from `1` (likely automated) to `99` (likely human). |
-| `cf.bot_management.api_score` | Number | Classifies the request by API score, from `1` (likely automated) to `99` (likely human). |
-| `cf.bot_management.bot_tags["<TAG>"]` | Boolean | Whether the bot traffic matches the specified tag, such as `google` or `bing`. |
+| `cf.bot_management.detection_ids` | Array&lt;Number&gt; | List of IDs that correspond to Bot Management heuristic detections made on the request. |
+| `cf.bot_management.tags` | Array&lt;String&gt; | List of tags associated with the bot traffic, such as `API`, `GOOGLE`, or `BING`. Match a tag with an expression such as `any(cf.bot_management.tags[*] eq "API")`. |
+| `cf.bot_management.signed_agent` | Boolean | Whether the request originates from a known agent that identifies itself with Web Bot Auth. |
 | `cf.bot_management.corporate_proxy` | Boolean | Whether the request originates from a known corporate proxy. |
 | `ip.src.asnum` | Number | The autonomous system number (ASN) of the incoming request's IP address. |
 

--- a/src/content/docs/bots/concepts/bot-tags.mdx
+++ b/src/content/docs/bots/concepts/bot-tags.mdx
@@ -38,12 +38,14 @@ The following values are **examples** of what may be present in the `BotTags` lo
 - apple
 - yandex
 
-## Enable bot tags
+When matching the Ruleset Engine field, use uppercase tag values such as `API`, `GOOGLE`, or `BING`.
 
-To enable bot tags, include the `BotTags` log field when using our [Logpush service](/logs/logpush/).
+## Use bot tags
 
-## Limitations
+To include bot tags in logs, add the `BotTags` field when using [Logpush](/logs/logpush/).
 
-Currently, bot tags are only available in log fields.
+To match bot tags in Ruleset Engine expressions, use the [`cf.bot_management.tags`](/ruleset-engine/rules-language/fields/reference/cf.bot_management.tags/) field. For example:
 
-Future work will add more values and extend bot tags to other Cloudflare products.
+```txt
+any(cf.bot_management.tags[*] eq "API")
+```

--- a/src/content/docs/bots/reference/bot-management-variables.mdx
+++ b/src/content/docs/bots/reference/bot-management-variables.mdx
@@ -13,7 +13,7 @@ import { Render } from "~/components"
 
 ## Ruleset Engine fields
 
-Bot Management provides access to several [new variables](/ruleset-engine/rules-language/fields/reference/?field-category=Bots) within the expression builder of Ruleset Engine-based products such as [WAF custom rules](/waf/custom-rules/).
+Bot Management provides access to several [fields](/ruleset-engine/rules-language/fields/reference/?field-category=Bots) within the expression builder of Ruleset Engine-based products such as [WAF custom rules](/waf/custom-rules/) and [Cache Rules](/cache/how-to/cache-rules/).
 
 - **Bot Score** (`cf.bot_management.score`): An integer between 1-99 that indicates [Cloudflare's level of certainty](/bots/concepts/bot-score/) that a request comes from a bot.
 - **Verified Bot** (`cf.bot_management.verified_bot`): A boolean value that indicates whether a request originates from a Cloudflare allowed bot. 
@@ -24,6 +24,7 @@ Bot Management provides access to several [new variables](/ruleset-engine/rules-
 - **Serves Static Resource** (`cf.bot_management.static_resource`): An identifier that matches [file extensions](/bots/additional-configurations/static-resources/) for many types of static resources. Use this variable if you send emails that retrieve static images.
 - **ja3Hash** (`cf.bot_management.ja3_hash`) and **ja4** (`cf.bot_management.ja4`): A [**JA3/JA4 fingerprint**](/bots/additional-configurations/ja3-ja4-fingerprint/) helps you profile specific SSL/TLS clients across different destination IPs, Ports, and X509 certificates.
 - **Bot Detection IDs** (`cf.bot_management.detection_ids`): List of IDs that correlate to the Bot Management heuristic detections made on a request (you can have multiple heuristic detections on the same request).
+- **Bot Tags** (`cf.bot_management.tags`): A list of tags associated with bot traffic.
 - **Signed Agent** (`cf.bot_management.signed_agent`): A boolean value that indicates whether the request originated from a known agent that self-identifies with Web Bot Auth. Such agents are now classified as [verified bots and agents](/bots/concepts/bot/verified-bots/) labeled as intermediary.
 - **Verified Bot Categories** (`cf.verified_bot_category`): A string that allows you to segment your verified bot traffic by its [type and purpose](/bots/concepts/bot/verified-bots/#legacy-categories).
 

--- a/src/content/docs/cache/how-to/cache-rules/settings.mdx
+++ b/src/content/docs/cache/how-to/cache-rules/settings.mdx
@@ -33,7 +33,21 @@ The fields available for Cache Rule matching expressions in the **Expression Bui
 - Cookie value of - `http.request.cookies`
 - File extension - `http.request.uri.path.extension`
 
-If you select the [Edit expression](/ruleset-engine/rules-language/expressions/edit-expressions/#expression-editor) option, you can enter any of the [available fields](/ruleset-engine/rules-language/fields/reference/).
+If you select the [Edit expression](/ruleset-engine/rules-language/expressions/edit-expressions/#expression-editor) option, you can enter additional fields supported by Cache Rules. These fields include:
+
+- `cf.bot_management.score`
+- `cf.bot_management.ja3_hash`
+- `cf.bot_management.ja4`
+- `cf.bot_management.verified_bot`
+- `cf.bot_management.static_resource`
+- `cf.bot_management.js_detection.passed`
+- `cf.bot_management.detection_ids`
+- `cf.bot_management.tags`
+- `cf.bot_management.signed_agent`
+- `cf.bot_management.corporate_proxy`
+- `ip.src.asnum`
+
+Bot Management fields require a [Bot Management subscription](/bots/plans/bm-subscription/). For field types, descriptions, and expression syntax, refer to the [Fields reference](/ruleset-engine/rules-language/fields/reference/).
 
 :::note
 

--- a/src/content/fields/index.yaml
+++ b/src/content/fields/index.yaml
@@ -608,6 +608,19 @@ entries:
     example_block: |-
       any(cf.bot_management.detection_ids[*] eq 33554817)
 
+  - name: cf.bot_management.tags
+    data_type: Array<String>
+    categories: [Request, Bots]
+    keywords: [request, bots, client, visitor, tags]
+    plan_info_label: Enterprise add-on
+    summary: Provides the tags associated with bot traffic.
+    description: |-
+      Use this field to match requests associated with a specific bot tag.
+
+      Requires a Cloudflare Enterprise plan with [Bot Management](/bots/plans/bm-subscription/) enabled.
+    example_block: |-
+      any(cf.bot_management.tags[*] eq "API")
+
   - name: cf.client.bot
     data_type: Boolean
     categories: [Request, Bots]


### PR DESCRIPTION
### Summary

- correct the existing July 16 Cache Rules changelog to list the Bot Management fields accepted by the Rulesets API
- document the Cache Rules field availability and `cf.bot_management.tags` expression syntax
- update Bot Management references that incorrectly described bot tags as log-only

No new changelog entry is added.

### Validation

- `pnpm run check`
- `pnpm run build` reaches page generation, then fails on the existing Astro dependency error: `cookie` does not provide an export named `parseCookie`