### PR TITLE
[Email Security] Add post-quantum key exchange changelog

### DIFF
--- a/src/content/changelog/email-security-cf1/2026-08-17-post-quantum-key-exchange-mx.mdx
+++ b/src/content/changelog/email-security-cf1/2026-08-17-post-quantum-key-exchange-mx.mdx
@@ -1,0 +1,17 @@
+---
+title: Post-quantum key exchange for MX deployments
+description: Cloudflare Email Security now supports post-quantum hybrid key exchange on inbound and outbound SMTP connections.
+date: 2026-08-17T09:00:00Z
+---
+
+Cloudflare Email Security now supports post-quantum hybrid key exchange with X25519MLKEM768 on the SMTP connections we make to receive and deliver mail. Deploying Email Security in front of a provider that supports post-quantum hybrid key agreement (like Google Workspace) will create a TLS 1.3 connection using post-quantum key agreement.
+
+Inbound MX connections and outbound delivery connections now negotiate the [X25519MLKEM768](/ssl/post-quantum-cryptography/#hybrid-key-agreement) hybrid key agreement when the peer supports it, protecting SMTP traffic against [harvest-now, decrypt-later](https://blog.cloudflare.com/pq-2024/) attacks.
+
+Support is backwards compatible and enabled automatically for all customers. Senders and receivers that do not yet advertise post-quantum key agreement continue to connect with classical key exchange.
+
+This applies to all Email Security packages:
+
+- **Advantage**
+- **Enterprise**
+- **Enterprise + PhishGuard**


### PR DESCRIPTION
Adds a changelog entry announcing post-quantum hybrid key exchange support (X25519MLKEM768) on Email Security's inbound MX and outbound delivery SMTP connections.

## Highlights

- Inbound MX and outbound delivery connections negotiate the [X25519MLKEM768](/ssl/post-quantum-cryptography/#hybrid-key-agreement) hybrid key agreement when the peer supports it, protecting SMTP traffic against harvest-now, decrypt-later attacks.
- Enabled automatically for all customers; backwards compatible with peers that do not yet advertise post-quantum key agreement.
- Applies to Advantage, Enterprise, and Enterprise + PhishGuard packages.

## Validation

- `pnpm run format:core:check` passes
- `pnpm run check` not run locally due to Node version mismatch (CI will validate)