### PR TITLE
fix: remove markdown service-doc from api-catalog

### DIFF
--- a/worker/index.preview.ts
+++ b/worker/index.preview.ts
@@ -36,10 +36,8 @@ const API_CATALOG = JSON.stringify({
 				},
 			],
 			"service-doc": [
-				{
-					href: "https://developers.cloudflare.com/api/index.md",
-					type: "text/markdown",
-				},
+				// TODO: Add a Markdown `service-doc` URL once /api/* supports a real
+				// Markdown representation (e.g. content negotiation or /index.md).
 				{
 					href: "https://developers.cloudflare.com/api/",
 					type: "text/html",

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -25,10 +25,8 @@ const API_CATALOG = JSON.stringify({
 				},
 			],
 			"service-doc": [
-				{
-					href: "https://developers.cloudflare.com/api/index.md",
-					type: "text/markdown",
-				},
+				// TODO: Add a Markdown `service-doc` URL once /api/* supports a real
+				// Markdown representation (e.g. content negotiation or /index.md).
 				{
 					href: "https://developers.cloudflare.com/api/",
 					type: "text/html",

--- a/worker/index.worker.test.ts
+++ b/worker/index.worker.test.ts
@@ -68,6 +68,36 @@ describe("Cloudflare Docs", () => {
 		});
 	});
 
+	describe(".well-known", () => {
+		it("api-catalog does not advertise a markdown service-doc yet", async () => {
+			const request = new Request("http://fakehost/.well-known/api-catalog");
+			const response = await SELF.fetch(request);
+			expect(response.status).toBe(200);
+			expect(response.headers.get("Content-Type")).toContain(
+				"application/linkset+json",
+			);
+
+			const catalog: any = await response.json();
+			const entry = (catalog.linkset as any[]).find(
+				(e) => e.anchor === "https://developers.cloudflare.com/api/",
+			);
+			expect(entry).toBeDefined();
+
+			const serviceDoc = entry["service-doc"] as any[];
+			expect(serviceDoc.some((d) => d.type === "text/markdown")).toBe(false);
+			expect(
+				serviceDoc.some((d) => String(d.href).endsWith("/api/index.md")),
+			).toBe(false);
+			expect(
+				serviceDoc.some(
+					(d) =>
+						d.type === "text/html" &&
+						d.href === "https://developers.cloudflare.com/api/",
+				),
+			).toBe(true);
+		});
+	});
+
 	describe("redirects", () => {
 		it("redirects requests with a trailing slash", async () => {
 			const request = new Request("http://fakehost/docs/");


### PR DESCRIPTION
### Summary

Removes the `text/markdown` `service-doc` entry from `/.well-known/api-catalog`.

The catalog previously advertised `https://developers.cloudflare.com/api/index.md` as Markdown, but that URL is owned by the generated API docs app and returns HTML. This change makes the discovery document truthful until the API docs support a real Markdown representation.
