### PR TITLE
[RealtimeKit] Add release notes navigation page

### DIFF
--- a/src/content/docs/realtime/realtimekit/release-notes/index.mdx
+++ b/src/content/docs/realtime/realtimekit/release-notes/index.mdx
@@ -1,14 +1,15 @@
 ---
-pcx_content_type: changelog
-title: Release Notes
-description: Release notes and changelog for the RealtimeKit Web Core SDK.
-release_notes_file_name:
-  - realtimekit-web-core
+pcx_content_type: navigation
+title: Release notes
+description: Find release notes for your RealtimeKit SDK and platform.
 sidebar:
-  label: Web Core SDK
   order: 15
+products:
+  - realtime
 ---
 
-import { ProductReleaseNotes } from "~/components";
+import { DirectoryListing } from "~/components";
 
-<ProductReleaseNotes />
+RealtimeKit ships a Core SDK and UI Kit for each supported platform. Select your platform and SDK to view its release notes.
+
+<DirectoryListing />

--- a/src/content/docs/realtime/realtimekit/release-notes/web-core.mdx
+++ b/src/content/docs/realtime/realtimekit/release-notes/web-core.mdx
@@ -1,0 +1,16 @@
+---
+pcx_content_type: changelog
+title: Web Core SDK
+description: Release notes and changelog for the RealtimeKit Web Core SDK.
+release_notes_file_name:
+  - realtimekit-web-core
+sidebar:
+  label: Web Core SDK
+  order: 1
+products:
+  - realtime
+---
+
+import { ProductReleaseNotes } from "~/components";
+
+<ProductReleaseNotes />


### PR DESCRIPTION
### Summary

Adds a RealtimeKit release notes navigation page so readers can select the release notes for their SDK and platform. 
Moves the Web Core SDK release notes (previously served at the release notes index) to their own dedicated page.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [x] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.