### PR TITLE
docs(_headers): document that rules apply in file order, and the singleton-header consequence

### DIFF
--- a/src/content/partials/workers/custom_headers.mdx
+++ b/src/content/partials/workers/custom_headers.mdx
@@ -56,9 +56,25 @@ You may define up to 100 header rules. Each line in the `_headers` file has a 2,
 
 If a header is applied twice in the `_headers` file, the values are joined with a comma separator.
 
+Rules are applied in the order they appear in the file.
+
+:::caution
+Joining works as intended for list-valued headers such as `X-Robots-Tag`. For a header that takes a single value, such as `Cache-Control`, joining two rules produces conflicting directives:
+
+```txt
+Cache-Control: public, max-age=604800, public, max-age=0, s-maxage=86400
+```
+
+[RFC 9111](https://www.rfc-editor.org/rfc/rfc9111) leaves two `max-age` values ambiguous, so implementations resolve it however they choose. Nothing errors and the asset still serves, which makes this easy to miss.
+
+To give one file a different single-valued header from the rule that already covers it, [detach the header](#detach-a-header) and set it again.
+:::
+
 ### Detach a header
 
 You may wish to remove a default header or a header which has been added by a more pervasive rule. This can be done by prepending the header name with an exclamation mark and space (`! `).
+
+Because rules are applied in file order, `! ` removes only what earlier rules have already added. A detach placed above the rule it is meant to override has no effect, so put the narrower rule after the broader one.
 
 ```txt
 /*
@@ -67,6 +83,19 @@ You may wish to remove a default header or a header which has been added by a mo
 /*.jpg
   ! Content-Security-Policy
 ```
+
+Detaching and setting the header again is how one file takes a different value for a single-valued header:
+
+```txt
+/assets/*
+  Cache-Control: public, max-age=0, s-maxage=86400
+
+/assets/model.bin
+  ! Cache-Control
+  Cache-Control: public, max-age=604800
+```
+
+`/assets/model.bin` is served with `max-age=604800` alone. Reversing the two blocks leaves the glob's value in place instead, because the detach would run before the value it targets was added.
 
 ### Match a path
 


### PR DESCRIPTION
Closes #32979.

## What this adds

Three short additions to the `_headers` docs, all measured on wrangler 4.125.0 with `wrangler dev --local`:

1. **Rules are applied in the order they appear in the file.** This is the load-bearing fact and it isn't stated anywhere today.
2. **A caution on single-valued headers.** The page's existing example joins `X-Robots-Tag`, where a comma-separated list is what the header means. The same join on `Cache-Control` gives two `max-age` values in one field, which RFC 9111 leaves ambiguous. Nothing errors and the asset still serves, so it ships easily.
3. **A worked override example**, since detach plus re-set is the fix and its ordering is not obvious.

## The measurement behind it

Same two files each time, only the `_headers` layout changing:

| layout | `Cache-Control` served |
|---|---|
| specific rule with `!` above the glob | `public, max-age=0, s-maxage=86400` (detach did nothing) |
| glob first, then specific with `!` and a new value | `public, max-age=604800` |
| glob first, then specific with `!` only | header absent |

`! ` removes only what earlier rules have already added, so a detach placed above the rule it targets is a silent no-op.

## A note on the issue

I filed #32979 claiming there was no way to override a glob's `Cache-Control` for one file. That was wrong, and I've corrected it on the issue. Detach already does this and is already documented. What the docs don't give you is the ordering rule that makes detach work, which is what this PR adds.

Doc-only change. It was written against `src/content/partials/workers/custom_headers.mdx`; #32998 inlined that partial into `workers/static-assets/headers.mdx` and `pages/configuration/headers.mdx`, so the same text now lands in both, and the wording avoids product-specific terms.

