### PR TITLE
[DO] Document disabling alarm retries after abort

### DIFF
--- a/src/content/changelog/durable-objects/2026-08-25-durable-object-alarm-abort-no-retry.mdx
+++ b/src/content/changelog/durable-objects/2026-08-25-durable-object-alarm-abort-no-retry.mdx
@@ -1,0 +1,37 @@
+---
+title: Prevent Durable Object alarm retries when using `ctx.abort()`
+description: Prevent a Durable Object alarm from retrying when ctx.abort() resets the object.
+products:
+  - durable-objects
+date: 2026-08-25
+---
+
+import { TypeScriptExample } from "~/components";
+
+By default, an alarm interrupted by `ctx.abort()` retries after the Durable Object resets. Pass `{ retryAlarm: false }` when the alarm should stop instead:
+
+<TypeScriptExample filename="src/index.ts">
+
+```ts
+import { DurableObject } from "cloudflare:workers";
+
+export class CleanupTask extends DurableObject {
+	async alarm(): Promise<void> {
+		await this.ctx.storage.deleteAll();
+
+		this.ctx.abort("Cleanup complete", { retryAlarm: false });
+	}
+}
+```
+
+</TypeScriptExample>
+
+For example, an alarm that deletes its storage can use this option to avoid repeating the cleanup or re-running the Durable Object constructor.
+
+Alarms can run concurrently with other requests to the same Durable Object. If another request calls `ctx.abort()` while an alarm is running, the `retryAlarm` option on that call also controls whether the alarm retries.
+
+The default retry prevents an unrelated request from permanently canceling the alarm. Set `retryAlarm: false` on every abort path that should stop an in-progress alarm, not only on calls from the alarm handler. Existing calls to `ctx.abort()` keep retrying alarms.
+
+For local development, `retryAlarm` requires Wrangler 4.126.0 or later.
+
+For more information, refer to [`ctx.abort()`](/durable-objects/api/state/#abort).

--- a/src/content/docs/durable-objects/api/state.mdx
+++ b/src/content/docs/durable-objects/api/state.mdx
@@ -301,7 +301,11 @@ If no parameter or a parameter of `0` is provided and a timeout has been previou
 
 ### `abort`
 
-`abort` is used to forcibly reset a Durable Object. A JavaScript `Error` with the message passed as a parameter will be logged. This error is not able to be caught within the application code.
+Calling `abort` immediately resets a Durable Object. The runtime logs a JavaScript `Error` with the message passed to `abort`. Application code cannot catch this error.
+
+By default, an alarm interrupted by `abort` retries after the Durable Object resets. A Durable Object can run an alarm concurrently with another request, and that request can call `abort` while the alarm is still running.
+
+The default retry prevents an unrelated request from permanently canceling the alarm. Pass `{ retryAlarm: false }` on any abort call that should prevent an interrupted alarm from retrying, including abort calls outside the alarm handler.
 
 <Tabs>
 
@@ -317,6 +321,11 @@ export class MyDurableObject extends DurableObject {
   async sayHello() {
     // Error: Hello, World! will be logged
     this.ctx.abort("Hello, World!");
+  }
+
+  async alarm() {
+    // Reset this instance without retrying the alarm
+    this.ctx.abort("Alarm complete", { retryAlarm: false });
   }
 }
 ```
@@ -340,15 +349,11 @@ class MyDurableObject(DurableObject):
 
 </Tabs>
 
-:::caution[Not available in local development]
-
-`abort` is not available in local development with the `wrangler dev` CLI command.
-
-:::
-
 #### Parameters
 
-- An optional `string` .
+- An optional `string` containing the error message to log.
+- An optional `DurableObjectAbortOptions` object:
+  - `retryAlarm` <Type text="boolean" />: Controls whether an alarm interrupted by this abort retries. It defaults to `true`.
 
 #### Return values
 


### PR DESCRIPTION
### Summary

Documents how `ctx.abort(reason, { retryAlarm: false })` resets a Durable Object without retrying its alarm. Adds a cleanup example to the changelog.

### Documentation checklist

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
