### PR TITLE
docs: update Debian Bookworm support timeline

### DIFF
--- a/src/content/docs/cloudflare-one/team-and-resources/devices/cloudflare-one-client/download/support-lifecycle.mdx
+++ b/src/content/docs/cloudflare-one/team-and-resources/devices/cloudflare-one-client/download/support-lifecycle.mdx
@@ -96,7 +96,7 @@ As of December 2025, the following versions of Debian are supported:
 
 | Debian version                 | Supported until |
 | ------------------------------ | --------------- |
-| Debian&nbsp;13&nbsp;(Trixie)   | August 2028     |
+| Debian&nbsp;13&nbsp;(Trixie)   | 2030            |
 | Debian&nbsp;12&nbsp;(Bookworm) | June 2028       |
 
 ### Ubuntu

--- a/src/content/docs/cloudflare-one/team-and-resources/devices/cloudflare-one-client/download/support-lifecycle.mdx
+++ b/src/content/docs/cloudflare-one/team-and-resources/devices/cloudflare-one-client/download/support-lifecycle.mdx
@@ -97,7 +97,7 @@ As of December 2025, the following versions of Debian are supported:
 | Debian version                 | Supported until |
 | ------------------------------ | --------------- |
 | Debian&nbsp;13&nbsp;(Trixie)   | August 2028     |
-| Debian&nbsp;12&nbsp;(Bookworm) | June 2026       |
+| Debian&nbsp;12&nbsp;(Bookworm) | June 2028       |
 
 ### Ubuntu
 

--- a/src/content/docs/cloudflare-one/team-and-resources/devices/cloudflare-one-client/download/support-lifecycle.mdx
+++ b/src/content/docs/cloudflare-one/team-and-resources/devices/cloudflare-one-client/download/support-lifecycle.mdx
@@ -96,7 +96,7 @@ As of December 2025, the following versions of Debian are supported:
 
 | Debian version                 | Supported until |
 | ------------------------------ | --------------- |
-| Debian&nbsp;13&nbsp;(Trixie)   | 2030            |
+| Debian&nbsp;13&nbsp;(Trixie)   | June 2030       |
 | Debian&nbsp;12&nbsp;(Bookworm) | June 2028       |
 
 ### Ubuntu


### PR DESCRIPTION
## Summary
<img width="1254" height="330" alt="image" src="https://github.com/user-attachments/assets/70e396cd-c9e8-4a61-9586-c4a4a8f2d1b6" />
- Update Debian 12 (Bookworm) support through June 2028 to match the [Debian LTS support window](https://www.debian.org/releases/)