### PR TITLE
Mark field cf.api_gateway.request_violates_schema as deprecated

### DIFF
--- a/src/content/fields/index.yaml
+++ b/src/content/fields/index.yaml
@@ -513,7 +513,7 @@ entries:
     data_type: Boolean
     categories: [Request]
     keywords: [request, api shield, client, visitor]
-    summary: Indicates whether the request [violated the schema](/api-shield/security/schema-validation/) assigned to the respective saved endpoint.
+    summary: This field is deprecated. Use [`cf.schema_validation.uploaded.violated`](/ruleset-engine/rules-language/fields/reference/cf.schema_validation.uploaded.violated/) instead.
 
   - name: cf.schema_validation.learned.violated
     data_type: Boolean


### PR DESCRIPTION
### Summary

Marks the field `cf.api_gateway.request_violates_schema` as deprecated and links to the new field `cf.schema_validation.uploaded.violated`

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
