### PR TITLE
[Fundamentals] Document audit log actor context values

### DIFF
--- a/src/content/docs/fundamentals/account/account-security/audit-logs.mdx
+++ b/src/content/docs/fundamentals/account/account-security/audit-logs.mdx
@@ -325,7 +325,14 @@ Use the following example to get a list of audit logs for a Cloudflare account.
 
 ### Actor
 
-The actor represents who performed the action. It includes identity attributes like user ID, email address, IP address, and the type of actor (`user`, `account`, `Cloudflare_admin`, or `system`). It also includes the context used to initiate the action, such as API or dashboard (`dash`).
+The actor represents who performed the action. It includes identity attributes like user ID, email address, IP address, and the type of actor (`user`, `account`, `Cloudflare_admin`, or `system`). It also includes the context used to initiate the action:
+
+- `api`: The action was performed through the API. The specific credential type was not recorded.
+- `api_key`: The action was authenticated with a Cloudflare Global API Key.
+- `api_token`: The action was authenticated with an API token.
+- `dash`: The action was performed through the Cloudflare dashboard.
+- `oauth`: The action was authenticated with an OAuth token.
+- `origin_ca_key`: The action was authenticated with an Origin CA key.
 
 ### Action
 


### PR DESCRIPTION
### Summary

Documentation clarification for Audit Logs (Version 2).

The **Actor** section under "Common terms and definitions" described the actor context field only as "the context used to initiate the action, such as API or dashboard (`dash`)". That named one value in passing and left the rest undocumented, so there was no way to learn the accepted values from the docs.

This enumerates all six values the V2 audit logs API returns, with a short description of each:

- `api`
- `api_key`
- `api_token`
- `dash`
- `oauth`
- `origin_ca_key`

The wording matches the value descriptions being added to the public OpenAPI schema for the same field, so the API reference and this page stay consistent.

The five credential-backed descriptions are derived from the audit log ingestor's credential-prefix mapping. `api` is worded conservatively ("performed through the API, specific credential type not recorded") because it is the one value the ingestor never assigns directly.

### Screenshots (optional)

N/A — prose-only change to an existing section.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
