### PR TITLE
[AI Gateway] Clarify caching opt-in behavior

### DIFF
--- a/src/content/docs/ai-gateway/features/caching.mdx
+++ b/src/content/docs/ai-gateway/features/caching.mdx
@@ -11,7 +11,7 @@ products:
 
 import { Render, TabItem, Tabs } from "~/components";
 
-AI Gateway can cache responses from your AI model providers, serving them directly from Cloudflare's cache for identical requests.
+When caching is enabled, AI Gateway can cache responses from your AI model providers, serving them directly from Cloudflare's cache for identical requests.
 
 ## Benefits of Using Caching
 
@@ -28,6 +28,8 @@ We plan on adding semantic search for caching in the future to improve cache hit
 :::
 
 ## Default configuration
+
+Caching is disabled by default. To enable caching globally, set the default caching configuration:
 
 <Tabs syncKey="dashPlusAPI"> <TabItem label="Dashboard">
 
@@ -53,7 +55,7 @@ To set the default caching configuration using the API:
 
 </TabItem> </Tabs>
 
-This caching behavior will be uniformly applied to all requests that support caching. If you need to modify the cache settings for specific requests, you have the flexibility to override this setting on a per-request basis.
+When caching is enabled globally, the default caching behavior applies to all requests that support caching. You can also opt individual requests into caching or override their cache settings with per-request headers.
 
 To check whether a response comes from cache or not, **cf-aig-cache-status** will be designated as `HIT` or `MISS`.
 
@@ -127,6 +129,7 @@ As an example, when submitting a request to OpenAI, include the header in the fo
 curl -X POST "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/v1/chat/completions" \
   --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
   --header "Content-Type: application/json" \
+  --header "cf-aig-cache-key: responseWithCustomTtl" \
   --header "cf-aig-cache-ttl: 3600" \
   --data '{
     "model": "openai/gpt-4.1-mini",
@@ -141,9 +144,9 @@ curl -X POST "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_
 
 ### Custom cache key (cf-aig-cache-key)
 
-Custom cache keys let you override the default cache key in order to precisely set the cacheability setting for any resource. To override the default cache key, you can use the header **cf-aig-cache-key**.
+The `cf-aig-cache-key` header lets you override the default cache key and opts the request into caching.
 
-When you use the **cf-aig-cache-key** header for the first time, you will receive a response from the provider. Subsequent requests with the same header will return the cached response. If the **cf-aig-cache-ttl** header is used, responses will be cached according to the specified Cache Time To Live. Otherwise, responses will be cached according to the cache settings in the dashboard. If caching is not enabled for the gateway, responses will be cached for 5 minutes by default.
+When you use the `cf-aig-cache-key` header for the first time, you will receive a response from the provider. Subsequent requests with the same header will return the cached response. If you include `cf-aig-cache-ttl`, the request uses that value for its cache TTL. Otherwise, the request uses the default cache TTL configured for the gateway. For requests that include `cf-aig-cache-key`, the cache TTL is 5 minutes when neither `cf-aig-cache-ttl` nor a default gateway cache TTL is configured.
 
 As an example, when submitting a request to OpenAI, include the header in the following manner:
 

--- a/src/content/docs/ai-gateway/features/caching.mdx
+++ b/src/content/docs/ai-gateway/features/caching.mdx
@@ -117,7 +117,7 @@ curl -X POST "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_
 
 ### Cache TTL (cf-aig-cache-ttl)
 
-Cache TTL, or Time To Live, is the duration a cached request remains valid before it expires and is refreshed from the original source. You can use **cf-aig-cache-ttl** to set the desired caching duration in seconds. The minimum TTL is 60 seconds and the maximum TTL is one month.
+Cache TTL, or Time To Live, is the duration a cached request remains valid before it expires and is refreshed from the original source. Use `cf-aig-cache-ttl` to set the caching duration for a request that already uses caching. To opt an individual request into caching, include `cf-aig-cache-key`. The minimum TTL is 60 seconds and the maximum TTL is one month.
 
 For example, if you set a TTL of one hour, it means that a request is kept in the cache for an hour. Within that hour, an identical request will be served from the cache instead of the original API. After an hour, the cache expires and the request will go to the original API for a fresh response, and that response will repopulate the cache for the next hour.
 
@@ -126,6 +126,7 @@ As an example, when submitting a request to OpenAI, include the header in the fo
 ```bash title="Request to be cached for an hour"
 # Run `wrangler whoami` to get your account ID to replace $CLOUDFLARE_ACCOUNT_ID,
 # and `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN.
+# Use a key shared only by requests with equivalent responses.
 curl -X POST "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/v1/chat/completions" \
   --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
   --header "Content-Type: application/json" \
@@ -146,7 +147,7 @@ curl -X POST "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_
 
 The `cf-aig-cache-key` header lets you override the default cache key and opts the request into caching.
 
-When you use the `cf-aig-cache-key` header for the first time, you will receive a response from the provider. Subsequent requests with the same header will return the cached response. If you include `cf-aig-cache-ttl`, the request uses that value for its cache TTL. Otherwise, the request uses the default cache TTL configured for the gateway. For requests that include `cf-aig-cache-key`, the cache TTL is 5 minutes when neither `cf-aig-cache-ttl` nor a default gateway cache TTL is configured.
+Choose a custom key that groups only requests with equivalent responses. Requests with the same custom key share a cached response. When you use the `cf-aig-cache-key` header for the first time, you will receive a response from the provider. Subsequent requests with the same header will return the cached response. If you include `cf-aig-cache-ttl`, the request uses that value for its cache TTL. Otherwise, the request uses the default cache TTL configured for the gateway. For requests that include `cf-aig-cache-key`, the cache TTL is 5 minutes when neither `cf-aig-cache-ttl` nor a default gateway cache TTL is configured.
 
 As an example, when submitting a request to OpenAI, include the header in the following manner:
 

--- a/src/content/docs/ai-gateway/features/caching.mdx
+++ b/src/content/docs/ai-gateway/features/caching.mdx
@@ -147,7 +147,7 @@ curl -X POST "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_
 
 The `cf-aig-cache-key` header lets you override the default cache key and opts the request into caching.
 
-Choose a custom key that groups only requests with equivalent responses. Requests with the same custom key share a cached response. When you use the `cf-aig-cache-key` header for the first time, you will receive a response from the provider. Subsequent requests with the same header will return the cached response. If you include `cf-aig-cache-ttl`, the request uses that value for its cache TTL. Otherwise, the request uses the default cache TTL configured for the gateway. For requests that include `cf-aig-cache-key`, the cache TTL is 5 minutes when neither `cf-aig-cache-ttl` nor a default gateway cache TTL is configured.
+Choose a custom key that groups only requests with equivalent responses. Requests with the same custom key share a cached response. When you use the `cf-aig-cache-key` header for the first time, you will receive a response from the provider. Subsequent requests with the same custom key value will return the cached response. If you include `cf-aig-cache-ttl`, the request uses that value for its cache TTL. Otherwise, the request uses the default cache TTL configured for the gateway. For requests that include `cf-aig-cache-key`, the cache TTL is 5 minutes when neither `cf-aig-cache-ttl` nor a default gateway cache TTL is configured.
 
 As an example, when submitting a request to OpenAI, include the header in the following manner:
 


### PR DESCRIPTION
## Summary

- Clarify that caching is disabled by default.
- Distinguish global caching from per-request opt-in.
- Scope the five-minute fallback to requests using `cf-aig-cache-key`.
- Ensure TTL examples include the per-request opt-in and key guidance.

## Testing

- `pnpm run check`
- `pnpm run lint`
- `pnpm run format:core:check`
- `pnpm exec prettier --check src/content/docs/ai-gateway/features/caching.mdx`
- `git diff --check`