### PR TITLE
docs: clarify Organization API authentication

### DIFF
--- a/src/content/docs/fundamentals/organizations/for-enterprise.mdx
+++ b/src/content/docs/fundamentals/organizations/for-enterprise.mdx
@@ -220,7 +220,7 @@ You can manage Organizations programmatically using the [Cloudflare Organization
 You can manage Organizations using the [Cloudflare Terraform provider](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/organization).
 
 :::note
-The Terraform provider currently requires **API Keys** for authentication with Organization resources. API Token support is not yet fully available for all Organization operations.
+To manage Organization resources through their full Terraform lifecycle, configure the provider with a [Global API key](/fundamentals/api/get-started/keys/) and the registered account email. User API Tokens support only some Organization operations. Refer to [API authentication](/fundamentals/organizations/limitations/#api-authentication).
 :::
 
 ## What you cannot do

--- a/src/content/docs/fundamentals/organizations/for-mssp-distributors.mdx
+++ b/src/content/docs/fundamentals/organizations/for-mssp-distributors.mdx
@@ -233,7 +233,7 @@ You can manage Organizations programmatically using the [Cloudflare Organization
 You can manage Organizations using the [Cloudflare Terraform provider](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/organization).
 
 :::note
-The Terraform provider currently requires **API Keys** for authentication with Organization resources. API Token support is not yet fully available for all Organization operations.
+To manage Organization resources through their full Terraform lifecycle, configure the provider with a [Global API key](/fundamentals/api/get-started/keys/) and the registered account email. User API Tokens support only some Organization operations. Refer to [API authentication](/fundamentals/organizations/limitations/#api-authentication).
 :::
 
 If you encounter errors during setup or management, refer to [Troubleshooting](/fundamentals/organizations/limitations/#troubleshooting).

--- a/src/content/docs/fundamentals/organizations/index.mdx
+++ b/src/content/docs/fundamentals/organizations/index.mdx
@@ -75,7 +75,7 @@ MSSP/Distributor Organizations support up to 5 levels of nested sub-organization
 - **Organization-level membership**: Invite members to the Organization once, granting them access to all child accounts.
 - **WAF and Gateway policy sharing**: Create security policies once and share them across accounts in your Organization.
 - **IdP federation**: Share a single identity provider configuration across all accounts in your Organization. Refer to [IdP federation](/cloudflare-one/integrations/identity-providers/idp-federation/) for setup details.
-- **API, SDK, and Terraform support**: Manage Organizations programmatically with the [Cloudflare Organizations API](/api/resources/organizations/), SDKs, or Terraform provider.
+- **API, SDK, and Terraform support**: Manage Organizations programmatically with the [Cloudflare Organizations API](/api/resources/organizations/), SDKs, or Terraform provider. User API Tokens support some Organization operations, but they cannot complete the full Terraform resource lifecycle. Refer to [API authentication](/fundamentals/organizations/limitations/#api-authentication).
 - **Enhanced account switcher**: Navigate between accounts with an Organization-aware account switcher in the dashboard.
 
 For a full list of features and limitations specific to each Organization type, refer to the [Enterprise](/fundamentals/organizations/for-enterprise/) or [MSSP/Distributor](/fundamentals/organizations/for-mssp-distributors/) guide.

--- a/src/content/docs/fundamentals/organizations/limitations.mdx
+++ b/src/content/docs/fundamentals/organizations/limitations.mdx
@@ -20,6 +20,14 @@ The following limitations currently apply to Cloudflare Organizations. For commo
 
 Each Organization supports a maximum of **500 accounts** and **5,000 zones**. This limit applies to both Enterprise and MSSP/Distributor Organizations. These limits may be adjusted as usage patterns are better understood during the beta.
 
+## API authentication
+
+User API Tokens support some Organization operations. They cannot complete the full Terraform resource lifecycle. To manage Organization resources with Terraform, configure the Cloudflare provider with a Global API key and the registered account email.
+
+A user API Token may create an Organization. A later Terraform refresh or `terraform plan` may fail when reading the Organization. If the request returns HTTP `403` with error code `10000`, use a Global API key and the account email instead.
+
+API Tokens remain the preferred authentication method for supported operations. A Global API key has full access to the user's Cloudflare resources. Refer to [Global API key limitations](/fundamentals/api/get-started/keys/#limitations).
+
 ## Enterprise Organizations
 
 | Limitation | Description |

--- a/src/content/docs/fundamentals/organizations/limitations.mdx
+++ b/src/content/docs/fundamentals/organizations/limitations.mdx
@@ -22,7 +22,7 @@ Each Organization supports a maximum of **500 accounts** and **5,000 zones**. Th
 
 ## API authentication
 
-User API Tokens support some Organization operations. They cannot complete the full Terraform resource lifecycle. To manage Organization resources with Terraform, configure the Cloudflare provider with a Global API key and the registered account email.
+User API Tokens support some Organization operations. They cannot complete the full Terraform resource lifecycle. Full user API Token support for Organization operations is planned. To manage Organization resources with Terraform, configure the Cloudflare provider with a Global API key and the registered account email.
 
 A user API Token may create an Organization. A later Terraform refresh or `terraform plan` may fail when reading the Organization. If the request returns HTTP `403` with error code `10000`, use a Global API key and the account email instead.
 


### PR DESCRIPTION
### Summary

- clarify that User API Tokens support only some Organization operations
- note that full User API Token support for Organization operations is planned
- document the Global API key and account email workaround for the full Terraform lifecycle
- add the limitation to the overview, Enterprise, and MSSP/Distributor guides

Tracks PT-3124.

### Validation

- `pnpm run check`
- `pnpm run build` (8,896 pages)

### Screenshots

**Organizations overview**

<img width="1530" height="226" alt="Organizations overview" src="https://github.com/user-attachments/assets/36d86cde-3b53-4c94-9934-2040fcccaa3d" />

**Limitations**

<img width="3456" height="1882" alt="API authentication limitation" src="https://github.com/user-attachments/assets/33092af0-942f-43c1-a9a2-9895e79f6f81" />

**Enterprise guide**

<img width="1570" height="228" alt="Enterprise Terraform authentication note" src="https://github.com/user-attachments/assets/f17770a1-194d-4e6b-93c9-704527744e37" />

**MSSP and Distributor guide**

<img width="1570" height="228" alt="MSSP and Distributor Terraform authentication note" src="https://github.com/user-attachments/assets/b1dde349-7c74-449e-ab63-2f837b7e194f" />

### Documentation checklist

- [x] The change adheres to the documentation style guide.
- [x] PT-3124 tracks the incorrect or outdated information corrected by this PR.
