### PR TITLE
Fix permission names for * Logs

### DIFF
--- a/src/content/docs/fundamentals/api/how-to/account-owned-token-template.mdx
+++ b/src/content/docs/fundamentals/api/how-to/account-owned-token-template.mdx
@@ -141,7 +141,7 @@ Use this table to find permission keys for your custom templates.
 | `page`               | Cloudflare Pages      | Page deployments         |
 | `stream`             | Stream                | Video streaming          |
 | `images`             | Images                | Image optimization       |
-| `logs`               | Logs                  | Log management           |
+| `account_logs`       | Logs                  | Log management           |
 
 ### Zone permissions
 
@@ -155,6 +155,7 @@ Use this table to find permission keys for your custom templates.
 | `page_rules`           | Page rules           | Traffic control        |
 | `cache`                | Cache purging        | Content updates        |
 | `ssl_and_certificates` | SSL/TLS certificates | Certificate management |
+| `logs`                 | Logs                  | Log management           |
 
 ### Access permissions
 


### PR DESCRIPTION
### Summary

The permission name is wrong. These are the correct ones:

- Account logs: `account_logs`
- Zone logs: `logs`


### Documentation checklist

- [X] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
