### PR TITLE
Update PII categories for AI Security for Apps model migration

### DIFF
--- a/src/content/docs/waf/detections/ai-security-for-apps/example-rules.mdx
+++ b/src/content/docs/waf/detections/ai-security-for-apps/example-rules.mdx
@@ -58,7 +58,7 @@ A financial services application legitimately handles credit card and bank accou
 - **When incoming requests match**:
 
   Enter the following expression in the editor:<br />
-  `(any(cf.llm.prompt.pii_categories[*] in {"CREDIT_CARD" "US_BANK_NUMBER" "IBAN_CODE"}) and ip.src.asnum ne 13335)`
+  `(any(cf.llm.prompt.pii_categories[*] in {"CREDIT_CARD" "BANK_ACCOUNT"}) and ip.src.asnum ne 13335)`
 
   Replace `13335` with your organization's ASN.
 

--- a/src/content/docs/waf/detections/ai-security-for-apps/pii-detection.mdx
+++ b/src/content/docs/waf/detections/ai-security-for-apps/pii-detection.mdx
@@ -27,7 +27,7 @@ When AI Security for Apps is enabled and a request arrives at a `cf-llm` labeled
 [1]: /ruleset-engine/rules-language/fields/reference/cf.llm.prompt.pii_detected/
 [2]: /ruleset-engine/rules-language/fields/reference/cf.llm.prompt.pii_categories/
 
-The detection is based on [Presidio](https://microsoft.github.io/presidio/supported_entities/), a data protection and de-identification SDK. Refer to the [`cf.llm.prompt.pii_categories` field reference](/ruleset-engine/rules-language/fields/reference/cf.llm.prompt.pii_categories/) for the full list of recognized categories.
+The detection is powered by an AI-based Named Entity Recognition (NER) model. Refer to the [`cf.llm.prompt.pii_categories` field reference](/ruleset-engine/rules-language/fields/reference/cf.llm.prompt.pii_categories/) for the full list of recognized categories.
 
 :::note[Detecting PII in responses]
 AI Security for Apps PII detection runs on incoming requests (prompts) only. If you also need to detect PII in LLM responses, you can use [Sensitive Data Detection](/waf/managed-rules/reference/sensitive-data-detection/) to scan response bodies for patterns like credit card numbers, Social Security numbers, and API keys. Sensitive Data Detection logs matches, but does not block responses. Use it alongside request-side rules for layered visibility.
@@ -35,47 +35,21 @@ AI Security for Apps PII detection runs on incoming requests (prompts) only. If 
 
 <Details header="Supported PII categories">
 
-| Category                    | Description                                                                   |
-| --------------------------- | ----------------------------------------------------------------------------- |
-| `CREDIT_CARD`               | Credit card number                                                            |
-| `CRYPTO`                    | Cryptocurrency wallet address                                                 |
-| `DATE_TIME`                 | Date or time expression                                                       |
-| `EMAIL_ADDRESS`             | Email address                                                                 |
-| `IBAN_CODE`                 | International bank account number                                             |
-| `IP_ADDRESS`                | IP address                                                                    |
-| `NRP`                       | Nationality, religious, or political group                                    |
-| `LOCATION`                  | Physical location or address                                                  |
-| `PERSON`                    | Person name                                                                   |
-| `PHONE_NUMBER`              | Phone number                                                                  |
-| `MEDICAL_LICENSE`           | Medical license number                                                        |
-| `URL`                       | URL                                                                           |
-| `US_BANK_NUMBER`            | US bank account number                                                        |
-| `US_DRIVER_LICENSE`         | US driver license number                                                      |
-| `US_ITIN`                   | US Individual Taxpayer Identification Number                                  |
-| `US_PASSPORT`               | US passport number                                                            |
-| `US_SSN`                    | US Social Security Number                                                     |
-| `UK_NHS`                    | UK National Health Service number                                             |
-| `UK_NINO`                   | UK National Insurance Number                                                  |
-| `ES_NIF`                    | Spanish tax identification number                                             |
-| `ES_NIE`                    | Spanish foreigner identification number                                       |
-| `IT_FISCAL_CODE`            | Italian fiscal code                                                           |
-| `IT_DRIVER_LICENSE`         | Italian driver license                                                        |
-| `IT_VAT_CODE`               | Italian VAT code                                                              |
-| `IT_PASSPORT`               | Italian passport number                                                       |
-| `IT_IDENTITY_CARD`          | Italian identity card                                                         |
-| `PL_PESEL`                  | Polish national identification number                                         |
-| `SG_NRIC_FIN`               | Singapore National Registration Identity Card / Foreign Identification Number |
-| `SG_UEN`                    | Singapore Unique Entity Number                                                |
-| `AU_ABN`                    | Australian Business Number                                                    |
-| `AU_ACN`                    | Australian Company Number                                                     |
-| `AU_TFN`                    | Australian Tax File Number                                                    |
-| `AU_MEDICARE`               | Australian Medicare number                                                    |
-| `IN_PAN`                    | Indian Permanent Account Number                                               |
-| `IN_AADHAAR`                | Indian Aadhaar number                                                         |
-| `IN_VEHICLE_REGISTRATION`   | Indian vehicle registration number                                            |
-| `IN_VOTER`                  | Indian voter ID                                                               |
-| `IN_PASSPORT`               | Indian passport number                                                        |
-| `FI_PERSONAL_IDENTITY_CODE` | Finnish personal identity code                                                |
+| Category        | Description             |
+| --------------- | ----------------------- |
+| `BANK_ACCOUNT`  | Bank account number    |
+| `CREDIT_CARD`   | Credit card number      |
+| `DATE_TIME`     | Date or time expression |
+| `DRIVER_LICENSE`| Driver license number   |
+| `EMAIL_ADDRESS` | Email address           |
+| `IP_ADDRESS`    | IPv4 address            |
+| `LOCATION`      | Physical location or address |
+| `PASSPORT`      | Passport number         |
+| `PERSON`        | Full or partial name of an individual |
+| `PHONE_NUMBER`  | Phone number            |
+| `TAX_ID`        | Tax identification number |
+| `US_SSN`        | US Social Security Number |
+| `URL`           | URL                     |
 
 </Details>
 

--- a/src/content/fields/index.yaml
+++ b/src/content/fields/index.yaml
@@ -1418,54 +1418,28 @@ entries:
     description: |-
       The possible values are the following:
 
-      Category                    | Description
-      ----------------------------|-----------------------------------------------------------------------------------------------------------------------------------------
-      `CREDIT_CARD`               | Credit card number
-      `CRYPTO`                    | Crypto wallet number (currently only Bitcoin address)
-      `DATE_TIME`                 | Absolute or relative dates or periods or times smaller than a day
-      `EMAIL_ADDRESS`             | Email address
-      `IBAN_CODE`                 | International Bank Account Number (IBAN)
-      `IP_ADDRESS`                | Internet Protocol (IP) address
-      `NRP`                       | A person's nationality, religious or political group
-      `LOCATION`                  | Name of politically or geographically defined location (cities, provinces, countries, international regions, bodies of water, mountains)
-      `PERSON`                    | Full person name
-      `PHONE_NUMBER`              | Telephone number
-      `MEDICAL_LICENSE`           | Common medical license numbers
-      `URL`                       | Uniform Resource Locator (URL), used to locate a resource on the Internet
-      `US_BANK_NUMBER`            | US bank account number
-      `US_DRIVER_LICENSE`         | US driver license
-      `US_ITIN`                   | US Individual Taxpayer Identification Number (ITIN)
-      `US_PASSPORT`               | US passport number
-      `US_SSN`                    | US Social Security Number (SSN)
-      `UK_NHS`                    | UK NHS number
-      `UK_NINO`                   | UK National Insurance Number
-      `ES_NIF`                    | Spanish NIF number (personal tax ID)
-      `ES_NIE`                    | Spanish NIE number (foreigners ID card)
-      `IT_FISCAL_CODE`            | Italian personal tax ID code
-      `IT_DRIVER_LICENSE`         | Italian driver license number
-      `IT_VAT_CODE`               | Italian VAT code number
-      `IT_PASSPORT`               | Italian passport number
-      `IT_IDENTITY_CARD`          | Italian identity card number
-      `PL_PESEL`                  | Polish PESEL number
-      `SG_NRIC_FIN`               | National Registration Identification Card (Singapore)
-      `SG_UEN`                    | Unique Entity Number (for entities registered in Singapore)
-      `AU_ABN`                    | Australian Business Number (ABN)
-      `AU_ACN`                    | Australian Company Number (ACN)
-      `AU_TFN`                    | Australian tax file number (TFN)
-      `AU_MEDICARE`               | Medicare number (issued by Australian government)
-      `IN_PAN`                    | Indian Permanent Account Number (PAN)
-      `IN_AADHAAR`                | Individual identity number (issued by Indian government)
-      `IN_VEHICLE_REGISTRATION`   | Vehicle registration number (issued by Indian government)
-      `IN_VOTER`                  | Numeric voter ID (issued by Indian Election Commission)
-      `IN_PASSPORT`               | Indian Passport Number
-      `FI_PERSONAL_IDENTITY_CODE` | Finnish Personal Identity Code
+      Category         | Description
+      -----------------|------------------------------------------
+      `BANK_ACCOUNT`   | Bank account number
+      `CREDIT_CARD`    | Credit card number
+      `DATE_TIME`      | Date or time expression
+      `DRIVER_LICENSE` | Driver license number
+      `EMAIL_ADDRESS`  | Email address
+      `IP_ADDRESS`     | Internet Protocol (IPv4) address
+      `LOCATION`       | Physical location or address
+      `PASSPORT`       | Passport number
+      `PERSON`         | Full or partial name of an individual
+      `PHONE_NUMBER`   | Telephone number
+      `TAX_ID`         | Tax identification number
+      `US_SSN`         | US Social Security Number (SSN)
+      `URL`            | Uniform Resource Locator (URL), used to locate a resource on the Internet
 
-      The categories list is based on the [list of PII entities supported by Presidio](https://microsoft.github.io/presidio/supported_entities/). Presidio is the data protection and de-identification SDK used in AI Security for Apps.
+      The categories are detected by an AI-based Named Entity Recognition (NER) model.
 
       Requires a Cloudflare Enterprise plan. You must also enable [AI Security for Apps](/waf/detections/ai-security-for-apps/).
     example_block: |-
-      # Matches requests where PII categorized as "EMAIL_ADDRESS" or "IBAN_CODE" was detected:
-      (cf.llm.prompt.pii_detected and any(cf.llm.prompt.pii_categories[*] in {"EMAIL_ADDRESS" "IBAN_CODE"}))
+      # Matches requests where PII categorized as "EMAIL_ADDRESS" or "BANK_ACCOUNT" was detected:
+      (cf.llm.prompt.pii_detected and any(cf.llm.prompt.pii_categories[*] in {"EMAIL_ADDRESS" "BANK_ACCOUNT"}))
 
   - name: cf.llm.prompt.unsafe_topic_detected
     data_type: Boolean


### PR DESCRIPTION
### Summary

Updates public documentation to reflect the PII detection model migration from Presidio to a new AI-based Named Entity Recognition (NER) model.

Replace the 39 Presidio-based PII categories with 13 categories supported by the new NER model. Remove Presidio attribution from docs; update example rules to use BANK_ACCOUNT instead of dropped IBAN_CODE/US_BANK_NUMBER.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
