### PR TITLE
Revert "fix: use shallow checkout in production publish workflow"

### DIFF
--- a/.github/workflows/publish-production.yml
+++ b/.github/workflows/publish-production.yml
@@ -12,6 +12,8 @@ jobs:
     permissions:
       contents: read
     steps:
+      # Full history (fetch-depth: 0) is required for accurate "Last updated"
+      # dates on pages and `lastmod` in the sitemap, both derived from `git log`.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0

--- a/.github/workflows/publish-production.yml
+++ b/.github/workflows/publish-production.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          fetch-depth: 1
+          fetch-depth: 0
       - name: Set up pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
         with:


### PR DESCRIPTION
### Summary

Reverts #33015, which changed the `publish-production` workflow checkout from `fetch-depth: 0` to `fetch-depth: 1`.

**Why this is needed:** the site's "Last updated" date is computed by `@cloudflare/nimbus-docs`'s `getLastUpdated()`, which shells out to `git log --name-status -- src/content` and takes the most recent commit that touched each file. Only 1 of 6,787 docs pages sets an explicit `lastUpdated` frontmatter override — every other page depends entirely on this git-history lookup.

A shallow checkout (`fetch-depth: 1`) only has the single tip commit in history, so `git log` can only see files changed in that one commit. Every other page's `getLastUpdated()` call misses and returns `undefined`, which hides the "Last updated" text on the page (`PageActions.astro`) site-wide.

The full clone in `fetch-depth: 0` is required for this to work correctly on `production`. The checkout time tradeoff (~20 min) is intentional until "Last updated" is decoupled from git history.