### PR TITLE
[Workers AI] Add GLM 5.3 Flash model

### DIFF
--- a/src/content/changelog/workers-ai/2026-08-26-glm-5.3-flash-workers-ai.mdx
+++ b/src/content/changelog/workers-ai/2026-08-26-glm-5.3-flash-workers-ai.mdx
@@ -8,14 +8,7 @@ date: 2026-08-26
 
 [`@cf/zai-org/glm-5.3-flash`](/workers-ai/models/glm-5.3-flash/) is now available on Workers AI. It is the first natively multimodal model in the GLM-5 series, built on a Mixture-of-Experts architecture with 320B total parameters and 18B active per token.
 
-GLM-5.3 Flash outperforms GLM-5.2 across benchmarks and real-world workloads at a lower price, while approaching Claude Opus 4.8 on coding and agentic benchmarks.
-
-**Key capabilities:**
-
-- **Vision**: Native multimodal support for processing images alongside text
-- **Reasoning**: Thinking mode for complex, step-by-step problem-solving
-- **Function calling**: Build agents that invoke tools and APIs across multiple conversation turns
-- **Large context window**: 1,048,576 token context window for long-horizon agentic workflows
+GLM-5.3 Flash is the first GLM-family model on Workers AI to support multimodal inputs. It outperforms GLM-5.2 across benchmarks and real-world workloads at a lower price, while approaching Claude Opus 4.8 on coding and agentic benchmarks.
 
 GLM-5.3 Flash requires the [Workers Paid plan](/workers/platform/pricing/#workers) or prepaid [AI Gateway credits](/ai-gateway/features/unified-billing/).
 

--- a/src/content/changelog/workers-ai/2026-08-26-glm-5.3-flash-workers-ai.mdx
+++ b/src/content/changelog/workers-ai/2026-08-26-glm-5.3-flash-workers-ai.mdx
@@ -1,0 +1,24 @@
+---
+title: "Z.ai GLM-5.3 Flash now available on Workers AI"
+description: GLM-5.3 Flash is now available on Workers AI, a 320B MoE model with vision, reasoning, and function calling.
+products:
+  - workers-ai
+date: 2026-08-26
+---
+
+[`@cf/zai-org/glm-5.3-flash`](/workers-ai/models/glm-5.3-flash/) is now available on Workers AI. It is the first natively multimodal model in the GLM-5 series, built on a Mixture-of-Experts architecture with 320B total parameters and 18B active per token.
+
+GLM-5.3 Flash outperforms GLM-5.2 across benchmarks and real-world workloads at a lower price, while approaching Claude Opus 4.8 on coding and agentic benchmarks.
+
+**Key capabilities:**
+
+- **Vision**: Native multimodal support for processing images alongside text
+- **Reasoning**: Thinking mode for complex, step-by-step problem-solving
+- **Function calling**: Build agents that invoke tools and APIs across multiple conversation turns
+- **Large context window**: 1,048,576 token context window for long-horizon agentic workflows
+
+GLM-5.3 Flash requires the [Workers Paid plan](/workers/platform/pricing/#workers) or prepaid [AI Gateway credits](/ai-gateway/features/unified-billing/).
+
+Use GLM-5.3 Flash through the [Workers AI binding](/workers-ai/configuration/bindings/) (`env.AI.run()`), the REST API, the [OpenAI-compatible endpoint](/workers-ai/configuration/open-ai-compatibility/), or [AI Gateway](/ai-gateway/).
+
+For more information, refer to the [GLM-5.3 Flash model page](/workers-ai/models/glm-5.3-flash/) and [pricing](/workers-ai/platform/pricing/).

--- a/src/content/docs/workers-ai/platform/pricing.mdx
+++ b/src/content/docs/workers-ai/platform/pricing.mdx
@@ -26,7 +26,7 @@ All limits reset daily at 00:00 UTC. If you exceed any one of the above limits, 
 | Workers Paid | 10,000 Neurons per day | $0.011 / 1,000 Neurons        |
 
 :::note
-Some models require a paid billing method. This applies to `@cf/moonshotai/kimi-k2.6`, `@cf/moonshotai/kimi-k2.7-code`, `@cf/zai-org/glm-5.2`, `@cf/deepseek-ai/deepseek-v4-flash-0731`, and `@cf/deepseek-ai/deepseek-v4-pro-0813`. You can access these models with either the [Workers Paid plan](/workers/platform/pricing/#workers) or prepaid [AI Gateway credits](/ai-gateway/features/unified-billing/).
+Some models require a paid billing method. This applies to `@cf/moonshotai/kimi-k2.6`, `@cf/moonshotai/kimi-k2.7-code`, `@cf/zai-org/glm-5.2`, `@cf/zai-org/glm-5.3-flash`, `@cf/deepseek-ai/deepseek-v4-flash-0731`, and `@cf/deepseek-ai/deepseek-v4-pro-0813`. You can access these models with either the [Workers Paid plan](/workers/platform/pricing/#workers) or prepaid [AI Gateway credits](/ai-gateway/features/unified-billing/).
 :::
 
 ## Pay with AI Gateway credits
@@ -77,6 +77,7 @@ The Price in Tokens column is equivalent to the Price in Neurons column - the di
 | @cf/ibm-granite/granite-4.0-h-micro          | $0.017 per M input tokens <br/> $0.112 per M output tokens                                        | 1542 neurons per M input tokens <br/> 10158 neurons per M output tokens                                                  |
 | @cf/zai-org/glm-4.7-flash                    | $0.060 per M input tokens <br/> $0.400 per M output tokens                                        | 5500 neurons per M input tokens <br/> 36400 neurons per M output tokens                                                  |
 | @cf/zai-org/glm-5.2                          | $1.400 per M input tokens <br/> $0.260 per M cached input tokens <br/> $4.400 per M output tokens | 127273 neurons per M input tokens <br/> 23636 neurons per M cached input tokens <br/> 400000 neurons per M output tokens |
+| @cf/zai-org/glm-5.3-flash                    | $0.150 per M input tokens <br/> $0.030 per M cached input tokens <br/> $0.500 per M output tokens | 13636 neurons per M input tokens <br/> 2727 neurons per M cached input tokens <br/> 45455 neurons per M output tokens |
 | @cf/nvidia/nemotron-3-120b-a12b              | $0.500 per M input tokens <br/> $1.500 per M output tokens                                        | 45455 neurons per M input tokens <br/> 136364 neurons per M output tokens                                                |
 | @cf/moonshotai/kimi-k2.5                     | $0.600 per M input tokens <br/> $0.100 per M cached input tokens <br/> $3.000 per M output tokens | 54545 neurons per M input tokens <br/> 9091 neurons per M cached input tokens <br/> 272727 neurons per M output tokens   |
 | @cf/moonshotai/kimi-k2.6                     | $0.950 per M input tokens <br/> $0.160 per M cached input tokens <br/> $4.000 per M output tokens | 86364 neurons per M input tokens <br/> 14545 neurons per M cached input tokens <br/> 363636 neurons per M output tokens  |

--- a/src/content/workers-ai-models/glm-5.3-flash.json
+++ b/src/content/workers-ai-models/glm-5.3-flash.json
@@ -58,377 +58,4208 @@
     "tags": [],
     "schema": {
         "input": {
-            "type": "object",
-            "oneOf": [
+            "anyOf": [
                 {
-                    "title": "Prompt",
-                    "properties": {
-                        "prompt": {
-                            "type": "string",
-                            "minLength": 1,
-                            "description": "The input text prompt for the model to generate a response."
-                        },
-                        "lora": {
-                            "type": "string",
-                            "description": "Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model."
-                        },
-                        "response_format": {
-                            "title": "JSON Mode",
-                            "type": "object",
+                    "type": "object",
+                    "oneOf": [
+                        {
+                            "title": "Prompt",
                             "properties": {
-                                "type": {
+                                "prompt": {
                                     "type": "string",
-                                    "enum": [
-                                        "json_object",
-                                        "json_schema"
+                                    "minLength": 1,
+                                    "description": "The input text prompt for the model to generate a response."
+                                },
+                                "model": {
+                                    "type": "string",
+                                    "description": "ID of the model to use (e.g. '@cf/zai-org/glm-4.7-flash, etc')."
+                                },
+                                "audio": {
+                                    "anyOf": [
+                                        {
+                                            "type": "object",
+                                            "description": "Parameters for audio output. Required when modalities includes 'audio'.",
+                                            "properties": {
+                                                "voice": {
+                                                    "oneOf": [
+                                                        {
+                                                            "type": "string"
+                                                        },
+                                                        {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "id": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "id"
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                "format": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "wav",
+                                                        "aac",
+                                                        "mp3",
+                                                        "flac",
+                                                        "opus",
+                                                        "pcm16"
+                                                    ]
+                                                }
+                                            },
+                                            "required": [
+                                                "voice",
+                                                "format"
+                                            ]
+                                        }
                                     ]
                                 },
-                                "json_schema": {}
-                            }
-                        },
-                        "raw": {
-                            "type": "boolean",
-                            "default": false,
-                            "description": "If true, a chat template is not applied and you must adhere to the specific model's expected formatting."
-                        },
-                        "stream": {
-                            "type": "boolean",
-                            "default": false,
-                            "description": "If true, the response will be streamed back incrementally using SSE, Server Sent Events."
-                        },
-                        "max_tokens": {
-                            "type": "integer",
-                            "default": 256,
-                            "description": "The maximum number of tokens to generate in the response."
-                        },
-                        "temperature": {
-                            "type": "number",
-                            "default": 0.6,
-                            "minimum": 0,
-                            "maximum": 5,
-                            "description": "Controls the randomness of the output; higher values produce more random results."
-                        },
-                        "top_p": {
-                            "type": "number",
-                            "minimum": 0.001,
-                            "maximum": 1,
-                            "description": "Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
-                        },
-                        "top_k": {
-                            "type": "integer",
-                            "minimum": 1,
-                            "maximum": 50,
-                            "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
-                        },
-                        "seed": {
-                            "type": "integer",
-                            "minimum": 1,
-                            "maximum": 9999999999,
-                            "description": "Random seed for reproducibility of the generation."
-                        },
-                        "repetition_penalty": {
-                            "type": "number",
-                            "minimum": 0,
-                            "maximum": 2,
-                            "description": "Penalty for repeated tokens; higher values discourage repetition."
-                        },
-                        "frequency_penalty": {
-                            "type": "number",
-                            "minimum": -2,
-                            "maximum": 2,
-                            "description": "Decreases the likelihood of the model repeating the same lines verbatim."
-                        },
-                        "presence_penalty": {
-                            "type": "number",
-                            "minimum": -2,
-                            "maximum": 2,
-                            "description": "Increases the likelihood of the model introducing new topics."
-                        }
-                    },
-                    "required": [
-                        "prompt"
-                    ]
-                },
-                {
-                    "title": "Messages",
-                    "properties": {
-                        "messages": {
-                            "type": "array",
-                            "description": "An array of message objects representing the conversation history.",
-                            "items": {
-                                "type": "object",
-                                "properties": {
-                                    "role": {
-                                        "type": "string",
-                                        "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
-                                    },
-                                    "content": {
-                                        "oneOf": [
-                                            {
+                                "frequency_penalty": {
+                                    "anyOf": [
+                                        {
+                                            "type": "number",
+                                            "minimum": -2,
+                                            "maximum": 2
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": 0,
+                                    "description": "Penalizes new tokens based on their existing frequency in the text so far."
+                                },
+                                "logit_bias": {
+                                    "anyOf": [
+                                        {
+                                            "type": "object"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "Modify the likelihood of specified tokens appearing in the completion. Maps token IDs to bias values from -100 to 100."
+                                },
+                                "logprobs": {
+                                    "anyOf": [
+                                        {
+                                            "type": "boolean"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": false,
+                                    "description": "Whether to return log probabilities of the output tokens."
+                                },
+                                "top_logprobs": {
+                                    "anyOf": [
+                                        {
+                                            "type": "integer",
+                                            "minimum": 0,
+                                            "maximum": 20
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "How many top log probabilities to return at each token position (0-20). Requires logprobs=true."
+                                },
+                                "max_tokens": {
+                                    "anyOf": [
+                                        {
+                                            "type": "integer"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "Deprecated in favor of max_completion_tokens. The maximum number of tokens to generate."
+                                },
+                                "max_completion_tokens": {
+                                    "anyOf": [
+                                        {
+                                            "type": "integer"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "An upper bound for the number of tokens that can be generated for a completion."
+                                },
+                                "metadata": {
+                                    "anyOf": [
+                                        {
+                                            "type": "object"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "Set of 16 key-value pairs that can be attached to the object."
+                                },
+                                "modalities": {
+                                    "anyOf": [
+                                        {
+                                            "type": "array",
+                                            "items": {
                                                 "type": "string",
-                                                "description": "The content of the message as a string."
+                                                "enum": [
+                                                    "text",
+                                                    "audio"
+                                                ]
+                                            }
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "Output types requested from the model (e.g. ['text'] or ['text', 'audio'])."
+                                },
+                                "n": {
+                                    "anyOf": [
+                                        {
+                                            "type": "integer",
+                                            "minimum": 1,
+                                            "maximum": 128
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": 1,
+                                    "description": "How many chat completion choices to generate for each input message."
+                                },
+                                "parallel_tool_calls": {
+                                    "type": "boolean",
+                                    "default": true,
+                                    "description": "Whether to enable parallel function calling during tool use."
+                                },
+                                "prediction": {
+                                    "anyOf": [
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "type": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "content"
+                                                    ]
+                                                },
+                                                "content": {
+                                                    "anyOf": [
+                                                        {
+                                                            "type": "string"
+                                                        },
+                                                        {
+                                                            "type": "array",
+                                                            "items": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "type": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "text"
+                                                                        ]
+                                                                    },
+                                                                    "text": {
+                                                                        "type": "string"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "type",
+                                                                    "text"
+                                                                ]
+                                                            }
+                                                        }
+                                                    ]
+                                                }
                                             },
-                                            {
-                                                "type": "array",
-                                                "description": "Array of text content parts.",
-                                                "items": {
+                                            "required": [
+                                                "type",
+                                                "content"
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "presence_penalty": {
+                                    "anyOf": [
+                                        {
+                                            "type": "number",
+                                            "minimum": -2,
+                                            "maximum": 2
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": 0,
+                                    "description": "Penalizes new tokens based on whether they appear in the text so far."
+                                },
+                                "reasoning_effort": {
+                                    "anyOf": [
+                                        {
+                                            "type": "string",
+                                            "enum": [
+                                                "low",
+                                                "medium",
+                                                "high"
+                                            ]
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "Constrains effort on reasoning for reasoning models (o1, o3-mini, etc.)."
+                                },
+                                "chat_template_kwargs": {
+                                    "type": "object",
+                                    "properties": {
+                                        "enable_thinking": {
+                                            "type": "boolean",
+                                            "default": true,
+                                            "description": "Whether to enable reasoning, enabled by default."
+                                        },
+                                        "clear_thinking": {
+                                            "type": "boolean",
+                                            "default": false,
+                                            "description": "If false, preserves reasoning context between turns."
+                                        }
+                                    }
+                                },
+                                "response_format": {
+                                    "anyOf": [
+                                        {
+                                            "description": "Specifies the format the model must output.",
+                                            "oneOf": [
+                                                {
                                                     "type": "object",
                                                     "properties": {
                                                         "type": {
                                                             "type": "string",
-                                                            "description": "Type of the content (text)"
-                                                        },
-                                                        "text": {
-                                                            "type": "string",
-                                                            "description": "Text content"
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        ]
-                                    }
-                                },
-                                "required": [
-                                    "role",
-                                    "content"
-                                ]
-                            }
-                        },
-                        "functions": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "properties": {
-                                    "name": {
-                                        "type": "string"
-                                    },
-                                    "code": {
-                                        "type": "string"
-                                    }
-                                },
-                                "required": [
-                                    "name",
-                                    "code"
-                                ]
-                            }
-                        },
-                        "tools": {
-                            "type": "array",
-                            "description": "A list of tools available for the assistant to use.",
-                            "items": {
-                                "type": "object",
-                                "oneOf": [
-                                    {
-                                        "properties": {
-                                            "name": {
-                                                "type": "string",
-                                                "description": "The name of the tool. More descriptive the better."
-                                            },
-                                            "description": {
-                                                "type": "string",
-                                                "description": "A brief description of what the tool does."
-                                            },
-                                            "parameters": {
-                                                "type": "object",
-                                                "description": "Schema defining the parameters accepted by the tool.",
-                                                "properties": {
-                                                    "type": {
-                                                        "type": "string",
-                                                        "description": "The type of the parameters object (usually 'object')."
-                                                    },
-                                                    "required": {
-                                                        "type": "array",
-                                                        "description": "List of required parameter names.",
-                                                        "items": {
-                                                            "type": "string"
+                                                            "enum": [
+                                                                "text"
+                                                            ]
                                                         }
                                                     },
+                                                    "required": [
+                                                        "type"
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "object",
                                                     "properties": {
-                                                        "type": "object",
-                                                        "description": "Definitions of each parameter.",
-                                                        "additionalProperties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "json_object"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "type"
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "json_schema"
+                                                            ]
+                                                        },
+                                                        "json_schema": {
                                                             "type": "object",
                                                             "properties": {
-                                                                "type": {
-                                                                    "type": "string",
-                                                                    "description": "The data type of the parameter."
+                                                                "name": {
+                                                                    "type": "string"
                                                                 },
                                                                 "description": {
-                                                                    "type": "string",
-                                                                    "description": "A description of the expected parameter."
+                                                                    "type": "string"
+                                                                },
+                                                                "schema": {
+                                                                    "type": "object"
+                                                                },
+                                                                "strict": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "boolean"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ]
                                                                 }
                                                             },
                                                             "required": [
-                                                                "type",
-                                                                "description"
+                                                                "name"
                                                             ]
                                                         }
-                                                    }
-                                                },
-                                                "required": [
-                                                    "type",
-                                                    "properties"
-                                                ]
-                                            }
+                                                    },
+                                                    "required": [
+                                                        "type",
+                                                        "json_schema"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "seed": {
+                                    "anyOf": [
+                                        {
+                                            "type": "integer"
                                         },
-                                        "required": [
-                                            "name",
-                                            "description",
-                                            "parameters"
-                                        ]
-                                    },
-                                    {
-                                        "properties": {
-                                            "type": {
-                                                "type": "string",
-                                                "description": "Specifies the type of tool (e.g., 'function')."
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "If specified, the system will make a best effort to sample deterministically."
+                                },
+                                "service_tier": {
+                                    "anyOf": [
+                                        {
+                                            "type": "string",
+                                            "enum": [
+                                                "auto",
+                                                "default",
+                                                "flex",
+                                                "scale",
+                                                "priority"
+                                            ]
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": "auto",
+                                    "description": "Specifies the processing type used for serving the request."
+                                },
+                                "stop": {
+                                    "description": "Up to 4 sequences where the API will stop generating further tokens.",
+                                    "anyOf": [
+                                        {
+                                            "type": "null"
+                                        },
+                                        {
+                                            "type": "string"
+                                        },
+                                        {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
                                             },
-                                            "function": {
-                                                "type": "object",
-                                                "description": "Details of the function tool.",
-                                                "properties": {
-                                                    "name": {
-                                                        "type": "string",
-                                                        "description": "The name of the function."
-                                                    },
-                                                    "description": {
-                                                        "type": "string",
-                                                        "description": "A brief description of what the function does."
-                                                    },
-                                                    "parameters": {
-                                                        "type": "object",
-                                                        "description": "Schema defining the parameters accepted by the function.",
-                                                        "properties": {
-                                                            "type": {
-                                                                "type": "string",
-                                                                "description": "The type of the parameters object (usually 'object')."
-                                                            },
-                                                            "required": {
-                                                                "type": "array",
-                                                                "description": "List of required parameter names.",
-                                                                "items": {
+                                            "minItems": 1,
+                                            "maxItems": 4
+                                        }
+                                    ]
+                                },
+                                "store": {
+                                    "anyOf": [
+                                        {
+                                            "type": "boolean"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": false,
+                                    "description": "Whether to store the output for model distillation / evals."
+                                },
+                                "stream": {
+                                    "anyOf": [
+                                        {
+                                            "type": "boolean"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": false,
+                                    "description": "If true, partial message deltas will be sent as server-sent events."
+                                },
+                                "stream_options": {
+                                    "anyOf": [
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "include_usage": {
+                                                    "type": "boolean"
+                                                },
+                                                "include_obfuscation": {
+                                                    "type": "boolean"
+                                                }
+                                            }
+                                        }
+                                    ]
+                                },
+                                "temperature": {
+                                    "anyOf": [
+                                        {
+                                            "type": "number",
+                                            "minimum": 0,
+                                            "maximum": 2
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": 1,
+                                    "description": "Sampling temperature between 0 and 2."
+                                },
+                                "tool_choice": {
+                                    "anyOf": [
+                                        {
+                                            "description": "Controls which (if any) tool is called by the model. 'none' = no tools, 'auto' = model decides, 'required' = must call a tool.",
+                                            "oneOf": [
+                                                {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "none",
+                                                        "auto",
+                                                        "required"
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "description": "Force a specific function tool.",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "function"
+                                                            ]
+                                                        },
+                                                        "function": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "name": {
                                                                     "type": "string"
                                                                 }
                                                             },
+                                                            "required": [
+                                                                "name"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "type",
+                                                        "function"
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "description": "Force a specific custom tool.",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "custom"
+                                                            ]
+                                                        },
+                                                        "custom": {
+                                                            "type": "object",
                                                             "properties": {
-                                                                "type": "object",
-                                                                "description": "Definitions of each parameter.",
-                                                                "additionalProperties": {
-                                                                    "type": "object",
-                                                                    "properties": {
-                                                                        "type": {
-                                                                            "type": "string",
-                                                                            "description": "The data type of the parameter."
-                                                                        },
-                                                                        "description": {
-                                                                            "type": "string",
-                                                                            "description": "A description of the expected parameter."
-                                                                        }
-                                                                    },
-                                                                    "required": [
-                                                                        "type",
-                                                                        "description"
-                                                                    ]
+                                                                "name": {
+                                                                    "type": "string"
                                                                 }
+                                                            },
+                                                            "required": [
+                                                                "name"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "type",
+                                                        "custom"
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "description": "Constrain to an allowed subset of tools.",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "allowed_tools"
+                                                            ]
+                                                        },
+                                                        "allowed_tools": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "mode": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "auto",
+                                                                        "required"
+                                                                    ]
+                                                                },
+                                                                "tools": {
+                                                                    "type": "array",
+                                                                    "items": {
+                                                                        "type": "object"
+                                                                    }
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "mode",
+                                                                "tools"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "type",
+                                                        "allowed_tools"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "tools": {
+                                    "type": "array",
+                                    "description": "A list of tools the model may call.",
+                                    "items": {
+                                        "oneOf": [
+                                            {
+                                                "type": "object",
+                                                "properties": {
+                                                    "type": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "function"
+                                                        ]
+                                                    },
+                                                    "function": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "name": {
+                                                                "type": "string",
+                                                                "description": "The name of the function to be called."
+                                                            },
+                                                            "description": {
+                                                                "type": "string",
+                                                                "description": "A description of what the function does."
+                                                            },
+                                                            "parameters": {
+                                                                "type": "object",
+                                                                "description": "The parameters the function accepts, described as a JSON Schema object."
+                                                            },
+                                                            "strict": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "boolean"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ],
+                                                                "default": false,
+                                                                "description": "Whether to enable strict schema adherence."
                                                             }
                                                         },
                                                         "required": [
-                                                            "type",
-                                                            "properties"
+                                                            "name"
                                                         ]
                                                     }
                                                 },
                                                 "required": [
-                                                    "name",
-                                                    "description",
-                                                    "parameters"
+                                                    "type",
+                                                    "function"
                                                 ]
+                                            },
+                                            {
+                                                "type": "object",
+                                                "properties": {
+                                                    "type": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "custom"
+                                                        ]
+                                                    },
+                                                    "custom": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "name": {
+                                                                "type": "string"
+                                                            },
+                                                            "description": {
+                                                                "type": "string"
+                                                            },
+                                                            "format": {
+                                                                "oneOf": [
+                                                                    {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "type": {
+                                                                                "type": "string",
+                                                                                "enum": [
+                                                                                    "text"
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "type"
+                                                                        ]
+                                                                    },
+                                                                    {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "type": {
+                                                                                "type": "string",
+                                                                                "enum": [
+                                                                                    "grammar"
+                                                                                ]
+                                                                            },
+                                                                            "grammar": {
+                                                                                "type": "object",
+                                                                                "properties": {
+                                                                                    "definition": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "syntax": {
+                                                                                        "type": "string",
+                                                                                        "enum": [
+                                                                                            "lark",
+                                                                                            "regex"
+                                                                                        ]
+                                                                                    }
+                                                                                },
+                                                                                "required": [
+                                                                                    "definition",
+                                                                                    "syntax"
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "type",
+                                                                            "grammar"
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "name"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type",
+                                                    "custom"
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                },
+                                "top_p": {
+                                    "anyOf": [
+                                        {
+                                            "type": "number",
+                                            "minimum": 0,
+                                            "maximum": 1
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": 1,
+                                    "description": "Nucleus sampling: considers the results of the tokens with top_p probability mass."
+                                },
+                                "user": {
+                                    "type": "string",
+                                    "description": "A unique identifier representing your end-user, for abuse monitoring."
+                                },
+                                "web_search_options": {
+                                    "anyOf": [
+                                        {
+                                            "type": "object",
+                                            "description": "Options for the web search tool (when using built-in web search).",
+                                            "properties": {
+                                                "search_context_size": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "low",
+                                                        "medium",
+                                                        "high"
+                                                    ],
+                                                    "default": "medium"
+                                                },
+                                                "user_location": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "approximate"
+                                                            ]
+                                                        },
+                                                        "approximate": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "city": {
+                                                                    "type": "string"
+                                                                },
+                                                                "country": {
+                                                                    "type": "string"
+                                                                },
+                                                                "region": {
+                                                                    "type": "string"
+                                                                },
+                                                                "timezone": {
+                                                                    "type": "string"
+                                                                }
+                                                            }
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "type",
+                                                        "approximate"
+                                                    ]
+                                                }
+                                            }
+                                        }
+                                    ]
+                                },
+                                "function_call": {
+                                    "anyOf": [
+                                        {
+                                            "type": "string",
+                                            "enum": [
+                                                "none",
+                                                "auto"
+                                            ]
+                                        },
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "name": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "name"
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "functions": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "name": {
+                                                "type": "string",
+                                                "description": "The name of the function to be called."
+                                            },
+                                            "description": {
+                                                "type": "string",
+                                                "description": "A description of what the function does."
+                                            },
+                                            "parameters": {
+                                                "type": "object",
+                                                "description": "The parameters the function accepts, described as a JSON Schema object."
+                                            },
+                                            "strict": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "boolean"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": false,
+                                                "description": "Whether to enable strict schema adherence."
                                             }
                                         },
                                         "required": [
-                                            "type",
-                                            "function"
+                                            "name"
+                                        ]
+                                    },
+                                    "minItems": 1,
+                                    "maxItems": 128
+                                }
+                            },
+                            "required": [
+                                "prompt"
+                            ]
+                        },
+                        {
+                            "title": "Messages",
+                            "properties": {
+                                "messages": {
+                                    "type": "array",
+                                    "description": "A list of messages comprising the conversation so far.",
+                                    "items": {
+                                        "oneOf": [
+                                            {
+                                                "type": "object",
+                                                "properties": {
+                                                    "role": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "developer"
+                                                        ]
+                                                    },
+                                                    "content": {
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "string"
+                                                            },
+                                                            {
+                                                                "type": "array",
+                                                                "items": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "enum": [
+                                                                                "text"
+                                                                            ]
+                                                                        },
+                                                                        "text": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "type",
+                                                                        "text"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
+                                                    },
+                                                    "name": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "role",
+                                                    "content"
+                                                ]
+                                            },
+                                            {
+                                                "type": "object",
+                                                "properties": {
+                                                    "role": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "system"
+                                                        ]
+                                                    },
+                                                    "content": {
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "string"
+                                                            },
+                                                            {
+                                                                "type": "array",
+                                                                "items": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "enum": [
+                                                                                "text"
+                                                                            ]
+                                                                        },
+                                                                        "text": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "type",
+                                                                        "text"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
+                                                    },
+                                                    "name": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "role",
+                                                    "content"
+                                                ]
+                                            },
+                                            {
+                                                "type": "object",
+                                                "properties": {
+                                                    "role": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "user"
+                                                        ]
+                                                    },
+                                                    "content": {
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "string"
+                                                            },
+                                                            {
+                                                                "type": "array",
+                                                                "items": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "enum": [
+                                                                                "text",
+                                                                                "image_url",
+                                                                                "video_url",
+                                                                                "input_audio",
+                                                                                "file"
+                                                                            ]
+                                                                        },
+                                                                        "text": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "image_url": {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "url": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "detail": {
+                                                                                    "type": "string",
+                                                                                    "enum": [
+                                                                                        "auto",
+                                                                                        "low",
+                                                                                        "high"
+                                                                                    ],
+                                                                                    "default": "auto"
+                                                                                }
+                                                                            }
+                                                                        },
+                                                                        "video_url": {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "url": {
+                                                                                    "type": "string"
+                                                                                }
+                                                                            }
+                                                                        },
+                                                                        "input_audio": {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "data": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "format": {
+                                                                                    "type": "string",
+                                                                                    "enum": [
+                                                                                        "wav",
+                                                                                        "mp3"
+                                                                                    ]
+                                                                                }
+                                                                            }
+                                                                        },
+                                                                        "file": {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "file_data": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "file_id": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "filename": {
+                                                                                    "type": "string"
+                                                                                }
+                                                                            }
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "type"
+                                                                    ]
+                                                                },
+                                                                "minItems": 1
+                                                            }
+                                                        ]
+                                                    },
+                                                    "name": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "role",
+                                                    "content"
+                                                ]
+                                            },
+                                            {
+                                                "type": "object",
+                                                "properties": {
+                                                    "role": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "assistant"
+                                                        ]
+                                                    },
+                                                    "content": {
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "string"
+                                                            },
+                                                            {
+                                                                "type": "null"
+                                                            },
+                                                            {
+                                                                "type": "array",
+                                                                "items": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "enum": [
+                                                                                "text",
+                                                                                "refusal"
+                                                                            ]
+                                                                        },
+                                                                        "text": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "refusal": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "type"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
+                                                    },
+                                                    "refusal": {
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "string"
+                                                            },
+                                                            {
+                                                                "type": "null"
+                                                            }
+                                                        ]
+                                                    },
+                                                    "name": {
+                                                        "type": "string"
+                                                    },
+                                                    "audio": {
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "id": {
+                                                                        "type": "string"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "id"
+                                                                ]
+                                                            }
+                                                        ]
+                                                    },
+                                                    "tool_calls": {
+                                                        "type": "array",
+                                                        "items": {
+                                                            "oneOf": [
+                                                                {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "id": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "enum": [
+                                                                                "function"
+                                                                            ]
+                                                                        },
+                                                                        "function": {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "name": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "arguments": {
+                                                                                    "type": "string",
+                                                                                    "description": "JSON-encoded arguments string."
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "name",
+                                                                                "arguments"
+                                                                            ]
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "id",
+                                                                        "type",
+                                                                        "function"
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "id": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "enum": [
+                                                                                "custom"
+                                                                            ]
+                                                                        },
+                                                                        "custom": {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "name": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "input": {
+                                                                                    "type": "string"
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "name",
+                                                                                "input"
+                                                                            ]
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "id",
+                                                                        "type",
+                                                                        "custom"
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        }
+                                                    },
+                                                    "function_call": {
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "name": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "arguments": {
+                                                                        "type": "string"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "name",
+                                                                    "arguments"
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                "required": [
+                                                    "role"
+                                                ]
+                                            },
+                                            {
+                                                "type": "object",
+                                                "properties": {
+                                                    "role": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "tool"
+                                                        ]
+                                                    },
+                                                    "content": {
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "string"
+                                                            },
+                                                            {
+                                                                "type": "array",
+                                                                "items": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "enum": [
+                                                                                "text"
+                                                                            ]
+                                                                        },
+                                                                        "text": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "type",
+                                                                        "text"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
+                                                    },
+                                                    "tool_call_id": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "role",
+                                                    "content",
+                                                    "tool_call_id"
+                                                ]
+                                            },
+                                            {
+                                                "type": "object",
+                                                "properties": {
+                                                    "role": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "function"
+                                                        ]
+                                                    },
+                                                    "content": {
+                                                        "type": "string"
+                                                    },
+                                                    "name": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "role",
+                                                    "content",
+                                                    "name"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "minItems": 1
+                                },
+                                "model": {
+                                    "type": "string",
+                                    "description": "ID of the model to use (e.g. '@cf/zai-org/glm-4.7-flash, etc')."
+                                },
+                                "audio": {
+                                    "anyOf": [
+                                        {
+                                            "type": "object",
+                                            "description": "Parameters for audio output. Required when modalities includes 'audio'.",
+                                            "properties": {
+                                                "voice": {
+                                                    "oneOf": [
+                                                        {
+                                                            "type": "string"
+                                                        },
+                                                        {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "id": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "id"
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                "format": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "wav",
+                                                        "aac",
+                                                        "mp3",
+                                                        "flac",
+                                                        "opus",
+                                                        "pcm16"
+                                                    ]
+                                                }
+                                            },
+                                            "required": [
+                                                "voice",
+                                                "format"
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "frequency_penalty": {
+                                    "anyOf": [
+                                        {
+                                            "type": "number",
+                                            "minimum": -2,
+                                            "maximum": 2
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": 0,
+                                    "description": "Penalizes new tokens based on their existing frequency in the text so far."
+                                },
+                                "logit_bias": {
+                                    "anyOf": [
+                                        {
+                                            "type": "object"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "Modify the likelihood of specified tokens appearing in the completion. Maps token IDs to bias values from -100 to 100."
+                                },
+                                "logprobs": {
+                                    "anyOf": [
+                                        {
+                                            "type": "boolean"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": false,
+                                    "description": "Whether to return log probabilities of the output tokens."
+                                },
+                                "top_logprobs": {
+                                    "anyOf": [
+                                        {
+                                            "type": "integer",
+                                            "minimum": 0,
+                                            "maximum": 20
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "How many top log probabilities to return at each token position (0-20). Requires logprobs=true."
+                                },
+                                "max_tokens": {
+                                    "anyOf": [
+                                        {
+                                            "type": "integer"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "Deprecated in favor of max_completion_tokens. The maximum number of tokens to generate."
+                                },
+                                "max_completion_tokens": {
+                                    "anyOf": [
+                                        {
+                                            "type": "integer"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "An upper bound for the number of tokens that can be generated for a completion."
+                                },
+                                "metadata": {
+                                    "anyOf": [
+                                        {
+                                            "type": "object"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "Set of 16 key-value pairs that can be attached to the object."
+                                },
+                                "modalities": {
+                                    "anyOf": [
+                                        {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "text",
+                                                    "audio"
+                                                ]
+                                            }
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "Output types requested from the model (e.g. ['text'] or ['text', 'audio'])."
+                                },
+                                "n": {
+                                    "anyOf": [
+                                        {
+                                            "type": "integer",
+                                            "minimum": 1,
+                                            "maximum": 128
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": 1,
+                                    "description": "How many chat completion choices to generate for each input message."
+                                },
+                                "parallel_tool_calls": {
+                                    "type": "boolean",
+                                    "default": true,
+                                    "description": "Whether to enable parallel function calling during tool use."
+                                },
+                                "prediction": {
+                                    "anyOf": [
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "type": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "content"
+                                                    ]
+                                                },
+                                                "content": {
+                                                    "anyOf": [
+                                                        {
+                                                            "type": "string"
+                                                        },
+                                                        {
+                                                            "type": "array",
+                                                            "items": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "type": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "text"
+                                                                        ]
+                                                                    },
+                                                                    "text": {
+                                                                        "type": "string"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "type",
+                                                                    "text"
+                                                                ]
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "required": [
+                                                "type",
+                                                "content"
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "presence_penalty": {
+                                    "anyOf": [
+                                        {
+                                            "type": "number",
+                                            "minimum": -2,
+                                            "maximum": 2
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": 0,
+                                    "description": "Penalizes new tokens based on whether they appear in the text so far."
+                                },
+                                "reasoning_effort": {
+                                    "anyOf": [
+                                        {
+                                            "type": "string",
+                                            "enum": [
+                                                "low",
+                                                "medium",
+                                                "high"
+                                            ]
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "Constrains effort on reasoning for reasoning models (o1, o3-mini, etc.)."
+                                },
+                                "chat_template_kwargs": {
+                                    "type": "object",
+                                    "properties": {
+                                        "enable_thinking": {
+                                            "type": "boolean",
+                                            "default": true,
+                                            "description": "Whether to enable reasoning, enabled by default."
+                                        },
+                                        "clear_thinking": {
+                                            "type": "boolean",
+                                            "default": false,
+                                            "description": "If false, preserves reasoning context between turns."
+                                        }
+                                    }
+                                },
+                                "response_format": {
+                                    "anyOf": [
+                                        {
+                                            "description": "Specifies the format the model must output.",
+                                            "oneOf": [
+                                                {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "text"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "type"
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "json_object"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "type"
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "json_schema"
+                                                            ]
+                                                        },
+                                                        "json_schema": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "name": {
+                                                                    "type": "string"
+                                                                },
+                                                                "description": {
+                                                                    "type": "string"
+                                                                },
+                                                                "schema": {
+                                                                    "type": "object"
+                                                                },
+                                                                "strict": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "boolean"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "name"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "type",
+                                                        "json_schema"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "seed": {
+                                    "anyOf": [
+                                        {
+                                            "type": "integer"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "If specified, the system will make a best effort to sample deterministically."
+                                },
+                                "service_tier": {
+                                    "anyOf": [
+                                        {
+                                            "type": "string",
+                                            "enum": [
+                                                "auto",
+                                                "default",
+                                                "flex",
+                                                "scale",
+                                                "priority"
+                                            ]
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": "auto",
+                                    "description": "Specifies the processing type used for serving the request."
+                                },
+                                "stop": {
+                                    "description": "Up to 4 sequences where the API will stop generating further tokens.",
+                                    "anyOf": [
+                                        {
+                                            "type": "null"
+                                        },
+                                        {
+                                            "type": "string"
+                                        },
+                                        {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            },
+                                            "minItems": 1,
+                                            "maxItems": 4
+                                        }
+                                    ]
+                                },
+                                "store": {
+                                    "anyOf": [
+                                        {
+                                            "type": "boolean"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": false,
+                                    "description": "Whether to store the output for model distillation / evals."
+                                },
+                                "stream": {
+                                    "anyOf": [
+                                        {
+                                            "type": "boolean"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": false,
+                                    "description": "If true, partial message deltas will be sent as server-sent events."
+                                },
+                                "stream_options": {
+                                    "anyOf": [
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "include_usage": {
+                                                    "type": "boolean"
+                                                },
+                                                "include_obfuscation": {
+                                                    "type": "boolean"
+                                                }
+                                            }
+                                        }
+                                    ]
+                                },
+                                "temperature": {
+                                    "anyOf": [
+                                        {
+                                            "type": "number",
+                                            "minimum": 0,
+                                            "maximum": 2
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": 1,
+                                    "description": "Sampling temperature between 0 and 2."
+                                },
+                                "tool_choice": {
+                                    "anyOf": [
+                                        {
+                                            "description": "Controls which (if any) tool is called by the model. 'none' = no tools, 'auto' = model decides, 'required' = must call a tool.",
+                                            "oneOf": [
+                                                {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "none",
+                                                        "auto",
+                                                        "required"
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "description": "Force a specific function tool.",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "function"
+                                                            ]
+                                                        },
+                                                        "function": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "name": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "name"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "type",
+                                                        "function"
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "description": "Force a specific custom tool.",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "custom"
+                                                            ]
+                                                        },
+                                                        "custom": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "name": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "name"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "type",
+                                                        "custom"
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "description": "Constrain to an allowed subset of tools.",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "allowed_tools"
+                                                            ]
+                                                        },
+                                                        "allowed_tools": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "mode": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "auto",
+                                                                        "required"
+                                                                    ]
+                                                                },
+                                                                "tools": {
+                                                                    "type": "array",
+                                                                    "items": {
+                                                                        "type": "object"
+                                                                    }
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "mode",
+                                                                "tools"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "type",
+                                                        "allowed_tools"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "tools": {
+                                    "type": "array",
+                                    "description": "A list of tools the model may call.",
+                                    "items": {
+                                        "oneOf": [
+                                            {
+                                                "type": "object",
+                                                "properties": {
+                                                    "type": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "function"
+                                                        ]
+                                                    },
+                                                    "function": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "name": {
+                                                                "type": "string",
+                                                                "description": "The name of the function to be called."
+                                                            },
+                                                            "description": {
+                                                                "type": "string",
+                                                                "description": "A description of what the function does."
+                                                            },
+                                                            "parameters": {
+                                                                "type": "object",
+                                                                "description": "The parameters the function accepts, described as a JSON Schema object."
+                                                            },
+                                                            "strict": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "boolean"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ],
+                                                                "default": false,
+                                                                "description": "Whether to enable strict schema adherence."
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "name"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type",
+                                                    "function"
+                                                ]
+                                            },
+                                            {
+                                                "type": "object",
+                                                "properties": {
+                                                    "type": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "custom"
+                                                        ]
+                                                    },
+                                                    "custom": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "name": {
+                                                                "type": "string"
+                                                            },
+                                                            "description": {
+                                                                "type": "string"
+                                                            },
+                                                            "format": {
+                                                                "oneOf": [
+                                                                    {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "type": {
+                                                                                "type": "string",
+                                                                                "enum": [
+                                                                                    "text"
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "type"
+                                                                        ]
+                                                                    },
+                                                                    {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "type": {
+                                                                                "type": "string",
+                                                                                "enum": [
+                                                                                    "grammar"
+                                                                                ]
+                                                                            },
+                                                                            "grammar": {
+                                                                                "type": "object",
+                                                                                "properties": {
+                                                                                    "definition": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "syntax": {
+                                                                                        "type": "string",
+                                                                                        "enum": [
+                                                                                            "lark",
+                                                                                            "regex"
+                                                                                        ]
+                                                                                    }
+                                                                                },
+                                                                                "required": [
+                                                                                    "definition",
+                                                                                    "syntax"
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "type",
+                                                                            "grammar"
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "name"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type",
+                                                    "custom"
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                },
+                                "top_p": {
+                                    "anyOf": [
+                                        {
+                                            "type": "number",
+                                            "minimum": 0,
+                                            "maximum": 1
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": 1,
+                                    "description": "Nucleus sampling: considers the results of the tokens with top_p probability mass."
+                                },
+                                "user": {
+                                    "type": "string",
+                                    "description": "A unique identifier representing your end-user, for abuse monitoring."
+                                },
+                                "web_search_options": {
+                                    "anyOf": [
+                                        {
+                                            "type": "object",
+                                            "description": "Options for the web search tool (when using built-in web search).",
+                                            "properties": {
+                                                "search_context_size": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "low",
+                                                        "medium",
+                                                        "high"
+                                                    ],
+                                                    "default": "medium"
+                                                },
+                                                "user_location": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "approximate"
+                                                            ]
+                                                        },
+                                                        "approximate": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "city": {
+                                                                    "type": "string"
+                                                                },
+                                                                "country": {
+                                                                    "type": "string"
+                                                                },
+                                                                "region": {
+                                                                    "type": "string"
+                                                                },
+                                                                "timezone": {
+                                                                    "type": "string"
+                                                                }
+                                                            }
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "type",
+                                                        "approximate"
+                                                    ]
+                                                }
+                                            }
+                                        }
+                                    ]
+                                },
+                                "function_call": {
+                                    "anyOf": [
+                                        {
+                                            "type": "string",
+                                            "enum": [
+                                                "none",
+                                                "auto"
+                                            ]
+                                        },
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "name": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "name"
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "functions": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "name": {
+                                                "type": "string",
+                                                "description": "The name of the function to be called."
+                                            },
+                                            "description": {
+                                                "type": "string",
+                                                "description": "A description of what the function does."
+                                            },
+                                            "parameters": {
+                                                "type": "object",
+                                                "description": "The parameters the function accepts, described as a JSON Schema object."
+                                            },
+                                            "strict": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "boolean"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": false,
+                                                "description": "Whether to enable strict schema adherence."
+                                            }
+                                        },
+                                        "required": [
+                                            "name"
+                                        ]
+                                    },
+                                    "minItems": 1,
+                                    "maxItems": 128
+                                }
+                            },
+                            "required": [
+                                "messages"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "requests": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "oneOf": [
+                                    {
+                                        "title": "Prompt",
+                                        "properties": {
+                                            "prompt": {
+                                                "type": "string",
+                                                "minLength": 1,
+                                                "description": "The input text prompt for the model to generate a response."
+                                            },
+                                            "model": {
+                                                "type": "string",
+                                                "description": "ID of the model to use (e.g. '@cf/zai-org/glm-4.7-flash, etc')."
+                                            },
+                                            "audio": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "object",
+                                                        "description": "Parameters for audio output. Required when modalities includes 'audio'.",
+                                                        "properties": {
+                                                            "voice": {
+                                                                "oneOf": [
+                                                                    {
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "id": {
+                                                                                "type": "string"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "id"
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "format": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                    "wav",
+                                                                    "aac",
+                                                                    "mp3",
+                                                                    "flac",
+                                                                    "opus",
+                                                                    "pcm16"
+                                                                ]
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "voice",
+                                                            "format"
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            "frequency_penalty": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "number",
+                                                        "minimum": -2,
+                                                        "maximum": 2
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": 0,
+                                                "description": "Penalizes new tokens based on their existing frequency in the text so far."
+                                            },
+                                            "logit_bias": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "Modify the likelihood of specified tokens appearing in the completion. Maps token IDs to bias values from -100 to 100."
+                                            },
+                                            "logprobs": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "boolean"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": false,
+                                                "description": "Whether to return log probabilities of the output tokens."
+                                            },
+                                            "top_logprobs": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "integer",
+                                                        "minimum": 0,
+                                                        "maximum": 20
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "How many top log probabilities to return at each token position (0-20). Requires logprobs=true."
+                                            },
+                                            "max_tokens": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "integer"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "Deprecated in favor of max_completion_tokens. The maximum number of tokens to generate."
+                                            },
+                                            "max_completion_tokens": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "integer"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "An upper bound for the number of tokens that can be generated for a completion."
+                                            },
+                                            "metadata": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "Set of 16 key-value pairs that can be attached to the object."
+                                            },
+                                            "modalities": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "array",
+                                                        "items": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "text",
+                                                                "audio"
+                                                            ]
+                                                        }
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "Output types requested from the model (e.g. ['text'] or ['text', 'audio'])."
+                                            },
+                                            "n": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "integer",
+                                                        "minimum": 1,
+                                                        "maximum": 128
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": 1,
+                                                "description": "How many chat completion choices to generate for each input message."
+                                            },
+                                            "parallel_tool_calls": {
+                                                "type": "boolean",
+                                                "default": true,
+                                                "description": "Whether to enable parallel function calling during tool use."
+                                            },
+                                            "prediction": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "type": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                    "content"
+                                                                ]
+                                                            },
+                                                            "content": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "type": "array",
+                                                                        "items": {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "type": {
+                                                                                    "type": "string",
+                                                                                    "enum": [
+                                                                                        "text"
+                                                                                    ]
+                                                                                },
+                                                                                "text": {
+                                                                                    "type": "string"
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "type",
+                                                                                "text"
+                                                                            ]
+                                                                        }
+                                                                    }
+                                                                ]
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "type",
+                                                            "content"
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            "presence_penalty": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "number",
+                                                        "minimum": -2,
+                                                        "maximum": 2
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": 0,
+                                                "description": "Penalizes new tokens based on whether they appear in the text so far."
+                                            },
+                                            "reasoning_effort": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "low",
+                                                            "medium",
+                                                            "high"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "Constrains effort on reasoning for reasoning models (o1, o3-mini, etc.)."
+                                            },
+                                            "chat_template_kwargs": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "enable_thinking": {
+                                                        "type": "boolean",
+                                                        "default": true,
+                                                        "description": "Whether to enable reasoning, enabled by default."
+                                                    },
+                                                    "clear_thinking": {
+                                                        "type": "boolean",
+                                                        "default": false,
+                                                        "description": "If false, preserves reasoning context between turns."
+                                                    }
+                                                }
+                                            },
+                                            "response_format": {
+                                                "anyOf": [
+                                                    {
+                                                        "description": "Specifies the format the model must output.",
+                                                        "oneOf": [
+                                                            {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "type": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "text"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "type"
+                                                                ]
+                                                            },
+                                                            {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "type": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "json_object"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "type"
+                                                                ]
+                                                            },
+                                                            {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "type": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "json_schema"
+                                                                        ]
+                                                                    },
+                                                                    "json_schema": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "name": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "description": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "schema": {
+                                                                                "type": "object"
+                                                                            },
+                                                                            "strict": {
+                                                                                "anyOf": [
+                                                                                    {
+                                                                                        "type": "boolean"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "null"
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "name"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "type",
+                                                                    "json_schema"
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            "seed": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "integer"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "If specified, the system will make a best effort to sample deterministically."
+                                            },
+                                            "service_tier": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "auto",
+                                                            "default",
+                                                            "flex",
+                                                            "scale",
+                                                            "priority"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": "auto",
+                                                "description": "Specifies the processing type used for serving the request."
+                                            },
+                                            "stop": {
+                                                "description": "Up to 4 sequences where the API will stop generating further tokens.",
+                                                "anyOf": [
+                                                    {
+                                                        "type": "null"
+                                                    },
+                                                    {
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "array",
+                                                        "items": {
+                                                            "type": "string"
+                                                        },
+                                                        "minItems": 1,
+                                                        "maxItems": 4
+                                                    }
+                                                ]
+                                            },
+                                            "store": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "boolean"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": false,
+                                                "description": "Whether to store the output for model distillation / evals."
+                                            },
+                                            "stream": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "boolean"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": false,
+                                                "description": "If true, partial message deltas will be sent as server-sent events."
+                                            },
+                                            "stream_options": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "include_usage": {
+                                                                "type": "boolean"
+                                                            },
+                                                            "include_obfuscation": {
+                                                                "type": "boolean"
+                                                            }
+                                                        }
+                                                    }
+                                                ]
+                                            },
+                                            "temperature": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "number",
+                                                        "minimum": 0,
+                                                        "maximum": 2
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": 1,
+                                                "description": "Sampling temperature between 0 and 2."
+                                            },
+                                            "tool_choice": {
+                                                "anyOf": [
+                                                    {
+                                                        "description": "Controls which (if any) tool is called by the model. 'none' = no tools, 'auto' = model decides, 'required' = must call a tool.",
+                                                        "oneOf": [
+                                                            {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                    "none",
+                                                                    "auto",
+                                                                    "required"
+                                                                ]
+                                                            },
+                                                            {
+                                                                "type": "object",
+                                                                "description": "Force a specific function tool.",
+                                                                "properties": {
+                                                                    "type": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "function"
+                                                                        ]
+                                                                    },
+                                                                    "function": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "name": {
+                                                                                "type": "string"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "name"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "type",
+                                                                    "function"
+                                                                ]
+                                                            },
+                                                            {
+                                                                "type": "object",
+                                                                "description": "Force a specific custom tool.",
+                                                                "properties": {
+                                                                    "type": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "custom"
+                                                                        ]
+                                                                    },
+                                                                    "custom": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "name": {
+                                                                                "type": "string"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "name"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "type",
+                                                                    "custom"
+                                                                ]
+                                                            },
+                                                            {
+                                                                "type": "object",
+                                                                "description": "Constrain to an allowed subset of tools.",
+                                                                "properties": {
+                                                                    "type": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "allowed_tools"
+                                                                        ]
+                                                                    },
+                                                                    "allowed_tools": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "mode": {
+                                                                                "type": "string",
+                                                                                "enum": [
+                                                                                    "auto",
+                                                                                    "required"
+                                                                                ]
+                                                                            },
+                                                                            "tools": {
+                                                                                "type": "array",
+                                                                                "items": {
+                                                                                    "type": "object"
+                                                                                }
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "mode",
+                                                                            "tools"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "type",
+                                                                    "allowed_tools"
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            "tools": {
+                                                "type": "array",
+                                                "description": "A list of tools the model may call.",
+                                                "items": {
+                                                    "oneOf": [
+                                                        {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "type": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "function"
+                                                                    ]
+                                                                },
+                                                                "function": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "name": {
+                                                                            "type": "string",
+                                                                            "description": "The name of the function to be called."
+                                                                        },
+                                                                        "description": {
+                                                                            "type": "string",
+                                                                            "description": "A description of what the function does."
+                                                                        },
+                                                                        "parameters": {
+                                                                            "type": "object",
+                                                                            "description": "The parameters the function accepts, described as a JSON Schema object."
+                                                                        },
+                                                                        "strict": {
+                                                                            "anyOf": [
+                                                                                {
+                                                                                    "type": "boolean"
+                                                                                },
+                                                                                {
+                                                                                    "type": "null"
+                                                                                }
+                                                                            ],
+                                                                            "default": false,
+                                                                            "description": "Whether to enable strict schema adherence."
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "name"
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "type",
+                                                                "function"
+                                                            ]
+                                                        },
+                                                        {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "type": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "custom"
+                                                                    ]
+                                                                },
+                                                                "custom": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "name": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "description": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "format": {
+                                                                            "oneOf": [
+                                                                                {
+                                                                                    "type": "object",
+                                                                                    "properties": {
+                                                                                        "type": {
+                                                                                            "type": "string",
+                                                                                            "enum": [
+                                                                                                "text"
+                                                                                            ]
+                                                                                        }
+                                                                                    },
+                                                                                    "required": [
+                                                                                        "type"
+                                                                                    ]
+                                                                                },
+                                                                                {
+                                                                                    "type": "object",
+                                                                                    "properties": {
+                                                                                        "type": {
+                                                                                            "type": "string",
+                                                                                            "enum": [
+                                                                                                "grammar"
+                                                                                            ]
+                                                                                        },
+                                                                                        "grammar": {
+                                                                                            "type": "object",
+                                                                                            "properties": {
+                                                                                                "definition": {
+                                                                                                    "type": "string"
+                                                                                                },
+                                                                                                "syntax": {
+                                                                                                    "type": "string",
+                                                                                                    "enum": [
+                                                                                                        "lark",
+                                                                                                        "regex"
+                                                                                                    ]
+                                                                                                }
+                                                                                            },
+                                                                                            "required": [
+                                                                                                "definition",
+                                                                                                "syntax"
+                                                                                            ]
+                                                                                        }
+                                                                                    },
+                                                                                    "required": [
+                                                                                        "type",
+                                                                                        "grammar"
+                                                                                    ]
+                                                                                }
+                                                                            ]
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "name"
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "type",
+                                                                "custom"
+                                                            ]
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "top_p": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "number",
+                                                        "minimum": 0,
+                                                        "maximum": 1
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": 1,
+                                                "description": "Nucleus sampling: considers the results of the tokens with top_p probability mass."
+                                            },
+                                            "user": {
+                                                "type": "string",
+                                                "description": "A unique identifier representing your end-user, for abuse monitoring."
+                                            },
+                                            "web_search_options": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "object",
+                                                        "description": "Options for the web search tool (when using built-in web search).",
+                                                        "properties": {
+                                                            "search_context_size": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                    "low",
+                                                                    "medium",
+                                                                    "high"
+                                                                ],
+                                                                "default": "medium"
+                                                            },
+                                                            "user_location": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "type": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "approximate"
+                                                                        ]
+                                                                    },
+                                                                    "approximate": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "city": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "country": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "region": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "timezone": {
+                                                                                "type": "string"
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "type",
+                                                                    "approximate"
+                                                                ]
+                                                            }
+                                                        }
+                                                    }
+                                                ]
+                                            },
+                                            "function_call": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "none",
+                                                            "auto"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "name": {
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "name"
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            "functions": {
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "name": {
+                                                            "type": "string",
+                                                            "description": "The name of the function to be called."
+                                                        },
+                                                        "description": {
+                                                            "type": "string",
+                                                            "description": "A description of what the function does."
+                                                        },
+                                                        "parameters": {
+                                                            "type": "object",
+                                                            "description": "The parameters the function accepts, described as a JSON Schema object."
+                                                        },
+                                                        "strict": {
+                                                            "anyOf": [
+                                                                {
+                                                                    "type": "boolean"
+                                                                },
+                                                                {
+                                                                    "type": "null"
+                                                                }
+                                                            ],
+                                                            "default": false,
+                                                            "description": "Whether to enable strict schema adherence."
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "name"
+                                                    ]
+                                                },
+                                                "minItems": 1,
+                                                "maxItems": 128
+                                            }
+                                        },
+                                        "required": [
+                                            "prompt"
+                                        ]
+                                    },
+                                    {
+                                        "title": "Messages",
+                                        "properties": {
+                                            "messages": {
+                                                "type": "array",
+                                                "description": "A list of messages comprising the conversation so far.",
+                                                "items": {
+                                                    "oneOf": [
+                                                        {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "role": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "developer"
+                                                                    ]
+                                                                },
+                                                                "content": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "array",
+                                                                            "items": {
+                                                                                "type": "object",
+                                                                                "properties": {
+                                                                                    "type": {
+                                                                                        "type": "string",
+                                                                                        "enum": [
+                                                                                            "text"
+                                                                                        ]
+                                                                                    },
+                                                                                    "text": {
+                                                                                        "type": "string"
+                                                                                    }
+                                                                                },
+                                                                                "required": [
+                                                                                    "type",
+                                                                                    "text"
+                                                                                ]
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "name": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "role",
+                                                                "content"
+                                                            ]
+                                                        },
+                                                        {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "role": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "system"
+                                                                    ]
+                                                                },
+                                                                "content": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "array",
+                                                                            "items": {
+                                                                                "type": "object",
+                                                                                "properties": {
+                                                                                    "type": {
+                                                                                        "type": "string",
+                                                                                        "enum": [
+                                                                                            "text"
+                                                                                        ]
+                                                                                    },
+                                                                                    "text": {
+                                                                                        "type": "string"
+                                                                                    }
+                                                                                },
+                                                                                "required": [
+                                                                                    "type",
+                                                                                    "text"
+                                                                                ]
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "name": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "role",
+                                                                "content"
+                                                            ]
+                                                        },
+                                                        {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "role": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "user"
+                                                                    ]
+                                                                },
+                                                                "content": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "array",
+                                                                            "items": {
+                                                                                "type": "object",
+                                                                                "properties": {
+                                                                                    "type": {
+                                                                                        "type": "string",
+                                                                                        "enum": [
+                                                                                            "text",
+                                                                                            "image_url",
+                                                                                            "video_url",
+                                                                                            "input_audio",
+                                                                                            "file"
+                                                                                        ]
+                                                                                    },
+                                                                                    "text": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "image_url": {
+                                                                                        "type": "object",
+                                                                                        "properties": {
+                                                                                            "url": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "detail": {
+                                                                                                "type": "string",
+                                                                                                "enum": [
+                                                                                                    "auto",
+                                                                                                    "low",
+                                                                                                    "high"
+                                                                                                ],
+                                                                                                "default": "auto"
+                                                                                            }
+                                                                                        }
+                                                                                    },
+                                                                                    "video_url": {
+                                                                                        "type": "object",
+                                                                                        "properties": {
+                                                                                            "url": {
+                                                                                                "type": "string"
+                                                                                            }
+                                                                                        }
+                                                                                    },
+                                                                                    "input_audio": {
+                                                                                        "type": "object",
+                                                                                        "properties": {
+                                                                                            "data": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "format": {
+                                                                                                "type": "string",
+                                                                                                "enum": [
+                                                                                                    "wav",
+                                                                                                    "mp3"
+                                                                                                ]
+                                                                                            }
+                                                                                        }
+                                                                                    },
+                                                                                    "file": {
+                                                                                        "type": "object",
+                                                                                        "properties": {
+                                                                                            "file_data": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "file_id": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "filename": {
+                                                                                                "type": "string"
+                                                                                            }
+                                                                                        }
+                                                                                    }
+                                                                                },
+                                                                                "required": [
+                                                                                    "type"
+                                                                                ]
+                                                                            },
+                                                                            "minItems": 1
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "name": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "role",
+                                                                "content"
+                                                            ]
+                                                        },
+                                                        {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "role": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "assistant"
+                                                                    ]
+                                                                },
+                                                                "content": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        },
+                                                                        {
+                                                                            "type": "array",
+                                                                            "items": {
+                                                                                "type": "object",
+                                                                                "properties": {
+                                                                                    "type": {
+                                                                                        "type": "string",
+                                                                                        "enum": [
+                                                                                            "text",
+                                                                                            "refusal"
+                                                                                        ]
+                                                                                    },
+                                                                                    "text": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "refusal": {
+                                                                                        "type": "string"
+                                                                                    }
+                                                                                },
+                                                                                "required": [
+                                                                                    "type"
+                                                                                ]
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "refusal": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "name": {
+                                                                    "type": "string"
+                                                                },
+                                                                "audio": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "id": {
+                                                                                    "type": "string"
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "id"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "tool_calls": {
+                                                                    "type": "array",
+                                                                    "items": {
+                                                                        "oneOf": [
+                                                                            {
+                                                                                "type": "object",
+                                                                                "properties": {
+                                                                                    "id": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "type": {
+                                                                                        "type": "string",
+                                                                                        "enum": [
+                                                                                            "function"
+                                                                                        ]
+                                                                                    },
+                                                                                    "function": {
+                                                                                        "type": "object",
+                                                                                        "properties": {
+                                                                                            "name": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "arguments": {
+                                                                                                "type": "string",
+                                                                                                "description": "JSON-encoded arguments string."
+                                                                                            }
+                                                                                        },
+                                                                                        "required": [
+                                                                                            "name",
+                                                                                            "arguments"
+                                                                                        ]
+                                                                                    }
+                                                                                },
+                                                                                "required": [
+                                                                                    "id",
+                                                                                    "type",
+                                                                                    "function"
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "type": "object",
+                                                                                "properties": {
+                                                                                    "id": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "type": {
+                                                                                        "type": "string",
+                                                                                        "enum": [
+                                                                                            "custom"
+                                                                                        ]
+                                                                                    },
+                                                                                    "custom": {
+                                                                                        "type": "object",
+                                                                                        "properties": {
+                                                                                            "name": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "input": {
+                                                                                                "type": "string"
+                                                                                            }
+                                                                                        },
+                                                                                        "required": [
+                                                                                            "name",
+                                                                                            "input"
+                                                                                        ]
+                                                                                    }
+                                                                                },
+                                                                                "required": [
+                                                                                    "id",
+                                                                                    "type",
+                                                                                    "custom"
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "function_call": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "name": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "arguments": {
+                                                                                    "type": "string"
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "name",
+                                                                                "arguments"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "role"
+                                                            ]
+                                                        },
+                                                        {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "role": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "tool"
+                                                                    ]
+                                                                },
+                                                                "content": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "array",
+                                                                            "items": {
+                                                                                "type": "object",
+                                                                                "properties": {
+                                                                                    "type": {
+                                                                                        "type": "string",
+                                                                                        "enum": [
+                                                                                            "text"
+                                                                                        ]
+                                                                                    },
+                                                                                    "text": {
+                                                                                        "type": "string"
+                                                                                    }
+                                                                                },
+                                                                                "required": [
+                                                                                    "type",
+                                                                                    "text"
+                                                                                ]
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "tool_call_id": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "role",
+                                                                "content",
+                                                                "tool_call_id"
+                                                            ]
+                                                        },
+                                                        {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "role": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "function"
+                                                                    ]
+                                                                },
+                                                                "content": {
+                                                                    "type": "string"
+                                                                },
+                                                                "name": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "role",
+                                                                "content",
+                                                                "name"
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                "minItems": 1
+                                            },
+                                            "model": {
+                                                "type": "string",
+                                                "description": "ID of the model to use (e.g. '@cf/zai-org/glm-4.7-flash, etc')."
+                                            },
+                                            "audio": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "object",
+                                                        "description": "Parameters for audio output. Required when modalities includes 'audio'.",
+                                                        "properties": {
+                                                            "voice": {
+                                                                "oneOf": [
+                                                                    {
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "id": {
+                                                                                "type": "string"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "id"
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "format": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                    "wav",
+                                                                    "aac",
+                                                                    "mp3",
+                                                                    "flac",
+                                                                    "opus",
+                                                                    "pcm16"
+                                                                ]
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "voice",
+                                                            "format"
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            "frequency_penalty": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "number",
+                                                        "minimum": -2,
+                                                        "maximum": 2
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": 0,
+                                                "description": "Penalizes new tokens based on their existing frequency in the text so far."
+                                            },
+                                            "logit_bias": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "Modify the likelihood of specified tokens appearing in the completion. Maps token IDs to bias values from -100 to 100."
+                                            },
+                                            "logprobs": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "boolean"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": false,
+                                                "description": "Whether to return log probabilities of the output tokens."
+                                            },
+                                            "top_logprobs": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "integer",
+                                                        "minimum": 0,
+                                                        "maximum": 20
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "How many top log probabilities to return at each token position (0-20). Requires logprobs=true."
+                                            },
+                                            "max_tokens": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "integer"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "Deprecated in favor of max_completion_tokens. The maximum number of tokens to generate."
+                                            },
+                                            "max_completion_tokens": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "integer"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "An upper bound for the number of tokens that can be generated for a completion."
+                                            },
+                                            "metadata": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "Set of 16 key-value pairs that can be attached to the object."
+                                            },
+                                            "modalities": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "array",
+                                                        "items": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "text",
+                                                                "audio"
+                                                            ]
+                                                        }
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "Output types requested from the model (e.g. ['text'] or ['text', 'audio'])."
+                                            },
+                                            "n": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "integer",
+                                                        "minimum": 1,
+                                                        "maximum": 128
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": 1,
+                                                "description": "How many chat completion choices to generate for each input message."
+                                            },
+                                            "parallel_tool_calls": {
+                                                "type": "boolean",
+                                                "default": true,
+                                                "description": "Whether to enable parallel function calling during tool use."
+                                            },
+                                            "prediction": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "type": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                    "content"
+                                                                ]
+                                                            },
+                                                            "content": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "type": "array",
+                                                                        "items": {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "type": {
+                                                                                    "type": "string",
+                                                                                    "enum": [
+                                                                                        "text"
+                                                                                    ]
+                                                                                },
+                                                                                "text": {
+                                                                                    "type": "string"
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "type",
+                                                                                "text"
+                                                                            ]
+                                                                        }
+                                                                    }
+                                                                ]
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "type",
+                                                            "content"
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            "presence_penalty": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "number",
+                                                        "minimum": -2,
+                                                        "maximum": 2
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": 0,
+                                                "description": "Penalizes new tokens based on whether they appear in the text so far."
+                                            },
+                                            "reasoning_effort": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "low",
+                                                            "medium",
+                                                            "high"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "Constrains effort on reasoning for reasoning models (o1, o3-mini, etc.)."
+                                            },
+                                            "chat_template_kwargs": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "enable_thinking": {
+                                                        "type": "boolean",
+                                                        "default": true,
+                                                        "description": "Whether to enable reasoning, enabled by default."
+                                                    },
+                                                    "clear_thinking": {
+                                                        "type": "boolean",
+                                                        "default": false,
+                                                        "description": "If false, preserves reasoning context between turns."
+                                                    }
+                                                }
+                                            },
+                                            "response_format": {
+                                                "anyOf": [
+                                                    {
+                                                        "description": "Specifies the format the model must output.",
+                                                        "oneOf": [
+                                                            {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "type": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "text"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "type"
+                                                                ]
+                                                            },
+                                                            {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "type": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "json_object"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "type"
+                                                                ]
+                                                            },
+                                                            {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "type": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "json_schema"
+                                                                        ]
+                                                                    },
+                                                                    "json_schema": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "name": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "description": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "schema": {
+                                                                                "type": "object"
+                                                                            },
+                                                                            "strict": {
+                                                                                "anyOf": [
+                                                                                    {
+                                                                                        "type": "boolean"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "null"
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "name"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "type",
+                                                                    "json_schema"
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            "seed": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "integer"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "If specified, the system will make a best effort to sample deterministically."
+                                            },
+                                            "service_tier": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "auto",
+                                                            "default",
+                                                            "flex",
+                                                            "scale",
+                                                            "priority"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": "auto",
+                                                "description": "Specifies the processing type used for serving the request."
+                                            },
+                                            "stop": {
+                                                "description": "Up to 4 sequences where the API will stop generating further tokens.",
+                                                "anyOf": [
+                                                    {
+                                                        "type": "null"
+                                                    },
+                                                    {
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "array",
+                                                        "items": {
+                                                            "type": "string"
+                                                        },
+                                                        "minItems": 1,
+                                                        "maxItems": 4
+                                                    }
+                                                ]
+                                            },
+                                            "store": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "boolean"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": false,
+                                                "description": "Whether to store the output for model distillation / evals."
+                                            },
+                                            "stream": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "boolean"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": false,
+                                                "description": "If true, partial message deltas will be sent as server-sent events."
+                                            },
+                                            "stream_options": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "include_usage": {
+                                                                "type": "boolean"
+                                                            },
+                                                            "include_obfuscation": {
+                                                                "type": "boolean"
+                                                            }
+                                                        }
+                                                    }
+                                                ]
+                                            },
+                                            "temperature": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "number",
+                                                        "minimum": 0,
+                                                        "maximum": 2
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": 1,
+                                                "description": "Sampling temperature between 0 and 2."
+                                            },
+                                            "tool_choice": {
+                                                "anyOf": [
+                                                    {
+                                                        "description": "Controls which (if any) tool is called by the model. 'none' = no tools, 'auto' = model decides, 'required' = must call a tool.",
+                                                        "oneOf": [
+                                                            {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                    "none",
+                                                                    "auto",
+                                                                    "required"
+                                                                ]
+                                                            },
+                                                            {
+                                                                "type": "object",
+                                                                "description": "Force a specific function tool.",
+                                                                "properties": {
+                                                                    "type": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "function"
+                                                                        ]
+                                                                    },
+                                                                    "function": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "name": {
+                                                                                "type": "string"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "name"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "type",
+                                                                    "function"
+                                                                ]
+                                                            },
+                                                            {
+                                                                "type": "object",
+                                                                "description": "Force a specific custom tool.",
+                                                                "properties": {
+                                                                    "type": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "custom"
+                                                                        ]
+                                                                    },
+                                                                    "custom": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "name": {
+                                                                                "type": "string"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "name"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "type",
+                                                                    "custom"
+                                                                ]
+                                                            },
+                                                            {
+                                                                "type": "object",
+                                                                "description": "Constrain to an allowed subset of tools.",
+                                                                "properties": {
+                                                                    "type": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "allowed_tools"
+                                                                        ]
+                                                                    },
+                                                                    "allowed_tools": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "mode": {
+                                                                                "type": "string",
+                                                                                "enum": [
+                                                                                    "auto",
+                                                                                    "required"
+                                                                                ]
+                                                                            },
+                                                                            "tools": {
+                                                                                "type": "array",
+                                                                                "items": {
+                                                                                    "type": "object"
+                                                                                }
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "mode",
+                                                                            "tools"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "type",
+                                                                    "allowed_tools"
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            "tools": {
+                                                "type": "array",
+                                                "description": "A list of tools the model may call.",
+                                                "items": {
+                                                    "oneOf": [
+                                                        {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "type": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "function"
+                                                                    ]
+                                                                },
+                                                                "function": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "name": {
+                                                                            "type": "string",
+                                                                            "description": "The name of the function to be called."
+                                                                        },
+                                                                        "description": {
+                                                                            "type": "string",
+                                                                            "description": "A description of what the function does."
+                                                                        },
+                                                                        "parameters": {
+                                                                            "type": "object",
+                                                                            "description": "The parameters the function accepts, described as a JSON Schema object."
+                                                                        },
+                                                                        "strict": {
+                                                                            "anyOf": [
+                                                                                {
+                                                                                    "type": "boolean"
+                                                                                },
+                                                                                {
+                                                                                    "type": "null"
+                                                                                }
+                                                                            ],
+                                                                            "default": false,
+                                                                            "description": "Whether to enable strict schema adherence."
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "name"
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "type",
+                                                                "function"
+                                                            ]
+                                                        },
+                                                        {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "type": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "custom"
+                                                                    ]
+                                                                },
+                                                                "custom": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "name": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "description": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "format": {
+                                                                            "oneOf": [
+                                                                                {
+                                                                                    "type": "object",
+                                                                                    "properties": {
+                                                                                        "type": {
+                                                                                            "type": "string",
+                                                                                            "enum": [
+                                                                                                "text"
+                                                                                            ]
+                                                                                        }
+                                                                                    },
+                                                                                    "required": [
+                                                                                        "type"
+                                                                                    ]
+                                                                                },
+                                                                                {
+                                                                                    "type": "object",
+                                                                                    "properties": {
+                                                                                        "type": {
+                                                                                            "type": "string",
+                                                                                            "enum": [
+                                                                                                "grammar"
+                                                                                            ]
+                                                                                        },
+                                                                                        "grammar": {
+                                                                                            "type": "object",
+                                                                                            "properties": {
+                                                                                                "definition": {
+                                                                                                    "type": "string"
+                                                                                                },
+                                                                                                "syntax": {
+                                                                                                    "type": "string",
+                                                                                                    "enum": [
+                                                                                                        "lark",
+                                                                                                        "regex"
+                                                                                                    ]
+                                                                                                }
+                                                                                            },
+                                                                                            "required": [
+                                                                                                "definition",
+                                                                                                "syntax"
+                                                                                            ]
+                                                                                        }
+                                                                                    },
+                                                                                    "required": [
+                                                                                        "type",
+                                                                                        "grammar"
+                                                                                    ]
+                                                                                }
+                                                                            ]
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "name"
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "type",
+                                                                "custom"
+                                                            ]
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "top_p": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "number",
+                                                        "minimum": 0,
+                                                        "maximum": 1
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": 1,
+                                                "description": "Nucleus sampling: considers the results of the tokens with top_p probability mass."
+                                            },
+                                            "user": {
+                                                "type": "string",
+                                                "description": "A unique identifier representing your end-user, for abuse monitoring."
+                                            },
+                                            "web_search_options": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "object",
+                                                        "description": "Options for the web search tool (when using built-in web search).",
+                                                        "properties": {
+                                                            "search_context_size": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                    "low",
+                                                                    "medium",
+                                                                    "high"
+                                                                ],
+                                                                "default": "medium"
+                                                            },
+                                                            "user_location": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "type": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "approximate"
+                                                                        ]
+                                                                    },
+                                                                    "approximate": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "city": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "country": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "region": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "timezone": {
+                                                                                "type": "string"
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "type",
+                                                                    "approximate"
+                                                                ]
+                                                            }
+                                                        }
+                                                    }
+                                                ]
+                                            },
+                                            "function_call": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "none",
+                                                            "auto"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "name": {
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "name"
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            "functions": {
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "name": {
+                                                            "type": "string",
+                                                            "description": "The name of the function to be called."
+                                                        },
+                                                        "description": {
+                                                            "type": "string",
+                                                            "description": "A description of what the function does."
+                                                        },
+                                                        "parameters": {
+                                                            "type": "object",
+                                                            "description": "The parameters the function accepts, described as a JSON Schema object."
+                                                        },
+                                                        "strict": {
+                                                            "anyOf": [
+                                                                {
+                                                                    "type": "boolean"
+                                                                },
+                                                                {
+                                                                    "type": "null"
+                                                                }
+                                                            ],
+                                                            "default": false,
+                                                            "description": "Whether to enable strict schema adherence."
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "name"
+                                                    ]
+                                                },
+                                                "minItems": 1,
+                                                "maxItems": 128
+                                            }
+                                        },
+                                        "required": [
+                                            "messages"
                                         ]
                                     }
                                 ]
                             }
-                        },
-                        "response_format": {
-                            "title": "JSON Mode",
-                            "type": "object",
-                            "properties": {
-                                "type": {
-                                    "type": "string",
-                                    "enum": [
-                                        "json_object",
-                                        "json_schema"
-                                    ]
-                                },
-                                "json_schema": {}
-                            }
-                        },
-                        "raw": {
-                            "type": "boolean",
-                            "default": false,
-                            "description": "If true, a chat template is not applied and you must adhere to the specific model's expected formatting."
-                        },
-                        "stream": {
-                            "type": "boolean",
-                            "default": false,
-                            "description": "If true, the response will be streamed back incrementally using SSE, Server Sent Events."
-                        },
-                        "max_tokens": {
-                            "type": "integer",
-                            "default": 256,
-                            "description": "The maximum number of tokens to generate in the response."
-                        },
-                        "temperature": {
-                            "type": "number",
-                            "default": 0.6,
-                            "minimum": 0,
-                            "maximum": 5,
-                            "description": "Controls the randomness of the output; higher values produce more random results."
-                        },
-                        "top_p": {
-                            "type": "number",
-                            "minimum": 0.001,
-                            "maximum": 1,
-                            "description": "Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
-                        },
-                        "top_k": {
-                            "type": "integer",
-                            "minimum": 1,
-                            "maximum": 50,
-                            "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
-                        },
-                        "seed": {
-                            "type": "integer",
-                            "minimum": 1,
-                            "maximum": 9999999999,
-                            "description": "Random seed for reproducibility of the generation."
-                        },
-                        "repetition_penalty": {
-                            "type": "number",
-                            "minimum": 0,
-                            "maximum": 2,
-                            "description": "Penalty for repeated tokens; higher values discourage repetition."
-                        },
-                        "frequency_penalty": {
-                            "type": "number",
-                            "minimum": -2,
-                            "maximum": 2,
-                            "description": "Decreases the likelihood of the model repeating the same lines verbatim."
-                        },
-                        "presence_penalty": {
-                            "type": "number",
-                            "minimum": -2,
-                            "maximum": 2,
-                            "description": "Increases the likelihood of the model introducing new topics."
                         }
-                    },
-                    "required": [
-                        "messages"
-                    ]
+                    }
                 }
             ]
         },
@@ -436,56 +4267,508 @@
             "oneOf": [
                 {
                     "type": "object",
+                    "contentType": "application/json",
                     "properties": {
-                        "response": {
+                        "id": {
                             "type": "string",
-                            "description": "The generated text response from the model"
+                            "description": "A unique identifier for the chat completion."
+                        },
+                        "object": {
+                            "type": "string"
+                        },
+                        "created": {
+                            "type": "integer",
+                            "description": "Unix timestamp (seconds) of when the completion was created."
+                        },
+                        "model": {
+                            "type": "string",
+                            "description": "The model used for the chat completion."
+                        },
+                        "choices": {
+                            "type": "array",
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "object",
+                                        "properties": {
+                                            "index": {
+                                                "type": "integer"
+                                            },
+                                            "message": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "role": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                    "assistant"
+                                                                ]
+                                                            },
+                                                            "content": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "refusal": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "annotations": {
+                                                                "type": "array",
+                                                                "items": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "enum": [
+                                                                                "url_citation"
+                                                                            ]
+                                                                        },
+                                                                        "url_citation": {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "url": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "title": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "start_index": {
+                                                                                    "type": "integer"
+                                                                                },
+                                                                                "end_index": {
+                                                                                    "type": "integer"
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "url",
+                                                                                "title",
+                                                                                "start_index",
+                                                                                "end_index"
+                                                                            ]
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "type",
+                                                                        "url_citation"
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "audio": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "id": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "data": {
+                                                                                "type": "string",
+                                                                                "description": "Base64 encoded audio bytes."
+                                                                            },
+                                                                            "expires_at": {
+                                                                                "type": "integer"
+                                                                            },
+                                                                            "transcript": {
+                                                                                "type": "string"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "id",
+                                                                            "data",
+                                                                            "expires_at",
+                                                                            "transcript"
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "tool_calls": {
+                                                                "type": "array",
+                                                                "items": {
+                                                                    "oneOf": [
+                                                                        {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "id": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "type": {
+                                                                                    "type": "string",
+                                                                                    "enum": [
+                                                                                        "function"
+                                                                                    ]
+                                                                                },
+                                                                                "function": {
+                                                                                    "type": "object",
+                                                                                    "properties": {
+                                                                                        "name": {
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "arguments": {
+                                                                                            "type": "string",
+                                                                                            "description": "JSON-encoded arguments string."
+                                                                                        }
+                                                                                    },
+                                                                                    "required": [
+                                                                                        "name",
+                                                                                        "arguments"
+                                                                                    ]
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "id",
+                                                                                "type",
+                                                                                "function"
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "id": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "type": {
+                                                                                    "type": "string",
+                                                                                    "enum": [
+                                                                                        "custom"
+                                                                                    ]
+                                                                                },
+                                                                                "custom": {
+                                                                                    "type": "object",
+                                                                                    "properties": {
+                                                                                        "name": {
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "input": {
+                                                                                            "type": "string"
+                                                                                        }
+                                                                                    },
+                                                                                    "required": [
+                                                                                        "name",
+                                                                                        "input"
+                                                                                    ]
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "id",
+                                                                                "type",
+                                                                                "custom"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "function_call": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "name": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "arguments": {
+                                                                                "type": "string"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "name",
+                                                                            "arguments"
+                                                                        ]
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ]
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "role",
+                                                            "content",
+                                                            "refusal"
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            "finish_reason": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "stop",
+                                                    "length",
+                                                    "tool_calls",
+                                                    "content_filter",
+                                                    "function_call"
+                                                ]
+                                            },
+                                            "logprobs": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "content": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "array",
+                                                                        "items": {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "token": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "logprob": {
+                                                                                    "type": "number"
+                                                                                },
+                                                                                "bytes": {
+                                                                                    "anyOf": [
+                                                                                        {
+                                                                                            "type": "array",
+                                                                                            "items": {
+                                                                                                "type": "integer"
+                                                                                            }
+                                                                                        },
+                                                                                        {
+                                                                                            "type": "null"
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                "top_logprobs": {
+                                                                                    "type": "array",
+                                                                                    "items": {
+                                                                                        "type": "object",
+                                                                                        "properties": {
+                                                                                            "token": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "logprob": {
+                                                                                                "type": "number"
+                                                                                            },
+                                                                                            "bytes": {
+                                                                                                "anyOf": [
+                                                                                                    {
+                                                                                                        "type": "array",
+                                                                                                        "items": {
+                                                                                                            "type": "integer"
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "null"
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        },
+                                                                                        "required": [
+                                                                                            "token",
+                                                                                            "logprob",
+                                                                                            "bytes"
+                                                                                        ]
+                                                                                    }
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "token",
+                                                                                "logprob",
+                                                                                "bytes",
+                                                                                "top_logprobs"
+                                                                            ]
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "refusal": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "array",
+                                                                        "items": {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "token": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "logprob": {
+                                                                                    "type": "number"
+                                                                                },
+                                                                                "bytes": {
+                                                                                    "anyOf": [
+                                                                                        {
+                                                                                            "type": "array",
+                                                                                            "items": {
+                                                                                                "type": "integer"
+                                                                                            }
+                                                                                        },
+                                                                                        {
+                                                                                            "type": "null"
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                "top_logprobs": {
+                                                                                    "type": "array",
+                                                                                    "items": {
+                                                                                        "type": "object",
+                                                                                        "properties": {
+                                                                                            "token": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "logprob": {
+                                                                                                "type": "number"
+                                                                                            },
+                                                                                            "bytes": {
+                                                                                                "anyOf": [
+                                                                                                    {
+                                                                                                        "type": "array",
+                                                                                                        "items": {
+                                                                                                            "type": "integer"
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "null"
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        },
+                                                                                        "required": [
+                                                                                            "token",
+                                                                                            "logprob",
+                                                                                            "bytes"
+                                                                                        ]
+                                                                                    }
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "token",
+                                                                                "logprob",
+                                                                                "bytes",
+                                                                                "top_logprobs"
+                                                                            ]
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ]
+                                                            }
+                                                        }
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "index",
+                                            "message",
+                                            "finish_reason",
+                                            "logprobs"
+                                        ]
+                                    }
+                                ]
+                            },
+                            "minItems": 1
                         },
                         "usage": {
-                            "type": "object",
-                            "description": "Usage statistics for the inference request",
-                            "properties": {
-                                "prompt_tokens": {
-                                    "type": "number",
-                                    "description": "Total number of tokens in input",
-                                    "default": 0
-                                },
-                                "completion_tokens": {
-                                    "type": "number",
-                                    "description": "Total number of tokens in output",
-                                    "default": 0
-                                },
-                                "total_tokens": {
-                                    "type": "number",
-                                    "description": "Total number of input and output tokens",
-                                    "default": 0
-                                }
-                            }
-                        },
-                        "tool_calls": {
-                            "type": "array",
-                            "description": "An array of tool calls requests made during the response generation",
-                            "items": {
-                                "type": "object",
-                                "properties": {
-                                    "arguments": {
-                                        "type": "object",
-                                        "description": "The arguments passed to be passed to the tool call request"
+                            "anyOf": [
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "prompt_tokens": {
+                                            "type": "integer"
+                                        },
+                                        "completion_tokens": {
+                                            "type": "integer"
+                                        },
+                                        "total_tokens": {
+                                            "type": "integer"
+                                        },
+                                        "prompt_tokens_details": {
+                                            "type": "object",
+                                            "properties": {
+                                                "cached_tokens": {
+                                                    "type": "integer"
+                                                },
+                                                "audio_tokens": {
+                                                    "type": "integer"
+                                                }
+                                            }
+                                        },
+                                        "completion_tokens_details": {
+                                            "type": "object",
+                                            "properties": {
+                                                "reasoning_tokens": {
+                                                    "type": "integer"
+                                                },
+                                                "audio_tokens": {
+                                                    "type": "integer"
+                                                },
+                                                "accepted_prediction_tokens": {
+                                                    "type": "integer"
+                                                },
+                                                "rejected_prediction_tokens": {
+                                                    "type": "integer"
+                                                }
+                                            }
+                                        }
                                     },
-                                    "name": {
-                                        "type": "string",
-                                        "description": "The name of the tool to be called"
-                                    }
+                                    "required": [
+                                        "prompt_tokens",
+                                        "completion_tokens",
+                                        "total_tokens"
+                                    ]
                                 }
-                            }
+                            ]
+                        },
+                        "system_fingerprint": {
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ]
+                        },
+                        "service_tier": {
+                            "anyOf": [
+                                {
+                                    "type": "string",
+                                    "enum": [
+                                        "auto",
+                                        "default",
+                                        "flex",
+                                        "scale",
+                                        "priority"
+                                    ]
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ]
                         }
                     },
                     "required": [
-                        "response"
+                        "id",
+                        "object",
+                        "created",
+                        "model",
+                        "choices"
                     ]
                 },
                 {
                     "type": "string",
+                    "contentType": "text/event-stream",
                     "format": "binary"
                 }
             ]

--- a/src/content/workers-ai-models/glm-5.3-flash.json
+++ b/src/content/workers-ai-models/glm-5.3-flash.json
@@ -1,0 +1,495 @@
+{
+    "name": "@cf/zai-org/glm-5.3-flash",
+    "properties": [
+        {
+            "property_id": "require_workers_paid",
+            "value": "true"
+        },
+        {
+            "property_id": "context_window",
+            "value": "1048576"
+        },
+        {
+            "property_id": "function_calling",
+            "value": "true"
+        },
+        {
+            "property_id": "reasoning",
+            "value": "true"
+        },
+        {
+            "property_id": "terms",
+            "value": "https://huggingface.co/zai-org/GLM-5.3-Flash/blob/main/LICENSE"
+        },
+        {
+            "property_id": "vision",
+            "value": "true"
+        },
+        {
+            "property_id": "price",
+            "value": [
+                {
+                    "unit": "per M input tokens",
+                    "price": 0.15,
+                    "currency": "USD"
+                },
+                {
+                    "unit": "per M output tokens",
+                    "price": 0.5,
+                    "currency": "USD"
+                },
+                {
+                    "unit": "per M cached input tokens",
+                    "price": 0.03,
+                    "currency": "USD"
+                }
+            ]
+        }
+    ],
+    "id": "95666467-f984-4211-b48a-7c246dd4adb7",
+    "source": 1,
+    "description": "The first natively multimodal model in the GLM-5 series. With 320B total parameters and just 18B active parameters, it outperforms GLM-5.2 across benchmarks and real-world workloads at one-tenth the price, while approaching Claude Opus 4.8 on coding and agentic benchmarks.",
+    "task": {
+        "id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+        "name": "Text Generation",
+        "description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+    },
+    "created_at": "2026-08-26 14:21:42.917",
+    "tags": [],
+    "schema": {
+        "input": {
+            "type": "object",
+            "oneOf": [
+                {
+                    "title": "Prompt",
+                    "properties": {
+                        "prompt": {
+                            "type": "string",
+                            "minLength": 1,
+                            "description": "The input text prompt for the model to generate a response."
+                        },
+                        "lora": {
+                            "type": "string",
+                            "description": "Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model."
+                        },
+                        "response_format": {
+                            "title": "JSON Mode",
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "enum": [
+                                        "json_object",
+                                        "json_schema"
+                                    ]
+                                },
+                                "json_schema": {}
+                            }
+                        },
+                        "raw": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, a chat template is not applied and you must adhere to the specific model's expected formatting."
+                        },
+                        "stream": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, the response will be streamed back incrementally using SSE, Server Sent Events."
+                        },
+                        "max_tokens": {
+                            "type": "integer",
+                            "default": 256,
+                            "description": "The maximum number of tokens to generate in the response."
+                        },
+                        "temperature": {
+                            "type": "number",
+                            "default": 0.6,
+                            "minimum": 0,
+                            "maximum": 5,
+                            "description": "Controls the randomness of the output; higher values produce more random results."
+                        },
+                        "top_p": {
+                            "type": "number",
+                            "minimum": 0.001,
+                            "maximum": 1,
+                            "description": "Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                        },
+                        "top_k": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                        },
+                        "seed": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 9999999999,
+                            "description": "Random seed for reproducibility of the generation."
+                        },
+                        "repetition_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Penalty for repeated tokens; higher values discourage repetition."
+                        },
+                        "frequency_penalty": {
+                            "type": "number",
+                            "minimum": -2,
+                            "maximum": 2,
+                            "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                        },
+                        "presence_penalty": {
+                            "type": "number",
+                            "minimum": -2,
+                            "maximum": 2,
+                            "description": "Increases the likelihood of the model introducing new topics."
+                        }
+                    },
+                    "required": [
+                        "prompt"
+                    ]
+                },
+                {
+                    "title": "Messages",
+                    "properties": {
+                        "messages": {
+                            "type": "array",
+                            "description": "An array of message objects representing the conversation history.",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "role": {
+                                        "type": "string",
+                                        "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
+                                    },
+                                    "content": {
+                                        "oneOf": [
+                                            {
+                                                "type": "string",
+                                                "description": "The content of the message as a string."
+                                            },
+                                            {
+                                                "type": "array",
+                                                "description": "Array of text content parts.",
+                                                "items": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "description": "Type of the content (text)"
+                                                        },
+                                                        "text": {
+                                                            "type": "string",
+                                                            "description": "Text content"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    }
+                                },
+                                "required": [
+                                    "role",
+                                    "content"
+                                ]
+                            }
+                        },
+                        "functions": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "code": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "name",
+                                    "code"
+                                ]
+                            }
+                        },
+                        "tools": {
+                            "type": "array",
+                            "description": "A list of tools available for the assistant to use.",
+                            "items": {
+                                "type": "object",
+                                "oneOf": [
+                                    {
+                                        "properties": {
+                                            "name": {
+                                                "type": "string",
+                                                "description": "The name of the tool. More descriptive the better."
+                                            },
+                                            "description": {
+                                                "type": "string",
+                                                "description": "A brief description of what the tool does."
+                                            },
+                                            "parameters": {
+                                                "type": "object",
+                                                "description": "Schema defining the parameters accepted by the tool.",
+                                                "properties": {
+                                                    "type": {
+                                                        "type": "string",
+                                                        "description": "The type of the parameters object (usually 'object')."
+                                                    },
+                                                    "required": {
+                                                        "type": "array",
+                                                        "description": "List of required parameter names.",
+                                                        "items": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "properties": {
+                                                        "type": "object",
+                                                        "description": "Definitions of each parameter.",
+                                                        "additionalProperties": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "type": {
+                                                                    "type": "string",
+                                                                    "description": "The data type of the parameter."
+                                                                },
+                                                                "description": {
+                                                                    "type": "string",
+                                                                    "description": "A description of the expected parameter."
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "type",
+                                                                "description"
+                                                            ]
+                                                        }
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type",
+                                                    "properties"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "name",
+                                            "description",
+                                            "parameters"
+                                        ]
+                                    },
+                                    {
+                                        "properties": {
+                                            "type": {
+                                                "type": "string",
+                                                "description": "Specifies the type of tool (e.g., 'function')."
+                                            },
+                                            "function": {
+                                                "type": "object",
+                                                "description": "Details of the function tool.",
+                                                "properties": {
+                                                    "name": {
+                                                        "type": "string",
+                                                        "description": "The name of the function."
+                                                    },
+                                                    "description": {
+                                                        "type": "string",
+                                                        "description": "A brief description of what the function does."
+                                                    },
+                                                    "parameters": {
+                                                        "type": "object",
+                                                        "description": "Schema defining the parameters accepted by the function.",
+                                                        "properties": {
+                                                            "type": {
+                                                                "type": "string",
+                                                                "description": "The type of the parameters object (usually 'object')."
+                                                            },
+                                                            "required": {
+                                                                "type": "array",
+                                                                "description": "List of required parameter names.",
+                                                                "items": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "properties": {
+                                                                "type": "object",
+                                                                "description": "Definitions of each parameter.",
+                                                                "additionalProperties": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "description": "The data type of the parameter."
+                                                                        },
+                                                                        "description": {
+                                                                            "type": "string",
+                                                                            "description": "A description of the expected parameter."
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "type",
+                                                                        "description"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "type",
+                                                            "properties"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": [
+                                                    "name",
+                                                    "description",
+                                                    "parameters"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "type",
+                                            "function"
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
+                        "response_format": {
+                            "title": "JSON Mode",
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "enum": [
+                                        "json_object",
+                                        "json_schema"
+                                    ]
+                                },
+                                "json_schema": {}
+                            }
+                        },
+                        "raw": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, a chat template is not applied and you must adhere to the specific model's expected formatting."
+                        },
+                        "stream": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, the response will be streamed back incrementally using SSE, Server Sent Events."
+                        },
+                        "max_tokens": {
+                            "type": "integer",
+                            "default": 256,
+                            "description": "The maximum number of tokens to generate in the response."
+                        },
+                        "temperature": {
+                            "type": "number",
+                            "default": 0.6,
+                            "minimum": 0,
+                            "maximum": 5,
+                            "description": "Controls the randomness of the output; higher values produce more random results."
+                        },
+                        "top_p": {
+                            "type": "number",
+                            "minimum": 0.001,
+                            "maximum": 1,
+                            "description": "Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                        },
+                        "top_k": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                        },
+                        "seed": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 9999999999,
+                            "description": "Random seed for reproducibility of the generation."
+                        },
+                        "repetition_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Penalty for repeated tokens; higher values discourage repetition."
+                        },
+                        "frequency_penalty": {
+                            "type": "number",
+                            "minimum": -2,
+                            "maximum": 2,
+                            "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                        },
+                        "presence_penalty": {
+                            "type": "number",
+                            "minimum": -2,
+                            "maximum": 2,
+                            "description": "Increases the likelihood of the model introducing new topics."
+                        }
+                    },
+                    "required": [
+                        "messages"
+                    ]
+                }
+            ]
+        },
+        "output": {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "properties": {
+                        "response": {
+                            "type": "string",
+                            "description": "The generated text response from the model"
+                        },
+                        "usage": {
+                            "type": "object",
+                            "description": "Usage statistics for the inference request",
+                            "properties": {
+                                "prompt_tokens": {
+                                    "type": "number",
+                                    "description": "Total number of tokens in input",
+                                    "default": 0
+                                },
+                                "completion_tokens": {
+                                    "type": "number",
+                                    "description": "Total number of tokens in output",
+                                    "default": 0
+                                },
+                                "total_tokens": {
+                                    "type": "number",
+                                    "description": "Total number of input and output tokens",
+                                    "default": 0
+                                }
+                            }
+                        },
+                        "tool_calls": {
+                            "type": "array",
+                            "description": "An array of tool calls requests made during the response generation",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "arguments": {
+                                        "type": "object",
+                                        "description": "The arguments passed to be passed to the tool call request"
+                                    },
+                                    "name": {
+                                        "type": "string",
+                                        "description": "The name of the tool to be called"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "required": [
+                        "response"
+                    ]
+                },
+                {
+                    "type": "string",
+                    "format": "binary"
+                }
+            ]
+        }
+    },
+    "deprecated": false
+}


### PR DESCRIPTION
### Summary

Adds the GLM-5.3 Flash model launch docs for Workers AI:

- New model page data (`glm-5.3-flash.json`, pulled from the catalog API)
- Pricing page updates: added GLM-5.3 Flash to the paid-models note and the pricing table
- New changelog announcement

GLM-5.3 Flash is a 320B-parameter MoE model (18B active) with vision, reasoning, and function calling. It has a 1,048,576 token context window and requires the Workers Paid plan or AI Gateway credits.

### Documentation checklist

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry? Added `2026-08-26-glm-5.3-flash-workers-ai.mdx`.
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).