### PR TITLE
Remove beta flag from Logpush transformers docs

### DIFF
--- a/src/content/docs/logs/logpush/transformers.mdx
+++ b/src/content/docs/logs/logpush/transformers.mdx
@@ -290,4 +290,3 @@ To debug, open the transformer in [Transformer Studio](#transformer-studio-ui) a
 - [Logpush job setup](/logs/logpush/logpush-job/) - creating and managing Logpush jobs
 - [Log fields reference](/logs/reference/log-fields/) - full field descriptions across datasets
 - [Filters](/logs/logpush/logpush-job/filters/) - simpler filtering without SQL
-- [Transformers API reference](/api/resources/logpush/subresources/transformers/) - full API endpoint documentation

--- a/src/content/docs/logs/logpush/transformers.mdx
+++ b/src/content/docs/logs/logpush/transformers.mdx
@@ -3,19 +3,12 @@ pcx_content_type: how-to
 title: Transformers
 sidebar:
   order: 3
-  badge: Beta
 description: Advanced filtering, reshaping, redacting, and computing on Logpush records with SQL before they leave Cloudflare.
 products:
   - logpush
 ---
 
-import { DashButton, Badge } from "~/components";
-
-<Badge text="Beta" variant="caution" />
-
-:::note[Closed beta]
-Transformers are in closed beta. Contact your Cloudflare Account Executive for access. Beta usage is not billed. The API surface may change before GA.
-:::
+import { DashButton } from "~/components";
 
 Transformers let you run a SQL query against each batch of records before Logpush delivers them to your destination. Use them to filter records you do not want to store, reshape fields to match a downstream schema, redact sensitive values, compute new fields, or add static metadata.
 

--- a/src/content/docs/logs/logpush/transformers.mdx
+++ b/src/content/docs/logs/logpush/transformers.mdx
@@ -290,3 +290,4 @@ To debug, open the transformer in [Transformer Studio](#transformer-studio-ui) a
 - [Logpush job setup](/logs/logpush/logpush-job/) - creating and managing Logpush jobs
 - [Log fields reference](/logs/reference/log-fields/) - full field descriptions across datasets
 - [Filters](/logs/logpush/logpush-job/filters/) - simpler filtering without SQL
+- [Transformers API reference](/api/resources/logpush/subresources/transformers/) - full API endpoint documentation


### PR DESCRIPTION
Logpush transformers are no longer in closed beta. Removes the sidebar badge, inline Beta badge component, and closed-beta callout note.