### PR TITLE
[RealtimeKit] Add network allowlist page

### DIFF
--- a/src/content/docs/realtime/realtimekit/faq.mdx
+++ b/src/content/docs/realtime/realtimekit/faq.mdx
@@ -4,7 +4,7 @@ title: FAQ
 description: Frequently asked questions about RealtimeKit meetings, recordings, and SDK usage.
 slug: realtime/realtimekit/faq
 sidebar:
-  order: 14
+  order: 15
 ---
 
 import { Details } from "~/components";
@@ -196,11 +196,17 @@ When you pass a watermark image URL via the [Start Recording](/api/resources/rea
 
 </Details>
 
-### Pre-call test
+### Network access
+
+<Details header="Which domains and ports must I allowlist when my network restricts outbound traffic?">
+
+If your network restricts outbound traffic, refer to [Network allowlist](/realtime/realtimekit/network-allowlist/) for the domains and ports required for your RealtimeKit integration.
+
+</Details>
 
 <Details header="How can I check if my network and devices are ready for a RealtimeKit meeting?">
 
-Go to [test.realtime.cloudflare.com](https://test.realtime.cloudflare.com/) and run the pre-call test. The test checks your camera, microphone, and network, and verifies connectivity to Cloudflare Realtime endpoints, so you can confirm that the required services are not blocked by your network or firewall before joining a meeting.
+Go to [test.realtime.cloudflare.com](https://test.realtime.cloudflare.com/) and run the pre-call test. The test checks your camera, microphone, and network, and verifies connectivity to Cloudflare Realtime endpoints, so you can confirm that the required services are not blocked by your network or firewall before joining a meeting. For required domains and ports, refer to [Network allowlist](/realtime/realtimekit/network-allowlist/).
 
 </Details>
 

--- a/src/content/docs/realtime/realtimekit/network-allowlist.mdx
+++ b/src/content/docs/realtime/realtimekit/network-allowlist.mdx
@@ -1,0 +1,59 @@
+---
+title: Network allowlist
+description: Allow the domains and ports required for RealtimeKit connectivity.
+pcx_content_type: reference
+products:
+  - realtime
+sidebar:
+  order: 14
+  label: Allowlist
+---
+
+If your network restricts outbound traffic, allow the following RealtimeKit domains and ports.
+
+## Allow service domains
+
+Allow these domains for RealtimeKit SDKs:
+
+| Domain                                 | Purpose                                                           |
+| -------------------------------------- | ----------------------------------------------------------------- |
+| `api.realtime.cloudflare.com`          | Handles requests from RealtimeKit SDKs                            |
+| `api-silos.realtime.cloudflare.com`    | Collects SDK logs                                                 |
+| `da-collector.realtime.cloudflare.com` | Collects call statistics                                          |
+| `location.realtime.cloudflare.com`     | Determines the location in call statistics reports                |
+| `r2.cloudflarestorage.com`             | Stores and retrieves chat messages                                |
+| `socket-edge.realtime.cloudflare.com`  | Establishes signaling connections between clients and RealtimeKit |
+
+If your application uses RealtimeKit Web UI Kit, also allow these domains:
+
+| Domain                                | Purpose                                                |
+| ------------------------------------- | ------------------------------------------------------ |
+| `rtk-assets.realtime.cloudflare.com`  | Serves Web UI Kit assets, including speaker-test audio |
+| `rtk-uploads.realtime.cloudflare.com` | Serves notification sounds and other Web UI Kit assets |
+
+Applications that use only RealtimeKit Core do not require the Web UI Kit asset domains.
+
+## Allow media traffic
+
+RealtimeKit uses the [Cloudflare Realtime SFU](/realtime/sfu/) for media connections. Allow the following Session Traversal Utilities for NAT (STUN) and Traversal Using Relays around NAT (TURN) traffic:
+
+| Protocol      | Domain                | Primary port | Alternate port |
+| ------------- | --------------------- | ------------ | -------------- |
+| STUN over UDP | `stun.cloudflare.com` | `3478/udp`   | `53/udp`       |
+| TURN over UDP | `turn.cloudflare.com` | `3478/udp`   | `53/udp`       |
+| TURN over TCP | `turn.cloudflare.com` | `3478/tcp`   | `80/tcp`       |
+| TURN over TLS | `turn.cloudflare.com` | `5349/tcp`   | `443/tcp`      |
+
+Allow the primary and alternate ports where possible. Do not rely only on `53/udp`, because Internet service providers and browsers can block this port.
+
+For protocol details, refer to [Service address and ports](/realtime/turn/#service-address-and-ports).
+
+## Use a wildcard domain
+
+If your network policy supports wildcard domains, you can use `*.realtime.cloudflare.com` instead of the listed `realtime.cloudflare.com` domains.
+
+Individual domain rules are recommended because they restrict access to only the required services. If you use the wildcard domain, you must still allow `r2.cloudflarestorage.com`, `stun.cloudflare.com`, and `turn.cloudflare.com` separately, because the wildcard does not cover them.
+
+## Verify connectivity
+
+Run the [RealtimeKit pre-call test](https://test.realtime.cloudflare.com/) to verify your device can reach the required services.


### PR DESCRIPTION
### Summary

Adds a reference page listing the domains and ports customers must allow through their network to use RealtimeKit, and adds an FAQ entry that links to it.

Ed Tech and Enterprise customers on restrictive networks need a definitive list of RealtimeKit domains and media ports to add to their network allowlist before they can use the product.


### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [x] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
