### PR TITLE
NOJIRA: correct flex purge batch limits from 30 to 100

### DIFF
--- a/src/content/docs/cache/how-to/purge-cache/purge-by-hostname.mdx
+++ b/src/content/docs/cache/how-to/purge-cache/purge-by-hostname.mdx
@@ -22,7 +22,7 @@ Purging by hostname means that all assets at URLs with a host that matches one o
 4. Follow the syntax instructions:
    * One hostname per line.
    * Separated by commas.
-   * You can purge up to 30 hostnames at a time.
+   * You can purge up to 100 hostnames at a time.
 5. Enter the appropriate value(s) in the text field using the format shown in the example.
 6. Select **Purge**.
 

--- a/src/content/docs/cache/how-to/purge-cache/purge-by-tags.mdx
+++ b/src/content/docs/cache/how-to/purge-cache/purge-by-tags.mdx
@@ -57,7 +57,7 @@ When your content reaches our edge network, Cloudflare:
 
 2. Under **Purge Cache**, select **Custom Purge**. The **Custom Purge** window appears.
 3. Under **Purge by**, select **Tag**.
-4. In the text box, enter your tags to use to purge the cached resources. To purge multiple cache-tagged resources, separate each tag with a comma or have one tag per line.
+4. In the text box, enter your tags to use to purge the cached resources. To purge multiple cache-tagged resources, separate each tag with a comma or have one tag per line. You can purge up to 100 tags at a time.
 5. Select **Purge**.
 
 For information on rate limits, refer to the [Availability and limits](/cache/how-to/purge-cache/#availability-and-limits) section.

--- a/src/content/docs/cache/how-to/purge-cache/purge_by_prefix.mdx
+++ b/src/content/docs/cache/how-to/purge-cache/purge_by_prefix.mdx
@@ -59,7 +59,7 @@ Depending on whether the upper tier has the resource or not, and whether the end
 There are several limitations regarding purge by prefix:
 
 * Path separators are limited to 31 for a prefix `(example.com/a/b/c/d/e/f/g/h/i/j/k/l/m…)`.
-* Purge requests are limited to 100 prefixes per request. For the combined hostname, tag, and prefix limit, refer to [Availability and limits](/cache/how-to/purge-cache/#availability-and-limits).
+* Purge requests are limited to 100 prefixes per request.
 * [Purge rate-limits apply](/api/resources/cache/methods/purge/).
 * URI query strings & fragments cannot purge by prefix:
   * `www.example.com/foo?a=b` (query string)

--- a/src/content/docs/cache/how-to/purge-cache/purge_by_prefix.mdx
+++ b/src/content/docs/cache/how-to/purge-cache/purge_by_prefix.mdx
@@ -33,7 +33,7 @@ Purging by prefix is useful in different scenarios, such as:
 3. Under **Purge by**, select **Prefix**.
 4. Follow the syntax instructions.
    * One prefix per line.
-   * Maximum 30 prefixes per API call.
+   * Maximum 100 prefixes per request.
 5. Enter the appropriate value(s) in the text field using the format shown in the example.
 6. Select **Purge**.
 
@@ -59,7 +59,7 @@ Depending on whether the upper tier has the resource or not, and whether the end
 There are several limitations regarding purge by prefix:
 
 * Path separators are limited to 31 for a prefix `(example.com/a/b/c/d/e/f/g/h/i/j/k/l/m…)`.
-* Purge requests are limited to 30 prefixes per request.
+* Purge requests are limited to 100 prefixes per request. For the combined hostname, tag, and prefix limit, refer to [Availability and limits](/cache/how-to/purge-cache/#availability-and-limits).
 * [Purge rate-limits apply](/api/resources/cache/methods/purge/).
 * URI query strings & fragments cannot purge by prefix:
   * `www.example.com/foo?a=b` (query string)


### PR DESCRIPTION
Hostname, tag, and prefix how-to pages still said 30 items per request. The API default was raised to 100 in CACHE-12090, and the dashboard already shows 100.

- Update hostname, tag, and prefix pages to 100 items per request
- Point prefix limits at the shared availability table so the 30 vs 100 contradiction does not come back