### PR TITLE
AI Search: document larger metadata values

### DIFF
--- a/src/content/changelog/ai-search/2026-08-23-larger-custom-metadata-values.mdx
+++ b/src/content/changelog/ai-search/2026-08-23-larger-custom-metadata-values.mdx
@@ -9,4 +9,4 @@ publish_future_dated_entry: true
 
 AI Search supports larger custom metadata values within a shared 10 KiB metadata envelope for each vector. The envelope includes AI Search system metadata and JSON overhead, so it is not a per-field limit. The first 64 UTF-8 bytes of each indexed string remain filterable.
 
-Existing vectors adopt this behavior when they are reindexed. For details, refer to [Metadata attributes](/ai-search/configuration/indexing/metadata/).
+For details, refer to [Metadata attributes](/ai-search/configuration/indexing/metadata/).

--- a/src/content/changelog/ai-search/2026-08-23-larger-custom-metadata-values.mdx
+++ b/src/content/changelog/ai-search/2026-08-23-larger-custom-metadata-values.mdx
@@ -1,0 +1,12 @@
+---
+title: Store larger custom metadata values in AI Search
+description: AI Search supports larger custom metadata values within a shared 10 KiB metadata envelope for each vector.
+products:
+  - ai-search
+date: 2026-08-23
+publish_future_dated_entry: true
+---
+
+AI Search supports larger custom metadata values within a shared 10 KiB metadata envelope for each vector. The envelope includes AI Search system metadata and JSON overhead, so it is not a per-field limit. The first 64 UTF-8 bytes of each indexed string remain filterable.
+
+Existing vectors adopt this behavior when they are reindexed. For details, refer to [Metadata attributes](/ai-search/configuration/indexing/metadata/).

--- a/src/content/changelog/ai-search/2026-08-25-larger-custom-metadata-values.mdx
+++ b/src/content/changelog/ai-search/2026-08-25-larger-custom-metadata-values.mdx
@@ -3,7 +3,7 @@ title: Store larger custom metadata values in AI Search
 description: AI Search supports larger custom metadata values within a shared 10 KiB metadata envelope for each vector.
 products:
   - ai-search
-date: 2026-08-23
+date: 2026-08-25
 publish_future_dated_entry: true
 ---
 

--- a/src/content/docs/ai-search/configuration/indexing/metadata.mdx
+++ b/src/content/docs/ai-search/configuration/indexing/metadata.mdx
@@ -77,8 +77,6 @@ Configured custom fields take priority over undeclared source metadata. AI Searc
 
 Only the first 64 UTF-8 bytes of each indexed string are filterable. Longer strings can be stored, but bytes after the first 64 are not filterable. For Vectorize details, refer to [Limits](/vectorize/platform/limits/) and [Metadata filtering](/vectorize/reference/metadata-filtering/).
 
-Existing vectors adopt these rules when they are reindexed.
-
 ## Limitations
 
 | Constraint                 | Limit                                               |

--- a/src/content/docs/ai-search/configuration/indexing/metadata.mdx
+++ b/src/content/docs/ai-search/configuration/indexing/metadata.mdx
@@ -26,12 +26,12 @@ Custom metadata allows you to define additional fields for filtering search resu
 
 ### Supported data types
 
-| Type       | Description                        | Example values                         |
-| ---------- | ---------------------------------- | -------------------------------------- |
-| `text`     | String values (max 500 characters) | `"documentation"`, `"blog-post"`       |
-| `number`   | Numeric values (parsed as float)   | `2.5`, `100`, `-3.14`                  |
-| `boolean`  | Boolean values                     | `true`, `false`, `1`, `0`, `yes`, `no` |
-| `datetime` | Date and time values               | `"2026-01-15T00:00:00Z"`               |
+| Type       | Description                      | Example values                         |
+| ---------- | -------------------------------- | -------------------------------------- |
+| `text`     | String values                    | `"documentation"`, `"blog-post"`       |
+| `number`   | Numeric values (parsed as float) | `2.5`, `100`, `-3.14`                  |
+| `boolean`  | Boolean values                   | `true`, `false`, `1`, `0`, `yes`, `no` |
+| `datetime` | Date and time values             | `"2026-01-15T00:00:00Z"`               |
 
 ### Define a schema
 
@@ -50,7 +50,6 @@ custom_metadata: [
 - Maximum of 5 custom metadata fields per AI Search instance
 - Field names are case-insensitive and stored as lowercase
 - Field names cannot use reserved names: `timestamp`, `folder`, `filename`
-- Text values are truncated to 500 characters
 - Changing the schema triggers a full re-index of all documents
 
 ### Add custom metadata attributes to documents
@@ -70,21 +69,22 @@ When you modify the `custom_metadata` schema:
 3. A full re-index is triggered for all documents.
 4. Existing vectors are updated with the new metadata structure.
 
+## Metadata storage and filtering
+
+AI Search stores metadata for each vector in a shared 10 KiB compact JSON UTF-8 envelope. The envelope includes field names, JSON syntax, required AI Search system metadata, and customer metadata. It is not a per-field limit.
+
+Configured custom fields take priority over undeclared source metadata. AI Search assembles metadata deterministically, retaining complete values that fit. When capacity remains, configured string values can be truncated on UTF-8 character boundaries. Required AI Search metadata is always preserved.
+
+Only the first 64 UTF-8 bytes of each indexed string are filterable. Longer strings can be stored, but bytes after the first 64 are not filterable. For Vectorize details, refer to [Limits](/vectorize/platform/limits/) and [Metadata filtering](/vectorize/reference/metadata-filtering/).
+
+Existing vectors adopt these rules when they are reindexed.
+
 ## Limitations
 
-| Constraint                | Limit                             |
-| ------------------------- | --------------------------------- |
-| Maximum custom fields     | 5 per AI Search instance          |
-| Maximum text value length | 500 characters                    |
-| Reserved field names      | `timestamp`, `folder`, `filename` |
-| Field name matching       | Case-insensitive                  |
-
-If file metadata exceeds size limits, the metadata is replaced with an error indicator:
-
-```json
-{
-	"file": { "error": "metadata is too large" }
-}
-```
-
-To avoid this, keep individual metadata values concise.
+| Constraint                 | Limit                                               |
+| -------------------------- | --------------------------------------------------- |
+| Maximum custom fields      | 5 per AI Search instance                            |
+| Metadata per vector        | 10 KiB total, including system data and JSON syntax |
+| Filterable indexed strings | First 64 UTF-8 bytes of each string                 |
+| Reserved field names       | `timestamp`, `folder`, `filename`                   |
+| Field name matching        | Case-insensitive                                    |

--- a/src/content/docs/ai-search/configuration/retrieval/filtering.mdx
+++ b/src/content/docs/ai-search/configuration/retrieval/filtering.mdx
@@ -14,6 +14,8 @@ Metadata filtering narrows down search results based on metadata, so only releva
 
 Filtering uses the metadata attributes extracted during indexing. To define custom attributes or use the built-in metadata attributes, refer to [Metadata attributes](/ai-search/configuration/indexing/metadata/).
 
+AI Search can store string values longer than the filterable prefix. Filters only match the first 64 UTF-8 bytes of each indexed string. Vectorize can store string arrays, but does not currently index or filter them.
+
 :::note
 If you are using the legacy AutoRAG API, refer to [Metadata filter format (legacy)](/ai-search/api/migration/autorag-filter-format/) for the filter syntax.
 :::
@@ -42,16 +44,16 @@ Filters are JSON objects where keys are metadata attribute names and values spec
 
 ### Supported operators
 
-| Operator | Description                       |
-| -------- | --------------------------------- |
-| `$eq`    | Equals                            |
-| `$ne`    | Not equals                        |
-| `$in`    | In (matches any value in array)   |
-| `$nin`   | Not in (excludes values in array) |
-| `$lt`    | Less than                         |
-| `$lte`   | Less than or equal to             |
-| `$gt`    | Greater than                      |
-| `$gte`   | Greater than or equal to          |
+| Operator | Description                                                  |
+| -------- | ------------------------------------------------------------ |
+| `$eq`    | Equals                                                       |
+| `$ne`    | Not equals                                                   |
+| `$in`    | Matches a stored scalar against any candidate scalar value   |
+| `$nin`   | Excludes a stored scalar matching any candidate scalar value |
+| `$lt`    | Less than                                                    |
+| `$lte`   | Less than or equal to                                        |
+| `$gt`    | Greater than                                                 |
+| `$gte`   | Greater than or equal to                                     |
 
 ### Implicit `$eq`
 
@@ -112,7 +114,7 @@ When you specify multiple keys, all conditions must match:
 
 ### `$in` operator
 
-Match any value in an array:
+Match a stored scalar field against any value in the candidate array. `$in` does not search inside stored arrays:
 
 ```json
 {

--- a/src/content/docs/ai-search/platform/limits-pricing.mdx
+++ b/src/content/docs/ai-search/platform/limits-pricing.mdx
@@ -12,18 +12,19 @@ products:
 
 The following limits apply based on your [Workers plan](/workers/platform/pricing/):
 
-| Limit                                       | Workers Free             | Workers Paid                 |
-| ------------------------------------------- | ------------------------ | ---------------------------- |
-| AI Search instances per account             | 100                      | 5,000                        |
-| Namespaces per account                      | 100                      | 100                          |
-| Files per instance                          | 100,000                  | 1M or 500K for hybrid search |
-| Pages per crawl, `discover` parse type      | 100,000                  | 100,000                      |
-| Max file size                               | 4 MB                     | 4 MB                         |
-| Queries per month                           | 20,000                   | Unlimited                    |
-| Instances per cross-instance search request | 10                       | 10                           |
-| Maximum pages crawled per day               | 500                      | Unlimited                    |
-| Max custom metadata fields                  | 5 per AI Search instance | 5 per AI Search instance     |
-| Max text metadata value length              | 500 characters           | 500 characters               |
+| Limit                                       | Workers Free                            | Workers Paid                            |
+| ------------------------------------------- | --------------------------------------- | --------------------------------------- |
+| AI Search instances per account             | 100                                     | 5,000                                   |
+| Namespaces per account                      | 100                                     | 100                                     |
+| Files per instance                          | 100,000                                 | 1M or 500K for hybrid search            |
+| Pages per crawl, `discover` parse type      | 100,000                                 | 100,000                                 |
+| Max file size                               | 4 MB                                    | 4 MB                                    |
+| Queries per month                           | 20,000                                  | Unlimited                               |
+| Instances per cross-instance search request | 10                                      | 10                                      |
+| Maximum pages crawled per day               | 500                                     | Unlimited                               |
+| Max custom metadata fields                  | 5 per AI Search instance                | 5 per AI Search instance                |
+| Metadata per vector                         | 10 KiB total, including system overhead | 10 KiB total, including system overhead |
+| Filterable indexed string data              | First 64 UTF-8 bytes per string         | First 64 UTF-8 bytes per string         |
 
 Website crawling is bounded by several of these limits at once. A `discover` crawl accepts up to 100,000 pages, but the files per instance and maximum pages crawled per day limits also apply, so the number of pages you end up with is whichever of those values is lowest. On Workers Free, the daily limit of 500 pages is the binding one.
 

--- a/src/content/release-notes/ai-search.yaml
+++ b/src/content/release-notes/ai-search.yaml
@@ -3,7 +3,7 @@ link: "/ai-search/platform/release-note/"
 productName: AI Search
 productLink: "/ai-search/"
 entries:
-  - publish_date: "2026-08-23"
+  - publish_date: "2026-08-25"
     title: Larger custom metadata values
     description: |-
       AI Search supports larger custom metadata values within a shared 10 KiB metadata envelope for each vector. The envelope includes system metadata and JSON overhead, and the first 64 UTF-8 bytes of each indexed string remain filterable. Refer to [Metadata attributes](/ai-search/configuration/indexing/metadata/) for details.

--- a/src/content/release-notes/ai-search.yaml
+++ b/src/content/release-notes/ai-search.yaml
@@ -3,6 +3,10 @@ link: "/ai-search/platform/release-note/"
 productName: AI Search
 productLink: "/ai-search/"
 entries:
+  - publish_date: "2026-08-23"
+    title: Larger custom metadata values
+    description: |-
+      AI Search supports larger custom metadata values within a shared 10 KiB metadata envelope for each vector. The envelope includes system metadata and JSON overhead, and the first 64 UTF-8 bytes of each indexed string remain filterable. Refer to [Metadata attributes](/ai-search/configuration/indexing/metadata/) for details.
   - publish_date: "2026-08-06"
     title: Custom domains, Cloudflare Access, and namespace public endpoints
     description: |-


### PR DESCRIPTION
## Changes
- Document the shared 10 KiB metadata envelope and deterministic overflow behavior.
- Clarify the 64-byte filterable string prefix and scalar `$in` semantics.
- Update AI Search limits, changelog, and release notes.