### PR TITLE
[AI Gateway] Add changelog for GPT-5.6 Sol 50% discount promotion

### DIFF
--- a/src/content/catalog-models/openai-gpt-5.6-sol.json
+++ b/src/content/catalog-models/openai-gpt-5.6-sol.json
@@ -282,7 +282,12 @@
 		"responses"
 	],
 	"providers": null,
-	"banner": null,
+	"banner": {
+		"id": "e2dc316b-8765-407f-8405-058ab5d502c8",
+		"text": "GPT-5.6 Sol is 50% off through Sept 18",
+		"severity": "info",
+		"dismissible": true
+	},
 	"created_at": "2026-07-10 02:48:18",
 	"schema": {
 		"input": {

--- a/src/content/changelog/ai-gateway/2026-08-19-gpt-5-6-sol-discount.mdx
+++ b/src/content/changelog/ai-gateway/2026-08-19-gpt-5-6-sol-discount.mdx
@@ -1,0 +1,23 @@
+---
+title: Get 50% off GPT-5.6 Sol through AI Gateway
+description: Save 50% on GPT-5.6 Sol routed through AI Gateway Unified Billing until September 18, 2026.
+products:
+  - ai-gateway
+date: 2026-08-19
+---
+
+GPT-5.6 Sol is available through AI Gateway, and for a limited time you can use it at 50% off. If you are already using AI Gateway, point to the `openai/gpt-5.6-sol` model and the discounted pricing applies automatically — no promo code needed.
+
+The promotion is available for [Unified Billing](/ai-gateway/features/unified-billing/) users only (not [Bring Your Own Keys](/ai-gateway/configuration/bring-your-own-keys/)). Load credits onto AI Gateway and start sending requests to `openai/gpt-5.6-sol`.
+
+Discounted pricing during the promotion:
+
+| Usage      | Promotional price | Standard price |
+| ---------- | ----------------- | -------------- |
+| Input      | $2.50 per 1M tokens | $5 per 1M tokens |
+| Output     | $15 per 1M tokens | $30 per 1M tokens |
+| Cache read | $0.25 per 1M tokens | $0.50 per 1M tokens |
+
+The promotion runs through September 18, 2026. After that date, GPT-5.6 Sol requests return to standard pricing.
+
+For more details, refer to the [Unified Billing documentation](/ai-gateway/features/unified-billing/) and the [GPT-5.6 Sol model page](/ai/models/openai/gpt-5.6-sol/).


### PR DESCRIPTION
### Summary

Adds a changelog entry announcing a limited-time promotion offering 50% off GPT-5.6 Sol when routed through AI Gateway with Unified Billing (not BYOK). The entry documents the discounted pricing and the September 18, 2026 end date.

### Documentation checklist

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
