### PR TITLE
fix(style): [R2] accessKeyId formatting in data-location.mdx

### DIFF
--- a/src/content/docs/r2/reference/data-location.mdx
+++ b/src/content/docs/r2/reference/data-location.mdx
@@ -121,7 +121,7 @@ import { S3Client, CreateBucketCommand } from "@aws-sdk/client-s3";
 const S3 = new S3Client({
 	endpoint: "https://<account_id>.eu.r2.cloudflarestorage.com",
 	credentials: {
-		accessKeyId: "<access_key_id",
+		accessKeyId: "<access_key_id>",
 		secretAccessKey: "<access_key_secret>",
 	},
 	region: "auto",


### PR DESCRIPTION
### Summary

Fixed a formatting issue in the Cloudflare R2 documentation where the accessKeyId placeholder was missing its closing > character.

### Updated:
- <access_key_id → <access_key_id>

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
