### PR TITLE
[Access] Document granular resource list permissions

### DIFF
--- a/src/content/changelog/access/2026-08-19-granular-permissions-resource-lists.mdx
+++ b/src/content/changelog/access/2026-08-19-granular-permissions-resource-lists.mdx
@@ -1,14 +1,14 @@
 ---
-title: Granular permissions filter Access resource lists
-description: Access resource lists are filtered to assigned resources for members without account-scoped Access permissions.
+title: Granular permissions now filter Access resource lists
+description: Members with granular Access permissions only see the applications, policies, service tokens, and identity providers assigned to them.
 date: 2026-08-19
 products:
   - fundamentals
 ---
 
-Members with resource-scoped Access roles can now view the resources they are allowed to access without an additional account-scoped role. Access filters resource lists based on each member's assigned roles.
+Members with granular Access permissions now only see the Access resources assigned to them. You can give different teams access to the applications, policies, service tokens, and identity providers they manage without showing them unrelated resources.
 
-This filtering applies to Access applications, policies, service tokens, and identity providers. Members with account-scoped Access permissions continue to see all resources in the account.
+For example, you can assign one set of Access applications to an engineering team and another set to a support team. Each team only sees the applications relevant to its work. Members with account-scoped Access permissions continue to see all resources in the account.
 
 The Cloudflare Access App Admin role also includes policies attached directly to the selected application. Reusable policies still require a separate Cloudflare Access Policy Admin role.
 

--- a/src/content/changelog/access/2026-08-19-granular-permissions-resource-lists.mdx
+++ b/src/content/changelog/access/2026-08-19-granular-permissions-resource-lists.mdx
@@ -1,0 +1,15 @@
+---
+title: Granular permissions filter Access resource lists
+description: Access resource lists are filtered to assigned resources for members without account-scoped Access permissions.
+date: 2026-08-19
+products:
+  - fundamentals
+---
+
+Members with resource-scoped Access roles can now view the resources they are allowed to access without an additional account-scoped role. Access filters resource lists based on each member's assigned roles.
+
+This filtering applies to Access applications, policies, service tokens, and identity providers. Members with account-scoped Access permissions continue to see all resources in the account.
+
+The Cloudflare Access App Admin role also includes policies attached directly to the selected application. Reusable policies still require a separate Cloudflare Access Policy Admin role.
+
+For more information, refer to [Resource-scoped roles](/fundamentals/manage-members/roles/#resource-scoped-roles).

--- a/src/content/changelog/access/2026-08-19-granular-permissions-resource-lists.mdx
+++ b/src/content/changelog/access/2026-08-19-granular-permissions-resource-lists.mdx
@@ -1,14 +1,16 @@
 ---
-title: Granular permissions now filter Access resource lists
-description: Members with granular Access permissions only see the applications, policies, service tokens, and identity providers assigned to them.
+title: Resource lists now support granular Access permissions
+description: Members with granular Access permissions can view Access resource lists filtered to the resources assigned to them.
 date: 2026-08-19
 products:
   - fundamentals
 ---
 
-Members with granular Access permissions now only see the Access resources assigned to them. You can give different teams access to the applications, policies, service tokens, and identity providers they manage without showing them unrelated resources.
+Access resource list pages and APIs now support granular permissions. Members can open list pages in the Cloudflare dashboard and make list API requests. Results include only the applications, policies, service tokens, and identity providers assigned to them.
 
-For example, you can assign one set of Access applications to an engineering team and another set to a support team. Each team only sees the applications relevant to its work. Members with account-scoped Access permissions continue to see all resources in the account.
+Previously, members whose only Access permissions were granular could not open resource list pages. List API requests returned `403` responses.
+
+You can assign one set of Access applications to an engineering team and another set to a support team. Each team sees only the applications relevant to its work. Members with account-scoped Access permissions continue to see all resources in the account.
 
 The Cloudflare Access App Admin role also includes policies attached directly to the selected application. Reusable policies still require a separate Cloudflare Access Policy Admin role.
 

--- a/src/content/changelog/access/2026-08-19-granular-permissions-resource-lists.mdx
+++ b/src/content/changelog/access/2026-08-19-granular-permissions-resource-lists.mdx
@@ -1,16 +1,16 @@
 ---
-title: Resource lists now support granular Access permissions
-description: Members with granular Access permissions can view Access resource lists filtered to the resources assigned to them.
+title: Access resource lists now support resource-scoped roles
+description: Members with resource-scoped Access roles can list only the applications, policies, service tokens, and identity providers they can manage.
 date: 2026-08-19
 products:
   - access
   - fundamentals
 ---
 
-Access resource list pages and APIs now support granular permissions. Members can open list pages in the Cloudflare dashboard and make list API requests. Results include only the applications, policies, service tokens, and identity providers assigned to them.
+Members with only resource-scoped Access roles can now open Access resource list pages in the Cloudflare dashboard and call list endpoints in the API. They no longer need an additional account-scoped read-only role to list resources.
 
-Previously, members whose only Access permissions were granular could not open resource list pages. List API requests returned `403` responses. Administrators can now limit Access resources to specific members or teams. Members can view only the resources assigned to them in the dashboard and API.
+The dashboard and API return only resources included in the member's permission policy scopes. Filtering applies to Access applications, policies, service tokens, and identity providers. This allows administrators to delegate specific Access resources without granting account-wide visibility. Previously, the dashboard blocked these list pages and API list requests returned `403` responses.
 
-The Cloudflare Access App Admin role also includes policies attached directly to the selected application. Reusable policies still require a separate Cloudflare Access Policy Admin role.
+For members with the Cloudflare Access App Admin role, policy lists include policies attached directly to the selected application. Reusable policies appear only when the member has the Cloudflare Access Policy Admin role for those policies.
 
-For more information, refer to [Resource-scoped roles](/fundamentals/manage-members/roles/#resource-scoped-roles).
+For role definitions and assignment details, refer to [Resource-scoped roles](/fundamentals/manage-members/roles/#resource-scoped-roles) and [Role scopes](/fundamentals/manage-members/scope/).

--- a/src/content/changelog/access/2026-08-19-granular-permissions-resource-lists.mdx
+++ b/src/content/changelog/access/2026-08-19-granular-permissions-resource-lists.mdx
@@ -3,13 +3,13 @@ title: Resource lists now support granular Access permissions
 description: Members with granular Access permissions can view Access resource lists filtered to the resources assigned to them.
 date: 2026-08-19
 products:
+  - access
   - fundamentals
 ---
 
 Access resource list pages and APIs now support granular permissions. Members can open list pages in the Cloudflare dashboard and make list API requests. Results include only the applications, policies, service tokens, and identity providers assigned to them.
 
-Previously, members whose only Access permissions were granular could not open resource list pages. List API requests returned `403` responses. Administrators can now limit Access resources to specific members or teams, with each member only being able to view the resources they've been granted to via the Dashboard & API.
-Administrators can now limit Access resources to specific members or teams.
+Previously, members whose only Access permissions were granular could not open resource list pages. List API requests returned `403` responses. Administrators can now limit Access resources to specific members or teams. Members can view only the resources assigned to them in the dashboard and API.
 
 The Cloudflare Access App Admin role also includes policies attached directly to the selected application. Reusable policies still require a separate Cloudflare Access Policy Admin role.
 

--- a/src/content/changelog/access/2026-08-19-granular-permissions-resource-lists.mdx
+++ b/src/content/changelog/access/2026-08-19-granular-permissions-resource-lists.mdx
@@ -10,7 +10,7 @@ Access resource list pages and APIs now support granular permissions. Members ca
 
 Previously, members whose only Access permissions were granular could not open resource list pages. List API requests returned `403` responses.
 
-You can assign one set of Access applications to an engineering team and another set to a support team. Each team sees only the applications relevant to its work. Members with account-scoped Access permissions continue to see all resources in the account.
+Administrators can now limit Access resources to specific members or teams.
 
 The Cloudflare Access App Admin role also includes policies attached directly to the selected application. Reusable policies still require a separate Cloudflare Access Policy Admin role.
 

--- a/src/content/changelog/access/2026-08-19-granular-permissions-resource-lists.mdx
+++ b/src/content/changelog/access/2026-08-19-granular-permissions-resource-lists.mdx
@@ -9,7 +9,6 @@ products:
 Access resource list pages and APIs now support granular permissions. Members can open list pages in the Cloudflare dashboard and make list API requests. Results include only the applications, policies, service tokens, and identity providers assigned to them.
 
 Previously, members whose only Access permissions were granular could not open resource list pages. List API requests returned `403` responses.
-
 Administrators can now limit Access resources to specific members or teams.
 
 The Cloudflare Access App Admin role also includes policies attached directly to the selected application. Reusable policies still require a separate Cloudflare Access Policy Admin role.

--- a/src/content/changelog/access/2026-08-19-granular-permissions-resource-lists.mdx
+++ b/src/content/changelog/access/2026-08-19-granular-permissions-resource-lists.mdx
@@ -8,7 +8,7 @@ products:
 
 Access resource list pages and APIs now support granular permissions. Members can open list pages in the Cloudflare dashboard and make list API requests. Results include only the applications, policies, service tokens, and identity providers assigned to them.
 
-Previously, members whose only Access permissions were granular could not open resource list pages. List API requests returned `403` responses.
+Previously, members whose only Access permissions were granular could not open resource list pages. List API requests returned `403` responses. Administrators can now limit Access resources to specific members or teams, with each member only being able to view the resources they've been granted to via the Dashboard & API.
 Administrators can now limit Access resources to specific members or teams.
 
 The Cloudflare Access App Admin role also includes policies attached directly to the selected application. Reusable policies still require a separate Cloudflare Access Policy Admin role.

--- a/src/content/docs/fundamentals/manage-members/roles.mdx
+++ b/src/content/docs/fundamentals/manage-members/roles.mdx
@@ -139,3 +139,9 @@ Resource-scoped roles is currently in Beta.
 | Access for Infrastructure Target Admin    | Can edit a specific [Access for Infrastructure target](/cloudflare-one/access-controls/applications/non-http/infrastructure-apps/) in an account.                                                                                                                           |
 | Individual Cloudflare Tunnel instances    | Scopes permissions to a specific [Cloudflare Tunnel](/cloudflare-one/networks/connectors/cloudflare-tunnel/) instance. Refer to [Granular permissions for Cloudflare Tunnel](/cloudflare-one/networks/connectors/granular-permissions/) for details.                         |
 | Individual Cloudflare Mesh nodes          | Scopes permissions to a specific [Cloudflare Mesh](/cloudflare-one/networks/connectors/cloudflare-mesh/) node. Refer to [Granular permissions for Cloudflare Tunnel and Cloudflare Mesh](/cloudflare-one/networks/connectors/granular-permissions/) for details. |
+
+### Access resource visibility
+
+For members without account-scoped Access permissions, Access list responses are filtered by resource-scoped roles. These members only see the applications, policies, service tokens, and identity providers that their assigned roles allow them to access.
+
+The Cloudflare Access App Admin role includes policies attached directly to the selected application. Reusable policies require a separate Cloudflare Access Policy Admin role.

--- a/src/content/docs/fundamentals/manage-members/roles.mdx
+++ b/src/content/docs/fundamentals/manage-members/roles.mdx
@@ -139,9 +139,3 @@ Resource-scoped roles is currently in Beta.
 | Access for Infrastructure Target Admin    | Can edit a specific [Access for Infrastructure target](/cloudflare-one/access-controls/applications/non-http/infrastructure-apps/) in an account.                                                                                                                           |
 | Individual Cloudflare Tunnel instances    | Scopes permissions to a specific [Cloudflare Tunnel](/cloudflare-one/networks/connectors/cloudflare-tunnel/) instance. Refer to [Granular permissions for Cloudflare Tunnel](/cloudflare-one/networks/connectors/granular-permissions/) for details.                         |
 | Individual Cloudflare Mesh nodes          | Scopes permissions to a specific [Cloudflare Mesh](/cloudflare-one/networks/connectors/cloudflare-mesh/) node. Refer to [Granular permissions for Cloudflare Tunnel and Cloudflare Mesh](/cloudflare-one/networks/connectors/granular-permissions/) for details. |
-
-### Access resource visibility
-
-For members without account-scoped Access permissions, Access list responses are filtered by resource-scoped roles. These members only see the applications, policies, service tokens, and identity providers that their assigned roles allow them to access.
-
-The Cloudflare Access App Admin role includes policies attached directly to the selected application. Reusable policies require a separate Cloudflare Access Policy Admin role.


### PR DESCRIPTION
## Summary

- document authorization-aware filtering for Access resource lists
- clarify how app-attached and reusable policies inherit granular permissions
- add an Access changelog entry

## Tests

- `pnpm run check`
- `pnpm run format:core:check`