### PR TITLE
chore: disable workers.dev URL in wrangler.jsonc

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -5,7 +5,7 @@
 	"compatibility_date": "2025-06-02",
 	"compatibility_flags": ["nodejs_compat"],
 	"main": "./worker/index.ts",
-	"workers_dev": true,
+	"workers_dev": false,
 	"route": {
 		"pattern": "developers.cloudflare.com/*",
 		"zone_name": "developers.cloudflare.com",

--- a/wrangler.preview.json
+++ b/wrangler.preview.json
@@ -5,6 +5,7 @@
 	"compatibility_date": "2025-06-02",
 	"compatibility_flags": ["nodejs_compat"],
 	"main": "./worker/index.preview.ts",
+	"workers_dev": false,
 	"rules": [
 		{ "type": "Text", "globs": ["**/__redirects"], "fallthrough": true }
 	],
@@ -15,6 +16,7 @@
 		"run_worker_first": true
 	},
 	"previews": {
+		"workers_dev": false,
 		"r2_buckets": [{ "binding": "MIDDLECACHE", "bucket_name": "middlecache" }]
 	},
 	"observability": {

--- a/wrangler.preview.json
+++ b/wrangler.preview.json
@@ -5,7 +5,6 @@
 	"compatibility_date": "2025-06-02",
 	"compatibility_flags": ["nodejs_compat"],
 	"main": "./worker/index.preview.ts",
-	"workers_dev": false,
 	"rules": [
 		{ "type": "Text", "globs": ["**/__redirects"], "fallthrough": true }
 	],
@@ -16,7 +15,6 @@
 		"run_worker_first": true
 	},
 	"previews": {
-		"workers_dev": false,
 		"r2_buckets": [{ "binding": "MIDDLECACHE", "bucket_name": "middlecache" }]
 	},
 	"observability": {


### PR DESCRIPTION
### Summary

Disables the `workers.dev` URL for the docs Worker by setting `workers_dev: false` in `wrangler.jsonc`.