### PR TITLE
fix: clarify contributor count

### DIFF
--- a/src/pages/contributors.astro
+++ b/src/pages/contributors.astro
@@ -100,22 +100,7 @@ function resolveAvatarUrl(c: unknown): string {
 
 					<div id="contributors-status" class="text-muted-foreground text-sm">
 						<span>
-							Showing{" "}
-							<span id="contributors-visible-count">
-								{initialContributors.length}
-							</span>
-							{
-								totalVisibleContributors > 0 && (
-									<Fragment> of {totalVisibleContributors}</Fragment>
-								)
-							}
-							{
-								totalContributorsAll > 0 &&
-									totalContributorsAll !== totalVisibleContributors && (
-										<Fragment> ({totalContributorsAll} total)</Fragment>
-									)
-							}{" "}
-							contributors
+							Showing {totalVisibleContributors} of {totalContributorsAll} total contributors
 						</span>
 						<button
 							type="button"
@@ -171,7 +156,6 @@ function resolveAvatarUrl(c: unknown): string {
 				(() => {
 					const GRID = document.getElementById("contributors-grid");
 					const SENTINEL = document.getElementById("contributors-sentinel");
-					const COUNT = document.getElementById("contributors-visible-count");
 					const TEMPLATE = document.getElementById("contributor-card-template");
 
 					if (!(GRID && SENTINEL)) {
@@ -182,13 +166,6 @@ function resolveAvatarUrl(c: unknown): string {
 					GRID.dataset.infiniteScrollReady = "true";
 					if (!(TEMPLATE instanceof HTMLTemplateElement)) {
 						return;
-					}
-
-					function updateVisibleCount() {
-						if (!COUNT) return;
-						COUNT.textContent = String(
-							GRID.querySelectorAll(":scope > [data-contributor-card]").length,
-						);
 					}
 
 					const total = Array.isArray(contributors) ? contributors.length : 0;
@@ -254,7 +231,6 @@ function resolveAvatarUrl(c: unknown): string {
 							if (cell) frag.append(cell);
 						}
 						GRID.append(frag);
-						updateVisibleCount();
 					}
 
 					function fillViewport() {
@@ -268,8 +244,6 @@ function resolveAvatarUrl(c: unknown): string {
 							appendBatch();
 						}
 					}
-
-					updateVisibleCount();
 
 					let io;
 					let onScroll;


### PR DESCRIPTION
### Summary

Updates the contributors-page status to show the total GitHub accounts available and the overall contributor total, rather than the incrementally rendered card count.

#### Before
<img width="1125" height="945" alt="2" src="https://github.com/user-attachments/assets/e211cbc2-ccd4-432b-b019-4c942c0176f0" />


#### After
<img width="1130" height="946" alt="1" src="https://github.com/user-attachments/assets/afb3246e-7fb0-4b16-8a9f-98771a267c6c" />


