### PR TITLE
Fix incorrect multi-domain guidance in Keyless SSL troubleshooting

### DIFF
--- a/src/content/docs/ssl/keyless-ssl/troubleshooting.mdx
+++ b/src/content/docs/ssl/keyless-ssl/troubleshooting.mdx
@@ -102,9 +102,9 @@ However, the key server is open source so you may attempt to build and deploy a 
 
 ## Key server multi-domain support
 
-You can use the same key server for multiple domains.
+A single key server can serve multiple domains. Add each certificate's private key to the `private_key_stores` block in `gokeyless.yaml`, or pass them with `--private-key-dirs` / `--private-key-files`. Refer to [Serve multiple private keys](/ssl/keyless-ssl/configuration/run-with-docker/#serve-multiple-private-keys) for details.
 
-However, if you do, you will need to add the hostname and the Zone ID of the new domain to the `gokeyless.yaml` file.
+The `hostname` and `zone_id` fields are single string values used only during enrollment. You do not need to update them for additional domains.
 
 ## Additional questions
 


### PR DESCRIPTION
The "Key server multi-domain support" troubleshooting section incorrectly tells users to add `hostname` and `zone_id` for each new domain. These are single string values used only during enrollment — additional domains only need their private keys added via `private_key_stores` or CLI flags. Updated the guidance and linked to the existing "Serve multiple private keys" section.