### PR TITLE
[Workers] Minor wording tweak in get-started guide

### DIFF
--- a/src/content/docs/workers/get-started/guide.mdx
+++ b/src/content/docs/workers/get-started/guide.mdx
@@ -15,7 +15,7 @@ import { Details, Render, PackageManagers } from "~/components";
 
 Set up and deploy your first Worker with Wrangler, the Cloudflare Developer Platform CLI.
 
-This guide will instruct you through setting up and deploying your first Worker.
+This guide will walk you through setting up and deploying your first Worker.
 
 ## Prerequisites
 
@@ -51,11 +51,11 @@ cd my-first-worker
 
 In your project directory, C3 will have generated the following:
 
-* `wrangler.jsonc`: Your [Wrangler](/workers/wrangler/configuration/#sample-wrangler-configuration) configuration file.
-* `index.js` (in `/src`): A minimal `'Hello World!'` Worker written in [ES module](/workers/reference/migrate-to-module-workers/) syntax.
-* `package.json`: A minimal Node dependencies configuration file.
-* `package-lock.json`: Refer to [`npm` documentation on `package-lock.json`](https://docs.npmjs.com/cli/v9/configuring-npm/package-lock-json).
-* `node_modules`: Refer to [`npm` documentation `node_modules`](https://docs.npmjs.com/cli/v7/configuring-npm/folders#node-modules).
+- `wrangler.jsonc`: Your [Wrangler](/workers/wrangler/configuration/#sample-wrangler-configuration) configuration file.
+- `index.js` (in `/src`): A minimal `'Hello World!'` Worker written in [ES module](/workers/reference/migrate-to-module-workers/) syntax.
+- `package.json`: A minimal Node dependencies configuration file.
+- `package-lock.json`: Refer to [`npm` documentation on `package-lock.json`](https://docs.npmjs.com/cli/v9/configuring-npm/package-lock-json).
+- `node_modules`: Refer to [`npm` documentation `node_modules`](https://docs.npmjs.com/cli/v7/configuring-npm/folders#node-modules).
 
 </Details>
 


### PR DESCRIPTION
### Summary

Test PR — minor wording tweak in the Workers get-started CLI guide. Changes "instruct you through" to "walk you through" for readability. Also normalizes bullet list markers via Prettier.

### Documentation checklist

- [x] The change adheres to [documentation style guide](https://developers.cloudflare.com/style-guide/).
