### PR TITLE
[Tunnel] Clarify ToS on large-file and streaming traffic

### DIFF
--- a/src/content/docs/cloudflare-one/faq/cloudflare-tunnels-faq.mdx
+++ b/src/content/docs/cloudflare-one/faq/cloudflare-tunnels-faq.mdx
@@ -60,6 +60,18 @@ If your server is correctly locked down, you will see:
 [ip-address] 443 (https): Connection refused
 ```
 
+## Large-file and streaming traffic through Tunnel
+
+It depends on how you route the traffic.
+
+Public hostname routes make applications available on the Internet through Cloudflare's reverse proxy. On Free, Pro, and Business plans, the [service-specific terms](https://www.cloudflare.com/service-specific-terms-application-services/#content-delivery-network-free-pro-or-business) require you to use a specific paid service to serve video and other large files.
+
+Refer to [Delivering videos with Cloudflare](/fundamentals/reference/policies-compliances/delivering-videos-with-cloudflare/) for available options, such as [Stream](/stream/).
+
+Private network routes do not publish applications to the Internet, and this restriction does not apply. Users and networks can reach these routes through the [Cloudflare One Client](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/), [Cloudflare Mesh](/cloudflare-one/networks/connectors/cloudflare-mesh/), or [Cloudflare WAN](/cloudflare-one/networks/connectors/cloudflare-wan/).
+
+For more information, refer to [Private networks](/cloudflare-one/networks/connectors/cloudflare-tunnel/private-net/).
+
 ## What records are created for routing to a Named Tunnel's hostname?
 
 Named Tunnels can be routed via DNS records, in which case we use CNAME records to point to the `<UUID>.cfargotunnel.com`; Or as Load Balancing endpoints, which also point to `<UUID>.cfargotunnel.com`.

--- a/src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/private-net/index.mdx
+++ b/src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/private-net/index.mdx
@@ -16,6 +16,10 @@ To reach private network IPs, end users must connect their device to Cloudflare 
 
 Administrators can optionally set [Gateway network policies](/cloudflare-one/traffic-policies/network-policies/) to control access to services based on user identity and device posture.
 
+:::note
+The restriction described in [Delivering videos with Cloudflare](/fundamentals/reference/policies-compliances/delivering-videos-with-cloudflare/) does not apply to private network routes. You can use these routes for large-file transfers, backups, and high-traffic workloads such as media servers.
+:::
+
 ## Connectors
 
 Here are the different ways you can connect your private network to Cloudflare:

--- a/src/content/docs/fundamentals/reference/policies-compliances/delivering-videos-with-cloudflare.mdx
+++ b/src/content/docs/fundamentals/reference/policies-compliances/delivering-videos-with-cloudflare.mdx
@@ -13,9 +13,15 @@ Cloudflare launched in 2010 believing everyone deserves a secure, fast, reliable
 
 Over time we recognized that some of our customers wanted to stream video using our network. To accommodate them, we developed our [Stream](https://www.cloudflare.com/products/cloudflare-stream/) product. Stream delivers great performance at an affordable rate charged based on how much load you place on our network.
 
-Unfortunately, while most people respect these limitations and understand they exist to ensure high quality of service for all Cloudflare customers, some users attempt to misconfigure our service to stream video in violation of our [Terms of Service](https://www.cloudflare.com/en-gb/website-terms/). We want to make sure our service is great for everyone, including public service initiatives we run like [Project Galileo](https://www.cloudflare.com/galileo/), [The Athenian Project](https://www.cloudflare.com/athenian/), and [Project Fair Shot](https://www.cloudflare.com/fair-shot/). A handful of people misusing our service limits our ability to run these initiatives.
+Unfortunately, while most people respect these limitations and understand they exist to ensure high quality of service for all Cloudflare customers, some users attempt to misconfigure our service to stream video in violation of our [service-specific terms](https://www.cloudflare.com/service-specific-terms-application-services/#content-delivery-network-free-pro-or-business). We want to make sure our service is great for everyone, including public service initiatives we run like [Project Galileo](https://www.cloudflare.com/galileo/), [The Athenian Project](https://www.cloudflare.com/athenian/), and [Project Fair Shot](https://www.cloudflare.com/fair-shot/). A handful of people misusing our service limits our ability to run these initiatives.
 
 The following are some recommendations for using Cloudflare's services based on what may have brought you to this page.
+
+:::note[Cloudflare Tunnel]
+Cloudflare Tunnel public hostname routes proxy traffic through Cloudflare. On Free, Pro, and Business plans, this traffic is subject to the terms described on this page.
+
+The restriction does not apply to private network routes. Refer to [Private networks](/cloudflare-one/networks/connectors/cloudflare-tunnel/private-net/) to route large-file or high-traffic workloads privately.
+:::
 
 ***
 

--- a/src/content/docs/tunnel/routing.mdx
+++ b/src/content/docs/tunnel/routing.mdx
@@ -28,6 +28,12 @@ You can publish multiple applications on a single tunnel. For each application, 
 
 When you add a route through the dashboard, Cloudflare automatically creates a DNS record pointing the hostname to your tunnel subdomain (`<UUID>.cfargotunnel.com`).
 
+:::note
+Public hostname routes proxy traffic through Cloudflare. On Free, Pro, and Business plans, the [service-specific terms](https://www.cloudflare.com/service-specific-terms-application-services/#content-delivery-network-free-pro-or-business) require you to use a specific paid service to serve video and other large files.
+
+Refer to [Delivering videos with Cloudflare](/fundamentals/reference/policies-compliances/delivering-videos-with-cloudflare/) for more information. To transfer large files privately, use a [private network route](/cloudflare-one/networks/connectors/cloudflare-tunnel/private-net/) instead.
+:::
+
 ## Supported protocols
 
 <Render


### PR DESCRIPTION
### Summary
Clarifies that Cloudflare Tunnel public hostname routes go through Cloudflare's CDN and are subject to the Terms of Service restriction on streaming and large file traffic. Private network routes are not subject to this restriction, since that traffic never passes through the CDN.

Adds a new FAQ entry and cross-linked notes on the Tunnel routing, private networks, and Delivering Videos with Cloudflare pages so users can find the compliant path without relying on a single community forum reply.
<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)
<img width="860" height="425" alt="image" src="https://github.com/user-attachments/assets/a71a91ad-1703-4cfc-bde4-199014ae6b53" />
<img width="870" height="543" alt="image" src="https://github.com/user-attachments/assets/3bf8bc29-cb85-41a9-bc09-e9eb82b26ce8" />
<img width="922" height="604" alt="image" src="https://github.com/user-attachments/assets/3db10f09-1cd8-45e0-9174-ea545467085c" />
<img width="861" height="799" alt="image" src="https://github.com/user-attachments/assets/fc103548-0525-4d76-8391-1a1a884a338b" />


### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
