### PR TITLE
docs(realtimekit): added faq for pre call check and added a button to do so

### DIFF
--- a/src/content/docs/realtime/realtimekit/faq.mdx
+++ b/src/content/docs/realtime/realtimekit/faq.mdx
@@ -196,6 +196,14 @@ When you pass a watermark image URL via the [Start Recording](/api/resources/rea
 
 </Details>
 
+### Pre-call test
+
+<Details header="How can I check if my network and devices are ready for a RealtimeKit meeting?">
+
+Go to [test.realtime.cloudflare.com](https://test.realtime.cloudflare.com/) and run the pre-call test. The test checks your camera, microphone, and network, and verifies connectivity to Cloudflare Realtime endpoints, so you can confirm that the required services are not blocked by your network or firewall before joining a meeting.
+
+</Details>
+
 ### Demo App
 
 <Details header="Can I use the Cloudflare hosted demo app or examples in my website as an iframe?">

--- a/src/content/docs/realtime/realtimekit/index.mdx
+++ b/src/content/docs/realtime/realtimekit/index.mdx
@@ -50,6 +50,13 @@ Your application controls who can join and what they can do. RealtimeKit provide
 >
 	View code examples
 </LinkButton>
+<LinkButton
+	variant="secondary"
+	href="https://test.realtime.cloudflare.com/"
+	target="_blank"
+>
+	Run a pre-call test
+</LinkButton>
 
 ## What you can build
 
@@ -136,8 +143,8 @@ media.
 	href="/realtime/realtimekit/custom-plugins/"
 	cta="Build a plugin"
 >
-	Add your own browser-based, interactive apps such as whiteboard, document viewer into the
-	meeting layout. Use [collaborative
+	Add your own browser-based, interactive apps such as whiteboard, document
+	viewer into the meeting layout. Use [collaborative
 	stores](/realtime/realtimekit/collaborative-stores/) to synchronize plugin
 	state across participants.
 </Feature>


### PR DESCRIPTION
### Summary

Added pre call check FAQ with a link to https://test.realtime.cloudflare.com/ along with a dedicated button in main page.

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
