### PR TITLE
ci: increase outdated PR threshold from 24h to 72h

### DIFF
--- a/.github/workflows/outdated-pr-check.yml
+++ b/.github/workflows/outdated-pr-check.yml
@@ -1,7 +1,7 @@
 name: Outdated PR Check
 
 # **What it does**: Posts Outdated PR Check commit statuses when a PR is opened or updated.
-#                   Fails if the branch is more than 24 hours out of date with production.
+#                   Fails if the branch is more than 72 hours out of date with production.
 # **Why we have it**: Gives contributors immediate feedback when their branch has drifted.
 #                     The daily refresh job (outdated-pr-refresh.yml) catches PRs that go
 #                     stale when production advances without any PR activity.
@@ -36,7 +36,7 @@ jobs:
       contents: read
       statuses: write
     steps:
-      - name: Check if PR base is within 24 hours of production
+      - name: Check if PR base is within 72 hours of production
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_SHA: ${{ github.event.pull_request.head.sha }}
@@ -70,7 +70,7 @@ jobs:
             NOW=$(date +%s)
             AGE=$((NOW - MERGE_BASE_TS))
 
-            if [ "$AGE" -gt 86400 ]; then
+            if [ "$AGE" -gt 259200 ]; then
               HOURS=$((AGE / 3600))
               STATE="failure"
               if [ "$HOURS" -gt 36 ]; then
@@ -82,7 +82,7 @@ jobs:
               fi
             else
               STATE="success"
-              DESCRIPTION="Branch is behind production but within the 24-hour grace period"
+              DESCRIPTION="Branch is behind production but within the 72-hour grace period"
             fi
           fi
 

--- a/.github/workflows/outdated-pr-check.yml
+++ b/.github/workflows/outdated-pr-check.yml
@@ -71,15 +71,10 @@ jobs:
             AGE=$((NOW - MERGE_BASE_TS))
 
             if [ "$AGE" -gt 259200 ]; then
-              HOURS=$((AGE / 3600))
+              DAYS=$((AGE / 86400))
+              UNIT=$( [ "$DAYS" -eq 1 ] && echo "day" || echo "days" )
               STATE="failure"
-              if [ "$HOURS" -gt 36 ]; then
-                DAYS=$((AGE / 86400))
-                UNIT=$( [ "$DAYS" -eq 1 ] && echo "day" || echo "days" )
-                DESCRIPTION="Branch is ${DAYS} ${UNIT} out of date with production. Please rebase or merge. Codeowners can comment /rebase on the PR to fix."
-              else
-                DESCRIPTION="Branch is ${HOURS}h out of date with production. Please rebase or merge. Codeowners can comment /rebase on the PR to fix."
-              fi
+              DESCRIPTION="Branch is ${DAYS} ${UNIT} out of date with production. Please rebase or merge. Codeowners can comment /rebase on the PR to fix."
             else
               STATE="success"
               DESCRIPTION="Branch is behind production but within the 72-hour grace period"

--- a/.github/workflows/outdated-pr-check.yml
+++ b/.github/workflows/outdated-pr-check.yml
@@ -72,9 +72,8 @@ jobs:
 
             if [ "$AGE" -gt 259200 ]; then
               DAYS=$((AGE / 86400))
-              UNIT=$( [ "$DAYS" -eq 1 ] && echo "day" || echo "days" )
               STATE="failure"
-              DESCRIPTION="Branch is ${DAYS} ${UNIT} out of date with production. Please rebase or merge. Codeowners can comment /rebase on the PR to fix."
+              DESCRIPTION="Branch is ${DAYS} days out of date with production. Please rebase or merge. Codeowners can comment /rebase on the PR to fix."
             else
               STATE="success"
               DESCRIPTION="Branch is behind production but within the 72-hour grace period"

--- a/.github/workflows/outdated-pr-refresh.yml
+++ b/.github/workflows/outdated-pr-refresh.yml
@@ -71,15 +71,10 @@ jobs:
               AGE=$((NOW - MERGE_BASE_TS))
 
               if [ "$AGE" -gt 259200 ]; then
-                HOURS=$((AGE / 3600))
+                DAYS=$((AGE / 86400))
+                UNIT=$( [ "$DAYS" -eq 1 ] && echo "day" || echo "days" )
                 STATE="failure"
-                if [ "$HOURS" -gt 36 ]; then
-                  DAYS=$((AGE / 86400))
-                  UNIT=$( [ "$DAYS" -eq 1 ] && echo "day" || echo "days" )
-                  DESCRIPTION="Branch is ${DAYS} ${UNIT} out of date with production. Please rebase or merge. Codeowners can comment /rebase on the PR to fix."
-                else
-                  DESCRIPTION="Branch is ${HOURS}h out of date with production. Please rebase or merge. Codeowners can comment /rebase on the PR to fix."
-                fi
+                DESCRIPTION="Branch is ${DAYS} ${UNIT} out of date with production. Please rebase or merge. Codeowners can comment /rebase on the PR to fix."
               else
                 STATE="success"
                 DESCRIPTION="Branch is behind production but within the 72-hour grace period"

--- a/.github/workflows/outdated-pr-refresh.yml
+++ b/.github/workflows/outdated-pr-refresh.yml
@@ -7,7 +7,7 @@ name: Refresh PR Outdated Checks
 #                     updated. This job handles the case where production moves forward and
 #                     a PR becomes stale without the contributor pushing anything.
 #                     Because this runs once daily, the effective enforcement window is
-#                     24–48 hours depending on when the PR was last rebased vs. the schedule.
+#                     72–96 hours depending on when the PR was last rebased vs. the schedule.
 # **Who does it impact**: All contributors with open PRs against production, including forks.
 
 on:
@@ -70,7 +70,7 @@ jobs:
               NOW=$(date +%s)
               AGE=$((NOW - MERGE_BASE_TS))
 
-              if [ "$AGE" -gt 86400 ]; then
+              if [ "$AGE" -gt 259200 ]; then
                 HOURS=$((AGE / 3600))
                 STATE="failure"
                 if [ "$HOURS" -gt 36 ]; then
@@ -82,7 +82,7 @@ jobs:
                 fi
               else
                 STATE="success"
-                DESCRIPTION="Branch is behind production but within the 24-hour grace period"
+                DESCRIPTION="Branch is behind production but within the 72-hour grace period"
               fi
             fi
 

--- a/.github/workflows/outdated-pr-refresh.yml
+++ b/.github/workflows/outdated-pr-refresh.yml
@@ -72,9 +72,8 @@ jobs:
 
               if [ "$AGE" -gt 259200 ]; then
                 DAYS=$((AGE / 86400))
-                UNIT=$( [ "$DAYS" -eq 1 ] && echo "day" || echo "days" )
                 STATE="failure"
-                DESCRIPTION="Branch is ${DAYS} ${UNIT} out of date with production. Please rebase or merge. Codeowners can comment /rebase on the PR to fix."
+                DESCRIPTION="Branch is ${DAYS} days out of date with production. Please rebase or merge. Codeowners can comment /rebase on the PR to fix."
               else
                 STATE="success"
                 DESCRIPTION="Branch is behind production but within the 72-hour grace period"


### PR DESCRIPTION
### Summary

Increases the "outdated PR" threshold from 24 hours to 72 hours in both the per-commit check (`outdated-pr-check.yml`) and the daily refresh job (`outdated-pr-refresh.yml`). This gives contributors more time before their branch is flagged as stale, reducing noise from the daily refresh job.

Changes:
- Age threshold: `86400` → `259200` seconds (24h → 72h)
- Updated all related comments and status descriptions to reflect the new grace period
- Updated the refresh job's documented effective enforcement window from 24–48h to 72–96h
