### PR TITLE
[Email Service] Document Outlook threading headers

### DIFF
--- a/src/content/docs/email-service/reference/headers.mdx
+++ b/src/content/docs/email-service/reference/headers.mdx
@@ -43,12 +43,16 @@ Headers that correspond to first-class API fields — `From`, `To`, `Cc`, `Bcc`,
 
 These headers can be set via the `headers` field. Any header not listed here and not starting with `X-` is rejected with `E_HEADER_NOT_ALLOWED`.
 
+Email Service rejects the entire send request if it contains a disallowed header. It does not remove the header and continue sending the message.
+
 ### Threading and reply headers
 
-| Header        | RFC                                                       | Notes                                       |
-| ------------- | --------------------------------------------------------- | ------------------------------------------- |
-| `In-Reply-To` | [RFC 5322](https://datatracker.ietf.org/doc/html/rfc5322) | Critical for email threading in all clients |
-| `References`  | [RFC 5322](https://datatracker.ietf.org/doc/html/rfc5322) | Critical for email threading in all clients |
+| Header         | RFC                                                       | Notes                                                    |
+| -------------- | --------------------------------------------------------- | -------------------------------------------------------- |
+| `In-Reply-To`  | [RFC 5322](https://datatracker.ietf.org/doc/html/rfc5322) | Critical for email threading in all clients              |
+| `References`   | [RFC 5322](https://datatracker.ietf.org/doc/html/rfc5322) | Critical for email threading in all clients              |
+| `Thread-Index` | Microsoft (non-standard)                                  | Conversation index used by Outlook and Exchange Online   |
+| `Thread-Topic` | Microsoft (non-standard)                                  | Conversation subject used by Outlook and Exchange Online |
 
 ### List management headers
 


### PR DESCRIPTION
### Summary

Documents two additional allowlisted headers for Email Service: `Thread-Index`
and `Thread-Topic`. Outlook and Exchange Online use these for conversation
grouping, and neither carries an `X-` prefix, so both need to be listed
explicitly on the allowlist page.

Also documents that a disallowed header causes the entire send request to be
rejected, rather than the header being stripped and the message sent.

### Documentation checklist

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
