### PR TITLE
Add @cjolowicz as CODEOWNER for log-explorer docs and changelog

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -95,7 +95,6 @@ package.json @cloudflare/content-engineering
 /src/content/changelog/waiting-room/ @angelampcosta @dcpena @cloudflare/firewall @cloudflare/appsec-reviewers @cloudflare/pm-changelogs @hsaxenaCF @danielegm @cloudflare/product-owners
 /src/content/changelog/logs/ @soheiokamoto @angelampcosta @rianvdm @dcpena @sahidya @cloudflare/pm-changelogs @cloudflare/product-owners
 /src/content/changelog/audit-logs/ @dcpena @sahidya @cloudflare/pm-changelogs @cloudflare/product-owners
-/src/content/changelog/log-explorer/ @angelampcosta @dcpena @sahidya @cjolowicz @cloudflare/pm-changelogs @cloudflare/product-owners
 /src/assets/images/ @cloudflare/pm-changelogs @cloudflare/product-owners
 /src/assets/images/changelog/ @cloudflare/pm-changelogs @cloudflare/product-owners
 /src/assets/images/changelog/dns/ @cloudflare/pm-changelogs @cloudflare/product-owners @hannes-cf @fattouche @xofyarg @dklbreitling @chreo @svenr-cf @kerolasa @matildeopbravo @vavrusa @mworsley-cloudflare @sebastiaanyn @vendemiat @Woutifier

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -95,7 +95,7 @@ package.json @cloudflare/content-engineering
 /src/content/changelog/waiting-room/ @angelampcosta @dcpena @cloudflare/firewall @cloudflare/appsec-reviewers @cloudflare/pm-changelogs @hsaxenaCF @danielegm @cloudflare/product-owners
 /src/content/changelog/logs/ @soheiokamoto @angelampcosta @rianvdm @dcpena @sahidya @cloudflare/pm-changelogs @cloudflare/product-owners
 /src/content/changelog/audit-logs/ @dcpena @sahidya @cloudflare/pm-changelogs @cloudflare/product-owners
-/src/content/changelog/log-explorer/ @angelampcosta @dcpena @sahidya @cloudflare/pm-changelogs @cloudflare/product-owners
+/src/content/changelog/log-explorer/ @angelampcosta @dcpena @sahidya @cjolowicz @cloudflare/pm-changelogs @cloudflare/product-owners
 /src/assets/images/ @cloudflare/pm-changelogs @cloudflare/product-owners
 /src/assets/images/changelog/ @cloudflare/pm-changelogs @cloudflare/product-owners
 /src/assets/images/changelog/dns/ @cloudflare/pm-changelogs @cloudflare/product-owners @hannes-cf @fattouche @xofyarg @dklbreitling @chreo @svenr-cf @kerolasa @matildeopbravo @vavrusa @mworsley-cloudflare @sebastiaanyn @vendemiat @Woutifier
@@ -104,7 +104,7 @@ package.json @cloudflare/content-engineering
 /src/content/changelog/waiting-room/ @angelampcosta @cloudflare/firewall @cloudflare/appsec-reviewers @cloudflare/pm-changelogs @hsaxenaCF @danielegm @cloudflare/product-owners
 /src/content/changelog/logs/ @soheiokamoto @angelampcosta @rianvdm @sahidya @cloudflare/pm-changelogs @cloudflare/product-owners
 /src/content/changelog/audit-logs/ @sahidya @cloudflare/pm-changelogs @cloudflare/product-owners
-/src/content/changelog/log-explorer/ @angelampcosta @sahidya @cloudflare/pm-changelogs @cloudflare/product-owners
+/src/content/changelog/log-explorer/ @angelampcosta @sahidya @cjolowicz @cloudflare/pm-changelogs @cloudflare/product-owners
 /src/assets/images/changelog/ @cloudflare/pm-changelogs @cloudflare/product-owners
 /src/assets/images/changelog/dns/ @cloudflare/pm-changelogs @cloudflare/product-owners @hannes-cf @fattouche @xofyarg @dklbreitling @chreo @svenr-cf @kerolasa @matildeopbravo @vavrusa @mworsley-cloudflare @sebastiaanyn @vendemiat @Woutifier
 /src/assets/images/changelog/1.1.1.1/ @cloudflare/pm-changelogs @cloudflare/product-owners @hannes-cf @fattouche @xofyarg @dklbreitling @chreo @svenr-cf @kerolasa @matildeopbravo @vavrusa @mworsley-cloudflare @sebastiaanyn @vendemiat @Woutifier
@@ -167,7 +167,7 @@ package.json @cloudflare/content-engineering
 /src/content/docs/rules/ @cloudflare/appsec-reviewers @smarsh-cf @maurizioabba @cloudflare/product-owners @mbullock1986
 /src/content/docs/ruleset-engine/ @cloudflare/appsec-reviewers @maurizioabba @cloudflare/product-owners @mbullock1986
 /src/content/fields/ @cloudflare/appsec-reviewers @maurizioabba @mbullock1986 @danielegm @xmflsct
-/src/content/docs/log-explorer/ @angelampcosta @sahidya @cloudflare/product-owners
+/src/content/docs/log-explorer/ @angelampcosta @sahidya @cjolowicz @cloudflare/product-owners
 
 # Developer Platform
 


### PR DESCRIPTION
Add @cjolowicz (Log Explorer engineering manager) as a CODEOWNER for the log-explorer documentation and changelog paths, so the engineering team can review doc updates.