### PR TITLE
[Email Service] Document RFC 2156 priority and expiry headers

### DIFF
--- a/src/content/docs/email-service/reference/headers.mdx
+++ b/src/content/docs/email-service/reference/headers.mdx
@@ -78,14 +78,17 @@ These headers can be set via the `headers` field. Any header not listed here and
 | `Keywords`         | [RFC 5322](https://datatracker.ietf.org/doc/html/rfc5322) | Message keywords (comma-separated for multiple values)    |
 | `Comments`         | [RFC 5322](https://datatracker.ietf.org/doc/html/rfc5322) | Additional comments (comma-separated for multiple values) |
 | `Importance`       | [RFC 2156](https://datatracker.ietf.org/doc/html/rfc2156) | Values: `high`, `normal`, `low`                           |
+| `Priority`         | [RFC 2156](https://datatracker.ietf.org/doc/html/rfc2156) | Values: `normal`, `non-urgent`, `urgent`                  |
 | `Sensitivity`      | [RFC 2156](https://datatracker.ietf.org/doc/html/rfc2156) | Values: `personal`, `private`, `company-confidential`     |
 | `Organization`     | [RFC 4021](https://datatracker.ietf.org/doc/html/rfc4021) | Sender's organization name                                |
 
 ### Delivery and notification
 
-| Header                          | RFC                                                       | Notes                    |
-| ------------------------------- | --------------------------------------------------------- | ------------------------ |
-| `Require-Recipient-Valid-Since` | [RFC 7293](https://datatracker.ietf.org/doc/html/rfc7293) | Address reuse protection |
+| Header                          | RFC                                                       | Notes                                                    |
+| ------------------------------- | --------------------------------------------------------- | -------------------------------------------------------- |
+| `Require-Recipient-Valid-Since` | [RFC 7293](https://datatracker.ietf.org/doc/html/rfc7293) | Address reuse protection                                 |
+| `Expires`                       | [RFC 2156](https://datatracker.ietf.org/doc/html/rfc2156) | Date and time after which the message is no longer valid |
+| `Reply-By`                      | [RFC 2156](https://datatracker.ietf.org/doc/html/rfc2156) | Date and time by which a reply is requested              |
 
 ### Modern standards
 


### PR DESCRIPTION
### Summary

Documents three additional allowlisted headers for Email Service, all defined
by [RFC 2156](https://datatracker.ietf.org/doc/html/rfc2156):

- `Priority` — added to **Content and display**, alongside the existing
  `Importance` and `Sensitivity` rows from the same RFC
- `Expires` and `Reply-By` — added to **Delivery and notification**

Values are listed for `Priority` in the same informational style as the
neighbouring `Importance` and `Sensitivity` rows.

### Documentation checklist

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
