### PR TITLE
docs: update DNSCrypt-Proxy GitHub links to DNSCrypt org

### DIFF
--- a/src/content/docs/1.1.1.1/encryption/dns-over-https/dns-over-https-client.mdx
+++ b/src/content/docs/1.1.1.1/encryption/dns-over-https/dns-over-https-client.mdx
@@ -19,7 +19,7 @@ Refer to [WARP client](/warp-client/) for guidance on WARP modes and get-started
 
 [DNSCrypt-Proxy](https://dnscrypt.info) 2.0+ supports DoH out of the box. It supports both 1.1.1.1 and other services. It also includes more advanced features, such as load balancing and local filtering.
 
-1. [Install DNSCrypt-Proxy](https://github.com/jedisct1/dnscrypt-proxy/wiki/installation).
+1. [Install DNSCrypt-Proxy](https://github.com/DNSCrypt/dnscrypt-proxy/wiki/installation).
 
 2. Verify that `dnscrypt-proxy` is installed and the version is 2.0 or later:
 
@@ -31,7 +31,7 @@ Refer to [WARP client](/warp-client/) for guidance on WARP modes and get-started
    2.0.8
    ```
 
-3. Set up the configuration file using the [official instructions](https://github.com/jedisct1/dnscrypt-proxy/wiki/installation#setting-up-dnscrypt-proxy), and add `cloudflare` and `cloudflare-ipv6` to the server list in `dnscrypt-proxy.toml`:
+3. Set up the configuration file using the [official instructions](https://github.com/DNSCrypt/dnscrypt-proxy/wiki/installation#setting-up-dnscrypt-proxy), and add `cloudflare` and `cloudflare-ipv6` to the server list in `dnscrypt-proxy.toml`:
 
    ```toml
    server_names = ['cloudflare', 'cloudflare-ipv6']
@@ -53,4 +53,4 @@ Refer to [WARP client](/warp-client/) for guidance on WARP modes and get-started
    Resolver IP:    172.68.140.217
    ```
 
-5. Register it as a system service so that it starts automatically when your device boots. Follow the [DNSCrypt-Proxy installation instructions](https://github.com/jedisct1/dnscrypt-proxy/wiki/installation).
+5. Register it as a system service so that it starts automatically when your device boots. Follow the [DNSCrypt-Proxy installation instructions](https://github.com/DNSCrypt/dnscrypt-proxy/wiki/installation).


### PR DESCRIPTION
Fixes https://github.com/cloudflare/cloudflare-docs/issues/32780

The DoH client tutorial still pointed at `jedisct1/dnscrypt-proxy`. The repo lives at `DNSCrypt/dnscrypt-proxy` now (wiki paths unchanged).

Updated all three GitHub links on the 1.1.1.1 DoH clients page.