### PR TITLE
docs(realtimekit): added release notes for 24 aug 2026 release of realtimekit

### DIFF
--- a/src/content/partials/realtime/realtimekit/web/language-pack-json.mdx
+++ b/src/content/partials/realtime/realtimekit/web/language-pack-json.mdx
@@ -185,6 +185,7 @@
   "recording.stopped": "Recording for this meeting has been stopped.",
   "recording.paused": "Recording for this meeting has been paused.",
   "recording.error.start": "Error while starting recording.",
+  "recording.error.already_recording": "A recording is already in progress.",
   "recording.error.stop": "Error while stopping recording",
   "recording.error.resume": "Error while resuming recording",
   "recording.start": "Start Recording",

--- a/src/content/release-notes/realtimekit-web-core.yaml
+++ b/src/content/release-notes/realtimekit-web-core.yaml
@@ -13,7 +13,6 @@ entries:
 
       **Fixes**
 
-      - Invalid authentication tokens are now detected and logged correctly when participant details are requested.
       - Fixed a Babel transpilation error that could occur when consuming ES2015 builds containing `RequestError`.
       - Fixed session recovery after SFU timeouts. Participants can now continue hearing and seeing others after a transient SFU API timeout.
       - Fixed bulk media consumer creation batching to support participant grids with up to 100 participants per page, increased from 24 per page.

--- a/src/content/release-notes/realtimekit-web-core.yaml
+++ b/src/content/release-notes/realtimekit-web-core.yaml
@@ -3,6 +3,21 @@ link: "/realtime/realtimekit/release-notes/"
 productName: RealtimeKit Web Core
 productLink: "/realtime/realtimekit/"
 entries:
+  - publish_date: "2026-08-24"
+    title: RealtimeKit Web Core 2.0.2
+    description: |-
+      **Enhancements**
+
+      - Generated API documentation now identifies class names correctly, providing more accurate type suggestions for TypeScript users.
+      - Starting a recording that is already in progress now returns error code `1005` instead of the generic error code `1000`. If your [`onError` callback](/realtime/realtimekit/core/#advanced-options) handles error code `1000` for this case, update it to handle `1005`.
+
+      **Fixes**
+
+      - Invalid authentication tokens are now detected and logged correctly when participant details are requested.
+      - Fixed a Babel transpilation error that could occur when consuming ES2015 builds containing `RequestError`.
+      - Fixed session recovery after SFU timeouts. Participants can now continue hearing and seeing others after a transient SFU API timeout.
+      - Fixed bulk media consumer creation batching to support participant grids with up to 100 participants per page, increased from 24 per page.
+
   - publish_date: "2026-07-17"
     title: RealtimeKit Web Core 2.0.1
     description: |-

--- a/src/content/release-notes/realtimekit-web-ui-kit.yaml
+++ b/src/content/release-notes/realtimekit-web-ui-kit.yaml
@@ -3,6 +3,19 @@ link: "/realtime/realtimekit/release-notes/"
 productName: RealtimeKit Web UI Kit
 productLink: "/realtime/realtimekit/"
 entries:
+  - publish_date: "2026-08-24"
+    title: RealtimeKit Web UI Kit 2.0.2
+    description: |-
+      **Fixes**
+
+      - Restored Safari 16.x compatibility by incorporating an [upstream Stencil fix](https://github.com/stenciljs/core/pull/6236).
+      - Fixed `rtk-idle-screen` incorrectly displaying non-fatal `preJoinError` events, such as declining to share media, as fatal errors.
+      - Starting a recording while one is already in progress now displays a specific message instead of a generic internal error.
+
+      **New localization keys**
+
+      - `recording.error.already_recording` — "A recording is already in progress."
+
   - publish_date: "2026-07-17"
     title: RealtimeKit Web UI Kit 2.0.1
     description: |-


### PR DESCRIPTION
### Summary

Added release notes for 24 August 2026 release of realtimekit sdks. New release version: 2.0.2 (web-core & ui-kit)

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
