### PR TITLE
docs(r2): clarify billing for failed 4xx requests in pricing FAQ

### DIFF
--- a/src/content/docs/r2/pricing.mdx
+++ b/src/content/docs/r2/pricing.mdx
@@ -164,8 +164,16 @@ To learn more about how usage is billed, refer to [Cloudflare Billing Policy](/b
 
 ## Frequently asked questions
 
-### Will I be charged for unauthorized requests to my R2 bucket?
+### Will I be charged for failed requests to my R2 bucket?
 
-No. You are not charged for operations when the caller does not have permission to make the request (HTTP 401 `Unauthorized` response status code).
+Requests that fail at the authentication layer are not charged. This includes:
+
+- HTTP 401 (`Unauthorized`) — missing or invalid credentials.
+- HTTP 403 when caused by an authentication failure such as `SignatureDoesNotMatch`, `ExpiredRequest`, or `RequestTimeTooSkewed`.
+
+Requests that pass authentication but fail for other reasons are counted and billed according to the operation's class. For example:
+
+- A `PutObject` returning HTTP 412 (`PreconditionFailed`) due to a conditional header like `If-None-Match` counts as a Class A operation.
+- A `PutObject` returning HTTP 400 (`BadDigest`) due to a mismatched `Content-MD5` counts as a Class A operation.
 
 [^1]: Egressing directly from R2, including via the [Workers API](/r2/api/workers/), [S3 API](/r2/api/s3/), and [`r2.dev` domains](/r2/buckets/public-buckets/#enable-managed-public-access) does not incur data transfer (egress) charges and is free. If you connect other metered services to an R2 bucket, you may be charged by those services.

--- a/src/content/docs/r2/pricing.mdx
+++ b/src/content/docs/r2/pricing.mdx
@@ -166,12 +166,13 @@ To learn more about how usage is billed, refer to [Cloudflare Billing Policy](/b
 
 ### Will I be charged for failed requests to my R2 bucket?
 
-Requests that fail at the authentication layer are not charged. This includes:
+Requests that fail during authentication or authorization are not charged. This includes:
 
 - HTTP 401 (`Unauthorized`) — missing or invalid credentials.
 - HTTP 403 when caused by an authentication failure such as `SignatureDoesNotMatch`, `ExpiredRequest`, or `RequestTimeTooSkewed`.
+- HTTP 403 (`AccessDenied`) when valid credentials do not have permission to perform the operation.
 
-Requests that pass authentication but fail for other reasons are counted and billed according to the operation's class. For example:
+Requests that pass authentication and authorization but fail for other reasons are counted and billed according to the operation's class. For example:
 
 - A `PutObject` returning HTTP 412 (`PreconditionFailed`) due to a conditional header like `If-None-Match` counts as a Class A operation.
 - A `PutObject` returning HTTP 400 (`BadDigest`) due to a mismatched `Content-MD5` counts as a Class A operation.


### PR DESCRIPTION
## What this PR does

Expands the R2 pricing FAQ to clarify which failed (4xx) requests are billed as Class A operations. The previous FAQ only mentioned HTTP 401 `Unauthorized` as exempt, leaving customers uncertain about other error codes like 412 `PreconditionFailed`, 403 `SignatureDoesNotMatch`, and 400 `BadDigest`.

## How this was verified

Empirically tested by firing controlled batches of each error type against a dedicated R2 test bucket and querying the `r2OperationsAdaptiveGroups` GraphQL analytics dataset for operation counts.

**Results:**

| Status | Error Code | In Analytics? | Billed? |
|--------|-----------|:------------:|:-------:|
| 200 | OK | Yes | Yes (control) |
| 412 | PreconditionFailed | Yes | **Yes** |
| 400 | BadDigest | Yes | **Yes** |
| 403 | SignatureDoesNotMatch | No | **No** |
| 403 | RequestTimeTooSkewed | No | **No** |
| 401 | Unauthorized | No | No (documented) |

**Rule:** Authentication-layer failures (401, 403 from signature/expiry checks) are not billed. Authenticated requests that fail post-auth (412, 400) are billed as Class A operations.

## Related

DEE-3763