### PR TITLE
[Logs] Update Logpush dataset field definitions (2026-08-20)

### DIFF
--- a/src/content/changelog/logs/2026-08-20-log-fields-updated.mdx
+++ b/src/content/changelog/logs/2026-08-20-log-fields-updated.mdx
@@ -1,0 +1,20 @@
+---
+title: New Logpush datasets and updated fields across multiple Logpush datasets in Cloudflare Logs
+description: New Logpush datasets are now available, and fields have been updated across multiple Logpush datasets in Cloudflare Logs.
+date: 2026-08-20
+---
+
+Cloudflare has updated [Logpush datasets](/logs/logpush/logpush-job/datasets/):
+
+### New datasets
+
+- **Account Abuse Protection Events**: A new dataset with fields including `AuthenticationIdentityProvider`, `AuthenticationMethod`, `AuthenticationStatus`, `BotScore`, `ClientASN`, `ClientCity`, `ClientCountry`, `ClientIP`, `Email`, `EphemeralID`, `EventSource`, `EventType`, `FraudEmailRisk`, `Host`, `JA4`, `RayID`, `Timestamp`, `UserAgent`, and `UserID`.
+- **Magic BGP Logs**: A new dataset with fields including `Direction`, `EventData`, `EventKind`, `EventTimestamp`, `TunnelID`, and `TunnelName`.
+
+### Updated fields in existing datasets
+
+- **Firewall events** (added): `AISecurityCustomTopicCategories`, `WAFRequestSignatureCategories`, and `WAFRequestSignatureRefs`.
+- **Gateway HTTP** (added): `ExperimentalFeatures` and `PackageInfo`.
+- **HTTP requests** (added): `AISecurityCustomTopicCategories`, `ClientTLSKeyExchangeGroup`, `WAFRequestSignatureCategories`, and `WAFRequestSignatureRefs`.
+
+For the complete field definitions for each dataset, refer to [Logpush datasets](/logs/logpush/logpush-job/datasets/).

--- a/src/content/docs/logs/logpush/logpush-job/datasets/account/account_abuse_protection_events.md
+++ b/src/content/docs/logs/logpush/logpush-job/datasets/account/account_abuse_protection_events.md
@@ -1,0 +1,124 @@
+---
+# Code generator. DO NOT EDIT.
+
+title: Account Abuse Protection Events
+pcx_content_type: configuration
+sidebar:
+  order: 21
+---
+
+The descriptions below detail the fields available for `account_abuse_protection_events`.
+
+## AuthenticationIdentityProvider
+
+Type: `string`
+
+The identity provider used for login authentication. Only populated for login events. <br />Possible values are <em>unknown</em> \| <em>other</em> \| <em>selfHosted</em> \| <em>amazon</em> \| <em>apple</em> \| <em>discord</em> \| <em>facebook</em> \| <em>github</em> \| <em>linkedin</em> \| <em>microsoft</em>.
+
+## AuthenticationMethod
+
+Type: `string`
+
+The authentication method used for login. Only populated for login events. <br />Possible values are <em>unknown</em> \| <em>password</em> \| <em>sso</em> \| <em>magicLink</em> \| <em>biometric</em> \| <em>passkey</em>.
+
+## AuthenticationStatus
+
+Type: `string`
+
+The outcome of a login attempt. Only populated for login events. <br />Possible values are <em>unknown</em> \| <em>other</em> \| <em>success</em> \| <em>failureOther</em> \| <em>failureUserNotFound</em> \| <em>failureIncorrectPassword</em> \| <em>failureAccountLocked</em> \| <em>pendingMfa</em>.
+
+## BotScore
+
+Type: `int`
+
+Cloudflare Bot Management score. Values from 1 (likely bot) to 99 (likely human).
+
+## ClientASN
+
+Type: `int`
+
+Client AS number.
+
+## ClientCity
+
+Type: `string`
+
+Approximate city of the client.
+
+## ClientCountry
+
+Type: `string`
+
+2-letter ISO-3166 country code of the client IP address.
+
+## ClientIP
+
+Type: `string`
+
+IP address of the client.
+
+## Email
+
+Type: `string`
+
+The email address associated with the event.
+
+## EphemeralID
+
+Type: `string`
+
+The Turnstile ephemeral device identifier, hex-encoded.
+
+## EventSource
+
+Type: `string`
+
+The source of the Account Abuse Protection event. <br />Possible values are <em>cdn</em> \| <em>api</em>.
+
+## EventType
+
+Type: `string`
+
+The type of user action. <br />Possible values are <em>login</em> \| <em>logout</em> \| <em>signup</em> \| <em>warpEnrollment</em> \| <em>profileUpdate</em> \| <em>transaction</em> \| <em>unknown</em> \| <em>passwordReset</em> \| <em>addPaymentMethod</em>.
+
+## FraudEmailRisk
+
+Type: `string`
+
+Risk level of the email address. <br />Possible values are <em>Unknown</em> \| <em>Low</em> \| <em>Medium</em> \| <em>High</em>.
+
+## Host
+
+Type: `string`
+
+The HTTP hostname requested by the visitor.
+
+## JA4
+
+Type: `string`
+
+The JA4 TLS client fingerprint.
+
+## RayID
+
+Type: `string`
+
+The RayID of the request.
+
+## Timestamp
+
+Type: `int or string`
+
+The date and time the event occurred. To specify the timestamp format, refer to [Output types](/logs/logpush/logpush-job/log-output-options/#output-types).
+
+## UserAgent
+
+Type: `string`
+
+The user-agent string of the visitor.
+
+## UserID
+
+Type: `string`
+
+A zone-unique identifier for the user, hex-encoded. Derived from the external user identifier provided during event submission.

--- a/src/content/docs/logs/logpush/logpush-job/datasets/account/firewall_events.md
+++ b/src/content/docs/logs/logpush/logpush-job/datasets/account/firewall_events.md
@@ -9,6 +9,12 @@ sidebar:
 
 The descriptions below detail the fields available for `firewall_events`.
 
+## AISecurityCustomTopicCategories
+
+Type: `object`
+
+Customer-defined AI Security topic labels and their relevance scores. A score of 1 indicates the highest relevance, and 99 indicates the lowest relevance.
+
 ## AISecurityInjectionScore
 
 Type: `int`
@@ -266,6 +272,18 @@ The Cloudflare security product-specific RuleID triggered by this request.
 Type: `string`
 
 The Cloudflare security product triggered by this request. <br />Possible sources are <em>unknown</em> \| <em>asn</em> \| <em>country</em> \| <em>ip</em> \| <em>iprange</em> \| <em>securitylevel</em> \| <em>zonelockdown</em> \| <em>waf</em> \| <em>firewallrules</em> \| <em>uablock</em> \| <em>ratelimit</em> \| <em>bic</em> \| <em>hot</em> \| <em>l7ddos</em> \| <em>validation</em> \| <em>botfight</em> \| <em>apishield</em> \| <em>botmanagement</em> \| <em>dlp</em> \| <em>firewallmanaged</em> \| <em>firewallcustom</em> \| <em>apishieldschemavalidation</em> \| <em>apishieldtokenvalidation</em> \| <em>apishieldsequencemitigation</em>.
+
+## WAFRequestSignatureCategories
+
+Type: `array[string]`
+
+List of attack signature categories matched for the request.
+
+## WAFRequestSignatureRefs
+
+Type: `array[string]`
+
+List of attack signature rule references (refs) matched for the request.
 
 ## ZoneName
 

--- a/src/content/docs/logs/logpush/logpush-job/datasets/account/gateway_http.md
+++ b/src/content/docs/logs/logpush/logpush-job/datasets/account/gateway_http.md
@@ -165,6 +165,12 @@ Type: `string`
 
 Email used to authenticate the client.
 
+## ExperimentalFeatures
+
+Type: `object`
+
+Experimental features which will be either permanently added to the schema or marked for deprecation. In that case, they will be removed 3 months after the notice. Current fields: 'mcp' - If MCP traffic was detected or not.
+
 ## FileInfo
 
 Type: `object`
@@ -206,6 +212,12 @@ Version name for the HTTP request.
 Type: `bool`
 
 If the requested was isolated with Cloudflare Browser Isolation or not.
+
+## PackageInfo
+
+Type: `object`
+
+Information about the software package detected in the HTTP request, including its ecosystem, namespace, name, version, and package URL (PURL).
 
 ## PolicyID
 

--- a/src/content/docs/logs/logpush/logpush-job/datasets/account/magic_bgp_logs.md
+++ b/src/content/docs/logs/logpush/logpush-job/datasets/account/magic_bgp_logs.md
@@ -1,0 +1,46 @@
+---
+# Code generator. DO NOT EDIT.
+
+title: Magic BGP Logs
+pcx_content_type: configuration
+sidebar:
+  order: 21
+---
+
+The descriptions below detail the fields available for `magic_bgp_logs`.
+
+## Direction
+
+Type: `string`
+
+Direction of the event relative to Cloudflare. Possible values are <em>to_cloudflare</em> \| <em>from_cloudflare</em>, or empty for non-message events.
+
+## EventData
+
+Type: `object`
+
+Payload describing the event. Schema depends on `EventKind`.<br /><em>open_message</em> carries `peer_asn`, `cloudflare_asn`, `bgp_id`, `hold_time`, and `capabilities`.<br /><em>update_message</em> carries `announced`, `as_path`, and `origin`.<br /><em>notification_message</em> carries `code`, `subcode`, and `reason`.<br /><em>route_refresh_message</em> carries `afi` and `safi`.<br /><em>bgp_state_transition</em> carries `from_state`, `to_state`, and `event`.<br /><em>tcp_handshake_failed</em> carries `reason`, `message`, `src`, and `dst`.<br /><em>stale_path_timer_expired</em> carries `purged_route_count`.<br /><em>session_config_changed</em> carries `disabled` and the changed fields.<br /><em>filter_config_changed</em> carries `import` and `export` filter change flags.<br /><em>redistribute_config_changed</em> carries a single boolean.
+
+## EventKind
+
+Type: `string`
+
+BGP event type. Possible values are <em>open_message</em> \| <em>update_message</em> \| <em>notification_message</em> \| <em>route_refresh_message</em> \| <em>bgp_state_transition</em> \| <em>tcp_handshake_failed</em> \| <em>stale_path_timer_expired</em> \| <em>session_config_changed</em> \| <em>filter_config_changed</em> \| <em>redistribute_config_changed</em>.
+
+## EventTimestamp
+
+Type: `int or string`
+
+Timestamp of when the event occurred.
+
+## TunnelID
+
+Type: `string`
+
+UUID (hex, no hyphens) of the IPsec / GRE tunnel the event belongs to.
+
+## TunnelName
+
+Type: `string`
+
+Name of the IPsec / GRE tunnel the event belongs to.

--- a/src/content/docs/logs/logpush/logpush-job/datasets/zone/account_abuse_protection_events.md
+++ b/src/content/docs/logs/logpush/logpush-job/datasets/zone/account_abuse_protection_events.md
@@ -1,0 +1,124 @@
+---
+# Code generator. DO NOT EDIT.
+
+title: Account Abuse Protection Events
+pcx_content_type: configuration
+sidebar:
+  order: 21
+---
+
+The descriptions below detail the fields available for `account_abuse_protection_events`.
+
+## AuthenticationIdentityProvider
+
+Type: `string`
+
+The identity provider used for login authentication. Only populated for login events. <br />Possible values are <em>unknown</em> \| <em>other</em> \| <em>selfHosted</em> \| <em>amazon</em> \| <em>apple</em> \| <em>discord</em> \| <em>facebook</em> \| <em>github</em> \| <em>linkedin</em> \| <em>microsoft</em>.
+
+## AuthenticationMethod
+
+Type: `string`
+
+The authentication method used for login. Only populated for login events. <br />Possible values are <em>unknown</em> \| <em>password</em> \| <em>sso</em> \| <em>magicLink</em> \| <em>biometric</em> \| <em>passkey</em>.
+
+## AuthenticationStatus
+
+Type: `string`
+
+The outcome of a login attempt. Only populated for login events. <br />Possible values are <em>unknown</em> \| <em>other</em> \| <em>success</em> \| <em>failureOther</em> \| <em>failureUserNotFound</em> \| <em>failureIncorrectPassword</em> \| <em>failureAccountLocked</em> \| <em>pendingMfa</em>.
+
+## BotScore
+
+Type: `int`
+
+Cloudflare Bot Management score. Values from 1 (likely bot) to 99 (likely human).
+
+## ClientASN
+
+Type: `int`
+
+Client AS number.
+
+## ClientCity
+
+Type: `string`
+
+Approximate city of the client.
+
+## ClientCountry
+
+Type: `string`
+
+2-letter ISO-3166 country code of the client IP address.
+
+## ClientIP
+
+Type: `string`
+
+IP address of the client.
+
+## Email
+
+Type: `string`
+
+The email address associated with the event.
+
+## EphemeralID
+
+Type: `string`
+
+The Turnstile ephemeral device identifier, hex-encoded.
+
+## EventSource
+
+Type: `string`
+
+The source of the Account Abuse Protection event. <br />Possible values are <em>cdn</em> \| <em>api</em>.
+
+## EventType
+
+Type: `string`
+
+The type of user action. <br />Possible values are <em>login</em> \| <em>logout</em> \| <em>signup</em> \| <em>warpEnrollment</em> \| <em>profileUpdate</em> \| <em>transaction</em> \| <em>unknown</em> \| <em>passwordReset</em> \| <em>addPaymentMethod</em>.
+
+## FraudEmailRisk
+
+Type: `string`
+
+Risk level of the email address. <br />Possible values are <em>Unknown</em> \| <em>Low</em> \| <em>Medium</em> \| <em>High</em>.
+
+## Host
+
+Type: `string`
+
+The HTTP hostname requested by the visitor.
+
+## JA4
+
+Type: `string`
+
+The JA4 TLS client fingerprint.
+
+## RayID
+
+Type: `string`
+
+The RayID of the request.
+
+## Timestamp
+
+Type: `int or string`
+
+The date and time the event occurred. To specify the timestamp format, refer to [Output types](/logs/logpush/logpush-job/log-output-options/#output-types).
+
+## UserAgent
+
+Type: `string`
+
+The user-agent string of the visitor.
+
+## UserID
+
+Type: `string`
+
+A zone-unique identifier for the user, hex-encoded. Derived from the external user identifier provided during event submission.

--- a/src/content/docs/logs/logpush/logpush-job/datasets/zone/firewall_events.md
+++ b/src/content/docs/logs/logpush/logpush-job/datasets/zone/firewall_events.md
@@ -9,6 +9,12 @@ sidebar:
 
 The descriptions below detail the fields available for `firewall_events`.
 
+## AISecurityCustomTopicCategories
+
+Type: `object`
+
+Customer-defined AI Security topic labels and their relevance scores. A score of 1 indicates the highest relevance, and 99 indicates the lowest relevance.
+
 ## AISecurityInjectionScore
 
 Type: `int`
@@ -266,6 +272,18 @@ The Cloudflare security product-specific RuleID triggered by this request.
 Type: `string`
 
 The Cloudflare security product triggered by this request. <br />Possible sources are <em>unknown</em> \| <em>asn</em> \| <em>country</em> \| <em>ip</em> \| <em>iprange</em> \| <em>securitylevel</em> \| <em>zonelockdown</em> \| <em>waf</em> \| <em>firewallrules</em> \| <em>uablock</em> \| <em>ratelimit</em> \| <em>bic</em> \| <em>hot</em> \| <em>l7ddos</em> \| <em>validation</em> \| <em>botfight</em> \| <em>apishield</em> \| <em>botmanagement</em> \| <em>dlp</em> \| <em>firewallmanaged</em> \| <em>firewallcustom</em> \| <em>apishieldschemavalidation</em> \| <em>apishieldtokenvalidation</em> \| <em>apishieldsequencemitigation</em>.
+
+## WAFRequestSignatureCategories
+
+Type: `array[string]`
+
+List of attack signature categories matched for the request.
+
+## WAFRequestSignatureRefs
+
+Type: `array[string]`
+
+List of attack signature rule references (refs) matched for the request.
 
 ## ZoneName
 

--- a/src/content/docs/logs/logpush/logpush-job/datasets/zone/http_requests.md
+++ b/src/content/docs/logs/logpush/logpush-job/datasets/zone/http_requests.md
@@ -9,6 +9,12 @@ sidebar:
 
 The descriptions below detail the fields available for `http_requests`.
 
+## AISecurityCustomTopicCategories
+
+Type: `object`
+
+Customer-defined AI Security topic labels and their relevance scores. A score of 1 indicates the highest relevance, and 99 indicates the lowest relevance.
+
 ## AISecurityInjectionScore
 
 Type: `int`
@@ -248,6 +254,12 @@ Client source port.
 Type: `int`
 
 The smoothed average of TCP round-trip time (SRTT). For the initial request on a connection, this is measured only during connection setup. For a subsequent request on the same connection, it is measured over the entire connection lifetime up until the time that request is received.
+
+## ClientTLSKeyExchangeGroup
+
+Type: `string`
+
+TLS key exchange group between the client and Cloudflare (for example, 'X25519MLKEM768'). 'UNK' means it could not be determined. 'NONE' means TLS was not used.
 
 ## ClientXRequestedWith
 
@@ -656,6 +668,18 @@ The full name of the most-recently matched variable.
 Type: `int`
 
 WAF score for an RCE attack.
+
+## WAFRequestSignatureCategories
+
+Type: `array[string]`
+
+List of attack signature categories matched for the request.
+
+## WAFRequestSignatureRefs
+
+Type: `array[string]`
+
+List of attack signature rule references (refs) matched for the request.
 
 ## WAFSQLiAttackScore
 


### PR DESCRIPTION
## Summary

Automated sync of Logpush dataset field definitions from [data/entities](https://gitlab.cfdata.org/cloudflare/data/entities).

### New datasets

- **Account Abuse Protection Events**: A new dataset with fields including `AuthenticationIdentityProvider`, `AuthenticationMethod`, `AuthenticationStatus`, `BotScore`, `ClientASN`, `ClientCity`, `ClientCountry`, `ClientIP`, `Email`, `EphemeralID`, `EventSource`, `EventType`, `FraudEmailRisk`, `Host`, `JA4`, `RayID`, `Timestamp`, `UserAgent`, and `UserID`.
- **Magic BGP Logs**: A new dataset with fields including `Direction`, `EventData`, `EventKind`, `EventTimestamp`, `TunnelID`, and `TunnelName`.
- **Account Abuse Protection Events**: A new dataset with fields including `AuthenticationIdentityProvider`, `AuthenticationMethod`, `AuthenticationStatus`, `BotScore`, `ClientASN`, `ClientCity`, `ClientCountry`, `ClientIP`, `Email`, `EphemeralID`, `EventSource`, `EventType`, `FraudEmailRisk`, `Host`, `JA4`, `RayID`, `Timestamp`, `UserAgent`, and `UserID`.

### Updated fields in existing datasets

- **Firewall events** (added): `AISecurityCustomTopicCategories`, `WAFRequestSignatureCategories`, and `WAFRequestSignatureRefs`.
- **Gateway HTTP** (added): `ExperimentalFeatures` and `PackageInfo`.
- **Firewall events** (added): `AISecurityCustomTopicCategories`, `WAFRequestSignatureCategories`, and `WAFRequestSignatureRefs`.
- **HTTP requests** (added): `AISecurityCustomTopicCategories`, `ClientTLSKeyExchangeGroup`, `WAFRequestSignatureCategories`, and `WAFRequestSignatureRefs`.

### Files changed
- `src/content/docs/logs/logpush/logpush-job/datasets/account/` — dataset pages
- `src/content/docs/logs/logpush/logpush-job/datasets/zone/` — dataset pages
- `src/content/changelog/logs/2026-08-20-log-fields-updated.mdx` — changelog

### Documentation checklist
- [x] Changelog entry added
- [x] Content generated by code generator (DO NOT EDIT manually)
