### PR TITLE
[DNS] Clarify that assigned nameservers cannot be changed

### DIFF
--- a/src/content/docs/dns/faq.mdx
+++ b/src/content/docs/dns/faq.mdx
@@ -92,6 +92,24 @@ This is important because, if a domain is in a **Moved** state for a [long enoug
 
 <Render file="recover-deleted-domain" product="dns" />
 
+### Why does my new zone have different nameservers than my other zones?
+
+Nameserver assignments happen at zone creation and [cannot be changed](/dns/nameservers/nameserver-options/#assignment-method) afterwards, even by Cloudflare Support.
+
+A newly added zone can be assigned a different pair from your other zones for a few reasons:
+
+- The same domain is (or was recently) active on another Cloudflare account.
+- The zone was previously deleted from Cloudflare and re-added.
+- A parent or child zone in the same account already uses the preferred nameserver pair.
+- The account uses [Foundation DNS advanced nameservers](/dns/foundation-dns/advanced-nameservers/), which use different sets (`blue`, `gold`, `orange`) and rotate to keep [directly descending zones](/dns/foundation-dns/advanced-nameservers/#nameservers-hosting-and-assignment) on different nameservers.
+
+To make future zones share the same nameservers, use one of the following options depending on your plan:
+
+- [Account custom nameservers](/dns/nameservers/custom-nameservers/account-custom-nameservers/) — available on Enterprise (self-serve), or on Business after [contacting Cloudflare Support](/support/contacting-cloudflare-support/) to enable them.
+- [DNS zone defaults](/dns/additional-options/dns-zone-defaults/) with advanced nameservers or account custom nameservers — available on Enterprise.
+
+Deleting and re-adding the zone does not force a specific nameserver assignment and can produce yet another different pair.
+
 ---
 
 ## DNS records

--- a/src/content/docs/dns/faq.mdx
+++ b/src/content/docs/dns/faq.mdx
@@ -96,11 +96,11 @@ This is important because, if a domain is in a **Moved** state for a [long enoug
 
 Nameserver assignments happen at zone creation and [cannot be changed](/dns/nameservers/nameserver-options/#assignment-method) afterwards, even by Cloudflare Support.
 
-A newly added zone can be assigned a different pair from your other zones for a few reasons:
+A newly added zone can be assigned different nameservers from your other zones for a few reasons:
 
 - The same domain is (or was recently) active on another Cloudflare account.
 - The zone was previously deleted from Cloudflare and re-added.
-- A parent or child zone in the same account already uses the preferred nameserver pair.
+- A parent or child zone in the same account already uses the preferred nameservers.
 - The account uses [Foundation DNS advanced nameservers](/dns/foundation-dns/advanced-nameservers/), which use different sets (`blue`, `gold`, `orange`) and rotate to keep [directly descending zones](/dns/foundation-dns/advanced-nameservers/#nameservers-hosting-and-assignment) on different nameservers.
 
 To make future zones share the same nameservers, use one of the following options depending on your plan:
@@ -108,7 +108,7 @@ To make future zones share the same nameservers, use one of the following option
 - [Account custom nameservers](/dns/nameservers/custom-nameservers/account-custom-nameservers/) — available on Enterprise (self-serve), or on Business after [contacting Cloudflare Support](/support/contacting-cloudflare-support/) to enable them.
 - [DNS zone defaults](/dns/additional-options/dns-zone-defaults/) with advanced nameservers or account custom nameservers — available on Enterprise.
 
-Deleting and re-adding the zone does not force a specific nameserver assignment and can produce yet another different pair.
+Deleting and re-adding the zone does not force a specific nameserver assignment and can produce yet another different set.
 
 ---
 

--- a/src/content/docs/dns/foundation-dns/advanced-nameservers.mdx
+++ b/src/content/docs/dns/foundation-dns/advanced-nameservers.mdx
@@ -74,6 +74,16 @@ Consider the domain `example.com`, and subdomains `abc.example.com` and `123.exa
 
 </Details>
 
+### Consistent assignment across new zones
+
+Advanced nameservers try to keep the same nameserver set (`blue`, `gold`, or `orange`) for new zones added to the same account, but a new zone can still be assigned a different set when:
+
+- The same name is (or was recently) active on another Cloudflare account.
+- A directly descending zone in the same or another account already uses the same set.
+- The zone was previously deleted from Cloudflare and re-added.
+
+[Assigned nameservers cannot be changed](/dns/nameservers/nameserver-options/#assignment-method) after a zone is created. If your zones must share the same nameservers, [account custom nameservers](/dns/nameservers/custom-nameservers/account-custom-nameservers/) provide a single set that every zone in the account can use, and can be configured as the account's [DNS zone default](/dns/additional-options/dns-zone-defaults/) so new zones automatically receive them.
+
 ## Custom Nameserver compatibility
 
 Advanced Nameserver features — such as multiple anycast network groups or dedicated release process — are currently available for Cloudflare-branded nameservers. Support of these features for [Custom Nameservers](/dns/nameservers/custom-nameservers/) is on the roadmap. Contact your account team for the latest availability.

--- a/src/content/docs/dns/foundation-dns/advanced-nameservers.mdx
+++ b/src/content/docs/dns/foundation-dns/advanced-nameservers.mdx
@@ -78,7 +78,7 @@ Consider the domain `example.com`, and subdomains `abc.example.com` and `123.exa
 
 Advanced nameservers try to keep the same nameserver set (`blue`, `gold`, or `orange`) for new zones added to the same account, but a new zone can still be assigned a different set when:
 
-- The same name is (or was recently) active on another Cloudflare account.
+- The same domain is (or was recently) active on another Cloudflare account.
 - A directly descending zone in the same or another account already uses the same set.
 - The zone was previously deleted from Cloudflare and re-added.
 

--- a/src/content/docs/dns/nameservers/nameserver-options.mdx
+++ b/src/content/docs/dns/nameservers/nameserver-options.mdx
@@ -22,10 +22,10 @@ When you add a domain on a [primary (full)](/dns/zone-setups/full-setup/) or [se
 The default assignment method is to use [standard nameservers](/dns/nameservers/#standard-nameservers) and favor consistent nameserver names across all zones within an account. Nonetheless, in case there are conflicts, you may get different nameserver names, even for domains that are within the same account.
 
 :::caution
-To prevent domain hijacking, you can no longer preset Cloudflare nameservers at your registrar before creating the respective zone in Cloudflare. If you preset your nameservers and then add the domain, your domain will be assigned a new pair of nameservers.
+To prevent domain hijacking, you can no longer preset Cloudflare nameservers at your registrar before creating the respective zone in Cloudflare. If you preset your nameservers and then add the domain, your domain will be assigned a new set of nameservers.
 :::
 
-:::note[Assigned nameservers are permanent]
+:::caution
 Once a zone is created, its assigned nameservers cannot be changed — not even by Cloudflare Support. If your new zone was assigned a different set from your other zones, refer to [Why does my new zone have different nameservers than my other zones?](/dns/faq/#why-does-my-new-zone-have-different-nameservers-than-my-other-zones) in the DNS FAQ. To keep new zones on the same nameservers going forward, refer to [Nameserver consistency](#nameserver-consistency).
 :::
 

--- a/src/content/docs/dns/nameservers/nameserver-options.mdx
+++ b/src/content/docs/dns/nameservers/nameserver-options.mdx
@@ -26,7 +26,7 @@ To prevent domain hijacking, you can no longer preset Cloudflare nameservers at 
 :::
 
 :::note[Assigned nameservers are permanent]
-Once a zone is created, its assigned nameservers cannot be changed — not even by Cloudflare Support. If your new zone was assigned a different set from your other zones, refer to [Why does my new zone have different nameservers than my other zones?](/dns/faq/#why-does-my-new-zone-have-different-nameservers-than-my-other-zones) in the DNS FAQ. To keep new zones on the same nameservers going forward, see [Nameserver consistency](#nameserver-consistency) below.
+Once a zone is created, its assigned nameservers cannot be changed — not even by Cloudflare Support. If your new zone was assigned a different set from your other zones, refer to [Why does my new zone have different nameservers than my other zones?](/dns/faq/#why-does-my-new-zone-have-different-nameservers-than-my-other-zones) in the DNS FAQ. To keep new zones on the same nameservers going forward, refer to [Nameserver consistency](#nameserver-consistency).
 :::
 
 ### Nameserver consistency

--- a/src/content/docs/dns/nameservers/nameserver-options.mdx
+++ b/src/content/docs/dns/nameservers/nameserver-options.mdx
@@ -25,7 +25,9 @@ The default assignment method is to use [standard nameservers](/dns/nameservers/
 To prevent domain hijacking, you can no longer preset Cloudflare nameservers at your registrar before creating the respective zone in Cloudflare. If you preset your nameservers and then add the domain, your domain will be assigned a new pair of nameservers.
 :::
 
-These nameserver assignments cannot be changed. However, depending on your subscription, you may have different options for better nameserver consistency.
+:::note[Assigned nameservers are permanent]
+Once a zone is created, its assigned nameservers cannot be changed — not even by Cloudflare Support. If your new zone was assigned a different set from your other zones, refer to [Why does my new zone have different nameservers than my other zones?](/dns/faq/#why-does-my-new-zone-have-different-nameservers-than-my-other-zones) in the DNS FAQ. To keep new zones on the same nameservers going forward, see [Nameserver consistency](#nameserver-consistency) below.
+:::
 
 ### Nameserver consistency
 


### PR DESCRIPTION
### Summary

DEE-3776

**What**

- DNS FAQ (`dns/faq.mdx`): new entry "Why does my new zone have different nameservers than my other zones?" under the existing `## Nameservers` section.
- Nameserver options (`dns/nameservers/nameserver-options.mdx`): replace a plain sentence in **Assignment method** with a `:::note` callout that points to the new FAQ entry and to the **Nameserver consistency** section.
- Foundation DNS advanced nameservers (`dns/foundation-dns/advanced-nameservers.mdx`): new **Consistent assignment across new zones** subsection that explains why a new zone might get a different color set (`blue` / `gold` / `orange`) and cross-links Account custom nameservers.

**Why**

Common customer question - Support sees it regularly - "why did my new zone get different nameservers than my other zones, can you reassign it?" The docs already state that assignments cannot be changed after zone creation, but the guidance is buried in prose. This makes the answer easier to find, states the "cannot be changed" rule up front, and points customers to the two supported paths for consistent nameservers across zones (Account custom nameservers on Business/Enterprise, or DNS zone defaults on Enterprise).

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [x] No page name or location changes; no redirects needed.
- [ ] Changelog: not applicable - clarification of existing documented behavior, no product change.