### PR TITLE
fix: improve homepage heading semantics

### DIFF
--- a/src/components/ProductCard.astro
+++ b/src/components/ProductCard.astro
@@ -11,6 +11,7 @@ interface Props {
 	href: string;
 	cta?: string;
 	category?: Category;
+	headingLevel?: 3 | 4;
 }
 
 const {
@@ -21,6 +22,7 @@ const {
 	href,
 	cta = "Get started",
 	category,
+	headingLevel,
 } = Astro.props;
 
 const CATEGORY_COLOR: Record<Category, string> = {
@@ -33,6 +35,9 @@ const CATEGORY_COLOR: Record<Category, string> = {
 
 // Per-card accent (category colour or brand), consumed by the hover rule.
 const cardColor = category ? CATEGORY_COLOR[category] : "var(--color-primary)";
+
+// Cards can be used in different contexts; let callers opt into semantic headings.
+const ScenarioTag = headingLevel === 4 ? "h4" : headingLevel === 3 ? "h3" : "p";
 ---
 
 <a
@@ -57,9 +62,11 @@ const cardColor = category ? CATEGORY_COLOR[category] : "var(--color-primary)";
 		</span>
 	</div>
 
-	<p class="text-foreground mb-2 text-base leading-snug font-medium md:text-lg">
+	<ScenarioTag
+		class="text-foreground mb-2 text-base leading-snug font-medium md:text-lg"
+	>
 		{scenario}
-	</p>
+	</ScenarioTag>
 	<p
 		class="text-muted-foreground mb-6 flex-1 text-sm leading-relaxed md:text-base"
 	>

--- a/src/components/ProductCardGrid.astro
+++ b/src/components/ProductCardGrid.astro
@@ -11,9 +11,9 @@ const { label } = Astro.props;
 <div>
 	{
 		label && (
-			<p class="text-muted-foreground mb-4 font-mono text-xs tracking-widest uppercase">
+			<h3 class="text-muted-foreground mb-4 font-mono text-xs tracking-widest uppercase">
 				{label}
-			</p>
+			</h3>
 		)
 	}
 	<div

--- a/src/components/landing/AccelerateSection.astro
+++ b/src/components/landing/AccelerateSection.astro
@@ -38,6 +38,7 @@ import { products } from "./accelerate-data";
 					detail={p.detail}
 					href={p.href}
 					cta={p.cta}
+					headingLevel={3}
 					category={p.category}
 				/>
 			))

--- a/src/components/landing/AgentSetup.astro
+++ b/src/components/landing/AgentSetup.astro
@@ -36,11 +36,11 @@ const ALL_GUIDES_HREF = "/agent-setup/";
 			>
 				<HalftoneBackground />
 				<div class="relative z-[1] flex flex-col gap-2.5">
-					<span
+					<h3
 						class="text-foreground max-w-[14ch] text-lg leading-tight font-medium md:text-xl"
 					>
 						Browse all agent setup guides
-					</span>
+					</h3>
 				</div>
 
 				<LinkButton

--- a/src/components/landing/ChangelogSection.astro
+++ b/src/components/landing/ChangelogSection.astro
@@ -159,9 +159,9 @@ const grid = entries.slice(1);
 							</span>
 						</div>
 						<div class="mb-6 flex-1">
-							<p class="text-foreground mb-2 line-clamp-2 text-base leading-snug font-medium md:text-lg">
+							<h3 class="text-foreground mb-2 line-clamp-2 text-base leading-snug font-medium md:text-lg">
 								{entry.title}
-							</p>
+							</h3>
 
 							<p class="text-muted-foreground line-clamp-2 text-sm leading-relaxed md:text-base">
 								{entry.description}

--- a/src/components/landing/SecureSection.astro
+++ b/src/components/landing/SecureSection.astro
@@ -97,6 +97,7 @@ const categories = [
 							detail={t.detail}
 							href={t.href}
 							cta={t.cta}
+							headingLevel={4}
 							category={"category" in cat ? cat.category : undefined}
 						/>
 					))}


### PR DESCRIPTION
Improves homepage semantic heading structure in SSR HTML for agent crawlers.

- Use headings for category labels and card titles (no visual/layout changes)
- Add optional ProductCard heading level for context-appropriate H3/H4