### PR TITLE
docs: restore Spectrum FTP active vs passive article link

### DIFF
--- a/src/content/docs/spectrum/about/ftp.mdx
+++ b/src/content/docs/spectrum/about/ftp.mdx
@@ -23,7 +23,7 @@ This feature requires an Enterprise plan. If you would like to upgrade, contact 
 
 FTP leverages two different sockets, one for issuing commands and the other for actual data transfer. The control socket takes care of users logging in and sending commands, and the data socket is where directory listings and files actually get transferred.
 
-There are two ways in which client and server can establish a data socket: active and passive. In active mode, the server connects *back* to the client on a port that they have specified, which can create issues where clients are behind an NAT. The alternative is passive mode, where the server opens an extra port that the client then connects to. For an overview of active versus passive FTP, refer to [Active FTP vs. Passive FTP, a Definitive Explanation](http://slacksite.com/other/ftp.html).
+There are two ways in which client and server can establish a data socket: active and passive. In active mode, the server connects *back* to the client on a port that they have specified, which can create issues where clients are behind an NAT. The alternative is passive mode, where the server opens an extra port that the client then connects to. For an overview of active versus passive FTP, refer to [Active FTP vs. Passive FTP, a Definitive Explanation](https://web.archive.org/web/20201112013727/http://slacksite.com/other/ftp.html).
 
 In passive mode, the FTP server communicates a port that the client should connect to, which is done on the control socket via a PASV command. By default, the FTP server responds with the IP address that it is listening on. This scenario is fine for servers running directly on a public-facing IP but creates issues when a server is behind an NAT, firewall, or Cloudflare Spectrum.
 


### PR DESCRIPTION
Fixes https://github.com/cloudflare/cloudflare-docs/issues/32786

`slacksite.com` no longer resolves (`No such host`). The Spectrum FTP page cited that article for active vs passive FTP.

Pointed the same title at a working Wayback snapshot:

https://web.archive.org/web/20201112013727/http://slacksite.com/other/ftp.html
