### PR TITLE
[Workers] Fix device login code examples

### DIFF
--- a/src/content/changelog/workers/2026-08-04-wrangler-login-device-flow.mdx
+++ b/src/content/changelog/workers/2026-08-04-wrangler-login-device-flow.mdx
@@ -24,11 +24,11 @@ To authorize Wrangler, please visit:
 
 and enter the code:
 
-  WDJB-MJHT
+  jPqK6Qvs
 
 You have 5 minutes to approve this request.
 
-Opening a link in your default browser: https://dash.cloudflare.com/oauth2/device?user_code=WDJB-MJHT
+Opening a link in your default browser: https://dash.cloudflare.com/oauth2/device?user_code=jPqK6Qvs
 Successfully logged in.
 ```
 

--- a/src/content/docs/workers/wrangler/commands/general.mdx
+++ b/src/content/docs/workers/wrangler/commands/general.mdx
@@ -141,11 +141,11 @@ To authorize Wrangler, please visit:
 
 and enter the code:
 
-  WDJB-MJHT
+  jPqK6Qvs
 
 You have 5 minutes to approve this request.
 
-Opening a link in your default browser: https://dash.cloudflare.com/oauth2/device?user_code=WDJB-MJHT
+Opening a link in your default browser: https://dash.cloudflare.com/oauth2/device?user_code=jPqK6Qvs
 Successfully logged in.
 ```
 


### PR DESCRIPTION
### Summary

Updates the `wrangler login --device` examples to use the device-code format returned by Cloudflare.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
