### PR TITLE
[CASB] Add developer docs and changelog for CASB remediation policies

### DIFF
--- a/src/content/changelog/casb/2026-07-18-casb-policies.mdx
+++ b/src/content/changelog/casb/2026-07-18-casb-policies.mdx
@@ -1,0 +1,73 @@
+---
+title: Automatically remediate security findings with CASB policies
+description: CASB policies let you automatically remediate posture findings and send webhooks the moment a finding is detected.
+products:
+  - casb
+date: 2026-07-18
+---
+
+import { Details } from "~/components";
+
+You can now automate your security response with **CASB policies** in Cloudflare One. Instead of manually triaging every posture finding, you can create a policy that automatically remediates a finding or sends a webhook the moment a matching finding is detected.
+
+CASB policies close the loop between detection and response. Security teams spend less time monitoring findings, while security posture is continuously enforced.
+
+### Run remediations
+
+A policy can perform a first-party remediation action directly against the SaaS integration API. When a policy triggers, Cloudflare revokes the external sharing configuration without human intervention.
+
+Remediation is currently supported for file-sharing findings in Microsoft 365 and Google Workspace. Support for additional finding types and integrations is coming soon.
+
+<Details header="Supported findings for remediation">
+
+**Google Workspace:**
+
+- File publicly accessible with edit access
+- File publicly accessible with view access
+- File shared outside company with edit access
+- File shared outside company with view access
+- File shared company-wide with edit access
+- File shared company-wide with view access
+- File publicly accessible with edit access with DLP Profile match
+- File publicly accessible with view access with DLP Profile match
+- File shared outside company with edit access with DLP Profile match
+- File shared outside company with view access with DLP Profile match
+- File shared company-wide with edit access with DLP Profile match
+- File shared company-wide with view access with DLP Profile match
+
+**Microsoft 365:**
+
+- File publicly accessible with edit access
+- File publicly accessible with view access
+- File shared company-wide with edit access
+- File shared company-wide with view access
+- File publicly accessible with edit access with DLP Profile match
+- File publicly accessible with view access with DLP Profile match
+- File shared company-wide with edit access with DLP Profile match
+- File shared company-wide with view access with DLP Profile match
+
+</Details>
+
+### Send webhooks
+
+A policy can send posture finding data to Slack, ServiceNow, or any other webhook destination. Webhook actions are supported for all posture finding types across CASB integrations.
+
+A single policy can perform both actions: remediate a finding and send a webhook.
+
+### Get started
+
+1. In [Cloudflare One](https://one.dash.cloudflare.com), go to **Cloud & SaaS findings** > **Policies**.
+2. Select **Create a policy**.
+3. Under **Basic information**, enter a **Policy name** and, optionally, a **Description**.
+4. Under **Choose how you want to trigger the policy**, select a **Vendor**, **Integration**, and **Finding type**.
+5. Under **Define what to do with findings that match your trigger**, choose **Run Remediation**, **Send webhooks**, or both.
+6. Under **Status**, turn on **Enable policy**.
+7. Select **Create policy**.
+
+### Learn more
+
+- Learn how to [create and manage CASB policies](/cloudflare-one/cloud-and-saas-findings/policies/) in Cloudflare One.
+- Configure [CASB webhooks](/cloudflare-one/integrations/cloud-and-saas/webhooks/) as a policy destination.
+- Learn how to [manage findings](/cloudflare-one/cloud-and-saas-findings/manage-findings/) in Cloudflare One.
+
+CASB policies are now available in Cloudflare One.

--- a/src/content/changelog/casb/2026-07-18-casb-policies.mdx
+++ b/src/content/changelog/casb/2026-07-18-casb-policies.mdx
@@ -1,52 +1,18 @@
 ---
-title: Automatically remediate security findings with CASB policies
-description: CASB policies let you automatically remediate posture findings and send webhooks the moment a finding is detected.
+title: Automatically remediate Microsoft 365 and Google Workspace findings with API-based CASB remediation policies
+description: CASB remediation policies automatically fix Microsoft 365 and Google Workspace file-sharing findings and send webhooks, without manual intervention.
 products:
   - casb
 date: 2026-07-18
 ---
 
-import { Details } from "~/components";
+[Cloudflare CASB](/cloudflare-one/integrations/cloud-and-saas/) is an API-based (agentless) tool that continuously scans your SaaS and cloud applications for security misconfigurations and data exposure. You can now use **CASB remediation policies** to automatically fix a finding or send a webhook the moment CASB detects it, without manual triage.
 
-You can now automate your security response with **CASB policies** in Cloudflare One. Instead of manually triaging every posture finding, you can create a policy that automatically remediates a finding or sends a webhook the moment a matching finding is detected.
-
-CASB policies close the loop between detection and response. Security teams spend less time monitoring findings, while security posture is continuously enforced.
-
-### Run remediations
+### Remediate Microsoft 365 and Google Workspace findings
 
 A policy can perform a first-party remediation action directly against the SaaS integration API. When a policy triggers, Cloudflare revokes the external sharing configuration without human intervention.
 
-Remediation is currently supported for file-sharing findings in Microsoft 365 and Google Workspace. Support for additional finding types and integrations is coming soon.
-
-<Details header="Supported findings for remediation">
-
-**Google Workspace:**
-
-- File publicly accessible with edit access
-- File publicly accessible with view access
-- File shared outside company with edit access
-- File shared outside company with view access
-- File shared company-wide with edit access
-- File shared company-wide with view access
-- File publicly accessible with edit access with DLP Profile match
-- File publicly accessible with view access with DLP Profile match
-- File shared outside company with edit access with DLP Profile match
-- File shared outside company with view access with DLP Profile match
-- File shared company-wide with edit access with DLP Profile match
-- File shared company-wide with view access with DLP Profile match
-
-**Microsoft 365:**
-
-- File publicly accessible with edit access
-- File publicly accessible with view access
-- File shared company-wide with edit access
-- File shared company-wide with view access
-- File publicly accessible with edit access with DLP Profile match
-- File publicly accessible with view access with DLP Profile match
-- File shared company-wide with edit access with DLP Profile match
-- File shared company-wide with view access with DLP Profile match
-
-</Details>
+Remediation is currently supported for file-sharing findings in Microsoft 365 and Google Workspace. Support for additional finding types and integrations is coming soon. For the full list of supported finding types, refer to [Run remediations](/cloudflare-one/cloud-and-saas-findings/policies/#run-remediations) in the CASB remediation policies documentation.
 
 ### Send webhooks
 
@@ -66,8 +32,8 @@ A single policy can perform both actions: remediate a finding and send a webhook
 
 ### Learn more
 
-- Learn how to [create and manage CASB policies](/cloudflare-one/cloud-and-saas-findings/policies/) in Cloudflare One.
+- Learn how to [create and manage CASB remediation policies](/cloudflare-one/cloud-and-saas-findings/policies/) in Cloudflare One.
 - Configure [CASB webhooks](/cloudflare-one/integrations/cloud-and-saas/webhooks/) as a policy destination.
 - Learn how to [manage findings](/cloudflare-one/cloud-and-saas-findings/manage-findings/) in Cloudflare One.
 
-CASB policies are now available in Cloudflare One.
+CASB remediation policies are now available in Cloudflare One.

--- a/src/content/changelog/casb/2026-08-21-casb-policies.mdx
+++ b/src/content/changelog/casb/2026-08-21-casb-policies.mdx
@@ -3,7 +3,7 @@ title: Automatically remediate Microsoft 365 and Google Workspace findings with 
 description: CASB remediation policies automatically fix Microsoft 365 and Google Workspace file-sharing findings and send webhooks, without manual intervention.
 products:
   - casb
-date: 2026-07-18
+date: 2026-08-21
 ---
 
 [Cloudflare CASB](/cloudflare-one/integrations/cloud-and-saas/) is an API-based (agentless) tool that continuously scans your SaaS and cloud applications for security misconfigurations and data exposure. You can now use **CASB remediation policies** to automatically fix a finding or send a webhook the moment CASB detects it, without manual triage.

--- a/src/content/docs/cloudflare-one/cloud-and-saas-findings/manage-findings.mdx
+++ b/src/content/docs/cloudflare-one/cloud-and-saas-findings/manage-findings.mdx
@@ -180,6 +180,8 @@ If the status is **Completed**, remediation succeeded. If the status is **Failed
 
 CASB will log remediation actions in **Logs** > **Admin**. For more information, refer to [Cloudflare One Logs](/cloudflare-one/insights/logs/).
 
+To automatically remediate future instances of a finding type without reviewing each one, refer to [Policies](/cloudflare-one/cloud-and-saas-findings/policies/).
+
 ## Resolve finding with a Gateway policy
 
 CASB detects security issues that already exist in your SaaS environment. To prevent the same issues from recurring, you can create a [Gateway HTTP policy](/cloudflare-one/traffic-policies/http-policies/) directly from a CASB finding. For example, you can block users from sharing files publicly or accessing unsanctioned applications.

--- a/src/content/docs/cloudflare-one/cloud-and-saas-findings/manage-findings.mdx
+++ b/src/content/docs/cloudflare-one/cloud-and-saas-findings/manage-findings.mdx
@@ -180,7 +180,7 @@ If the status is **Completed**, remediation succeeded. If the status is **Failed
 
 CASB will log remediation actions in **Logs** > **Admin**. For more information, refer to [Cloudflare One Logs](/cloudflare-one/insights/logs/).
 
-To automatically remediate future instances of a finding type without reviewing each one, refer to [Policies](/cloudflare-one/cloud-and-saas-findings/policies/).
+To automatically remediate matching findings without reviewing each one, refer to [Remediation Policies](/cloudflare-one/cloud-and-saas-findings/policies/).
 
 ## Resolve finding with a Gateway policy
 

--- a/src/content/docs/cloudflare-one/cloud-and-saas-findings/policies.mdx
+++ b/src/content/docs/cloudflare-one/cloud-and-saas-findings/policies.mdx
@@ -3,15 +3,17 @@ pcx_content_type: how-to
 description: Automatically remediate findings or send webhooks with CASB policies in Cloudflare One.
 products:
   - cloudflare-one
-title: Policies
+title: Remediation Policies
 sidebar:
   order: 2
 tags:
   - Compliance
 ---
 
+import { Details } from "~/components";
+
 :::note[Availability]
-Requires a paid Cloudflare CASB plan. The CASB Policies feature is not available for free CASB integrations.
+Requires a paid Cloudflare CASB plan. Remediation Policies are not available for free CASB integrations.
 :::
 
 Use CASB policies to automatically remediate a finding or send a webhook as soon as CASB detects it. A policy defines the vendor, the finding type match, and the action Cloudflare should take.
@@ -54,9 +56,39 @@ Remediation actions perform a first-party fix directly against the integration's
 
 CASB currently supports remediation actions for Microsoft 365 and Google Workspace file and folder finding types. If a finding type does not support remediation, **Run Remediation** displays **No automated remediation available for this finding type** and cannot be enabled.
 
+<Details header="Supported findings for remediation">
+
+**Google Workspace:**
+
+- File publicly accessible with edit access
+- File publicly accessible with view access
+- File shared outside company with edit access
+- File shared outside company with view access
+- File shared company-wide with edit access
+- File shared company-wide with view access
+- File publicly accessible with edit access with DLP Profile match
+- File publicly accessible with view access with DLP Profile match
+- File shared outside company with edit access with DLP Profile match
+- File shared outside company with view access with DLP Profile match
+- File shared company-wide with edit access with DLP Profile match
+- File shared company-wide with view access with DLP Profile match
+
+**Microsoft 365:**
+
+- File publicly accessible with edit access
+- File publicly accessible with view access
+- File shared company-wide with edit access
+- File shared company-wide with view access
+- File publicly accessible with edit access with DLP Profile match
+- File publicly accessible with view access with DLP Profile match
+- File shared company-wide with edit access with DLP Profile match
+- File shared company-wide with view access with DLP Profile match
+
+</Details>
+
 Remediation requires [Read-Write permissions](/cloudflare-one/cloud-and-saas-findings/manage-findings/#configure-remediation-permissions) on the integration. If the integration only has Read permissions, upgrade the integration before the policy can remediate matching findings.
 
-To learn more about monitoring and managing instance remediations, refer to [Manage remediated findings](/cloudflare-one/cloud-and-saas-findings/manage-findings/#manage-remediated-findings).
+For more information, refer to [Manage remediated findings](/cloudflare-one/cloud-and-saas-findings/manage-findings/#manage-remediated-findings).
 
 ### Send webhooks
 
@@ -84,7 +116,7 @@ Every policy produces two categories of logs, available under **Insights** in Cl
 
 For compliance reporting, the Cloud & SaaS Security policies log ties a specific finding to a specific automated action and timestamp.
 
-For more information on logs in Cloudflare One, refer to [Cloudflare One Logs](/cloudflare-one/insights/logs/).
+For more information, refer to [Cloudflare One Logs](/cloudflare-one/insights/logs/).
 
 ## Limitations
 

--- a/src/content/docs/cloudflare-one/cloud-and-saas-findings/policies.mdx
+++ b/src/content/docs/cloudflare-one/cloud-and-saas-findings/policies.mdx
@@ -1,0 +1,96 @@
+---
+pcx_content_type: how-to
+description: Automatically remediate findings or send webhooks with CASB policies in Cloudflare One.
+products:
+  - cloudflare-one
+title: Policies
+sidebar:
+  order: 2
+tags:
+  - Compliance
+---
+
+:::note[Availability]
+Requires a paid Cloudflare CASB plan. The CASB Policies feature is not available for free CASB integrations.
+:::
+
+Use CASB policies to automatically remediate a finding or send a webhook as soon as CASB detects it. A policy defines the vendor, the finding type match, and the action Cloudflare should take.
+
+Policies build on [manual remediation](/cloudflare-one/cloud-and-saas-findings/manage-findings/#remediate-findings) and [CASB webhooks](/cloudflare-one/integrations/cloud-and-saas/webhooks/). Instead of each finding instance needing to be actioned manually, a configured policy automatically triggers action on all newly discovered matching finding instances.
+
+## Prerequisites
+
+- A configured [Cloud or SaaS integration](/cloudflare-one/integrations/cloud-and-saas/).
+- [Read-Write permissions](/cloudflare-one/cloud-and-saas-findings/manage-findings/#configure-remediation-permissions) on the integration, required for remediation actions.
+- A [configured webhook destination](/cloudflare-one/integrations/cloud-and-saas/webhooks/#create-a-webhook), required for webhook actions.
+
+## How policies work
+
+When CASB detects a finding, it checks whether the finding matches a customer-configured policy. If a policy matches, Cloudflare runs the policy's configured action against that finding instance automatically.
+
+A policy can run a remediation action, send a webhook, or both.
+
+## Create a policy
+
+1. In [Cloudflare One](https://one.dash.cloudflare.com), go to **Cloud & SaaS findings** > **Policies**.
+2. Select **Create a policy**.
+3. Under **Basic information**, enter a **Policy name**. Optionally, enter a **Description**.
+4. Under **Choose how you want to trigger the policy**, select a **Vendor**.
+5. Select one or more **Integrations**, or select **Apply to all integrations** to apply the policy to every integration for the vendor.
+6. Select a **Finding type**. Only finding types available for the selected vendor and integrations appear here.
+7. Under **Define what to do with findings that match your trigger**, choose one or both actions:
+   - **Run Remediation** to have Cloudflare perform a first-party remediation action against the SaaS integration API. This option is only available for select finding types.
+   - **Send webhooks** to send a notification to one or more webhook destinations.
+8. Under **Status**, turn on **Enable policy**.
+9. Select **Create policy**.
+
+Policies will be in effect for all newly discovered finding instances going forward. New or updated policies are not applied retroactively to existing finding instances.
+
+CASB policies appear in a list showing each policy's name, integration, finding type, webhook, remediation action, status, and the time it last ran.
+
+### Run remediations
+
+Remediation actions perform a first-party fix directly against the integration's API, such as revoking a public file share.
+
+CASB currently supports remediation actions for Microsoft 365 and Google Workspace file and folder finding types. If a finding type does not support remediation, **Run Remediation** displays **No automated remediation available for this finding type** and cannot be enabled.
+
+Remediation requires [Read-Write permissions](/cloudflare-one/cloud-and-saas-findings/manage-findings/#configure-remediation-permissions) on the integration. If the integration only has Read permissions, upgrade the integration before the policy can remediate matching findings.
+
+To learn more about monitoring and managing instance remediations, refer to [Manage remediated findings](/cloudflare-one/cloud-and-saas-findings/manage-findings/#manage-remediated-findings).
+
+### Send webhooks
+
+Webhook actions send the finding instance to a previously configured webhook destination. Use this to route findings to systems such as Slack, Microsoft Teams, Jira, ServiceNow, Tines, or a custom HTTPS endpoint.
+
+When a policy sends a webhook, the payload uses the same format as a webhook sent manually from a finding instance. For the payload structure and field descriptions, refer to [Payload format](/cloudflare-one/integrations/cloud-and-saas/webhooks/#payload-format).
+
+## Edit, turn off, or delete a policy
+
+1. In [Cloudflare One](https://one.dash.cloudflare.com), go to **Cloud & SaaS findings** > **Policies**.
+2. Select the policy to update.
+3. Modify the policy's basic information, trigger, or actions.
+4. Select **Save changes**.
+
+To turn a policy on or off, use the **Enable policy** toggle under **Status**. A policy's status displays as **Enabled** or **Disabled** in the policy list. A disabled policy stops matching new findings until enabled again.
+
+To delete a policy, open the policy and select **Delete**.
+
+## Logs
+
+Every policy produces two categories of logs, available under **Insights** in Cloudflare One:
+
+- **Admin Activity logs** record changes to a policy definition, including who created, edited, or disabled the policy, and when.
+- **Cloud & SaaS Security policies logs** record the runtime outcome of each policy invocation, including the finding that triggered the policy, the asset acted on, whether the action succeeded or failed, and the error returned by the vendor if it failed (for example, a `401 Unauthorized` response or a rate limit error).
+
+For compliance reporting, the Cloud & SaaS Security policies log ties a specific finding to a specific automated action and timestamp.
+
+For more information on logs in Cloudflare One, refer to [Cloudflare One Logs](/cloudflare-one/insights/logs/).
+
+## Limitations
+
+- Remediation actions in a policy are only available for Microsoft 365 and Google Workspace file and folder finding types.
+- A policy only applies to new instances of a finding type detected after the policy is created.
+
+## Troubleshooting
+
+For help diagnosing issues, refer to [CASB troubleshooting](/cloudflare-one/integrations/cloud-and-saas/troubleshooting/casb/).

--- a/src/content/docs/cloudflare-one/integrations/cloud-and-saas/webhooks.mdx
+++ b/src/content/docs/cloudflare-one/integrations/cloud-and-saas/webhooks.mdx
@@ -86,7 +86,7 @@ Cloudflare queues webhook sends in the background. A success message means that 
 
 For more information on finding workflows, refer to [Manage findings](/cloudflare-one/cloud-and-saas-findings/manage-findings/).
 
-To automatically send a webhook for future instances of a finding type without sending each one manually, refer to [Policies](/cloudflare-one/cloud-and-saas-findings/policies/).
+To automatically send a webhook for matching findings without sending each one manually, refer to [Remediation Policies](/cloudflare-one/cloud-and-saas-findings/policies/).
 
 ## Payload format
 

--- a/src/content/docs/cloudflare-one/integrations/cloud-and-saas/webhooks.mdx
+++ b/src/content/docs/cloudflare-one/integrations/cloud-and-saas/webhooks.mdx
@@ -86,6 +86,8 @@ Cloudflare queues webhook sends in the background. A success message means that 
 
 For more information on finding workflows, refer to [Manage findings](/cloudflare-one/cloud-and-saas-findings/manage-findings/).
 
+To automatically send a webhook for future instances of a finding type without sending each one manually, refer to [Policies](/cloudflare-one/cloud-and-saas-findings/policies/).
+
 ## Payload format
 
 CASB sends a JSON payload that describes the posture finding instance.


### PR DESCRIPTION
## Summary

Combines the CASB policies developer docs with the corresponding changelog entry.

- New page: `cloudflare-one/cloud-and-saas-findings/policies.mdx` — prerequisites, how policies work, create/edit/delete a policy, remediation actions, webhook actions, logs, limitations, troubleshooting.
- Cross-links added from `manage-findings.mdx` and `webhooks.mdx` to the new Policies page.
- New changelog entry: `changelog/casb/2026-07-18-casb-policies.mdx`, rewritten from an earlier "CASB Workflows" draft to align with the shipped feature name ("CASB policies") and the exact UI steps/terminology confirmed in the dev docs (Cloud & SaaS findings > Policies, Run Remediation / Send webhooks actions, Enable policy toggle).

## Notes for reviewers

- UI steps and field names were verified against dashboard screenshots.
- The example webhook payload was intentionally omitted from the Policies page in favor of linking to the existing canonical payload example in `webhooks.mdx`.
- Availability note reflects that Policies require a paid CASB plan (not available on Free CASB integrations).
- This supersedes the closed PR #31392 ("Casb workflows changelog docs"), which used outdated "Workflows" naming.