### PR TITLE
[SSL] Add Cloudflare Email Security to PQC products page

### DIFF
--- a/src/content/docs/ssl/post-quantum-cryptography/pqc-cloudflare-products.mdx
+++ b/src/content/docs/ssl/post-quantum-cryptography/pqc-cloudflare-products.mdx
@@ -144,6 +144,19 @@ TLS 1.3 control-plane connection used by the [Cloudflare One Appliance](/cloudfl
 
 Reference: [PQC SASE](https://blog.cloudflare.com/post-quantum-sase/), [Cloudflare One Appliance](/cloudflare-wan/configuration/appliance/reference/), [PQC and Cloudflare One](/ssl/post-quantum-cryptography/pqc-and-zero-trust/#cloudflare-ipsec).
 
+### Cloudflare Email Security
+
+Post-quantum protection applies to inbound and outbound TLS 1.3 SMTP connections between Cloudflare [Email Security](/cloudflare-one/email-security/) MX deployments and third-party mail servers:
+
+| Protection    | Status            |
+| ------------- | ----------------- |
+| Key agreement | ✅ X25519MLKEM768 |
+| Signatures    | Not yet           |
+
+Reference: [Email Security](/cloudflare-one/email-security/), [MX/Inline deployment](/cloudflare-one/email-security/setup/pre-delivery-deployment/mx-inline-deployment/).
+
+Post-quantum key agreement is negotiated automatically when the remote SMTP peer advertises support (for example, [Google Workspace](https://workspace.google.com/)). Senders and receivers that do not yet advertise post-quantum key agreement continue to connect with classical key exchange.
+
 ## Contributing
 
 This listing is maintained alongside the rest of the Cloudflare SSL/TLS documentation. If you spot an inaccuracy or have an update after a product announcement, [contributions](/style-guide/contributions/) are welcome.


### PR DESCRIPTION
### Summary

Split out of #32966 per [review feedback](https://github.com/cloudflare/cloudflare-docs/pull/32966#discussion_r3846781998).

Adds a Cloudflare Email Security section to the PQC in Cloudflare products page, covering post-quantum key agreement on inbound and outbound TLS 1.3 SMTP connections between Email Security MX deployments and third-party mail servers.

### Documentation checklist

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).