### PR TITLE
[Workers] Tighten overview page bullet point wording

### DIFF
--- a/src/content/docs/workers/index.mdx
+++ b/src/content/docs/workers/index.mdx
@@ -21,7 +21,7 @@ import { Description, RelatedProduct, LinkButton } from "~/components";
 
 With Cloudflare Workers, you can expect to:
 
-- Deliver fast performance with high reliability anywhere in the world
+- Deliver fast, reliable performance anywhere in the world
 - Build full-stack apps with your framework of choice, including [React](/workers/framework-guides/web-apps/react/), [Vue](/workers/framework-guides/web-apps/vue/), [Svelte](/workers/framework-guides/web-apps/sveltekit/), [Next](/workers/framework-guides/web-apps/nextjs/), [Astro](/workers/framework-guides/web-apps/astro/), [React Router](/workers/framework-guides/web-apps/react-router/), [and more](/workers/framework-guides/)
 - Use your preferred language, including [JavaScript](/workers/languages/javascript/), [TypeScript](/workers/languages/typescript/), [Python](/workers/languages/python/), [Rust](/workers/languages/rust/), [and more](/workers/runtime-apis/webassembly/)
 - Gain deep visibility and insight with built-in [observability](/workers/observability/logs/)


### PR DESCRIPTION
### Summary

Minor wording tweak on the Workers overview page — tightens the first bullet point from "Deliver fast performance with high reliability anywhere in the world" to "Deliver fast, reliable performance anywhere in the world" for conciseness.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
