### PR TITLE
[Pages] Recommend Workers for new projects

### DIFF
--- a/src/content/docs/pages/framework-guides/index.mdx
+++ b/src/content/docs/pages/framework-guides/index.mdx
@@ -10,6 +10,8 @@ products:
   - pages
 ---
 
-import { DirectoryListing } from "~/components";
+import { DirectoryListing, Render } from "~/components";
+
+<Render file="workers-for-new-projects" product="pages" />
 
 <DirectoryListing />

--- a/src/content/docs/pages/get-started/index.mdx
+++ b/src/content/docs/pages/get-started/index.mdx
@@ -9,7 +9,9 @@ products:
 
 ---
 
-import { DirectoryListing } from "~/components";
+import { DirectoryListing, Render } from "~/components";
+
+<Render file="workers-for-new-projects" product="pages" />
 
 Choose a setup method for your Pages project:
 

--- a/src/content/docs/pages/index.mdx
+++ b/src/content/docs/pages/index.mdx
@@ -22,6 +22,8 @@ import {
 	Aside,
 } from "~/components";
 
+<Render file="workers-for-new-projects" product="pages" />
+
 <Description>
 
 Create full-stack applications that are instantly deployed to the Cloudflare global network.

--- a/src/content/docs/pages/migrations/index.mdx
+++ b/src/content/docs/pages/migrations/index.mdx
@@ -11,6 +11,8 @@ products:
 
 ---
 
-import { DirectoryListing } from "~/components";
+import { DirectoryListing, Render } from "~/components";
+
+<Render file="workers-for-new-projects" product="pages" />
 
 <DirectoryListing />

--- a/src/content/partials/pages/workers-for-new-projects.mdx
+++ b/src/content/partials/pages/workers-for-new-projects.mdx
@@ -1,0 +1,7 @@
+---
+{}
+---
+
+:::note[Are you sure you want to use Pages?]
+[Workers supports most Pages use cases and offers a broader feature set](/workers/static-assets/migration-guides/migrate-from-pages/). It is Cloudflare's primary platform for building applications. Start new projects with Workers.
+:::


### PR DESCRIPTION
### Summary

Adds a reusable note to the Pages overview, Get started, Framework guides, and Migrations entry points. The note recommends Workers as Cloudflare's primary application platform for new projects while directing readers to the Pages-to-Workers migration guidance.

### Screenshots (optional)

<!-- TODO: add screenshots before requesting review -->

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
