### PR TITLE
docs: redirect short Pages framework-guide URLs

### DIFF
--- a/public/__redirects
+++ b/public/__redirects
@@ -1493,6 +1493,10 @@
 /pages/how-to/deploy-a-jekyll-site/ /pages/framework-guides/deploy-a-jekyll-site/ 301
 /pages/how-to/deploy-a-nextjs-site/ /workers/framework-guides/web-apps/nextjs 301
 /pages/framework-guides/deploy-a-svelte-site/ /pages/framework-guides/deploy-a-svelte-kit-site/ 301
+/pages/framework-guides/astro/ /pages/framework-guides/deploy-an-astro-site/ 301
+/pages/framework-guides/react/ /pages/framework-guides/deploy-a-react-site/ 301
+/pages/framework-guides/svelte/ /pages/framework-guides/deploy-a-svelte-kit-site/ 301
+/pages/framework-guides/vue/ /pages/framework-guides/deploy-a-vue-site/ 301
 /pages/how-to/deploy-anything/ /pages/framework-guides/deploy-anything/ 301
 /pages/how-to/deploy-a-react-application/ /pages/framework-guides/deploy-a-react-site/ 301
 /pages/framework-guides/deploy-a-react-application/ /pages/framework-guides/deploy-a-react-site/ 301


### PR DESCRIPTION
Fixes https://github.com/cloudflare/cloudflare-docs/issues/32782

The Cloudflare frontends marketing page links to short Pages slugs that 404:

- `/pages/framework-guides/react/`
- `/pages/framework-guides/vue/`
- `/pages/framework-guides/svelte/`
- `/pages/framework-guides/astro/`

The guides already exist under the `deploy-a-*-site` names (`deploy-an-astro-site`, `deploy-a-svelte-kit-site` for Svelte). This adds 301s in `public/__redirects` so those short URLs land on the existing pages.
