### PR TITLE
fix: use shallow checkout in production publish workflow

### DIFF
--- a/.github/workflows/publish-production.yml
+++ b/.github/workflows/publish-production.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          fetch-depth: 0
+          fetch-depth: 1
       - name: Set up pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
         with:


### PR DESCRIPTION
### Summary

Changes the `publish-production` workflow to use a shallow checkout (`fetch-depth: 1`) instead of a full clone (`fetch-depth: 0`).

The full clone downloads the repo's entire ~1.5 GB git history (25k+ commits) on every push to `production`, making the checkout step take 20+ minutes. Nothing in the workflow's build or deploy steps needs git history, so the shallow clone cuts that down to the ~558 MB current tree that every other workflow already fetches.