### PR TITLE
[AI Gateway] Add GPT-5.6 Sol pricing banner

### DIFF
--- a/src/content/catalog-models/openai-gpt-5.6-sol.json
+++ b/src/content/catalog-models/openai-gpt-5.6-sol.json
@@ -282,7 +282,12 @@
 		"responses"
 	],
 	"providers": null,
-	"banner": null,
+	"banner": {
+		"id": "e2dc316b-8765-407f-8405-058ab5d502c8",
+		"text": "GPT-5.6 Sol is 50% off through Sept 18",
+		"severity": "info",
+		"dismissible": true
+	},
 	"created_at": "2026-07-10 02:48:18",
 	"schema": {
 		"input": {


### PR DESCRIPTION
### Summary

Adds the current promotional banner for GPT-5.6 Sol to the AI Gateway model catalog so users see that the model is 50% off through September 18.

### Documentation checklist

- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
