### PR TITLE
[SSL] Add per-zone PQC visibility to PQC products page

### DIFF
--- a/src/content/changelog/logs/2026-08-20-pqc-key-exchange-visibility.mdx
+++ b/src/content/changelog/logs/2026-08-20-pqc-key-exchange-visibility.mdx
@@ -1,0 +1,15 @@
+---
+title: Per-zone post-quantum visibility in Logpush and Log Explorer
+description: The http_requests dataset now includes ClientTLSKeyExchangeGroup, exposing the TLS key exchange negotiated on every client-to-Cloudflare connection.
+products:
+  - logs
+  - log-explorer
+date: 2026-08-20
+---
+
+[Cloudflare Radar](https://radar.cloudflare.com/post-quantum) publishes global statistics on post-quantum key agreement adoption across all Cloudflare traffic, but until now customers had no way to see the same measurement scoped to their own zones. This is now possible because the [`http_requests`](/logs/logpush/logpush-job/datasets/zone/http_requests/) Logpush dataset — also queryable in [Log Explorer](/log-explorer/) — includes a new `ClientTLSKeyExchangeGroup` field.
+
+The field reports the TLS key exchange group negotiated on the client-to-Cloudflare connection, by group name. Post-quantum connections appear as `X25519MLKEM768`, and classical connections appear as `X25519`, `P-256`, or another named group. A value of `UNK` means the group could not be determined, and `NONE` means TLS was not used.
+
+With this field, you can build per-zone reports showing what percentage of your inbound HTTPS traffic is protected by post-quantum key agreement, break the number down by hostname, path, user agent, or country, and push the data into your SIEM via any [Logpush destination](/logs/logpush/logpush-job/enable-destinations/).
+

--- a/src/content/docs/ssl/post-quantum-cryptography/pqc-cloudflare-products.mdx
+++ b/src/content/docs/ssl/post-quantum-cryptography/pqc-cloudflare-products.mdx
@@ -40,6 +40,8 @@ Reference: [PQC for all websites and APIs](https://blog.cloudflare.com/post-quan
 - The Cloudflare API and dashboard.
 - [Cloudflare Access](/cloudflare-one/access-controls/applications/http-apps/self-hosted-public-app/) self-hosted applications (browser-to-edge leg).
 
+Customers can measure per-zone post-quantum key agreement adoption on their inbound traffic using the [`ClientTLSKeyExchangeGroup`](/logs/logpush/logpush-job/datasets/zone/http_requests/#clienttlskeyexchangegroup) field in the `http_requests` Logpush dataset, which is also queryable in [Log Explorer](/log-explorer/).
+
 This section only covers the inbound TLS connection from the end-user client to Cloudflare's edge. When a Worker fetches data from a backend storage service ([D1](/d1/), [KV](/kv/), [Durable Objects](/durable-objects/), [R2](/r2/), [Workers AI](/workers-ai/), [Hyperdrive](/hyperdrive/), and similar), that connection is governed by the [Cloudflare internal network](#cloudflare-internal-network) section. When a Worker calls out to a third-party origin via `fetch()`, it is governed by the [Cloudflare to origin](#cloudflare-to-origin) section.
 
 ## Cloudflare internal network


### PR DESCRIPTION
### Summary

This PR:

- documents the new ClientTLSKeyExchangeGroup field on the PQC in Cloudflare products page, so customers can measure per-zone post-quantum key agreement adoption via the http_requests Logpush dataset and Log Explorer.

- adds a changelog entry cross-listed to both the logs and log-explorer product changelogs.

The Cloudflare Email Security section has been split out into #33048 per review feedback.

### Documentation checklist

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).