### PR TITLE
Fixes python examples links and shortens ASGI code.

### DIFF
--- a/src/content/docs/workers/languages/python/index.mdx
+++ b/src/content/docs/workers/languages/python/index.mdx
@@ -89,7 +89,7 @@ Or you can clone the examples repository to explore more options:
 
 ```bash
 git clone https://github.com/cloudflare/python-workers-examples
-cd python-workers-examples/01-hello
+cd python-workers-examples/hello
 ```
 
 ## Next Up

--- a/src/content/docs/workers/languages/python/packages/fastapi.mdx
+++ b/src/content/docs/workers/languages/python/packages/fastapi.mdx
@@ -35,12 +35,8 @@ app = FastAPI()
 def read_root():
     return {"Hello": "World"}
 
-import asgi
-from workers import WorkerEntrypoint
-
-class Default(WorkerEntrypoint):
-    async def fetch(self, request):
-        return await asgi.fetch(app, request, self.env)
+from workers import asgi
+Default = asgi.entrypoint(app)
 ```
 
 3. Create a `wrangler.jsonc` file to configure your Worker:
@@ -127,16 +123,13 @@ dev = [
 Then write your worker:
 
 ```python title="src/worker.py"
-from workers import WorkerEntrypoint
 from fastapi import FastAPI, Request
 from fastapi.responses import Response
-import asgi
+from workers import asgi
 
-class Default(WorkerEntrypoint):
-    async def fetch(self, request):
-        return await asgi.fetch(app, request, self.env)
 
 app = FastAPI()
+Default = asgi.entrypoint(app)
 
 @app.get("/api/hello")
 async def api_hello():
@@ -166,6 +159,6 @@ Clone the `cloudflare/python-workers-examples` repository and run the FastAPI ex
 
 ```bash
 git clone https://github.com/cloudflare/python-workers-examples
-cd python-workers-examples/03-fastapi
+cd python-workers-examples/fastapi
 uv run pywrangler dev
 ```

--- a/src/content/docs/workers/languages/python/packages/langchain.mdx
+++ b/src/content/docs/workers/languages/python/packages/langchain.mdx
@@ -25,7 +25,7 @@ Clone the `cloudflare/python-workers-examples` repository and run the LangChain 
 
 ```bash
 git clone https://github.com/cloudflare/python-workers-examples
-cd 05-langchain
+cd python-workers-examples/langchain
 uv run pywrangler dev
 ```
 


### PR DESCRIPTION
We've recently renamed the directories in the python-workers-examples repo (in https://github.com/cloudflare/python-workers-examples/pull/95), so this renames them in the docs too. Also changes the examples to use the new asgi syntax.

