### PR TITLE
[AI Gateway] Clarify Guardrails streaming evaluation behavior

### DIFF
--- a/src/content/docs/ai-gateway/features/guardrails/supported-model-types.mdx
+++ b/src/content/docs/ai-gateway/features/guardrails/supported-model-types.mdx
@@ -12,10 +12,10 @@ AI Gateway's Guardrails detects the type of AI model being used and applies safe
 
 - **Text generation models**: Both prompts and responses are evaluated.
 - **Embedding models**: Only the prompt is evaluated, as the response consists of numerical embeddings, which are not meaningful for moderation.
-- **Unknown models**: If the model type cannot be determined, only the prompt is evaluated, while the response bypass Guardrails.
+- **Unknown models**: If the model type cannot be determined, only the prompt is evaluated, while the response bypasses Guardrails.
 
-:::note[Note]
+:::note
 
-Guardrails does not yet support streaming responses. Support for streaming is planned for a future update.
+When `stream: true`, prompt evaluations run normally. Guardrails skips response evaluations for streaming requests — the client still receives a real streaming response. To enable response-side evaluation, set `stream: false`. Response-side evaluation for streaming requests is on our roadmap.
 
 :::

--- a/src/content/docs/ai-gateway/features/guardrails/supported-model-types.mdx
+++ b/src/content/docs/ai-gateway/features/guardrails/supported-model-types.mdx
@@ -16,6 +16,6 @@ AI Gateway's Guardrails detects the type of AI model being used and applies safe
 
 :::note
 
-Guardrails handles streaming (`stream: true`) requests differently across API surfaces. See [Streaming behavior](/ai-gateway/features/guardrails/usage-considerations/#streaming-behavior) for details.
+Guardrails does not support streaming (`stream: true`) requests. See [Streaming behavior](/ai-gateway/features/guardrails/usage-considerations/#streaming-behavior) for details.
 
 :::

--- a/src/content/docs/ai-gateway/features/guardrails/supported-model-types.mdx
+++ b/src/content/docs/ai-gateway/features/guardrails/supported-model-types.mdx
@@ -16,6 +16,6 @@ AI Gateway's Guardrails detects the type of AI model being used and applies safe
 
 :::note
 
-Guardrails does not support streaming (`stream: true`) requests. See [Streaming behavior](/ai-gateway/features/guardrails/usage-considerations/#streaming-behavior) for details.
+Guardrails does not support streaming (`stream: true`) requests. For more information, refer to [Streaming behavior](/ai-gateway/features/guardrails/usage-considerations/#streaming-behavior).
 
 :::

--- a/src/content/docs/ai-gateway/features/guardrails/supported-model-types.mdx
+++ b/src/content/docs/ai-gateway/features/guardrails/supported-model-types.mdx
@@ -16,6 +16,6 @@ AI Gateway's Guardrails detects the type of AI model being used and applies safe
 
 :::note
 
-Guardrails skips response evaluation for streaming (`stream: true`) requests. See [Streaming behavior](/ai-gateway/features/guardrails/usage-considerations/#streaming-behavior) for details.
+Guardrails handles streaming (`stream: true`) requests differently across API surfaces. See [Streaming behavior](/ai-gateway/features/guardrails/usage-considerations/#streaming-behavior) for details.
 
 :::

--- a/src/content/docs/ai-gateway/features/guardrails/supported-model-types.mdx
+++ b/src/content/docs/ai-gateway/features/guardrails/supported-model-types.mdx
@@ -12,10 +12,10 @@ AI Gateway's Guardrails detects the type of AI model being used and applies safe
 
 - **Text generation models**: Both prompts and responses are evaluated.
 - **Embedding models**: Only the prompt is evaluated, as the response consists of numerical embeddings, which are not meaningful for moderation.
-- **Unknown models**: If the model type cannot be determined, only the prompt is evaluated, while the response bypasses Guardrails.
+- **Unknown models**: If AI Gateway cannot determine the model type, it evaluates only the prompt and bypasses Guardrails for the response.
 
 :::note
 
-When `stream: true`, prompt evaluations run normally. Guardrails skips response evaluations for streaming requests — the client still receives a real streaming response. To enable response-side evaluation, set `stream: false`. Response-side evaluation for streaming requests is on our roadmap.
+Guardrails skips response evaluation for streaming (`stream: true`) requests. See [Streaming behavior](/ai-gateway/features/guardrails/usage-considerations/#streaming-behavior) for details.
 
 :::

--- a/src/content/docs/ai-gateway/features/guardrails/usage-considerations.mdx
+++ b/src/content/docs/ai-gateway/features/guardrails/usage-considerations.mdx
@@ -48,10 +48,12 @@ These codes also appear in the `guardrails` property of the AI Gateway REST API,
 
 Guardrails evaluation depends on whether the request uses streaming:
 
-| Mode | Prompt evaluation | Response evaluation |
-| ---- | ----------------- | ------------------- |
-| `stream: false` | Runs | Runs |
-| `stream: true` | Runs | Skipped |
+| Mode            | Prompt evaluation | Response evaluation |
+| --------------- | ----------------- | ------------------- |
+| `stream: false` | Runs              | Runs                |
+| `stream: true`  | Runs              | Skipped             |
+
+Response evaluation applies to text generation models. Embedding and unknown model types bypass response evaluation regardless of streaming mode — see [Supported model types](/ai-gateway/features/guardrails/supported-model-types/) for details.
 
 When `stream: true`, the client still receives a real streaming response — Guardrails skips only the response-side evaluation. Response-side evaluation for streaming requests is on our roadmap.
 

--- a/src/content/docs/ai-gateway/features/guardrails/usage-considerations.mdx
+++ b/src/content/docs/ai-gateway/features/guardrails/usage-considerations.mdx
@@ -48,7 +48,7 @@ These codes also appear in the `guardrails` property of the AI Gateway REST API,
 
 Guardrails does not support streaming (`stream: true`) requests. Prompts are still evaluated and enforced, but response behavior depends on the API surface.
 
-On the REST API (`/ai/*`), Guardrails evaluates the response and logs the result, but does not enforce it — the client receives the full streaming response regardless of what Guardrails would have flagged. On the gateway endpoints (`gateway.ai.cloudflare.com/v1/*`), Guardrails buffers the full response, evaluates it, and returns a single non-streamed payload — the request no longer streams.
+On the REST API (`api.cloudflare.com/*`), Guardrails evaluates the response and logs the result, but does not enforce it — the client receives the full streaming response regardless of what Guardrails would have flagged. On the gateway endpoints (`gateway.ai.cloudflare.com/v1/*`), Guardrails buffers the full response, evaluates it, and returns a single non-streamed payload — the request no longer streams.
 
 For non-streaming (`stream: false`) requests, both prompts and responses are evaluated and enforced.
 

--- a/src/content/docs/ai-gateway/features/guardrails/usage-considerations.mdx
+++ b/src/content/docs/ai-gateway/features/guardrails/usage-considerations.mdx
@@ -46,16 +46,16 @@ These codes also appear in the `guardrails` property of the AI Gateway REST API,
 
 ### Streaming behavior
 
-Guardrails evaluation depends on whether the request uses streaming:
+Guardrails handles streaming (`stream: true`) requests differently depending on the API surface:
 
-| Mode            | Prompt evaluation | Response evaluation |
-| --------------- | ----------------- | ------------------- |
-| `stream: false` | Runs              | Runs                |
-| `stream: true`  | Runs              | Skipped             |
+- **REST API (`/ai/*`)**: Guardrails runs against the response and logs the evaluation, but does not enforce the result — the client receives the full streaming response regardless of what Guardrails would have flagged.
+- **Legacy gateway endpoints (`gateway.ai.cloudflare.com/v1/*`)**: Guardrails buffers the response, evaluates it, and returns a single non-streamed payload — streaming does not apply when Guardrails is enabled on this surface.
+
+Guardrails evaluates prompts on both surfaces regardless of streaming mode. For non-streaming (`stream: false`) requests, Guardrails evaluates and enforces responses on both surfaces.
 
 Response evaluation applies to text generation models. Embedding and unknown model types bypass response evaluation regardless of streaming mode — see [Supported model types](/ai-gateway/features/guardrails/supported-model-types/) for details.
 
-When `stream: true`, the client still receives a real streaming response — Guardrails skips only the response-side evaluation. Response-side evaluation for streaming requests is on our roadmap.
+Full response-side enforcement on streaming REST API requests is on our roadmap.
 
 :::note
 

--- a/src/content/docs/ai-gateway/features/guardrails/usage-considerations.mdx
+++ b/src/content/docs/ai-gateway/features/guardrails/usage-considerations.mdx
@@ -43,7 +43,17 @@ These codes also appear in the `guardrails` property of the AI Gateway REST API,
 - **Latency impact**: Enabling Guardrails introduces additional latency to requests. Typically, evaluations using Llama Guard 3 8B on Workers AI add approximately 500 milliseconds per request. However, larger requests may experience increased latency, though this increase is not linear. Consider this when balancing safety and performance.
 - **Handling long content**: When evaluating long prompts or responses, Guardrails automatically segments the content into smaller chunks, processing each through separate Guardrail requests. This approach ensures comprehensive moderation but may result in increased latency for longer inputs.
 - **Supported languages**: Llama Guard 3.3 8B supports content safety classification in the following languages: English, French, German, Hindi, Italian, Portuguese, Spanish, and Thai.
-- **Streaming support**: Streaming is not supported when using Guardrails.
+
+### Streaming behavior
+
+Guardrails evaluation depends on whether the request uses streaming:
+
+| Mode | Prompt evaluation | Response evaluation |
+| ---- | ----------------- | ------------------- |
+| `stream: false` | Runs | Runs |
+| `stream: true` | Runs | Skipped |
+
+When `stream: true`, the client still receives a real streaming response — Guardrails skips only the response-side evaluation. Response-side evaluation for streaming requests is on our roadmap.
 
 :::note
 

--- a/src/content/docs/ai-gateway/features/guardrails/usage-considerations.mdx
+++ b/src/content/docs/ai-gateway/features/guardrails/usage-considerations.mdx
@@ -46,14 +46,13 @@ These codes also appear in the `guardrails` property of the AI Gateway REST API,
 
 ### Streaming behavior
 
-Guardrails does not support streaming (`stream: true`) requests. Prompts are still evaluated and enforced, but response behavior depends on the API surface:
+Guardrails does not support streaming (`stream: true`) requests. Prompts are still evaluated and enforced, but response behavior depends on the API surface.
 
-- **REST API (`/ai/*`)**: Guardrails evaluates the response and logs the result, but does not enforce it — the client receives the full streaming response regardless of what Guardrails would have flagged.
-- **Legacy gateway endpoints (`gateway.ai.cloudflare.com/v1/*`)**: Guardrails buffers the full response, evaluates it, and returns a single non-streamed payload — the request no longer streams.
+On the REST API (`/ai/*`), Guardrails evaluates the response and logs the result, but does not enforce it — the client receives the full streaming response regardless of what Guardrails would have flagged. On the legacy gateway endpoints (`gateway.ai.cloudflare.com/v1/*`), Guardrails buffers the full response, evaluates it, and returns a single non-streamed payload — the request no longer streams.
 
 For non-streaming (`stream: false`) requests, both prompts and responses are evaluated and enforced.
 
-Response evaluation applies to text generation models. Embedding and unknown model types bypass response evaluation regardless of streaming mode — see [Supported model types](/ai-gateway/features/guardrails/supported-model-types/) for details.
+Response evaluation applies to text generation models. Embedding and unknown model types bypass response evaluation regardless of streaming mode. For more information, refer to [Supported model types](/ai-gateway/features/guardrails/supported-model-types/).
 
 Full Guardrails support for streaming requests is on our roadmap.
 

--- a/src/content/docs/ai-gateway/features/guardrails/usage-considerations.mdx
+++ b/src/content/docs/ai-gateway/features/guardrails/usage-considerations.mdx
@@ -46,16 +46,16 @@ These codes also appear in the `guardrails` property of the AI Gateway REST API,
 
 ### Streaming behavior
 
-Guardrails handles streaming (`stream: true`) requests differently depending on the API surface:
+Guardrails does not support streaming (`stream: true`) requests. Prompts are still evaluated and enforced, but response behavior depends on the API surface:
 
-- **REST API (`/ai/*`)**: Guardrails runs against the response and logs the evaluation, but does not enforce the result — the client receives the full streaming response regardless of what Guardrails would have flagged.
-- **Legacy gateway endpoints (`gateway.ai.cloudflare.com/v1/*`)**: Guardrails buffers the response, evaluates it, and returns a single non-streamed payload — streaming does not apply when Guardrails is enabled on this surface.
+- **REST API (`/ai/*`)**: Guardrails evaluates the response and logs the result, but does not enforce it — the client receives the full streaming response regardless of what Guardrails would have flagged.
+- **Legacy gateway endpoints (`gateway.ai.cloudflare.com/v1/*`)**: Guardrails buffers the full response, evaluates it, and returns a single non-streamed payload — the request no longer streams.
 
-Guardrails evaluates prompts on both surfaces regardless of streaming mode. For non-streaming (`stream: false`) requests, Guardrails evaluates and enforces responses on both surfaces.
+For non-streaming (`stream: false`) requests, both prompts and responses are evaluated and enforced.
 
 Response evaluation applies to text generation models. Embedding and unknown model types bypass response evaluation regardless of streaming mode — see [Supported model types](/ai-gateway/features/guardrails/supported-model-types/) for details.
 
-Full response-side enforcement on streaming REST API requests is on our roadmap.
+Full Guardrails support for streaming requests is on our roadmap.
 
 :::note
 

--- a/src/content/docs/ai-gateway/features/guardrails/usage-considerations.mdx
+++ b/src/content/docs/ai-gateway/features/guardrails/usage-considerations.mdx
@@ -48,7 +48,7 @@ These codes also appear in the `guardrails` property of the AI Gateway REST API,
 
 Guardrails does not support streaming (`stream: true`) requests. Prompts are still evaluated and enforced, but response behavior depends on the API surface.
 
-On the REST API (`/ai/*`), Guardrails evaluates the response and logs the result, but does not enforce it — the client receives the full streaming response regardless of what Guardrails would have flagged. On the legacy gateway endpoints (`gateway.ai.cloudflare.com/v1/*`), Guardrails buffers the full response, evaluates it, and returns a single non-streamed payload — the request no longer streams.
+On the REST API (`/ai/*`), Guardrails evaluates the response and logs the result, but does not enforce it — the client receives the full streaming response regardless of what Guardrails would have flagged. On the gateway endpoints (`gateway.ai.cloudflare.com/v1/*`), Guardrails buffers the full response, evaluates it, and returns a single non-streamed payload — the request no longer streams.
 
 For non-streaming (`stream: false`) requests, both prompts and responses are evaluated and enforced.
 

--- a/src/content/docs/ai-gateway/features/guardrails/usage-considerations.mdx
+++ b/src/content/docs/ai-gateway/features/guardrails/usage-considerations.mdx
@@ -52,7 +52,9 @@ On the REST API (`api.cloudflare.com/*`), Guardrails evaluates the response and 
 
 For non-streaming (`stream: false`) requests, both prompts and responses are evaluated and enforced.
 
-Response evaluation applies to text generation models. Embedding and unknown model types bypass response evaluation regardless of streaming mode. For more information, refer to [Supported model types](/ai-gateway/features/guardrails/supported-model-types/).
+Guardrails evaluates response payload text, including URL strings in image generation model responses. It does not retrieve or evaluate referenced images. Embedding and unknown model types bypass response evaluation regardless of streaming mode.
+
+For more information, refer to [Supported model types](/ai-gateway/features/guardrails/supported-model-types/).
 
 Full Guardrails support for streaming requests is on our roadmap.
 


### PR DESCRIPTION
### Summary

Replaces two inaccurate statements about Guardrails and streaming with precise, behavior-matched documentation. Behavior confirmed by the AI Gateway team from source code review.

**What was wrong:**

- `usage-considerations.mdx`: "Streaming is not supported when using Guardrails" — misleading because prompt evaluation still runs and the transport still streams.
- `supported-model-types.mdx`: "Guardrails does not yet support streaming responses" — same problem, plus an ambiguous "planned for a future update" phrase.

**What is true:**

| Mode | Prompt evaluation | Response evaluation |
|---|---|---|
| `stream: false` | Runs | Runs |
| `stream: true` | Runs | Skipped |

**Changes:**

1. `usage-considerations.mdx`: Removes the streaming bullet from the "Additional considerations" list and replaces it with a dedicated `### Streaming behavior` subsection containing the table above.
2. `supported-model-types.mdx`: Replaces the note with accurate text; removes redundant `[Note]` label; fixes a pre-existing subject–verb agreement error ("bypass" → "bypasses").

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).