### PR TITLE
fix: return markdown 404 for agent clients

### DIFF
--- a/worker/index.preview.ts
+++ b/worker/index.preview.ts
@@ -22,32 +22,6 @@ const redirectsEvaluator = generateRedirectsEvaluator(redirectsFileContents, {
 
 const LLMS_FULL_R2_PREFIX = "v1/cloudflare-docs-llms-full";
 
-// Short Markdown 404 for agent clients. Status stays a real 404; the body
-// gives agents recovery links instead of the HTML splash page.
-const MARKDOWN_404 = `# Page not found
-
-The page you requested does not exist or has moved.
-
-Browse the documentation via [llms.txt](/llms.txt).
-
-Search the documentation via the [AI Search API](https://ai-search.developers.cloudflare.com/api/ai-search/search) (POST \`{"messages":[{"role":"user","content":"your query"}]}\`).
-`;
-
-/** True when the client asked for Markdown, via /index.md or Accept header. */
-function requestsMarkdown(request: Request): boolean {
-	if (new URL(request.url).pathname.endsWith("/index.md")) return true;
-	return (request.headers.get("Accept") ?? "").includes("text/markdown");
-}
-
-function markdownNotFound(): Response {
-	return new Response(MARKDOWN_404, {
-		status: 404,
-		headers: {
-			"Content-Type": "text/markdown; charset=utf-8",
-		},
-	});
-}
-
 // RFC 9727 requires the path to be exactly /.well-known/api-catalog with no
 // extension. The Cloudflare ASSETS binding cannot serve extensionless files
 // from dot-prefixed directories, so this must be handled directly in the worker.

--- a/worker/index.preview.ts
+++ b/worker/index.preview.ts
@@ -21,6 +21,30 @@ const redirectsEvaluator = generateRedirectsEvaluator(redirectsFileContents, {
 
 const LLMS_FULL_R2_PREFIX = "v1/cloudflare-docs-llms-full";
 
+// Short Markdown 404 for agent clients. Status stays a real 404; the body
+// gives agents recovery links instead of the HTML splash page.
+const MARKDOWN_404 = `# Page not found
+
+The page you requested does not exist or has moved.
+
+Browse the documentation via [llms.txt](/llms.txt).
+`;
+
+/** True when the client asked for Markdown, via /index.md or Accept header. */
+function requestsMarkdown(request: Request): boolean {
+	if (new URL(request.url).pathname.endsWith("/index.md")) return true;
+	return (request.headers.get("Accept") ?? "").includes("text/markdown");
+}
+
+function markdownNotFound(): Response {
+	return new Response(MARKDOWN_404, {
+		status: 404,
+		headers: {
+			"Content-Type": "text/markdown; charset=utf-8",
+		},
+	});
+}
+
 // RFC 9727 requires the path to be exactly /.well-known/api-catalog with no
 // extension. The Cloudflare ASSETS binding cannot serve extensionless files
 // from dot-prefixed directories, so this must be handled directly in the worker.
@@ -278,6 +302,10 @@ export default class extends WorkerEntrypoint<Env> {
 		const response = await this.env.ASSETS.fetch(request);
 
 		if (response.status === 404) {
+			if (requestsMarkdown(request)) {
+				return markdownNotFound();
+			}
+
 			const section = new URL(response.url).pathname.split("/").at(1);
 
 			if (!section) return response;

--- a/worker/index.preview.ts
+++ b/worker/index.preview.ts
@@ -12,6 +12,7 @@
 import { WorkerEntrypoint } from "cloudflare:workers";
 import { generateRedirectsEvaluator } from "redirects-in-workers";
 import redirectsFileContents from "../dist/__redirects";
+import { markdownNotFound, requestsMarkdown } from "./markdown-404";
 
 const redirectsEvaluator = generateRedirectsEvaluator(redirectsFileContents, {
 	maxLineLength: 10_000, // Usually 2_000

--- a/worker/index.preview.ts
+++ b/worker/index.preview.ts
@@ -28,6 +28,8 @@ const MARKDOWN_404 = `# Page not found
 The page you requested does not exist or has moved.
 
 Browse the documentation via [llms.txt](/llms.txt).
+
+Search the documentation via the [AI Search API](https://ai-search.developers.cloudflare.com/api/ai-search/search) (POST \`{"messages":[{"role":"user","content":"your query"}]}\`).
 `;
 
 /** True when the client asked for Markdown, via /index.md or Accept header. */

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -17,6 +17,8 @@ const MARKDOWN_404 = `# Page not found
 The page you requested does not exist or has moved.
 
 Browse the documentation via [llms.txt](/llms.txt).
+
+Search the documentation via the [AI Search API](https://ai-search.developers.cloudflare.com/api/ai-search/search) (POST \`{"messages":[{"role":"user","content":"your query"}]}\`).
 `;
 
 /** True when the client asked for Markdown, via /index.md or Accept header. */

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -1,6 +1,7 @@
 import { WorkerEntrypoint } from "cloudflare:workers";
 import { generateRedirectsEvaluator } from "redirects-in-workers";
 import redirectsFileContents from "../dist/__redirects";
+import { markdownNotFound, requestsMarkdown } from "./markdown-404";
 
 const redirectsEvaluator = generateRedirectsEvaluator(redirectsFileContents, {
 	maxLineLength: 10_000, // Usually 2_000
@@ -9,32 +10,6 @@ const redirectsEvaluator = generateRedirectsEvaluator(redirectsFileContents, {
 });
 
 const LLMS_FULL_R2_PREFIX = "v1/cloudflare-docs-llms-full";
-
-// Short Markdown 404 for agent clients. Status stays a real 404; the body
-// gives agents recovery links instead of the HTML splash page.
-const MARKDOWN_404 = `# Page not found
-
-The page you requested does not exist or has moved.
-
-Browse the documentation via [llms.txt](/llms.txt).
-
-Search the documentation via the [AI Search API](https://ai-search.developers.cloudflare.com/api/ai-search/search) (POST \`{"messages":[{"role":"user","content":"your query"}]}\`).
-`;
-
-/** True when the client asked for Markdown, via /index.md or Accept header. */
-function requestsMarkdown(request: Request): boolean {
-	if (new URL(request.url).pathname.endsWith("/index.md")) return true;
-	return (request.headers.get("Accept") ?? "").includes("text/markdown");
-}
-
-function markdownNotFound(): Response {
-	return new Response(MARKDOWN_404, {
-		status: 404,
-		headers: {
-			"Content-Type": "text/markdown; charset=utf-8",
-		},
-	});
-}
 
 // RFC 9727 requires the path to be exactly /.well-known/api-catalog with no
 // extension. The Cloudflare ASSETS binding cannot serve extensionless files

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -10,6 +10,30 @@ const redirectsEvaluator = generateRedirectsEvaluator(redirectsFileContents, {
 
 const LLMS_FULL_R2_PREFIX = "v1/cloudflare-docs-llms-full";
 
+// Short Markdown 404 for agent clients. Status stays a real 404; the body
+// gives agents recovery links instead of the HTML splash page.
+const MARKDOWN_404 = `# Page not found
+
+The page you requested does not exist or has moved.
+
+Browse the documentation via [llms.txt](/llms.txt).
+`;
+
+/** True when the client asked for Markdown, via /index.md or Accept header. */
+function requestsMarkdown(request: Request): boolean {
+	if (new URL(request.url).pathname.endsWith("/index.md")) return true;
+	return (request.headers.get("Accept") ?? "").includes("text/markdown");
+}
+
+function markdownNotFound(): Response {
+	return new Response(MARKDOWN_404, {
+		status: 404,
+		headers: {
+			"Content-Type": "text/markdown; charset=utf-8",
+		},
+	});
+}
+
 // RFC 9727 requires the path to be exactly /.well-known/api-catalog with no
 // extension. The Cloudflare ASSETS binding cannot serve extensionless files
 // from dot-prefixed directories, so this must be handled directly in the worker.
@@ -202,6 +226,10 @@ export default class extends WorkerEntrypoint<Env> {
 		const response = await this.env.ASSETS.fetch(request);
 
 		if (response.status === 404) {
+			if (requestsMarkdown(request)) {
+				return markdownNotFound();
+			}
+
 			const section = new URL(response.url).pathname.split("/").at(1);
 
 			if (!section) return response;

--- a/worker/index.worker.test.ts
+++ b/worker/index.worker.test.ts
@@ -43,6 +43,18 @@ describe("Cloudflare Docs", () => {
 			expect(body).toContain("/llms.txt");
 		});
 
+		it("responds with markdown 404 for parameterized Accept media types", async () => {
+			const request = new Request("http://fakehost/non-existent", {
+				headers: { Accept: "text/markdown; charset=utf-8, text/html;q=1.0" },
+			});
+			const response = await SELF.fetch(request);
+			expect(response.status).toBe(404);
+			expect(response.headers.get("Content-Type")).toContain("text/markdown");
+			const body = await response.text();
+			expect(body).toContain("# Page not found");
+			expect(body).toContain("/llms.txt");
+		});
+
 		it("returns html 404 for unrelated Accept media types", async () => {
 			const request = new Request("http://fakehost/non-existent", {
 				headers: {

--- a/worker/index.worker.test.ts
+++ b/worker/index.worker.test.ts
@@ -26,6 +26,7 @@ describe("Cloudflare Docs", () => {
 			const body = await response.text();
 			expect(body).toContain("# Page not found");
 			expect(body).toContain("/llms.txt");
+			expect(body).toContain("ai-search.developers.cloudflare.com");
 		});
 
 		it("responds with markdown 404 for Accept: text/markdown requests", async () => {

--- a/worker/index.worker.test.ts
+++ b/worker/index.worker.test.ts
@@ -17,7 +17,9 @@ describe("Cloudflare Docs", () => {
 			expect(response.status).toBe(404);
 			expect(await response.text()).toContain("Check the URL,");
 		});
+	});
 
+	describe("markdown 404 handling", () => {
 		it("responds with markdown 404 for /index.md requests", async () => {
 			const request = new Request("http://fakehost/non-existent/index.md");
 			const response = await SELF.fetch(request);
@@ -39,6 +41,18 @@ describe("Cloudflare Docs", () => {
 			const body = await response.text();
 			expect(body).toContain("# Page not found");
 			expect(body).toContain("/llms.txt");
+		});
+
+		it("returns html 404 for unrelated Accept media types", async () => {
+			const request = new Request("http://fakehost/non-existent", {
+				headers: {
+					Accept: "text/markdown-extra, application/not-text-markdown",
+				},
+			});
+			const response = await SELF.fetch(request);
+			expect(response.status).toBe(404);
+			expect(response.headers.get("Content-Type")).toContain("text/html");
+			expect(await response.text()).toContain("Check the URL,");
 		});
 	});
 

--- a/worker/index.worker.test.ts
+++ b/worker/index.worker.test.ts
@@ -17,6 +17,28 @@ describe("Cloudflare Docs", () => {
 			expect(response.status).toBe(404);
 			expect(await response.text()).toContain("Check the URL,");
 		});
+
+		it("responds with markdown 404 for /index.md requests", async () => {
+			const request = new Request("http://fakehost/non-existent/index.md");
+			const response = await SELF.fetch(request);
+			expect(response.status).toBe(404);
+			expect(response.headers.get("Content-Type")).toContain("text/markdown");
+			const body = await response.text();
+			expect(body).toContain("# Page not found");
+			expect(body).toContain("/llms.txt");
+		});
+
+		it("responds with markdown 404 for Accept: text/markdown requests", async () => {
+			const request = new Request("http://fakehost/non-existent", {
+				headers: { Accept: "text/markdown" },
+			});
+			const response = await SELF.fetch(request);
+			expect(response.status).toBe(404);
+			expect(response.headers.get("Content-Type")).toContain("text/markdown");
+			const body = await response.text();
+			expect(body).toContain("# Page not found");
+			expect(body).toContain("/llms.txt");
+		});
 	});
 
 	describe("redirects", () => {

--- a/worker/index.worker.test.ts
+++ b/worker/index.worker.test.ts
@@ -26,7 +26,7 @@ describe("Cloudflare Docs", () => {
 			expect(response.status).toBe(404);
 			expect(response.headers.get("Content-Type")).toContain("text/markdown");
 			const body = await response.text();
-			expect(body).toContain("# Page not found");
+			expect(body).toContain("# 404 Page not found");
 			expect(body).toContain("/llms.txt");
 			expect(body).toContain("ai-search.developers.cloudflare.com");
 		});
@@ -39,7 +39,7 @@ describe("Cloudflare Docs", () => {
 			expect(response.status).toBe(404);
 			expect(response.headers.get("Content-Type")).toContain("text/markdown");
 			const body = await response.text();
-			expect(body).toContain("# Page not found");
+			expect(body).toContain("# 404 Page not found");
 			expect(body).toContain("/llms.txt");
 		});
 
@@ -51,7 +51,7 @@ describe("Cloudflare Docs", () => {
 			expect(response.status).toBe(404);
 			expect(response.headers.get("Content-Type")).toContain("text/markdown");
 			const body = await response.text();
-			expect(body).toContain("# Page not found");
+			expect(body).toContain("# 404 Page not found");
 			expect(body).toContain("/llms.txt");
 		});
 

--- a/worker/markdown-404.ts
+++ b/worker/markdown-404.ts
@@ -1,0 +1,28 @@
+// Shared Markdown 404 helpers for the production and preview workers. A
+// client that asks for Markdown (via /index.md or Accept: text/markdown)
+// gets a short Markdown body with recovery links instead of the HTML splash
+// page. Status stays a real 404.
+
+const MARKDOWN_404 = `# Page not found
+
+The page you requested does not exist or has moved.
+
+Browse the documentation via [llms.txt](/llms.txt).
+
+Search the documentation via the [AI Search API](https://ai-search.developers.cloudflare.com/api/ai-search/search) (POST \`{"messages":[{"role":"user","content":"your query"}]}\`).
+`;
+
+/** True when the client asked for Markdown, via /index.md or Accept header. */
+export function requestsMarkdown(request: Request): boolean {
+	if (new URL(request.url).pathname.endsWith("/index.md")) return true;
+	return (request.headers.get("Accept") ?? "").includes("text/markdown");
+}
+
+export function markdownNotFound(): Response {
+	return new Response(MARKDOWN_404, {
+		status: 404,
+		headers: {
+			"Content-Type": "text/markdown; charset=utf-8",
+		},
+	});
+}

--- a/worker/markdown-404.ts
+++ b/worker/markdown-404.ts
@@ -3,7 +3,7 @@
 // gets a short Markdown body with recovery links instead of the HTML splash
 // page. Status stays a real 404.
 
-const MARKDOWN_404 = `# Page not found
+const MARKDOWN_404 = `# 404 Page not found
 
 The page you requested does not exist or has moved.
 

--- a/worker/markdown-404.ts
+++ b/worker/markdown-404.ts
@@ -15,7 +15,9 @@ Search the documentation via the [AI Search API](https://ai-search.developers.cl
 /** True when the client asked for Markdown, via /index.md or Accept header. */
 export function requestsMarkdown(request: Request): boolean {
 	if (new URL(request.url).pathname.endsWith("/index.md")) return true;
-	return (request.headers.get("Accept") ?? "").includes("text/markdown");
+	return (request.headers.get("Accept") ?? "")
+		.split(",")
+		.some((type) => type.trim().toLowerCase() === "text/markdown");
 }
 
 export function markdownNotFound(): Response {

--- a/worker/markdown-404.ts
+++ b/worker/markdown-404.ts
@@ -17,7 +17,9 @@ export function requestsMarkdown(request: Request): boolean {
 	if (new URL(request.url).pathname.endsWith("/index.md")) return true;
 	return (request.headers.get("Accept") ?? "")
 		.split(",")
-		.some((type) => type.trim().toLowerCase() === "text/markdown");
+		.some(
+			(type) => type.split(";")[0].trim().toLowerCase() === "text/markdown",
+		);
 }
 
 export function markdownNotFound(): Response {


### PR DESCRIPTION
### Summary

Agent clients (LLM crawlers, fetch tools) that request a nonexistent page in Markdown mode — via `/index.md` or `Accept: text/markdown` — now get a short Markdown 404 body linking to `/llms.txt` and the AI Search API, instead of the HTML splash page.

HTML 404 behavior for browsers is unchanged.

<img width="1682" height="195" alt="Screenshot 2026-08-21 at 10 15 32 PM" src="https://github.com/user-attachments/assets/386e9892-4a6a-4b8b-8b49-d3d735841362" />

