### PR TITLE
feat: publish /.well-known/ai-catalog.json

### DIFF
--- a/worker/ai-catalog.ts
+++ b/worker/ai-catalog.ts
@@ -1,4 +1,4 @@
-type AiCatalogEntry = {
+export type AiCatalogEntry = {
 	identifier: string;
 	displayName: string;
 	type: string;
@@ -8,7 +8,7 @@ type AiCatalogEntry = {
 	representativeQueries?: [string, string, ...string[]];
 };
 
-type AiCatalogManifest = {
+export type AiCatalogManifest = {
 	specVersion: "1.0";
 	host: {
 		displayName: string;

--- a/worker/ai-catalog.ts
+++ b/worker/ai-catalog.ts
@@ -1,0 +1,90 @@
+type AiCatalogEntry = {
+	identifier: string;
+	displayName: string;
+	type: string;
+	url: string;
+	description: string;
+	tags?: string[];
+	representativeQueries?: [string, string, ...string[]];
+};
+
+type AiCatalogManifest = {
+	specVersion: "1.0";
+	host: {
+		displayName: string;
+		identifier: string;
+		documentationUrl: string;
+	};
+	entries: AiCatalogEntry[];
+};
+
+export const AI_CATALOG_MANIFEST: AiCatalogManifest = {
+	specVersion: "1.0",
+	host: {
+		displayName: "Cloudflare Developer Documentation",
+		identifier: "did:web:developers.cloudflare.com",
+		documentationUrl: "https://developers.cloudflare.com/",
+	},
+	entries: [
+		{
+			identifier: "urn:air:developers.cloudflare.com:api:openapi",
+			displayName: "Cloudflare API OpenAPI Specification",
+			type: "application/vnd.oai.openapi+json",
+			url: "https://developers.cloudflare.com/openapi.json",
+			description: "OpenAPI specification for the Cloudflare REST API (v4).",
+			tags: ["cloudflare", "api", "openapi"],
+			representativeQueries: [
+				"Find Cloudflare API endpoints and request/response shapes",
+				"How do I update a DNS record using the Cloudflare API?",
+			],
+		},
+		{
+			identifier: "urn:air:developers.cloudflare.com:mcp:server-card",
+			displayName: "Cloudflare MCP Servers",
+			type: "application/mcp-server-card+json",
+			url: "https://developers.cloudflare.com/.well-known/mcp/server-card.json",
+			description:
+				"Server card listing Cloudflare MCP server endpoints and connection details.",
+			tags: ["cloudflare", "mcp"],
+			representativeQueries: [
+				"How do I connect to Cloudflare's MCP servers?",
+				"What Cloudflare MCP servers are available?",
+			],
+		},
+		{
+			identifier: "urn:air:developers.cloudflare.com:skills:index",
+			displayName: "Cloudflare Agent Skills Index",
+			type: "application/agent-skills+json",
+			url: "https://developers.cloudflare.com/.well-known/agent-skills/index.json",
+			description:
+				"Index of Cloudflare-published agent skills (metadata and download links).",
+			tags: ["cloudflare", "agent-skills"],
+			representativeQueries: [
+				"What agent skills does Cloudflare publish?",
+				"Where can I download Cloudflare agent skills?",
+			],
+		},
+		{
+			identifier: "urn:air:developers.cloudflare.com:docs:llms-txt",
+			displayName: "Cloudflare Docs LLM Index (llms.txt)",
+			type: "text/plain",
+			url: "https://developers.cloudflare.com/llms.txt",
+			description:
+				"Text index for AI systems: a structured list of Cloudflare docs sections and per-product llms.txt links.",
+			tags: ["cloudflare", "documentation", "llms.txt"],
+			representativeQueries: [
+				"Where is the Cloudflare docs llms.txt index?",
+				"List Cloudflare products and their documentation roots",
+			],
+		},
+	],
+};
+
+export const AI_CATALOG_BODY = JSON.stringify(AI_CATALOG_MANIFEST);
+
+export const AI_CATALOG_HEADERS: Record<string, string> = {
+	"Content-Type": "application/ai-catalog+json; charset=utf-8",
+	// The ARD / AI Catalog serving guidance calls out permissive CORS so
+	// discovery clients (including in-browser ones) can fetch this document.
+	"Access-Control-Allow-Origin": "*",
+};

--- a/worker/ai-catalog.worker.test.ts
+++ b/worker/ai-catalog.worker.test.ts
@@ -1,0 +1,40 @@
+import { SELF } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+
+describe("ai-catalog", () => {
+	it("serves a valid ai-catalog manifest with CORS", async () => {
+		const response = await SELF.fetch(
+			new Request("http://fakehost/.well-known/ai-catalog.json"),
+		);
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get("Content-Type")).toContain(
+			"application/ai-catalog+json",
+		);
+		expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
+
+		const body = (await response.json()) as any;
+		expect(body.specVersion).toBe("1.0");
+		expect(body.host?.displayName).toBeTruthy();
+		expect(Array.isArray(body.entries)).toBe(true);
+		expect(body.entries.length).toBeGreaterThan(0);
+
+		for (const entry of body.entries as any[]) {
+			expect(typeof entry.identifier).toBe("string");
+			expect(
+				entry.identifier.startsWith("urn:air:developers.cloudflare.com:"),
+			).toBe(true);
+			expect(typeof entry.displayName).toBe("string");
+			expect(entry.displayName.length).toBeGreaterThan(0);
+			expect(typeof entry.type).toBe("string");
+			expect(entry.type.length).toBeGreaterThan(0);
+			expect(typeof entry.description).toBe("string");
+			expect(entry.description.length).toBeGreaterThan(0);
+
+			const hasUrl = typeof entry.url === "string" && entry.url.length > 0;
+			const hasData = entry.data != null;
+			expect(hasUrl).toBe(true);
+			expect(hasData).toBe(false);
+		}
+	});
+});

--- a/worker/ai-catalog.worker.test.ts
+++ b/worker/ai-catalog.worker.test.ts
@@ -35,6 +35,7 @@ describe("ai-catalog", () => {
 			expect(typeof entry.url).toBe("string");
 			expect(entry.url.length).toBeGreaterThan(0);
 			expect(() => new URL(entry.url)).not.toThrow();
+			expect(new URL(entry.url).protocol).toMatch(/^https?:$/);
 
 			// The catalog intentionally never embeds inline data — all entries
 			// are URL references that consumers dereference separately.

--- a/worker/ai-catalog.worker.test.ts
+++ b/worker/ai-catalog.worker.test.ts
@@ -1,8 +1,9 @@
 import { SELF } from "cloudflare:test";
 import { describe, expect, it } from "vitest";
+import type { AiCatalogManifest } from "./ai-catalog";
 
 describe("ai-catalog", () => {
-	it("serves a valid ai-catalog manifest with CORS", async () => {
+	it("serves a valid ai-catalog manifest with ACAO header", async () => {
 		const response = await SELF.fetch(
 			new Request("http://fakehost/.well-known/ai-catalog.json"),
 		);
@@ -13,13 +14,13 @@ describe("ai-catalog", () => {
 		);
 		expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
 
-		const body = (await response.json()) as any;
+		const body = (await response.json()) as AiCatalogManifest;
 		expect(body.specVersion).toBe("1.0");
 		expect(body.host?.displayName).toBeTruthy();
 		expect(Array.isArray(body.entries)).toBe(true);
 		expect(body.entries.length).toBeGreaterThan(0);
 
-		for (const entry of body.entries as any[]) {
+		for (const entry of body.entries) {
 			expect(typeof entry.identifier).toBe("string");
 			expect(
 				entry.identifier.startsWith("urn:air:developers.cloudflare.com:"),
@@ -31,10 +32,13 @@ describe("ai-catalog", () => {
 			expect(typeof entry.description).toBe("string");
 			expect(entry.description.length).toBeGreaterThan(0);
 
-			const hasUrl = typeof entry.url === "string" && entry.url.length > 0;
-			const hasData = entry.data != null;
-			expect(hasUrl).toBe(true);
-			expect(hasData).toBe(false);
+			expect(typeof entry.url).toBe("string");
+			expect(entry.url.length).toBeGreaterThan(0);
+			expect(() => new URL(entry.url)).not.toThrow();
+
+			// The catalog intentionally never embeds inline data — all entries
+			// are URL references that consumers dereference separately.
+			expect(entry).not.toHaveProperty("data");
 		}
 	});
 });

--- a/worker/index.preview.ts
+++ b/worker/index.preview.ts
@@ -13,6 +13,7 @@ import { WorkerEntrypoint } from "cloudflare:workers";
 import { generateRedirectsEvaluator } from "redirects-in-workers";
 import redirectsFileContents from "../dist/__redirects";
 import { markdownNotFound, requestsMarkdown } from "./markdown-404";
+import { AI_CATALOG_BODY, AI_CATALOG_HEADERS } from "./ai-catalog";
 
 const redirectsEvaluator = generateRedirectsEvaluator(redirectsFileContents, {
 	maxLineLength: 10_000, // Usually 2_000
@@ -175,6 +176,12 @@ export default class extends WorkerEntrypoint<Env> {
 					"Content-Type":
 						'application/linkset+json; profile="https://www.rfc-editor.org/info/rfc9727"',
 				},
+			});
+		}
+
+		if (pathname === "/.well-known/ai-catalog.json") {
+			return new Response(AI_CATALOG_BODY, {
+				headers: AI_CATALOG_HEADERS,
 			});
 		}
 

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -2,6 +2,7 @@ import { WorkerEntrypoint } from "cloudflare:workers";
 import { generateRedirectsEvaluator } from "redirects-in-workers";
 import redirectsFileContents from "../dist/__redirects";
 import { markdownNotFound, requestsMarkdown } from "./markdown-404";
+import { AI_CATALOG_BODY, AI_CATALOG_HEADERS } from "./ai-catalog";
 
 const redirectsEvaluator = generateRedirectsEvaluator(redirectsFileContents, {
 	maxLineLength: 10_000, // Usually 2_000
@@ -99,6 +100,12 @@ export default class extends WorkerEntrypoint<Env> {
 					"Content-Type":
 						'application/linkset+json; profile="https://www.rfc-editor.org/info/rfc9727"',
 				},
+			});
+		}
+
+		if (pathname === "/.well-known/ai-catalog.json") {
+			return new Response(AI_CATALOG_BODY, {
+				headers: AI_CATALOG_HEADERS,
 			});
 		}
 


### PR DESCRIPTION
### Summary

Publishes an AI Catalog manifest at `/.well-known/ai-catalog.json` to advertise existing agent-facing resources.

- Serves `application/ai-catalog+json; charset=utf-8` with `Access-Control-Allow-Origin: *`.
- Entries included:
- `https://developers.cloudflare.com/openapi.json`
- `https://developers.cloudflare.com/.well-known/mcp/server-card.json`
- `https://developers.cloudflare.com/.well-known/agent-skills/index.json`
- `https://developers.cloudflare.com/llms.txt`

Validation:
- `pnpm exec vitest run --project Workers worker/ai-catalog.worker.test.ts`
- `pnpm run check`
