### PR TITLE
Add python-workers-314 compat flag

### DIFF
--- a/src/content/compatibility-flags/python-workers-314.md
+++ b/src/content/compatibility-flags/python-workers-314.md
@@ -1,0 +1,17 @@
+---
+_build:
+  publishResources: false
+  render: never
+  list: never
+
+name: "Python 314 for Python Workers"
+sort_date: "2026-09-08"
+enable_date: "2026-09-08"
+enable_flag: "python_workers_314"
+---
+
+When this flag is set, Python 3.14 is used for Python Workers.
+Normally, you don't need to enable this flag manually,
+and the Python version is selected based on the compatibility date or your worker.
+
+


### PR DESCRIPTION
### Summary

Adds a documentation for a new compat flag in Python workers: `python-workers-314 ` which enables python 314 in Python workers.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).