### PR TITLE
chore: remove legacy Outdated PR Check context posts

### DIFF
--- a/.github/workflows/outdated-pr-check.yml
+++ b/.github/workflows/outdated-pr-check.yml
@@ -86,18 +86,6 @@ jobs:
             fi
           fi
 
-          # Post the legacy context (required by current branch protection).
-          gh api \
-            --method POST \
-            -H "Accept: application/vnd.github+json" \
-            "/repos/${REPO}/statuses/${PR_SHA}" \
-            -f state="$STATE" \
-            -f context="Outdated PR Check" \
-            -f description="$DESCRIPTION" \
-            || echo "Failed to post status — skipping"
-
-          # Post the new semantic context (additive — will become required after branch
-          # protection is updated and the legacy context is removed in a follow-up PR).
           gh api \
             --method POST \
             -H "Accept: application/vnd.github+json" \

--- a/.github/workflows/outdated-pr-refresh.yml
+++ b/.github/workflows/outdated-pr-refresh.yml
@@ -86,18 +86,6 @@ jobs:
               fi
             fi
 
-            # Post the legacy context (required by current branch protection).
-            gh api \
-              --method POST \
-              -H "Accept: application/vnd.github+json" \
-              "/repos/${REPO}/statuses/${PR_SHA}" \
-              -f state="$STATE" \
-              -f context="Outdated PR Check" \
-              -f description="$DESCRIPTION" \
-              || { echo "  Failed to post status for PR #${PR_NUMBER} — continuing"; true; }
-
-            # Post the new semantic context (additive — will become required after branch
-            # protection is updated and the legacy context is removed in a follow-up PR).
             gh api \
               --method POST \
               -H "Accept: application/vnd.github+json" \


### PR DESCRIPTION
### Summary

Follow-up to #32331. Removes the legacy `Outdated PR Check` context posts from both workflows, keeping only the semantic contexts (`/ On Commit` and `/ Scheduled`).

### Branch protection update (do before merging)

Update `production` branch protection required status checks:

- **Remove:** `Outdated PR Check`
- **Add:** `Outdated PR Check / On Commit`

`Outdated PR Check / Scheduled` should NOT be required — it only runs on a daily cron, so requiring it would block new PRs until the next scheduled run.
