### PR TITLE
chore: initialize Outdated PR Check / Scheduled on PR events

### DIFF
--- a/.github/workflows/outdated-pr-check.yml
+++ b/.github/workflows/outdated-pr-check.yml
@@ -96,13 +96,24 @@ jobs:
             -f description="$DESCRIPTION" \
             || echo "Failed to post status — skipping"
 
-          # Post the new semantic context (additive — will become required after branch
-          # protection is updated and the legacy context is removed in a follow-up PR).
+          # Post the on-commit semantic context.
           gh api \
             --method POST \
             -H "Accept: application/vnd.github+json" \
             "/repos/${REPO}/statuses/${PR_SHA}" \
             -f state="$STATE" \
             -f context="Outdated PR Check / On Commit" \
+            -f description="$DESCRIPTION" \
+            || echo "Failed to post status — skipping"
+
+          # Initialize the scheduled semantic context with the same result so the
+          # required check exists immediately. The daily refresh workflow updates
+          # this context as production advances.
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/${REPO}/statuses/${PR_SHA}" \
+            -f state="$STATE" \
+            -f context="Outdated PR Check / Scheduled" \
             -f description="$DESCRIPTION" \
             || echo "Failed to post status — skipping"


### PR DESCRIPTION
### Summary

Follow-up to #32331. Initializes `Outdated PR Check / Scheduled` on PR open/update with the same freshness result as `On Commit`, so both semantic contexts exist immediately on every PR head SHA. The daily refresh workflow later updates `Scheduled` as production advances.

Legacy `Outdated PR Check` is kept until a follow-up removes it.

### Branch protection (after this lands)

Require both:
- `Outdated PR Check / On Commit`
- `Outdated PR Check / Scheduled`

Keep `Outdated PR Check` required until the legacy-removal follow-up merges.
