### PR TITLE
chore: revert semantic Outdated PR Check contexts

### DIFF
--- a/.github/workflows/outdated-pr-check.yml
+++ b/.github/workflows/outdated-pr-check.yml
@@ -86,23 +86,11 @@ jobs:
             fi
           fi
 
-          # Post the legacy context (required by current branch protection).
           gh api \
             --method POST \
             -H "Accept: application/vnd.github+json" \
             "/repos/${REPO}/statuses/${PR_SHA}" \
             -f state="$STATE" \
             -f context="Outdated PR Check" \
-            -f description="$DESCRIPTION" \
-            || echo "Failed to post status — skipping"
-
-          # Post the new semantic context (additive — will become required after branch
-          # protection is updated and the legacy context is removed in a follow-up PR).
-          gh api \
-            --method POST \
-            -H "Accept: application/vnd.github+json" \
-            "/repos/${REPO}/statuses/${PR_SHA}" \
-            -f state="$STATE" \
-            -f context="Outdated PR Check / On Commit" \
             -f description="$DESCRIPTION" \
             || echo "Failed to post status — skipping"

--- a/.github/workflows/outdated-pr-refresh.yml
+++ b/.github/workflows/outdated-pr-refresh.yml
@@ -86,24 +86,12 @@ jobs:
               fi
             fi
 
-            # Post the legacy context (required by current branch protection).
             gh api \
               --method POST \
               -H "Accept: application/vnd.github+json" \
               "/repos/${REPO}/statuses/${PR_SHA}" \
               -f state="$STATE" \
               -f context="Outdated PR Check" \
-              -f description="$DESCRIPTION" \
-              || { echo "  Failed to post status for PR #${PR_NUMBER} — continuing"; true; }
-
-            # Post the new semantic context (additive — will become required after branch
-            # protection is updated and the legacy context is removed in a follow-up PR).
-            gh api \
-              --method POST \
-              -H "Accept: application/vnd.github+json" \
-              "/repos/${REPO}/statuses/${PR_SHA}" \
-              -f state="$STATE" \
-              -f context="Outdated PR Check / Scheduled" \
               -f description="$DESCRIPTION" \
               || { echo "  Failed to post status for PR #${PR_NUMBER} — continuing"; true; }
 


### PR DESCRIPTION
### Summary

Reverts the semantic contexts (`/ On Commit`, `/ Scheduled`) added in #32331. Both workflows go back to posting only `Outdated PR Check`, which is the existing required branch protection check. No branch protection changes needed.
