### PR TITLE
AI Search: add six Workers AI text generation models

### DIFF
--- a/src/content/changelog/ai-search/2026-08-26-new-workers-ai-models.mdx
+++ b/src/content/changelog/ai-search/2026-08-26-new-workers-ai-models.mdx
@@ -3,7 +3,7 @@ title: New Workers AI text generation models in AI Search
 description: AI Search adds six Workers AI models for text generation.
 products:
   - ai-search
-date: 2026-08-27
+date: 2026-08-26
 publish_future_dated_entry: true
 ---
 

--- a/src/content/changelog/ai-search/2026-08-27-new-workers-ai-models.mdx
+++ b/src/content/changelog/ai-search/2026-08-27-new-workers-ai-models.mdx
@@ -1,0 +1,23 @@
+---
+title: New Workers AI text generation models in AI Search
+description: AI Search adds six Workers AI models for text generation.
+products:
+  - ai-search
+date: 2026-08-27
+publish_future_dated_entry: true
+---
+
+[AI Search](/ai-search/) now supports six additional [Workers AI](/workers-ai/) models for text generation:
+
+| Model                                         | Context window (tokens) |
+| --------------------------------------------- | ----------------------- |
+| `@cf/deepseek-ai/deepseek-v4-flash-0731`      | 1,048,576               |
+| `@cf/deepseek-ai/deepseek-v4-pro-0813`        | 1,048,576               |
+| `@cf/openai/gpt-oss-120b`                     | 128,000                 |
+| `@cf/openai/gpt-oss-20b`                      | 128,000                 |
+| `@cf/qwen/qwen3.8-27b`                        | 262,144                 |
+| `@cf/moonshotai/kimi-k2.7-code`               | 262,144                 |
+
+These models run on Workers AI, so they do not require an additional provider key. Select a model when creating or updating an AI Search instance in the dashboard or through the API.
+
+For the full list of supported models, refer to [Supported models](/ai-search/configuration/models/supported-models/).

--- a/src/content/docs/ai-search/configuration/models/supported-models.mdx
+++ b/src/content/docs/ai-search/configuration/models/supported-models.mdx
@@ -40,6 +40,12 @@ Production models are the actively supported and recommended models that are sta
 |                      | `@cf/meta/llama-3.1-8b-instruct-fast`         | 60,000                  |
 |                      | `@cf/meta/llama-3.1-8b-instruct-fp8`          | 32,000                  |
 |                      | `@cf/meta/llama-4-scout-17b-16e-instruct`     | 131,000                 |
+|                      | `@cf/deepseek-ai/deepseek-v4-flash-0731`      | 1,048,576               |
+|                      | `@cf/deepseek-ai/deepseek-v4-pro-0813`        | 1,048,576               |
+|                      | `@cf/openai/gpt-oss-120b`                     | 128,000                 |
+|                      | `@cf/openai/gpt-oss-20b`                      | 128,000                 |
+|                      | `@cf/qwen/qwen3.8-27b`                        | 262,144                 |
+|                      | `@cf/moonshotai/kimi-k2.7-code`               | 262,144                 |
 |                      | `@cf/zai-org/glm-4.7-flash`                   | 131,072                 |
 |                      | `@cf/qwen/qwen3-30b-a3b-fp8`                  | 32,000                  |
 


### PR DESCRIPTION
## Changes

- Add six Workers AI text generation models to the AI Search supported-model reference.
- Add an AI Search changelog entry for August 27, 2026.