### PR TITLE
[DLS] Clarify Audit Logs CMB compatibility

### DIFF
--- a/src/content/docs/data-localization/compatibility.mdx
+++ b/src/content/docs/data-localization/compatibility.mdx
@@ -108,6 +108,7 @@ The tables below show whether each Cloudflare product is compatible with each DL
 
 | Product      | Geo Key Manager | Regional Services | Customer Metadata Boundary |
 | ------------ | --------------- | ----------------- | -------------------------- |
+| Audit Logs   | ⚫️             | ⚫️               | 🚧 [^51]                   |
 | Logpull      | ⚫️             | ⚫️               | 🚧 [^12]                   |
 | Logpush      | ⚫️             | ✅                | 🚧 [^13]                   |
 | Log Explorer | ⚫️             | ⚫️               | ✘ [^23]                    |
@@ -218,3 +219,5 @@ The tables below show whether each Cloudflare product is compatible with each DL
 [^49]: Dashboard Analytics are empty when using CMB outside the US region. Use [Logpush](/logs/logpush/) instead.
 
 [^50]: Email and webhook notifications for DDoS and WAF events may not fire reliably when Customer Metadata Boundary is set to `eu`. This behavior is intermittent and under investigation. If timely alerts are critical, use [Logpush](/logs/logpush/) as a complementary monitoring mechanism.
+
+[^51]: [Audit Logs v2](/fundamentals/account/account-security/audit-logs/) respects Customer Metadata Boundary and is available when CMB is set to the US or EU. Legacy Audit Logs v1 does not respect CMB, and its `audit_logs` Logpush dataset is unavailable when CMB is set to EU. To use v2 with Logpush, create a separate job using [`audit_logs_v2`](/logs/logpush/logpush-job/datasets/account/audit_logs_v2/). Existing v1 jobs do not migrate automatically.

--- a/src/content/docs/data-localization/metadata-boundary/logpush-datasets.mdx
+++ b/src/content/docs/data-localization/metadata-boundary/logpush-datasets.mdx
@@ -28,7 +28,8 @@ If you enable CMB for a region where a dataset is not available (marked ✘ in t
 | ------------------------------------------- | ------- | ------------ | ---------------------------- | ---------------------------- |
 | Access Requests                             | Account | ✅           | ✅                           | ✅                           |
 | AI Gateway Events                           | Account | ✅           | ✅                           | ✅                           |
-| Audit Logs                                  | Account | ✘            | ✅                           | ✘                            |
+| Audit Logs (legacy, `audit_logs`)            | Account | ✘            | ✅                           | ✘                            |
+| Audit Logs v2 (`audit_logs_v2`)              | Account | ✅           | ✅                           | ✅                           |
 | Browser Isolation User Actions              | Account | ✅           | ✅                           | ✅                           |
 | CASB Findings                               | Account | ✘            | ✅                           | ✘                            |
 | Client-side security (formerly Page Shield) | Zone    | ✅           | ✅                           | ✅                           |


### PR DESCRIPTION
### Summary

Clarifies Customer Metadata Boundary support for Audit Logs v1 and v2. Separates `audit_logs` from `audit_logs_v2` and notes that v2 requires a separate Logpush job because existing v1 jobs do not migrate automatically.

### Tests

- `pnpm run format`
- `pnpm run check`
- `pnpm run build`

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
