### PR TITLE
[R2] Document US jurisdiction

### DIFF
--- a/src/content/changelog/r2/2026-08-17-r2-us-jurisdiction.mdx
+++ b/src/content/changelog/r2/2026-08-17-r2-us-jurisdiction.mdx
@@ -1,0 +1,37 @@
+---
+title: New `us` jurisdiction for R2
+description: Restrict R2 bucket data storage and processing to the United States.
+products:
+  - r2
+date: 2026-08-17
+---
+
+import { WranglerConfig } from "~/components";
+
+R2 now supports a `us` [jurisdiction](/r2/reference/data-location/#jurisdictional-restrictions), letting you create buckets that store and process data within the United States. Use the `us` jurisdiction to meet United States data residency requirements.
+
+Use the jurisdiction-specific S3 endpoint to create and access buckets in the `us` jurisdiction:
+
+`https://<ACCOUNT_ID>.us.r2.cloudflarestorage.com`
+
+To access a bucket in the `us` jurisdiction from Workers, set `jurisdiction` in your R2 binding:
+
+<WranglerConfig>
+
+```jsonc
+{
+	"r2_buckets": [
+		{
+			"binding": "MY_BUCKET",
+			"bucket_name": "<YOUR_BUCKET_NAME>",
+			"jurisdiction": "us"
+		}
+	]
+}
+```
+
+</WranglerConfig>
+
+Once an R2 bucket is created, its jurisdiction cannot be changed.
+
+For setup instructions and the full list of supported jurisdictions, refer to [R2 data location](/r2/reference/data-location/#jurisdictional-restrictions).

--- a/src/content/changelog/r2/2026-08-17-r2-us-jurisdiction.mdx
+++ b/src/content/changelog/r2/2026-08-17-r2-us-jurisdiction.mdx
@@ -8,7 +8,7 @@ date: 2026-08-17
 
 import { WranglerConfig } from "~/components";
 
-R2 now supports a `us` [jurisdiction](/r2/reference/data-location/#jurisdictional-restrictions), letting you create buckets that store and process data within the United States. Use the `us` jurisdiction to meet United States data residency requirements.
+R2 now supports a `us` [jurisdiction](/r2/reference/data-location/#jurisdictional-restrictions), which guarantees that bucket data is stored and processed within the United States. Use this jurisdiction when you need explicit US data residency guarantees.
 
 Use the jurisdiction-specific S3 endpoint to create and access buckets in the `us` jurisdiction:
 

--- a/src/content/docs/r2/api/tokens.mdx
+++ b/src/content/docs/r2/api/tokens.mdx
@@ -48,6 +48,7 @@ Buckets created with jurisdictions must be accessed via jurisdiction-specific en
 
 - European Union (EU): `https://<ACCOUNT_ID>.eu.r2.cloudflarestorage.com`
 - FedRAMP: `https://<ACCOUNT_ID>.fedramp.r2.cloudflarestorage.com`
+- United States (US): `https://<ACCOUNT_ID>.us.r2.cloudflarestorage.com`
 
 :::caution
 

--- a/src/content/docs/r2/reference/data-location.mdx
+++ b/src/content/docs/r2/reference/data-location.mdx
@@ -143,6 +143,7 @@ The following jurisdictions are supported:
 | ------------ | ------------------------ |
 | eu           | European Union           |
 | fedramp      | FedRAMP                  |
+| us           | United States            |
 
 :::note
 

--- a/src/content/docs/r2/reference/partners/snowflake-regions.mdx
+++ b/src/content/docs/r2/reference/partners/snowflake-regions.mdx
@@ -14,25 +14,25 @@ This page details which R2 location or jurisdiction is recommended based on your
 You have the following inputs to control the physical location where objects in your R2 buckets are stored (for more information refer to [data location](/r2/reference/data-location/)):
 
 - [**Location hints**](/r2/reference/data-location/#location-hints): Specify a geophrical area (for example, Asia-Pacific or Western Europe). R2 makes a best effort to place your bucket in or near that location to optimize performance. You can confirm bucket placement after creation by navigating to the **Settings** tab of your bucket and referring to the **Bucket details** section.
-- [**Jurisdictions**](/r2/reference/data-location/#jurisdictional-restrictions): Enforce that data is both stored and processed within a specific jurisdiction (for example, the EU or FedRAMP environment). Use jurisdictions when you need to ensure data is stored and processed within a jurisdiction to meet data residency requirements, including local regulations such as the [GDPR](https://gdpr-info.eu/) or [FedRAMP](https://blog.cloudflare.com/cloudflare-achieves-fedramp-authorization/).
+- [**Jurisdictions**](/r2/reference/data-location/#jurisdictional-restrictions): Enforce that data is both stored and processed within a specific jurisdiction (for example, US, EU, or FedRAMP environments). Use jurisdictions when you need to ensure data is stored and processed within a jurisdiction to meet data residency requirements, including local regulations such as the [GDPR](https://gdpr-info.eu/) or [FedRAMP](https://blog.cloudflare.com/cloudflare-achieves-fedramp-authorization/).
 
 ## North and South America (Commercial)
 
-| Snowflake region name        | Cloud | Region ID        | Recommended R2 location |
-| ---------------------------- | ----- | ---------------- | ----------------------- |
-| Canada (Central)             | AWS   | `ca-central-1`   | Location hint: `enam`   |
-| South America (Sao Paulo)    | AWS   | `sa-east-1`      | Location hint: `enam`   |
-| US West (Oregon)             | AWS   | `us-west-2`      | Location hint: `wnam`   |
-| US East (Ohio)               | AWS   | `us-east-2`      | Location hint: `enam`   |
-| US East (N. Virginia)        | AWS   | `us-east-1`      | Location hint: `enam`   |
-| US Central1 (Iowa)           | GCP   | `us-central1`    | Location hint: `enam`   |
-| US East4 (N. Virginia)       | GCP   | `us-east4`       | Location hint: `enam`   |
-| Canada Central (Toronto)     | Azure | `canadacentral`  | Location hint: `enam`   |
-| Central US (Iowa)            | Azure | `centralus`      | Location hint: `enam`   |
-| East US 2 (Virginia)         | Azure | `eastus2`        | Location hint: `enam`   |
-| Mexico Central (Mexico City) | Azure | `mexicocentral`  | Location hint: `wnam`   |
-| South Central US (Texas)     | Azure | `southcentralus` | Location hint: `enam`   |
-| West US 2 (Washington)       | Azure | `westus2`        | Location hint: `wnam`   |
+| Snowflake region name        | Cloud | Region ID        | Recommended R2 location               |
+| ---------------------------- | ----- | ---------------- | ------------------------------------- |
+| Canada (Central)             | AWS   | `ca-central-1`   | Location hint: `enam`                 |
+| South America (Sao Paulo)    | AWS   | `sa-east-1`      | Location hint: `enam`                 |
+| US West (Oregon)             | AWS   | `us-west-2`      | Jurisdiction: `us` or hint: `wnam`    |
+| US East (Ohio)               | AWS   | `us-east-2`      | Jurisdiction: `us` or hint: `enam`    |
+| US East (N. Virginia)        | AWS   | `us-east-1`      | Jurisdiction: `us` or hint: `enam`    |
+| US Central1 (Iowa)           | GCP   | `us-central1`    | Jurisdiction: `us` or hint: `enam`    |
+| US East4 (N. Virginia)       | GCP   | `us-east4`       | Jurisdiction: `us` or hint: `enam`    |
+| Canada Central (Toronto)     | Azure | `canadacentral`  | Location hint: `enam`                 |
+| Central US (Iowa)            | Azure | `centralus`      | Jurisdiction: `us` or hint: `enam`    |
+| East US 2 (Virginia)         | Azure | `eastus2`        | Jurisdiction: `us` or hint: `enam`    |
+| Mexico Central (Mexico City) | Azure | `mexicocentral`  | Location hint: `wnam`                 |
+| South Central US (Texas)     | Azure | `southcentralus` | Jurisdiction: `us` or hint: `enam`    |
+| West US 2 (Washington)       | Azure | `westus2`        | Jurisdiction: `us` or hint: `wnam`    |
 
 ## U.S. Government
 


### PR DESCRIPTION
### Summary

Documents the generally available `us` jurisdiction for R2.

- Adds US to supported jurisdiction and endpoint references.
- Updates Snowflake recommendations for US regions.
- Adds a changelog with S3 and Workers examples.

### Documentation checklist

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))?
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).