### PR TITLE
WAF Release 25th August

### DIFF
--- a/src/content/changelog/waf/2026-08-25-waf-release.mdx
+++ b/src/content/changelog/waf/2026-08-25-waf-release.mdx
@@ -1,0 +1,99 @@
+---
+title: "WAF Release - 2026-08-25"
+description: Cloudflare WAF managed rulesets 2026-08-25 release
+date: 2026-08-25
+---
+
+import { RuleID } from "~/components";
+
+This release moves four new detections from Log to Block, merges the XSS, HTML Injection - Script Tag - Beta rule into the original rule, and adds a Generic Rules - Remote Code Execution rule in Block mode.
+
+**Key Findings**
+
+- Four new detections move from Log to Block: HTTP/2 Request Smuggling - Request Body Anomaly and XSS - JavaScript Event Handler Coercion across Headers, Body, and URI.
+
+- The XSS, HTML Injection - Script Tag - Beta rule is merged into the original rule.
+
+- A Generic Rules - Remote Code Execution detection is added in Block mode.
+
+<table style="width: 100%">
+	<thead>
+		<tr>
+			<th>Ruleset</th>
+			<th>Rule ID</th>
+			<th>Legacy Rule ID</th>
+			<th>Description</th>
+			<th>Previous Action</th>
+			<th>New Action</th>
+			<th>Comments</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>Cloudflare Managed Ruleset</td>
+			<td>
+				<RuleID id="a80f214f0947435dabb2ba2d1489d892" />
+			</td>
+			<td>N/A</td>
+			<td>HTTP/2 Request Smuggling - Request Body Anomaly</td>
+			<td>Log</td>
+			<td>Block</td>
+			<td>This is a new detection.</td>
+		</tr>
+		<tr>
+			<td>Cloudflare Managed Ruleset</td>
+			<td>
+				<RuleID id="58a184412d2b4113bca6379b20646260" />
+			</td>
+			<td>N/A</td>
+			<td>XSS - JavaScript Event Handler Coercion - Headers</td>
+			<td>Log</td>
+			<td>Block</td>
+			<td>This is a new detection.</td>
+		</tr>
+		<tr>
+			<td>Cloudflare Managed Ruleset</td>
+			<td>
+				<RuleID id="e79cb939d6aa41db984e6db3d706d517" />
+			</td>
+			<td>N/A</td>
+			<td>XSS - JavaScript Event Handler Coercion - Body</td>
+			<td>Log</td>
+			<td>Block</td>
+			<td>This is a new detection.</td>
+		</tr>
+		<tr>
+			<td>Cloudflare Managed Ruleset</td>
+			<td>
+				<RuleID id="7e3249c7a5d8469697478746660886c8" />
+			</td>
+			<td>N/A</td>
+			<td>XSS - JavaScript Event Handler Coercion - URI</td>
+			<td>Log</td>
+			<td>Block</td>
+			<td>This is a new detection.</td>
+		</tr>
+		<tr>
+			<td>Cloudflare Managed Ruleset</td>
+			<td>
+				<RuleID id="d34bc5db8cbc4e18a44ed115c293b926" />
+			</td>
+			<td>N/A</td>
+			<td>XSS, HTML Injection - Script Tag - Beta</td>
+			<td>Log</td>
+			<td>Block</td>
+			<td>This rule is merged into the original rule "XSS, HTML Injection - Script Tag" (ID:{" "}<RuleID id="9c8dda9708cc4452ac76e7be7b58420b" />).</td>
+		</tr>
+		<tr>
+			<td>Cloudflare Managed Ruleset</td>
+			<td>
+				<RuleID id="2b6b94ec864d47f99630ecf72ca6cce3" />
+			</td>
+			<td>N/A</td>
+			<td>Generic Rules - Remote Code Execution</td>
+			<td>N/A</td>
+			<td>Block</td>
+			<td>This is a new detection.</td>
+		</tr>
+	</tbody>
+</table>

--- a/src/content/changelog/waf/scheduled-waf-release.mdx
+++ b/src/content/changelog/waf/scheduled-waf-release.mdx
@@ -1,7 +1,7 @@
 ---
-title: WAF Release - Scheduled changes for 2026-08-24
-description: WAF managed ruleset changes scheduled for 2026-08-24
-date: 2026-08-17
+title: WAF Release - Scheduled changes for 2026-09-01
+description: WAF managed ruleset changes scheduled for 2026-09-01
+date: 2026-08-25
 publish_future_dated_entry: true
 ---
 
@@ -21,68 +21,16 @@ import { RuleID } from "~/components";
 	</thead>
 	<tbody>
 		<tr>
-			<td>2026-08-17</td>
-			<td>2026-08-24</td>
+			<td>2026-08-25</td>
+			<td>2026-09-01</td>
 			<td>Log</td>
 			<td>N/A</td>
 			<td>
-				<RuleID id="a80f214f0947435dabb2ba2d1489d892" />
+				<RuleID id="d2d75b2f0614405f9fab0354bcfa0966" />
 			</td>
-			<td>HTTP/2 Request Smuggling - Request Body Anomaly</td>
+			<td>SQLi - WHERE Comparison With WITH Clause</td>
 			<td>
 				This is a new detection.
-			</td>
-		</tr>
-		<tr>
-			<td>2026-08-17</td>
-			<td>2026-08-24</td>
-			<td>Log</td>
-			<td>N/A</td>
-			<td>
-				<RuleID id="58a184412d2b4113bca6379b20646260" />
-			</td>
-			<td>XSS - JavaScript Event Handler Coercion - Headers</td>
-			<td>
-				This is a new detection.
-			</td>
-		</tr>
-		<tr>
-			<td>2026-08-17</td>
-			<td>2026-08-24</td>
-			<td>Log</td>
-			<td>N/A</td>
-			<td>
-				<RuleID id="e79cb939d6aa41db984e6db3d706d517" />
-			</td>
-			<td>XSS - JavaScript Event Handler Coercion - Body</td>
-			<td>
-				This is a new detection.
-			</td>
-		</tr>
-		<tr>
-			<td>2026-08-17</td>
-			<td>2026-08-24</td>
-			<td>Log</td>
-			<td>N/A</td>
-			<td>
-				<RuleID id="7e3249c7a5d8469697478746660886c8" />
-			</td>
-			<td>XSS - JavaScript Event Handler Coercion - URI</td>
-			<td>
-				This is a new detection.
-			</td>
-		</tr>
-		<tr>
-			<td>2026-08-17</td>
-			<td>2026-08-24</td>
-			<td>Log</td>
-			<td>N/A</td>
-			<td>
-				<RuleID id="d34bc5db8cbc4e18a44ed115c293b926" />
-			</td>
-			<td>XSS, HTML Injection - Script Tag - Beta</td>
-			<td>
-				This rule will be merged into the original rule "XSS, HTML Injection - Script Tag" (ID:{" "}<RuleID id="9c8dda9708cc4452ac76e7be7b58420b" />).
 			</td>
 		</tr>
 	</tbody>


### PR DESCRIPTION
## Summary

- Publish the 2026-08-25 WAF release.
- Schedule one new detection in Log mode for 2026-09-01.

## Validation

- Reviewed the complete two-file diff.
- Validated the scheduled MDX with the WAF changelog tooling.
- Verified both changed paths use regular `100644` file modes.
- `git diff --cached --check` passed.

The release file is hand-authored because its emergency `N/A` to `Block` row is outside the standard scheduled-to-release automation schema.