### PR TITLE
Fix overlapping note text in SASE diagram caption

### DIFF
--- a/src/content/docs/reference-architecture/architectures/sase.mdx
+++ b/src/content/docs/reference-architecture/architectures/sase.mdx
@@ -342,14 +342,7 @@ Note the following traffic flows:
 
 _Note: Labels in this image may reflect a previous product name._
 
-<sub>
-	*Note: All of the endpoints connected via Cloudflare Mesh or device agent
-	are automatically assigned IP addresses from the 100.96.0.0/12 address range,
-	while endpoints connected to Cloudflare WAN retain their assigned RFC1918
-	private IP addresses. `cloudflared` can be deployed in any of the locations by
-	an application owner to provide hostname-based connectivity to the
-	application.*
-</sub>
+_Note: All of the endpoints connected via Cloudflare Mesh or device agent are automatically assigned IP addresses from the 100.96.0.0/12 address range, while endpoints connected to Cloudflare WAN retain their assigned RFC1918 private IP addresses. `cloudflared` can be deployed in any of the locations by an application owner to provide hostname-based connectivity to the application._
 
 Once the networks, applications, and user devices are connected to Cloudflare — regardless of the connection methods and devices used — all traffic can be inspected, authenticated, and filtered by the Cloudflare SASE services, then securely routed to their intended destinations. Additionally, consistent policies can be applied across all traffic, no matter how it arrives at Cloudflare.
 


### PR DESCRIPTION

### Summary

Fixes overlapping caption text under the network architecture diagram in the [SASE reference architecture](https://developers.cloudflare.com/reference-architecture/architectures/sase/#using-network-equipment) page. The second "Note" was wrapped in a malformed multi-line \<sub\> block, which caused it to render on top of the preceding note instead of as a separate paragraph. Converted it to a standard italic note paragraph, consistent with the rest of the docs.
No changelog entry needed (typo/rendering fix), no new page, and no files were renamed, so the rest of the checklist items don't apply here.


### Screenshots

Before:

<img width="817" height="684" alt="Screenshot 2026-08-18 at 17 12 41" src="https://github.com/user-attachments/assets/a0acb798-e87b-43eb-9df7-c0e6c0d5136c" />

After:

<img width="796" height="795" alt="Screenshot 2026-08-18 at 17 13 19" src="https://github.com/user-attachments/assets/f4b93052-28d8-4ec5-8584-67be283fea2c" />
