### PR TITLE
[Access] Document service token secret format

### DIFF
--- a/src/content/changelog/access/2026-08-26-service-token-secret-format.mdx
+++ b/src/content/changelog/access/2026-08-26-service-token-secret-format.mdx
@@ -1,0 +1,13 @@
+---
+title: Access service token secrets use a scannable format
+description: New Access service token secrets include a recognizable prefix and checksum for credential scanning tools.
+date: 2026-08-26
+products:
+  - access
+---
+
+Cloudflare Access service token Client Secrets created on or after August 26, 2026, use the format `cfast_[40 alphanumeric characters][8-character checksum]`. The prefix and checksum make these credentials easier for secret scanning tools to identify with fewer false positives.
+
+Existing service token secrets continue to work and do not require rotation. The Client ID and the `CF-Access-Client-Id` and `CF-Access-Client-Secret` authentication headers are unchanged.
+
+For more information, refer to [Service tokens](/cloudflare-one/access-controls/service-credentials/service-tokens/).

--- a/src/content/changelog/access/2026-08-26-service-token-secret-format.mdx
+++ b/src/content/changelog/access/2026-08-26-service-token-secret-format.mdx
@@ -8,6 +8,6 @@ products:
 
 Cloudflare Access service token Client Secrets created on or after August 26, 2026, use the format `cfast_[40 alphanumeric characters][8-character checksum]`. The prefix and checksum make these credentials easier for secret scanning tools to identify with fewer false positives.
 
-Existing service token secrets continue to work and do not require rotation. The Client ID and the `CF-Access-Client-Id` and `CF-Access-Client-Secret` authentication headers are unchanged.
+Existing service token secrets continue to work and do not require rotation. Both formats use the same Client ID and the same `CF-Access-Client-Id` and `CF-Access-Client-Secret` authentication headers.
 
 For more information, refer to [Service tokens](/cloudflare-one/access-controls/service-credentials/service-tokens/).

--- a/src/content/docs/cloudflare-one/access-controls/service-credentials/service-tokens.mdx
+++ b/src/content/docs/cloudflare-one/access-controls/service-credentials/service-tokens.mdx
@@ -33,7 +33,7 @@ You can now configure your Access applications and [device enrollment permission
 
 ### Client Secret format
 
-New service token Client Secrets use the format `cfast_[40 alphanumeric characters][8-character checksum]`. The prefix and checksum make the secrets easier for credential scanning tools to identify.
+As of August 26, 2026, new service token Client Secrets use the format `cfast_[40 alphanumeric characters][8-character checksum]`. The prefix and checksum make the secrets easier for credential scanning tools to identify.
 
 Existing Client Secrets use a 64-character hexadecimal format. These secrets continue to work and do not require rotation. The Client ID and authentication headers are unchanged for both formats.
 

--- a/src/content/docs/cloudflare-one/access-controls/service-credentials/service-tokens.mdx
+++ b/src/content/docs/cloudflare-one/access-controls/service-credentials/service-tokens.mdx
@@ -35,7 +35,7 @@ You can now configure your Access applications and [device enrollment permission
 
 As of August 26, 2026, new service token Client Secrets use the format `cfast_[40 alphanumeric characters][8-character checksum]`. The prefix and checksum make the secrets easier for credential scanning tools to identify.
 
-Existing Client Secrets use a 64-character hexadecimal format. These secrets continue to work and do not require rotation. The Client ID and authentication headers are unchanged for both formats.
+Existing Client Secrets use a 64-character hexadecimal format. These secrets continue to work and do not require rotation. Both formats use the same Client ID and authentication headers.
 
 ## Connect your service to Access
 

--- a/src/content/docs/cloudflare-one/access-controls/service-credentials/service-tokens.mdx
+++ b/src/content/docs/cloudflare-one/access-controls/service-credentials/service-tokens.mdx
@@ -31,6 +31,12 @@ This section covers how to create, rotate, renew, disable, and revoke a service 
 
 You can now configure your Access applications and [device enrollment permissions](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/deployment/device-enrollment/#check-for-service-token) to accept this service token. Make sure to set the policy action to [**Service Auth**](/cloudflare-one/access-controls/policies/#service-auth); otherwise, Access will prompt for an identity provider login.
 
+### Client Secret format
+
+New service token Client Secrets use the format `cfast_[40 alphanumeric characters][8-character checksum]`. The prefix and checksum make the secrets easier for credential scanning tools to identify.
+
+Existing Client Secrets use a 64-character hexadecimal format. These secrets continue to work and do not require rotation. The Client ID and authentication headers are unchanged for both formats.
+
 ## Connect your service to Access
 
 ### Request


### PR DESCRIPTION
## Summary

- document the new `cfast_` Access service token Client Secret format
- clarify that existing secrets continue to work and authentication headers are unchanged
- add an Access changelog entry for the August 26 rollout

## Validation

- `pnpm run check:astro`
- `pnpm run check:worker`
- Prettier check for both changed files
- `pnpm run build` ran for 10 minutes without errors but did not finish before the local timeout