### PR TITLE
[Workers] Document static assets base paths

### DIFF
--- a/src/content/changelog/workers/2026-08-25-static-assets-base-path.mdx
+++ b/src/content/changelog/workers/2026-08-25-static-assets-base-path.mdx
@@ -1,0 +1,27 @@
+---
+title: Serve Workers Static Assets from a URL path prefix
+description: Workers Static Assets can now serve an asset directory from a URL path prefix with the `assets.base_path` configuration option.
+products:
+  - workers
+date: 2026-08-25
+---
+
+import { WranglerConfig } from "~/components";
+
+Workers Static Assets now supports the `assets.base_path` configuration option. Set it to expose the root of `assets.directory` beneath a URL path prefix.
+
+For example, this configuration serves the contents of `./dist` from `/blog/`:
+
+<WranglerConfig>
+
+```toml
+[assets]
+directory = "./dist"
+base_path = "/blog"
+```
+
+</WranglerConfig>
+
+The Cloudflare Vite plugin uses a root-relative Vite [`base`](https://vite.dev/config/shared-options.html#base) value when `assets.base_path` is not set. An explicit `assets.base_path` overrides the Vite value.
+
+To configure the option, refer to [Serving a subdirectory](/workers/static-assets/routing/advanced/serving-a-subdirectory/).

--- a/src/content/docs/workers/configuration/multipart-upload-metadata.mdx
+++ b/src/content/docs/workers/configuration/multipart-upload-metadata.mdx
@@ -51,6 +51,7 @@ At a minimum, the `main_module` key is required to upload a Worker.
 - `assets` <Type text="object" /> <MetaInfo text="optional" />
   - [Asset](/workers/static-assets/) configuration for a Worker.
   - `config` <Type text="object" /> <MetaInfo text="optional" />
+    - [base_path](/workers/static-assets/routing/advanced/serving-a-subdirectory/) determines the URL path prefix where static assets are available.
     - [html_handling](/workers/static-assets/routing/advanced/html-handling/) determines the redirects and rewrites of requests for HTML content.
     - [not_found_handling](/workers/static-assets/#routing-behavior) determines the response when a request does not match a static asset.
   - `jwt` field provides a token authorizing assets to be attached to a Worker.

--- a/src/content/docs/workers/static-assets/routing/advanced/serving-a-subdirectory.mdx
+++ b/src/content/docs/workers/static-assets/routing/advanced/serving-a-subdirectory.mdx
@@ -43,6 +43,6 @@ Set `assets.base_path` to `/blog` in your Wrangler configuration file:
 
 Requests to `example.com/blog/` serve `dist/index.html`. Requests to `example.com/blog/posts/post1` serve `dist/posts/post1.html`.
 
-Requests outside `/blog` do not resolve static assets. The [asset binding](/workers/static-assets/binding/#binding) remains asset-relative, so binding requests do not include `base_path`.
+Requests outside `/blog` do not resolve static assets. Requests made through the [assets binding](/workers/static-assets/binding/#binding) also use the mounted public path. Forwarding the original request works unchanged. When constructing a request, include `/blog` in its pathname, for example, `env.ASSETS.fetch("https://assets.local/blog/posts/post1")`.
 
 Paths in `_headers`, `_redirects`, and `assets.run_worker_first` use the public URL path. Include `/blog` in those paths when they apply to this example.

--- a/src/content/docs/workers/static-assets/routing/advanced/serving-a-subdirectory.mdx
+++ b/src/content/docs/workers/static-assets/routing/advanced/serving-a-subdirectory.mdx
@@ -8,27 +8,21 @@ products:
 
 import { FileTree, WranglerConfig } from "~/components";
 
-:::note
-This feature requires Wrangler v3.98.0 or later.
-:::
+Set `assets.base_path` to serve static assets from a URL subpath. The files remain at the root of `assets.directory`.
 
-Like with any other Worker, [you can configure a Worker with assets to run on a path of your domain](/workers/configuration/routing/routes/).
-Assets defined for a Worker must be nested in a directory structure that mirrors the desired path.
-
-For example, to serve assets from `example.com/blog/*`, create a `blog` directory in your asset directory.
+For example, use this asset directory to serve a blog:
 
 <FileTree>
 
 - dist
-  - blog
-    - index.html
-    - posts
-      - post1.html
-      - post2.html
+  - index.html
+  - posts
+    - post1.html
+    - post2.html
 
 </FileTree>
 
-With a [Wrangler configuration file](/workers/wrangler/configuration/) like so:
+Set `assets.base_path` to `/blog` in your Wrangler configuration file:
 
 <WranglerConfig>
 
@@ -39,13 +33,16 @@ With a [Wrangler configuration file](/workers/wrangler/configuration/) like so:
 	"main": "src/index.js",
 	"route": "example.com/blog/*",
 	"assets": {
-		"directory": "dist"
+		"directory": "dist",
+		"base_path": "/blog"
 	}
 }
 ```
 
 </WranglerConfig>
 
-In this example, requests to `example.com/blog/` will serve the `index.html` file, and requests to `example.com/blog/posts/post1` will serve the `post1.html` file.
+Requests to `example.com/blog/` serve `dist/index.html`. Requests to `example.com/blog/posts/post1` serve `dist/posts/post1.html`.
 
-If you have a file outside the configured path, it will not be served, unless it is part of the `assets.not_found_handling` for [Single Page Applications](/workers/static-assets/routing/single-page-application/) or [custom 404 pages](/workers/static-assets/routing/static-site-generation/). For example, if you have a `home.html` file in the root of your asset directory, it will not be served when requesting `example.com/blog/home`. However, if needed, these files can still be manually fetched over [the binding](/workers/static-assets/binding/#binding).
+Requests outside `/blog` do not resolve static assets. The [asset binding](/workers/static-assets/binding/#binding) remains asset-relative, so binding requests do not include `base_path`.
+
+Paths in `_headers`, `_redirects`, and `assets.run_worker_first` use the public URL path. Include `/blog` in those paths when they apply to this example.

--- a/src/content/docs/workers/vite-plugin/reference/static-assets.mdx
+++ b/src/content/docs/workers/vite-plugin/reference/static-assets.mdx
@@ -47,6 +47,8 @@ The following example configures the `not_found_handling` for a single-page appl
 
 </WranglerConfig>
 
+If `assets.base_path` is not set, the plugin uses the root-relative Vite [`base`](https://vite.dev/config/shared-options.html#base) value. Set `assets.base_path` explicitly to override the Vite value. Relative paths, full URLs, and protocol-relative Vite base values are not used for `assets.base_path`.
+
 ## Features
 
 The Vite plugin ensures that all of Vite's [static asset handling](https://vite.dev/guide/assets) features are supported in your Worker as well as in your frontend.

--- a/src/content/docs/workers/wrangler/configuration.mdx
+++ b/src/content/docs/workers/wrangler/configuration.mdx
@@ -1212,6 +1212,8 @@ The following options are available under the `assets` key.
   - Not required if you're using the [Cloudflare Vite plugin](/workers/vite-plugin/), which will automatically point to the client build output.
 - `binding` <Type text="string" /> <MetaInfo text="optional" />
   - The binding name used to refer to the assets. Optional, and only useful when a Worker script is set with `main`.
+- `base_path` <Type text="string" /> <MetaInfo text={'optional, defaults to "/"'} />
+  - The URL path prefix where static assets are available. For example, set this to `/docs` to serve the root of `assets.directory` from `/docs/`. Refer to [Serving a subdirectory](/workers/static-assets/routing/advanced/serving-a-subdirectory/).
 - `run_worker_first` <Type text="boolean | string[]" /> <MetaInfo text="optional, defaults to false" />
   - Controls whether static assets are fetched directly, or a Worker script is invoked. Can be a boolean (`true`/`false`) or an array of route pattern strings with support for glob patterns (`*`) and exception patterns (`!` prefix). Patterns must begin with `/` or `!/`. Learn more about fetching assets when using [`run_worker_first`](/workers/static-assets/routing/worker-script/#run-your-worker-script-first).
 - `html_handling`: <Type text={'"auto-trailing-slash" | "force-trailing-slash" | "drop-trailing-slash" | "none"'} /> <MetaInfo text={'optional, defaults to "auto-trailing-slash"'} />
@@ -1228,6 +1230,7 @@ Example:
 	"assets": {
 		"directory": "./public",
 		"binding": "ASSETS",
+		"base_path": "/docs",
 		"html_handling": "force-trailing-slash",
 		"not_found_handling": "404-page",
 	},


### PR DESCRIPTION
### Summary

<!-- Add context such as the type of documentation being updated or added -->
Updating configuration documentation to reflect the addition of base paths, which can be used to serve assets to a subdirectory. Explains how it can be used to do this, as well as how it is inherited from Vite's `base` option.

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
