### PR TITLE
Update to secret token in entra.mdx

### DIFF
--- a/src/content/docs/fundamentals/account/account-security/scim-setup/entra.mdx
+++ b/src/content/docs/fundamentals/account/account-security/scim-setup/entra.mdx
@@ -25,7 +25,7 @@ Once you have [gathered the required data](/fundamentals/account/account-securit
 
 1. Inside the newly created application under **Manage** from the sidebar menu, select **Provisioning**.
 2. Select **New configuration** and enter the **Tenant URL**: `https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/scim/v2`. Replace `<ACCOUNT_ID>` with your own account ID.
-3. Paste the SCIM provisioning API token value as **Secret token**.
+3. Retrieve the SCIM provisioning API token [previously generated](/fundamentals/account/account-security/scim-setup/#create-an-api-token) and paste its value as **Secret token**.
 4. Select **Test Connection** then **Save** the configuration.
 
 ## Configure user and group synchronization


### PR DESCRIPTION
Despite it being mentioned in the prerequisites ("Once you have gathered the required data..."), several team members at my customer missed the creation and scope of the API token and couldn't complete step 3 of the "Provision the Enterprise application" section. This update is to remind the user to double-check creation and scope before acting.

### Summary

Reminding users to create and properly scope their SCIM API token before using its value as Secret token.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

- [ ?] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/). <-- called the hyperlink in the diff, hope this is fitting.