### PR TITLE
chore: add Flagship code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -246,10 +246,10 @@ package.json @cloudflare/content-engineering
 /src/content/docs/r2-sql/  @Marcinthecloud @netgusto @sesteves @sejoker @laplab @jonesphillip @jonathanc-n @cloudflare/product-owners
 /src/content/docs/r2-data-catalog/ @Marcinthecloud @sejoker @jonesphillip @laplab @vovacf201 @nagraham @cloudflare/product-owners
 /src/content/changelog/r2-data-catalog/ @Marcinthecloud @sejoker @jonesphillip @laplab @vovacf201 @nagraham @cloudflare/product-owners
-/src/content/docs/flagship/ @roerohan @palashgo @akshitsinha @abhishekkankani @thebongy @cloudflare/product-owners
-/src/content/directory/flagship.yaml @roerohan @palashgo @akshitsinha @abhishekkankani @thebongy @cloudflare/product-owners
-/src/assets/images/flagship/ @roerohan @palashgo @akshitsinha @abhishekkankani @thebongy @cloudflare/product-owners
-/src/icons/flagship.svg @roerohan @palashgo @akshitsinha @abhishekkankani @thebongy @cloudflare/product-owners
+/src/content/docs/flagship/ @roerohan @palashgo @akshitsinha @abhishekkankani @thebongy @cloudflare/flagship @irvinebroque @ishita1805 @vaibhavshn @karishnu @cloudflare/product-owners
+/src/content/directory/flagship.yaml @roerohan @palashgo @akshitsinha @abhishekkankani @thebongy @cloudflare/flagship @irvinebroque @ishita1805 @vaibhavshn @karishnu @cloudflare/product-owners
+/src/assets/images/flagship/ @roerohan @palashgo @akshitsinha @abhishekkankani @thebongy @cloudflare/flagship @irvinebroque @ishita1805 @vaibhavshn @karishnu @cloudflare/product-owners
+/src/icons/flagship.svg @roerohan @palashgo @akshitsinha @abhishekkankani @thebongy @cloudflare/flagship @irvinebroque @ishita1805 @vaibhavshn @karishnu @cloudflare/product-owners
 
 # DDoS Protection
 


### PR DESCRIPTION
### Summary

Adds the Flagship team and additional maintainers as owners for every Flagship documentation, directory, image, and icon path in CODEOWNERS.
