### PR TITLE
[Browser Run] Clarify skipped status behavior in crawl endpoint

### DIFF
--- a/src/content/docs/browser-run/quick-actions/crawl-endpoint.mdx
+++ b/src/content/docs/browser-run/quick-actions/crawl-endpoint.mdx
@@ -228,12 +228,14 @@ When `render` is `true` (the default), crawl jobs also support all standard Brow
 
 ### Viewing skipped URLs
 
-To view URLs that were discovered but skipped, query the crawl job results with `status=skipped`. URLs can be skipped due to `includeExternalLinks`, `includeSubdomains`, `includePatterns`/`excludePatterns`, or the `modifiedSince` parameter. Skipped URLs will also be visible in the dashboard in a future release.
+The `skipped` status applies to URLs that the crawler discovered and evaluated individually, but then chose not to fetch because they were excluded by your crawl configuration, such as `includeExternalLinks`, `includeSubdomains`, or `includePatterns`/`excludePatterns`. To view these URLs, query the crawl job results with `status=skipped`.
 
 ```bash
 curl -X GET 'https://api.cloudflare.com/client/v4/accounts/{account_id}/browser-rendering/crawl/{job_id}?status=skipped' \
   -H 'Authorization: Bearer YOUR_API_TOKEN'
 ```
+
+Because `skipped` only tracks URLs that were evaluated one by one, it applies mainly to crawls that use `source: links` (or `source: all`), where the crawler follows links scraped from pages and checks each one against your configuration. When crawling from a sitemap (`source: sitemaps`), URLs that fall outside your configuration are filtered out in bulk before they are evaluated individually, so they are omitted from the job entirely rather than recorded as `skipped`. As a result, the set of `skipped` URLs is not an exhaustive list of every URL that was left out of the crawl.
 
 ### `render` parameter
 


### PR DESCRIPTION
### Summary

Clarify what URLs with status `skipped` actually include

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
