### PR TITLE
[Workers] Add integrations otlp endpoint

### DIFF
--- a/src/content/docs/workers/observability/exporting-opentelemetry-data/index.mdx
+++ b/src/content/docs/workers/observability/exporting-opentelemetry-data/index.mdx
@@ -33,7 +33,7 @@ Below are common OTLP endpoint formats for popular observability providers. Refe
 | [**Axiom**](/workers/observability/exporting-opentelemetry-data/axiom/)                 | `https://api.axiom.co/v1/traces`                             | `https://api.axiom.co/v1/logs`                               |
 | [**Sentry**](/workers/observability/exporting-opentelemetry-data/sentry/)               | `https://{HOST}/api/{PROJECT_ID}/integration/otlp/v1/traces` | `https://{HOST}/api/{PROJECT_ID}/integration/otlp/v1/logs`   |
 | [**PostHog**](/workers/observability/exporting-opentelemetry-data/posthog/)             | Not supported                                                | `https://{REGION}.i.posthog.com/i/v1/logs`                   |
-| [**Datadog**](https://docs.datadoghq.com/opentelemetry/setup/otlp_ingest/)              | `https://otlp.{SITE}.datadoghq.com/v1/traces`                    | `https://otlp.{SITE}.datadoghq.com/v1/logs`                  |
+| [**Datadog**](https://docs.datadoghq.com/opentelemetry/setup/otlp_ingest/managed_platforms/)              | `https://cloudflare.integrations.otlp.{SITE}.datadoghq.com/v1/traces` | `https://cloudflare.integrations.otlp.{SITE}.datadoghq.com/v1/logs` |
 | [**New Relic**](https://docs.newrelic.com/docs/opentelemetry/best-practices/opentelemetry-otlp/) | `https://otlp.nr-data.net/v1/traces` | `https://otlp.nr-data.net/v1/logs` |
 | [**Splunk Observability**](https://dev.splunk.com/observability/reference/api/ingest_data/latest) | `https://ingest.{REALM}.signalfx.com/v2/trace/otlp` | N/A |
 | [**Splunk Platform**](https://github.com/splunk/splunk-connect-for-otlp) | `http://splunk.internal:4318/v1/traces` | `http://splunk.internal:4318/v1/logs` |

--- a/src/content/docs/workers/observability/exporting-opentelemetry-data/index.mdx
+++ b/src/content/docs/workers/observability/exporting-opentelemetry-data/index.mdx
@@ -33,7 +33,7 @@ Below are common OTLP endpoint formats for popular observability providers. Refe
 | [**Axiom**](/workers/observability/exporting-opentelemetry-data/axiom/)                 | `https://api.axiom.co/v1/traces`                             | `https://api.axiom.co/v1/logs`                               |
 | [**Sentry**](/workers/observability/exporting-opentelemetry-data/sentry/)               | `https://{HOST}/api/{PROJECT_ID}/integration/otlp/v1/traces` | `https://{HOST}/api/{PROJECT_ID}/integration/otlp/v1/logs`   |
 | [**PostHog**](/workers/observability/exporting-opentelemetry-data/posthog/)             | Not supported                                                | `https://{REGION}.i.posthog.com/i/v1/logs`                   |
-| [**Datadog**](https://docs.datadoghq.com/opentelemetry/setup/otlp_ingest/managed_platforms/)              | `https://cloudflare.integrations.otlp.{SITE}.datadoghq.com/v1/traces` | `https://cloudflare.integrations.otlp.{SITE}.datadoghq.com/v1/logs` |
+| [**Datadog**](https://docs.datadoghq.com/opentelemetry/setup/otlp_ingest/managed_platforms/)              | `https://cloudflare.integrations.otlp.{DD_SITE}/v1/traces` | `https://cloudflare.integrations.otlp.{DD_SITE}/v1/logs` |
 | [**New Relic**](https://docs.newrelic.com/docs/opentelemetry/best-practices/opentelemetry-otlp/) | `https://otlp.nr-data.net/v1/traces` | `https://otlp.nr-data.net/v1/logs` |
 | [**Splunk Observability**](https://dev.splunk.com/observability/reference/api/ingest_data/latest) | `https://ingest.{REALM}.signalfx.com/v2/trace/otlp` | N/A |
 | [**Splunk Platform**](https://github.com/splunk/splunk-connect-for-otlp) | `http://splunk.internal:4318/v1/traces` | `http://splunk.internal:4318/v1/logs` |


### PR DESCRIPTION
### Summary

Updating Datadog-specific documentation to include our Cloudflare-specific OTLP endpoint. There are 2 changes here:

1. Customers exporting OTLP from cloudflare should use the cloudflare specific endpoint I included here
2. Updating the docs page to include our managed platform specific docs
