### PR TITLE
[Logs] Add Microsoft Sentinel connector deprecation notice

### DIFF
--- a/src/content/changelog/logs/2026-08-26-sentinel-functions-connector-deprecation.mdx
+++ b/src/content/changelog/logs/2026-08-26-sentinel-functions-connector-deprecation.mdx
@@ -1,0 +1,21 @@
+---
+title: Azure Functions-based Microsoft Sentinel connector deprecation
+description: Cloudflare Enterprise customers must migrate to the Cloudflare for Microsoft Sentinel CCF connector by 2026-09-14.
+products:
+  - logpush-connectors
+date: 2026-08-26
+---
+
+Cloudflare Enterprise customers using the [Azure Functions-based Microsoft Sentinel connector](https://marketplace.microsoft.com/en-us/product/cloudflare.cloudflare_sentinel?tab=Overview) must migrate to the [Cloudflare for Microsoft Sentinel Codeless Connector Framework (CCF) connector](https://marketplace.microsoft.com/en-us/product/cloudflare.azure-sentinel-solution-cloudflare-ccf?tab=Overview) by 2026-09-14.
+
+Microsoft is deprecating the Azure Monitor HTTP Data Collector API. Support for the API ends on 2026-09-14. As a result, Cloudflare will no longer maintain the Azure Functions-based connector after that date.
+
+To migrate, follow the [Microsoft Sentinel integration setup guide](/analytics/analytics-integrations/sentinel/).
+
+## Additional resources
+
+- [Download Cloudflare's CCF Sentinel Solution](https://marketplace.microsoft.com/en-us/product/azure-application/cloudflare.azure-sentinel-solution-cloudflare-ccf?tab=Overview)
+- [Microsoft Sentinel data lake overview](https://learn.microsoft.com/en-us/azure/sentinel/datalake/sentinel-lake-overview)
+- [About the CCF platform](https://learn.microsoft.com/en-us/azure/sentinel/create-codeless-connector)
+
+For more information, refer to Microsoft's [Azure Monitor HTTP Data Collector API deprecation notice](https://learn.microsoft.com/en-us/previous-versions/azure/azure-monitor/logs/data-collector-api?tabs=powershell).

--- a/src/content/directory/logpush-connectors.yaml
+++ b/src/content/directory/logpush-connectors.yaml
@@ -1,0 +1,11 @@
+id: LQ7hVR
+name: Logpush Connectors
+
+entry:
+  title: Logpush Connectors
+  url: /logs/logpush/logpush-job/enable-destinations/
+  show: false
+
+meta:
+  title: Cloudflare Logpush Connectors docs
+  author: "@cloudflare"


### PR DESCRIPTION
## Summary

- announce the Azure Functions-based Microsoft Sentinel connector deprecation and migration deadline
- link customers to the CCF connector, setup guide, and Microsoft resources
- add a Logpush Connectors product tag for connector changelogs

## Tests

- `pnpm exec prettier --check src/content/directory/logpush-connectors.yaml src/content/changelog/logs/2026-08-26-sentinel-functions-connector-deprecation.mdx`
- `pnpm exec astro check --minimumFailingSeverity=error`