### PR TITLE
[AI Gateway] Correct BYOK note for AI binding path

### DIFF
--- a/src/content/docs/ai-gateway/usage/worker-binding-methods.mdx
+++ b/src/content/docs/ai-gateway/usage/worker-binding-methods.mdx
@@ -89,7 +89,7 @@ const resp = await env.AI.run(
 Third-party models require an AI Gateway and use [Unified Billing](/ai-gateway/features/unified-billing/). Cloudflare manages the provider credentials and deducts credits from your account. You do not need to supply your own API keys.
 
 :::note
-[BYOK (Bring Your Own Keys)](/ai-gateway/configuration/bring-your-own-keys/) is not supported for third-party models called through the AI binding. To use your own provider keys, use the [provider-native endpoints](/ai-gateway/usage/providers/) instead.
+On the AI binding path, only a [BYOK (Bring Your Own Keys)](/ai-gateway/configuration/bring-your-own-keys/) key stored under the `default` alias is used. Keys stored under other aliases are not consulted, and the request falls through to Unified Billing. To select a non-default alias, use the [provider-native endpoints](/ai-gateway/usage/providers/) with the `cf-aig-byok-alias` header. See [credential precedence](/ai-gateway/features/unified-billing/#credential-precedence) for details.
 :::
 
 Browse available models in the [model catalog](/ai/models/).


### PR DESCRIPTION
### Summary

Fixes a contradiction between two AI Gateway pages describing BYOK behavior on the AI binding (`env.AI.run()`) path.

The [worker binding methods](https://developers.cloudflare.com/ai-gateway/usage/worker-binding-methods/) page stated BYOK was flatly "not supported for third-party models called through the AI binding." But the newer [credential precedence](https://developers.cloudflare.com/ai-gateway/features/unified-billing/#credential-precedence) section on the Unified Billing page documents that BYOK _is_ consulted on that path — a key stored under the `default` alias prevents fall-through to Unified Billing, while non-default aliases are ignored.

This aligns the older note with the more precise, more recent credential-precedence rules: on the AI binding path only the `default`-alias key is used, other aliases fall through to Unified Billing, and `cf-aig-byok-alias` on provider-native endpoints is how you select a non-default alias. Adds a link to the credential-precedence section so the two pages stay in sync.

### Documentation checklist

- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
