### PR TITLE
[Workers AI] Document GLM-5.2 reasoning effort

### DIFF
--- a/src/components/models/ModelDetailPage.astro
+++ b/src/components/models/ModelDetailPage.astro
@@ -144,6 +144,7 @@ const authorName = model.authorName;
 const requiresWorkersPaid =
 	model.properties.require_workers_paid === true ||
 	model.properties.require_workers_paid === "true";
+const hasReasoningEffortGuidance = model.name === "@cf/zai-org/glm-5.2";
 
 // `hasSchema`: input must have at least one key.
 const hasSchema = Object.keys(model.schema.input).length > 0;
@@ -214,6 +215,11 @@ const pageTitle = `${displayName} (${authorName})`;
 const headTitle = `${pageTitle} · Cloudflare AI docs`;
 
 const headings: MarkdownHeading[] = [
+	hasReasoningEffortGuidance && {
+		depth: 2,
+		slug: "reasoning-effort",
+		text: "Reasoning effort",
+	},
 	hasPlayground && { depth: 2, slug: "playground", text: "Playground" },
 	hasCodeExamples && { depth: 2, slug: "usage", text: "Usage" },
 	hasRemainingExamples && { depth: 2, slug: "examples", text: "Examples" },
@@ -342,6 +348,42 @@ const headings: MarkdownHeading[] = [
 	}
 
 	<ModelFeatures model={model} />
+
+	{
+		hasReasoningEffortGuidance && (
+			<Fragment>
+				<AnchorHeading
+					depth={2}
+					title="Reasoning effort"
+					slug="reasoning-effort"
+				/>
+				<p>
+					GLM-5.2 supports <code>high</code> and <code>max</code> reasoning
+					effort, or you can turn reasoning off. For compatibility with Chat
+					Completions and other protocols in the ecosystem, other reasoning
+					efforts will be mapped to these modes:
+				</p>
+				<ul>
+					<li>
+						<code>none</code> and <code>minimal</code> turn reasoning off.
+					</li>
+					<li>
+						<code>low</code> and <code>medium</code> map to <code>high</code>.
+					</li>
+					<li>
+						<code>xhigh</code> maps to <code>max</code>.
+					</li>
+				</ul>
+				<p>
+					This is the same mapping used by Z.ai's API, and{" "}
+					<a href="https://docs.z.ai/api-reference/llm/chat-completion#body-one-of-0-reasoning-effort">
+						in their <code>reasoning_effort</code> documentation
+					</a>
+					.
+				</p>
+			</Fragment>
+		)
+	}
 
 	{
 		/* Defensive dead branch (model not in slice): nova-3 transport pricing. */

--- a/src/components/models/ModelFeatures.astro
+++ b/src/components/models/ModelFeatures.astro
@@ -138,7 +138,7 @@ const price = Array.isArray(properties.price)
 				{properties.reasoning && (
 					<tr>
 						<td>Reasoning</td>
-						<td>Yes</td>
+						<td>{properties.reasoning_options ?? "Yes"}</td>
 					</tr>
 				)}
 				{properties.vision && (

--- a/src/components/models/ModelFeatures.astro
+++ b/src/components/models/ModelFeatures.astro
@@ -138,7 +138,7 @@ const price = Array.isArray(properties.price)
 				{properties.reasoning && (
 					<tr>
 						<td>Reasoning</td>
-						<td>{properties.reasoning_options ?? "Yes"}</td>
+						<td>{properties.reasoning_effort ?? "Yes"}</td>
 					</tr>
 				)}
 				{properties.vision && (

--- a/src/components/models/SchemaDisplay.astro
+++ b/src/components/models/SchemaDisplay.astro
@@ -171,6 +171,7 @@ function collectRows(
 		let isNullable = false;
 		let nullableType: string | undefined;
 		let nullableChildDescription: string | undefined;
+		let nullableChildEnumValues: unknown[] | undefined;
 		if ((hasOneOf || hasAnyOf) && reg.children?.length === 2) {
 			const childTypes = reg.children.map((c) =>
 				String((c as RegularNode).primaryType ?? ""),
@@ -183,6 +184,10 @@ function collectRows(
 				nullableType = childTypes[nonNullIndex];
 				nullableChildDescription = nonNullChild.annotations?.description as
 					string | undefined;
+				nullableChildEnumValues =
+					(nonNullChild.validations?.enum as unknown[]) ??
+					((nonNullChild.fragment as Record<string, unknown>)
+						?.enum as unknown[]);
 				isNullable = true;
 			}
 		}
@@ -207,7 +212,8 @@ function collectRows(
 		// Check both validations and fragment for enum (different schema parsers put it in different places)
 		const enumValues = (
 			(reg.validations?.enum as unknown[]) ??
-			((reg.fragment as Record<string, unknown>)?.enum as unknown[])
+			((reg.fragment as Record<string, unknown>)?.enum as unknown[]) ??
+			nullableChildEnumValues
 		)?.map(String);
 
 		// Collect all metadata from fragment and validations

--- a/src/content/workers-ai-models/glm-5.2.json
+++ b/src/content/workers-ai-models/glm-5.2.json
@@ -38,7 +38,7 @@
             "value": "true"
         },
         {
-            "property_id": "reasoning_options",
+            "property_id": "reasoning_effort",
             "value": "Off, High, Max"
         }
     ],

--- a/src/content/workers-ai-models/glm-5.2.json
+++ b/src/content/workers-ai-models/glm-5.2.json
@@ -36,6 +36,10 @@
         {
             "property_id": "reasoning",
             "value": "true"
+        },
+        {
+            "property_id": "reasoning_options",
+            "value": "Off, High, Max"
         }
     ],
     "id": "4edc7dfe-de78-4156-890c-85b79227694e",
@@ -297,7 +301,8 @@
                                             "enum": [
                                                 "low",
                                                 "medium",
-                                                "high"
+                                                "high",
+                                                "max"
                                             ]
                                         },
                                         {
@@ -1563,7 +1568,8 @@
                                             "enum": [
                                                 "low",
                                                 "medium",
-                                                "high"
+                                                "high",
+                                                "max"
                                             ]
                                         },
                                         {
@@ -2399,7 +2405,8 @@
                                                         "enum": [
                                                             "low",
                                                             "medium",
-                                                            "high"
+                                                            "high",
+                                                            "max"
                                                         ]
                                                     },
                                                     {
@@ -3665,7 +3672,8 @@
                                                         "enum": [
                                                             "low",
                                                             "medium",
-                                                            "high"
+                                                            "high",
+                                                            "max"
                                                         ]
                                                     },
                                                     {

--- a/src/content/workers-ai-models/glm-5.2.json
+++ b/src/content/workers-ai-models/glm-5.2.json
@@ -299,8 +299,7 @@
                                         {
                                             "type": "string",
                                             "enum": [
-                                                "low",
-                                                "medium",
+                                                "none",
                                                 "high",
                                                 "max"
                                             ]
@@ -1566,8 +1565,7 @@
                                         {
                                             "type": "string",
                                             "enum": [
-                                                "low",
-                                                "medium",
+                                                "none",
                                                 "high",
                                                 "max"
                                             ]
@@ -2403,8 +2401,7 @@
                                                     {
                                                         "type": "string",
                                                         "enum": [
-                                                            "low",
-                                                            "medium",
+                                                            "none",
                                                             "high",
                                                             "max"
                                                         ]
@@ -3670,8 +3667,7 @@
                                                     {
                                                         "type": "string",
                                                         "enum": [
-                                                            "low",
-                                                            "medium",
+                                                            "none",
                                                             "high",
                                                             "max"
                                                         ]


### PR DESCRIPTION
Add docs for the already-supported GLM-5.2 `max` reasoning effort, and the reasoning effort mapping, with link to Z.ai's API docs that do the same mapping.

Current docs page: https://developers.cloudflare.com/ai/models/%40cf/zai-org/glm-5.2/

<img width="776" height="1261" alt="image" src="https://github.com/user-attachments/assets/6d6d022e-68c7-4f4c-8e30-f154764d68e8" />

- Show `Off, High, Max` in the GLM-5.2 Model Info card.
- Document how Chat Completions reasoning effort values map to GLM-5.2 modes, with a link to the Z.ai API reference.
- Add `max` to every GLM-5.2 `reasoning_effort` schema variant.

### Validation

- `pnpm run check`
- `pnpm run lint`
- `pnpm run format:check`
- `pnpm run test -- --run` (124 tests)
- `pnpm run build` (8,902 pages)