### PR TITLE
[Cloudflare One] Clarify SCIM policy evaluation

### DIFF
--- a/src/content/docs/cloudflare-one/integrations/identity-providers/entra-id.mdx
+++ b/src/content/docs/cloudflare-one/integrations/identity-providers/entra-id.mdx
@@ -180,6 +180,8 @@ If you are concerned that users' emails or UPNs may change, you can pass the use
 
 The Microsoft Entra ID integration allows you to synchronize IdP groups and automatically deprovision users using [SCIM](/cloudflare-one/team-and-resources/users/scim/).
 
+<Render file="access/scim-policy-behavior" product="cloudflare-one" />
+
 ### Prerequisites
 
 - Microsoft Entra ID P1 or P2 license
@@ -234,7 +236,7 @@ SCIM requires a separate enterprise application from the one created during [ini
 10. Once the SCIM application is created, [assign users and groups to the application](https://learn.microsoft.com/entra/identity/enterprise-apps/assign-user-or-group-access-portal).
 
 :::note
-Groups in this SCIM application should match the groups in your other [Cloudflare Access enterprise application](/cloudflare-one/integrations/identity-providers/entra-id/#set-up-entra-id-as-an-identity-provider). Because SCIM group membership updates will overwrite any groups in a user's identity, assigning the same groups to each app ensures consistent policy evaluation.
+Groups in this SCIM application should match the groups in your other [Cloudflare Access enterprise application](/cloudflare-one/integrations/identity-providers/entra-id/#set-up-entra-id-as-an-identity-provider). Matching the groups keeps the Gateway identity synchronized with the groups that Entra ID returns when the user authenticates to Access.
 :::
 
 11. Go to **Provisioning** and select **Start provisioning**.

--- a/src/content/docs/cloudflare-one/integrations/identity-providers/generic-oidc.mdx
+++ b/src/content/docs/cloudflare-one/integrations/identity-providers/generic-oidc.mdx
@@ -115,6 +115,8 @@ To test that your connection is working, go to **Authentication** > **Login meth
 
 The generic OIDC integration allows you to synchronize user groups and automatically deprovision users using [SCIM](/cloudflare-one/team-and-resources/users/scim/).
 
+<Render file="access/scim-policy-behavior" product="cloudflare-one" />
+
 ### Prerequisites
 
 Your identity provider must support SCIM version 2.0.
@@ -136,7 +138,7 @@ Setup instructions vary depending on the identity provider. In your identity pro
 If you would like to build policies based on IdP groups:
 
 - Ensure that your IdP sends a `groups` field. The naming must match exactly (case insensitive). All other values will be sent as a OIDC claim.
-- If your IdP requires creating a new SCIM application, ensure that the groups in the SCIM application match the groups in the [original SSO application](/cloudflare-one/integrations/identity-providers/generic-oidc/#1-create-an-application-in-your-identity-provider). Because SCIM group membership updates will overwrite any groups in a user's identity, assigning the same groups to each app ensures consistent policy evaluation.
+- If your IdP requires a new SCIM application, ensure that its groups match the groups in the [original SSO application](/cloudflare-one/integrations/identity-providers/generic-oidc/#1-create-an-application-in-your-identity-provider). Matching the groups keeps the Gateway identity synchronized with the groups that the IdP returns when the user authenticates to Access.
 
 ### 3. Verify SCIM provisioning
 

--- a/src/content/docs/cloudflare-one/integrations/identity-providers/generic-saml.mdx
+++ b/src/content/docs/cloudflare-one/integrations/identity-providers/generic-saml.mdx
@@ -97,6 +97,8 @@ You can now [test the IdP integration](/cloudflare-one/integrations/identity-pro
 
 The generic SAML integration allows you to synchronize user groups and automatically deprovision users using [SCIM](/cloudflare-one/team-and-resources/users/scim/).
 
+<Render file="access/scim-policy-behavior" product="cloudflare-one" />
+
 ### Prerequisites
 
 Your identity provider must support SCIM version 2.0.
@@ -118,7 +120,7 @@ Setup instructions vary depending on the identity provider. In your identity pro
 If you would like to build policies based on IdP groups:
 
 - Ensure that your IdP sends a `groups` field. The naming must match exactly (case insensitive). All other values will be sent as a SAML attribute.
-- If your IdP requires creating a new SCIM application, ensure that the groups in the SCIM application match the groups in the [original SSO application](/cloudflare-one/integrations/identity-providers/generic-saml/#1-create-an-application-in-your-identity-provider). Because SCIM group membership updates will overwrite any groups in a user's identity, assigning the same groups to each app ensures consistent policy evaluation.
+- If your IdP requires a new SCIM application, ensure that its groups match the groups in the [original SSO application](/cloudflare-one/integrations/identity-providers/generic-saml/#1-create-an-application-in-your-identity-provider). Matching the groups keeps the Gateway identity synchronized with the groups that the IdP returns when the user authenticates to Access.
 
 ### 3. Verify SCIM provisioning
 

--- a/src/content/docs/cloudflare-one/integrations/identity-providers/jumpcloud-saml.mdx
+++ b/src/content/docs/cloudflare-one/integrations/identity-providers/jumpcloud-saml.mdx
@@ -78,6 +78,8 @@ You can now [test your connection](/cloudflare-one/integrations/identity-provide
 
 The JumpCloud integration allows you to synchronize user groups and automatically deprovision users using [SCIM](/cloudflare-one/team-and-resources/users/scim/).
 
+<Render file="access/scim-policy-behavior" product="cloudflare-one" />
+
 ### 1. Enable SCIM in Cloudflare One
 
 <Render

--- a/src/content/docs/cloudflare-one/integrations/identity-providers/okta.mdx
+++ b/src/content/docs/cloudflare-one/integrations/identity-providers/okta.mdx
@@ -99,6 +99,8 @@ The Okta integration allows you to synchronize IdP groups and automatically depr
 - The OIDC application you created when adding Okta as an identity provider. You can create this application via the [Okta App Catalog](#set-up-okta-as-an-oidc-provider-okta-app-catalog) or via a [Custom App Integration](#set-up-okta-as-an-oidc-provider-custom-app-integration).
 - A second Okta application of type **SCIM 2.0 Test App (Header Auth)**. This is technically a SAML app but is responsible for sending user and group info via SCIM.
 
+<Render file="access/scim-policy-behavior" product="cloudflare-one" />
+
 :::note
 If you would like to only maintain one Okta app instance, Okta does support SAML and SCIM within the same application. Create a [generic SAML integration](/cloudflare-one/integrations/identity-providers/generic-saml/) and configure those values in the **Sign-On** field of your Okta SCIM application.
 :::
@@ -156,7 +158,7 @@ If you would like to only maintain one Okta app instance, Okta does support SAML
 16. In the **Push Groups** tab, add the Okta groups you want to synchronize with Cloudflare Access. These groups will display in the Access policy builder and are the group memberships that will be added and removed upon membership change in Okta.
 
     :::note
-    Groups in this SCIM app Push Groups integration should match the groups in your base [OIDC app integration](/cloudflare-one/integrations/identity-providers/okta/#set-up-okta-as-an-oidc-provider). Because SCIM group membership updates will overwrite any groups in a user's identity, assigning the same groups to each app ensures consistent policy evaluation.
+    Groups in this SCIM app Push Groups integration should match the groups in your base [OIDC app integration](/cloudflare-one/integrations/identity-providers/okta/#set-up-okta-as-an-oidc-provider). Matching the groups keeps the Gateway identity synchronized with the groups that Okta returns when the user authenticates to Access.
     :::
 
 To verify the integration, select **View Logs** in the Okta SCIM application.
@@ -183,6 +185,6 @@ To verify the integration, select **View Logs** in the Okta SCIM application.
 
 If you see the error `Failed to fetch user/group information from the identity`, double-check your Okta configuration:
 
-- If your Okta tenant has more than 100 groups, ensure you include an Okta API token in the identity provider configuration. Cloudflare uses the token to retrieve groups from Okta for policy evaluation.
+- If your Okta tenant has more than 100 groups, include an Okta API token in the identity provider configuration. This setting is specific to Okta and is not part of SCIM. The token lets Cloudflare retrieve Okta group names for the policy builder. Access does not use the API token to evaluate a user's group membership during authentication.
 - If Okta returns more than 100 groups in a user's OIDC token, Okta may omit some group memberships from the token. This is an Okta token claim limitation, not a Cloudflare limit. If a required group is omitted, Cloudflare cannot evaluate policies that depend on that group. To avoid this, narrow the Okta groups claim filter so that only groups used in Cloudflare policies are included. For more information, refer to [Okta's group functions and dynamic allowlists documentation](https://support.okta.com/help/s/article/limitations-of-group-functions-dynamic-allowlists?language=en_US).
 - The request may be blocked by the [ThreatInsights feature](https://help.okta.com/en/prod/Content/Topics/Security/threat-insight/ti-index.htm) within Okta.

--- a/src/content/docs/cloudflare-one/team-and-resources/users/scim.mdx
+++ b/src/content/docs/cloudflare-one/team-and-resources/users/scim.mdx
@@ -23,11 +23,13 @@ Users provisioned via the [Zero Trust SCIM integration](#sync-users-and-groups-i
 
 ## Supported identity providers
 
-Cloudflare Access supports SCIM provisioning for all SAML and OIDC identity providers that use SCIM version `2.0`.
+Cloudflare One supports SCIM provisioning for all SAML and OIDC identity providers that use SCIM version `2.0`.
 
 ## Sync users and groups in Zero Trust policies
 
 Cloudflare Access can automatically deprovision users from Zero Trust after they are deactivated in the identity provider and display synchronized group names in the Access and Gateway policy builders. Cloudflare does not provision new users in Zero Trust when they are added to the identity provider -- users must first register a device with the Cloudflare One Client or authenticate to an Access application.
+
+<Render file="access/scim-policy-behavior" product="cloudflare-one" />
 
 To set up SCIM for Zero Trust, refer to our [SSO integration](/cloudflare-one/integrations/identity-providers/) guides.
 

--- a/src/content/partials/cloudflare-one/access/okta-zt-steps.mdx
+++ b/src/content/partials/cloudflare-one/access/okta-zt-steps.mdx
@@ -14,7 +14,7 @@ import {} from "~/components";
     - **Client secret**: Enter your Okta client secret.
     - **Okta account URL**: Enter your [Okta domain](https://developer.okta.com/docs/guides/find-your-domain/main/), for example `https://my-company.okta.com`.
 
-14. (Optional) Create an Okta API token and enter it in the [Cloudflare dashboard](https://dash.cloudflare.com/) under **Zero Trust** > **Integrations** > **Identity providers** (the token can be read-only). Use an API token if your Okta tenant has more than 100 groups. Without this token, Cloudflare may not be able to retrieve all Okta groups for policy evaluation.
+14. (Optional) Create an Okta API token and enter it in the [Cloudflare dashboard](https://dash.cloudflare.com/) under **Zero Trust** > **Integrations** > **Identity providers** (the token can be read-only). Use an API token if your Okta tenant has more than 100 groups. This setting is specific to Okta and is not part of SCIM. The token only retrieves Okta group names for the policy builder. Access evaluates group membership from the user's OIDC token during authentication.
 
 15. (Optional) To configure [custom OIDC claims](/cloudflare-one/integrations/identity-providers/generic-oidc/#custom-oidc-claims):
     1. In Okta, create a [custom authorization server](https://developer.okta.com/docs/guides/customize-authz-server/main/) and ensure that the `groups` scope is enabled.

--- a/src/content/partials/cloudflare-one/access/scim-policy-behavior.mdx
+++ b/src/content/partials/cloudflare-one/access/scim-policy-behavior.mdx
@@ -1,0 +1,9 @@
+---
+{}
+---
+
+SCIM affects Access and Gateway policy evaluation differently.
+
+Access evaluates a user's identity and group membership from the SAML assertion or OIDC token returned by the identity provider during authentication. SCIM provides readable group names in the Access policy builder, but Access does not use SCIM group membership to evaluate a login. If you turn on **Enable user deprovisioning**, removing a user from the SCIM application revokes their active Access sessions. You can also configure SCIM to revoke sessions after group membership changes. Access evaluates the updated identity provider data when the user authenticates again.
+
+Gateway evaluates identity-based policies against the [User Registry identity](/cloudflare-one/team-and-resources/users/users/). SCIM updates this identity when users or group memberships change, without waiting for the user to authenticate again. Cloudflare One Client device profiles use the same synchronized identity.


### PR DESCRIPTION
## Summary

- Explain how SCIM affects Access and Gateway policy evaluation differently.
- Document Access session revocation through SCIM deprovisioning.
- Clarify that the Okta API token only retrieves Okta group names for the policy builder.

## Tests

- pnpm run check