### PR TITLE
[Workers AI] Use a newer model in the Wrangler starter guide

### DIFF
--- a/src/content/docs/workers-ai/get-started/workers-wrangler.mdx
+++ b/src/content/docs/workers-ai/get-started/workers-wrangler.mdx
@@ -73,7 +73,7 @@ You can also bind Workers AI to a Pages Function. For more information, refer to
 
 ## 3. Run an inference task in your Worker
 
-You are now ready to run an inference task in your Worker. In this case, you will use an LLM, [`llama-3.1-8b-instruct`](/workers-ai/models/llama-3.1-8b-instruct/), to answer a question.
+You are now ready to run an inference task in your Worker. In this case, you will use an LLM, [`gemma-4-26b-a4b-it`](/workers-ai/models/gemma-4-26b-a4b-it/), to answer a question.
 
 Update the `index.ts` file in your `hello-ai` application directory with the following code:
 
@@ -88,17 +88,29 @@ export interface Env {
 
 export default {
 	async fetch(request, env): Promise<Response> {
-		const response = await env.AI.run("@cf/meta/llama-3.1-8b-instruct", {
-			prompt: "What is the origin of the phrase Hello, World",
+		const response = await env.AI.run("@cf/google/gemma-4-26b-a4b-it", {
+			messages: [
+				{
+					role: "system",
+					content: "You are a helpful assistant.",
+				},
+				{
+					role: "user",
+					content: "What is the origin of the phrase Hello, World",
+				},
+			],
+			chat_template_kwargs: {
+				enable_thinking: false,
+			},
 		});
 
-		return new Response(JSON.stringify(response));
+		return Response.json(response);
 	},
 } satisfies ExportedHandler<Env>;
 ```
 </TypeScriptExample>
 
-Up to this point, you have created an AI binding for your Worker and configured your Worker to be able to execute the Llama 3.1 model. You can now test your project locally before you deploy globally.
+Up to this point, you have created an AI binding for your Worker and configured your Worker to execute the Gemma 4 26B A4B model with reasoning disabled. You can now test your project locally before you deploy globally.
 
 ## 4. Develop locally with Wrangler
 
@@ -110,11 +122,26 @@ npx wrangler dev
 
 <Render file="ai-local-usage-charges" product="workers" />
 
-You will be prompted to log in after you run `wrangler dev`. When you run `npx wrangler dev`, Wrangler will give you a URL (most likely `localhost:8787`) to review your Worker. After you go to the URL Wrangler provides, a message will render that resembles the following example:
+You will be prompted to log in after you run `wrangler dev`. When you run `npx wrangler dev`, Wrangler will give you a URL (most likely `localhost:8787`) to review your Worker. After you go to the URL Wrangler provides, the response will have a shape similar to the following example:
 
 ```json
 {
-	"response": "Ah, a most excellent question, my dear human friend! *adjusts glasses*\n\nThe origin of the phrase \"Hello, World\" is a fascinating tale that spans several decades and multiple disciplines. It all began in the early days of computer programming, when a young man named Brian Kernighan was tasked with writing a simple program to demonstrate the basics of a new programming language called C.\nKernighan, a renowned computer scientist and author, was working at Bell Labs in the late 1970s when he created the program. He wanted to showcase the language's simplicity and versatility, so he wrote a basic \"Hello, World!\" program that printed the familiar greeting to the console.\nThe program was included in Kernighan and Ritchie's influential book \"The C Programming Language,\" published in 1978. The book became a standard reference for C programmers, and the \"Hello, World!\" program became a sort of \"Hello, World!\" for the programming community.\nOver time, the phrase \"Hello, World!\" became a shorthand for any simple program that demonstrated the basics"
+	"id": "<generated id>",
+	"object": "chat.completion",
+	"created": 0,
+	"model": "@cf/google/gemma-4-26b-a4b-it",
+	"choices": [
+		{
+			"index": 0,
+			"message": {
+				"role": "assistant",
+				"content": "<generated response>",
+				"refusal": null
+			},
+			"finish_reason": "stop",
+			"logprobs": null
+		}
+	]
 }
 ```
 
@@ -140,7 +167,7 @@ https://hello-ai.<YOUR_SUBDOMAIN>.workers.dev
 
 Your Worker will be deployed to your custom [`workers.dev`](/workers/configuration/routing/workers-dev/) subdomain. You can now visit the URL to run your AI Worker.
 
-By finishing this tutorial, you have created a Worker, connected it to Workers AI through an AI binding, and ran an inference task from the Llama 3 model.
+By finishing this tutorial, you have created a Worker, connected it to Workers AI through an AI binding, and run an inference task using the Gemma 4 26B A4B model.
 
 ## Related resources
 


### PR DESCRIPTION
### Summary

Updates the Workers AI Wrangler starter guide to use
`@cf/google/gemma-4-26b-a4b-it`, a newer model generation. The example now
uses Gemma's documented messages input, disables reasoning for the basic
request, and shows the chat-completion response shape.

Fixes #32501

PR #32728 proposes the still-active
`@cf/meta/llama-3.1-8b-instruct-fast` variant. The original version of this
PR used `@cf/meta/llama-3.2-3b-instruct`; this update supersedes both
alternatives by using Gemma 4.

### Validation

- Astro and Worker checks passed
- ESLint and formatting checks passed
- Node, Astro, and Workers tests passed
- Full documentation build passed
- Live Gemma 4 smoke test unavailable because Wrangler is not authenticated

### Documentation checklist

- [x] The change adheres to the documentation style guide.
- [x] An issue has been opened for the outdated information this PR fixes.