### PR TITLE
Update Sentinel and Splunk analytics integrations

### DIFF
--- a/src/content/docs/analytics/analytics-integrations/sentinel.mdx
+++ b/src/content/docs/analytics/analytics-integrations/sentinel.mdx
@@ -161,7 +161,7 @@ For the full list of storage-related failure modes and mitigations, refer to Mic
 
 We support the following fields to be utilized within the Sentinel Connectors (CCF & Function based). You can push all log fields to Azure using our logpush function as described in [Enable Microsoft Azure](/logs/logpush/logpush-job/enable-destinations/azure/) documentation.
 
-The CCF connector normalizes Cloudflare log fields to the [Microsoft Sentinel ASIM schema](https://learn.microsoft.com/en-us/azure/sentinel/normalization) where a canonical equivalent exists (for example, `ClientIP` becomes `SrcIpAddr`, `EdgeResponseStatus` becomes `HttpStatusCode`), and preserves Cloudflare-native names for fields that do not have a schema equivalent. Use the field names in the tables below in your KQL queries against the connector's output table.
+The CCF connector normalizes Cloudflare log fields to the [Microsoft Sentinel ASIM schema](https://learn.microsoft.com/en-us/azure/sentinel/normalization) where a canonical equivalent exists (for example, `ClientIP` becomes `SrcIpAddr`, `EdgeResponseStatus` becomes `HttpStatusCode`), and preserves Cloudflare-native names for fields that do not have a schema equivalent. Use the field names in the following tables in your KQL queries against the connector's output table.
 
 <Details header="Parser fields">
 

--- a/src/content/docs/analytics/analytics-integrations/sentinel.mdx
+++ b/src/content/docs/analytics/analytics-integrations/sentinel.mdx
@@ -30,7 +30,7 @@ Before you begin, make sure the following prerequisites are met.
 ### Azure resources
 
 - **Azure subscription** with permission to create and manage resources (`Contributor` or `Owner` role recommended).
-- **Azure Storage account** with [Azure Data Lake Storage Gen2 enabled](https://learn.microsoft.com/en-us/azure/storage/blobs/create-data-lake-storage-account) (hierarchical namespace on). Logpush writes the Cloudflare log files to this account.
+- **Azure Storage account** with [Azure Data Lake Storage Gen2 enabled](https://learn.microsoft.com/en-us/azure/storage/blobs/create-data-lake-storage-account) (hierarchical namespace on). Although the generic Logpush Azure destination supports standard Blob Storage, the CCF connector requires hierarchical namespace. Logpush writes the Cloudflare log files to this account.
 - **Azure Blob container** inside the storage account, dedicated to receiving Cloudflare Logpush files. The CCF connector monitors this container for new files via Event Grid.
 - **Microsoft Sentinel workspace** already deployed on top of a Log Analytics workspace. The connector's Data Collection Rule (DCR) and Data Collection Endpoint (DCE) are tied to this Log Analytics workspace, and all ingested Cloudflare log records land in tables within it.
 - **Cloudflare account** with access to the domain or account whose logs you want to export, and permission to configure Logpush jobs.

--- a/src/content/docs/analytics/analytics-integrations/sentinel.mdx
+++ b/src/content/docs/analytics/analytics-integrations/sentinel.mdx
@@ -18,7 +18,7 @@ Cloudflare has integrations with Microsoft Sentinel to make analyzing your Cloud
 **[Sentinel Function Based Connector](https://azuremarketplace.microsoft.com/en-us/marketplace/apps/cloudflare.cloudflare_sentinel?tab=Overview)**: The Cloudflare connector for Microsoft Sentinel uses [Azure Functions](https://azure.microsoft.com/en-us/products/functions) to process security logs from Cloudflare's Logpush service and ingest them directly into the SIEM platform.
 
 :::caution[Legacy connector deprecation — action required by 2026-09-14]
-Microsoft is deprecating the Azure Monitor HTTP Data Collector API on 2026-09-14. As a result, Cloudflare will no longer maintain the Azure Functions-based Microsoft Sentinel connector after that date. Cloudflare Enterprise customers using the Function-based connector must migrate to the CCF connector documented below by 2026-09-14. Refer to the [deprecation changelog entry](/changelog/2026-08-26-sentinel-functions-connector-deprecation/) for details.
+Microsoft is deprecating the Azure Monitor HTTP Data Collector API on 2026-09-14. As a result, Cloudflare will no longer maintain the Azure Functions-based Microsoft Sentinel connector after that date. Cloudflare Enterprise customers using the Function-based connector must migrate to the CCF connector documented in this guide by 2026-09-14. Refer to the [deprecation changelog entry](/changelog/2026-08-26-sentinel-functions-connector-deprecation/) for details.
 :::
 
 This guide provides clear, step-by-step instructions for integrating Cloudflare logs with the CCF connector for Microsoft Sentinel using Azure Blob Storage. By following these steps, you will be able to securely collect, store, and analyze your Cloudflare logs within Microsoft Sentinel, enhancing your organization's security monitoring and incident response capabilities.
@@ -42,7 +42,7 @@ The CCF connector authenticates to Azure using a service principal that is manag
 - **Microsoft Sentinel Contributor** (or `Contributor` / `Owner`) on the Microsoft Sentinel workspace.
 - **Owner** or **EventGrid Contributor** on the storage account, so that the deployment can create the Event Grid system topic and subscription.
 
-For reference, the connector's service principal receives the following roles on the storage account at deployment time:
+For reference, the Cloudflare CCF connector service principal receives the following roles on the storage account at deployment time:
 
 - `Storage Blob Data Reader` on the storage account, to read log files from the Blob container.
 - `Storage Queue Data Contributor` on the storage account, to read and delete pointer messages from the Storage Queue.
@@ -106,7 +106,7 @@ For complete details, refer to the [Cloudflare Logpush to Azure documentation](/
 
 On the connector page, fill in the following fields:
 
-- **Service Principal ID**: this field is prepopulated with the object ID of the Microsoft-managed service principal used by the connector. If it is empty, ensure that admin consent has been granted for the Microsoft Sentinel application in your Entra ID tenant, then reload the page. Refer to Microsoft's [admin consent workflow](https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/configure-admin-consent-workflow) for details.
+- **Service Principal ID**: this field is prepopulated with the object ID of the Cloudflare CCF connector service principal in your tenant. If it is empty, ensure that admin consent has been granted for the Cloudflare CCF connector application in your Microsoft Entra tenant, then reload the page. Refer to Microsoft's [admin consent workflow](https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/configure-admin-consent-workflow) for details.
 - **Blob Container URL**: in the Azure portal, open the storage account that receives Cloudflare logs. Under **Data storage** > **Containers**, open the target container, go to **Properties**, and copy the URL.
 - **Storage Account Resource Group Name**, **Storage Account Location**, and **Storage Account Subscription ID**: available on the storage account's **Overview** page.
 - **Event Grid System Topic Name**: leave this field blank on the first deployment. The ARM template creates the topic automatically. If you are reconfiguring an existing deployment, open **Event Grid** > **System topics** in the Azure portal, filter by location, and copy the name of the topic whose **Source** matches your storage account.

--- a/src/content/docs/analytics/analytics-integrations/sentinel.mdx
+++ b/src/content/docs/analytics/analytics-integrations/sentinel.mdx
@@ -161,24 +161,11 @@ For the full list of storage-related failure modes and mitigations, refer to Mic
 
 We support the following fields to be utilized within the Sentinel Connectors (CCF & Function based). You can push all log fields to Azure using our logpush function as described in [Enable Microsoft Azure](/logs/logpush/logpush-job/enable-destinations/azure/) documentation.
 
+The CCF connector normalizes Cloudflare log fields to the [Microsoft Sentinel ASIM schema](https://learn.microsoft.com/en-us/azure/sentinel/normalization) where a canonical equivalent exists (for example, `ClientIP` becomes `SrcIpAddr`, `EdgeResponseStatus` becomes `HttpStatusCode`), and preserves Cloudflare-native names for fields that do not have a schema equivalent. Use the field names in the tables below in your KQL queries against the connector's output table.
+
 <Details header="Parser fields">
 
-ClientDeviceType<br />
-Source<br />
-ClientSSLCipher<br />
-ClientTlsCipher<br />
-ClientSSLProtocol<br />
-ClientTlsProtocol<br />
-FirewallMatchesActions<br />
-Event<br />
-FirewallMatchesRuleIDs<br />
-RuleID<br />
-ClientRequestBytes<br />
-ClientBytes<br />
-ClientSrcPort<br />
-ClientPort<br />
-EdgeResponseBytes<br />
-OriginBytes<br />
+Application<br />
 BotScore<br />
 BotScoreSrc<br />
 CacheCacheStatus<br />
@@ -186,17 +173,31 @@ CacheResponseBytes<br />
 CacheResponseStatus<br />
 CacheTieredFill<br />
 ClientASN<br />
-ClientCountry<br />
-ClientIP<br />
+ClientASNDescription<br />
+ClientDeviceType<br />
 ClientIPClass<br />
-ClientRequestHost<br />
-ClientRequestMethod<br />
+ClientMatchedIpFirewall<br />
+ClientRefererHost<br />
+ClientRefererPath<br />
+ClientRefererQuery<br />
+ClientRefererScheme<br />
 ClientRequestPath<br />
 ClientRequestProtocol<br />
-ClientRequestReferer<br />
+ClientRequestQuery<br />
+ClientRequestScheme<br />
 ClientRequestURI<br />
-ClientRequestUserAgent<br />
+ClientTcpRtt<br />
+ClientTlsClientHelloServerName<br />
+ClientTlsStatus<br />
 ClientXRequestedWith<br />
+ColoCode<br />
+ConnectTimestamp<br />
+Datetime<br />
+DisconnectTimestamp<br />
+DstBytes<br />
+DstIpAddr<br />
+DstPortNumber<br />
+DvcAction<br />
 EdgeColoCode<br />
 EdgeColoID<br />
 EdgeEndTimestamp<br />
@@ -207,21 +208,47 @@ EdgeRateLimitAction<br />
 EdgeRateLimitID<br />
 EdgeRequestHost<br />
 EdgeResponseCompressionRatio<br />
-EdgeResponseContentType<br />
 EdgeResponseStatus<br />
 EdgeServerIP<br />
 EdgeStartTimestamp<br />
+EventResult<br />
+EventSubType<br />
 FirewallMatchesSources<br />
-OriginIP<br />
+HttpContentType<br />
+HttpReferrerOriginal<br />
+HttpRequestHeaderHost<br />
+HttpRequestMethod<br />
+HttpStatusCode<br />
+HttpUserAgentOriginal<br />
+IpFirewall<br />
+MatchIndex<br />
+NetworkProtocol<br />
+NetworkRuleName<br />
+OriginProto<br />
 OriginResponseBytes<br />
 OriginResponseHTTPExpires<br />
 OriginResponseHTTPLastModified<br />
-OriginResponseStatus<br />
 OriginResponseTime<br />
 OriginSSLProtocol<br />
+OriginTcpRtt<br />
+OriginTlsCipher<br />
+OriginTlsFingerprint<br />
+OriginTlsMode<br />
+OriginTlsProtocol<br />
+OriginTlsStatus<br />
+OriginatorRayID<br />
 ParentRayID<br />
+ProxyProtocol<br />
 RayID<br />
 SecurityLevel<br />
+SrcBytes<br />
+SrcGeoCountry<br />
+SrcIpAddr<br />
+SrcPortNumber<br />
+TimeGenerated<br />
+Timestamp<br />
+TlsCipher<br />
+TlsVersion<br />
 WAFAction<br />
 WAFFlags<br />
 WAFMatchedVar<br />
@@ -233,136 +260,61 @@ WorkerStatus<br />
 WorkerSubrequest<br />
 WorkerSubrequestCount<br />
 ZoneID<br />
-Application<br />
-ClientMatchedIpFirewall<br />
-ClientProto<br />
-ClientTcpRtt<br />
-ClientTlsClientHelloServerName<br />
-ClientTlsStatus<br />
-ColoCode<br />
-ConnectTimestamp<br />
-DisconnectTimestamp<br />
-IpFirewall<br />
-OriginPort<br />
-OriginProto<br />
-OriginTcpRtt<br />
-OriginTlsCipher<br />
-OriginTlsFingerprint<br />
-OriginTlsMode<br />
-OriginTlsProtocol<br />
-OriginTlsStatus<br />
-ProxyProtocol<br />
-Status<br />
-Timestamp<br />
-ClientASNDescription<br />
-ClientRefererHost<br />
-ClientRefererPath<br />
-ClientRefererQuery<br />
-ClientRefererScheme<br />
-ClientRequestQuery<br />
-ClientRequestScheme<br />
-Datetime<br />
-Kind<br />
-MatchIndex<br />
-OriginatorRayID<br />
-TimeGenerated<br />
 
 </Details>
 
-<Details header="WorkBook fields">
+<Details header="Workbook fields">
 
-ClientCountry_s<br />
-ClientDeviceType_s<br />
-ClientIP_s<br />
-ClientIPClass_s<br />
-ClientRequestMethod_s<br />
-ClientRequestProtocol_s<br />
-ClientRequestReferer_s<br />
-ClientRequestURI_s<br />
-ClientRequestUserAgent_s<br />
-EdgePathingOp_s<br />
-EdgePathingSrc_s<br />
-EdgePathingStatus_s<br />
-EdgeResponseContentType_s<br />
+ClientDeviceType<br />
+ClientIP<br />
+ClientIPClass<br />
+ClientRequestProtocol<br />
+ClientRequestReferer<br />
+ClientRequestURI<br />
+ClientRequestUserAgent<br />
+EdgePathingOp<br />
+EdgePathingSrc<br />
+EdgePathingStatus<br />
+EdgeResponseContentType<br />
+EdgeResponseStatus<br />
+HttpRequestMethod<br />
+HttpStatusCode<br />
+TimeGenerated<br />
 threat<br />
-TimeGenerated<br />
-EdgePathingSrc_s<br />
-EdgePathingOp_s<br />
-EdgePathingStatus_s<br />
-EdgeResponseStatus_d<br />
-OriginResponseStatus_d<br />
-TimeGenerated<br />
 
 </Details>
 
 <Details header="Analytic rules">
 
 ClientIPClass<br />
-SrcIpAddr<br />
 ClientRequestURI<br />
-HttpUserAgentOriginal<br />
-HttpRequestMethod<br />
-TimeGenerated<br />
-SrcGeoCountry<br />
-ClientRequestURI<br />
+DstBytes<br />
 HttpRequestMethod<br />
 HttpStatusCode<br />
-DstBytes<br />
+HttpUserAgentOriginal<br />
 SrcBytes<br />
+SrcGeoCountry<br />
+SrcIpAddr<br />
+TimeGenerated<br />
+WAFAction<br />
 WAFRuleID<br />
 WAFRuleMessage<br />
-WAFAction<br />
 
 </Details>
 
 <Details header="Hunting queries">
 
-TimeGenerated<br />
-HttpStatusCode<br />
-SrcIpAddr<br />
 ClientRequestURI<br />
 ClientTlsStatus<br />
-HttpUserAgentOriginal<br />
-OriginTlsStatus<br />
-NetworkRuleName<br />
 EdgeRequestHost<br />
-SrcGeoCountry<br />
 EdgeResponseStatus<br />
-ClientCountry<br />
-ClientDeviceType<br />
-status<br />
-OriginResponseStatus<br />
-WorkerSubrequest<br />
-http_method<br />
-dest_ip<br />
-dest_host<br />
-uri_path<br />
-http_user_agent<br />
-status<br />
-src_ip<br />
-OriginResponseStatus<br />
-RayID<br />
-WorkerSubrequest<br />
-http_method<br />
-bytes_out<br />
-bytes_cached_requests<br />
-threat<br />
-ClientRequestProtocol<br />
-http_referrer<br />
-ClientIPClass<br />
-cf_http_status_codes<br />
-http_content_type<br />
-cf_http_status_codes<br />
-cached_requests<br />
-CacheCacheStatus<br />
-ClientASN<br />
-EdgePathingSrc<br />
-EdgePathingOp<br />
-EdgePathingStatus<br />
-ClientRequestUserAgent<br />
-SecurityAction<br />
-SecurityRuleID<br />
-SecurityRuleDescription<br />
+HttpStatusCode<br />
+HttpUserAgentOriginal<br />
+NetworkRuleName<br />
+OriginTlsStatus<br />
+SrcGeoCountry<br />
+SrcIpAddr<br />
+TimeGenerated<br />
 
 </Details>
 

--- a/src/content/docs/analytics/analytics-integrations/sentinel.mdx
+++ b/src/content/docs/analytics/analytics-integrations/sentinel.mdx
@@ -37,15 +37,11 @@ Before you begin, make sure the following prerequisites are met.
 
 ### RBAC roles
 
-The CCF connector authenticates to Azure using a service principal that is managed by Microsoft Sentinel. The ARM template that deploys the connector assigns the required roles automatically, so you only need to make sure that the deploying user has enough privileges:
+The CCF connector authenticates to Azure using a service principal that belongs to the Cloudflare CCF connector application, registered as a multi-tenant Microsoft Entra application. The ARM template that deploys the connector assigns the required roles to this service principal automatically.
 
-- **Microsoft Sentinel Contributor** (or `Contributor` / `Owner`) on the Microsoft Sentinel workspace.
-- **Owner** or **EventGrid Contributor** on the storage account, so that the deployment can create the Event Grid system topic and subscription.
+The deploying user must have **Microsoft Sentinel Contributor** (or `Contributor` / `Owner`) on the Microsoft Sentinel workspace and **Owner** or **EventGrid Contributor** on the storage account, so that the deployment can create the Event Grid system topic and subscription.
 
-For reference, the Cloudflare CCF connector service principal receives the following roles on the storage account at deployment time:
-
-- `Storage Blob Data Reader` on the storage account, to read log files from the Blob container.
-- `Storage Queue Data Contributor` on the storage account, to read and delete pointer messages from the Storage Queue.
+At deployment time, the Cloudflare CCF connector service principal receives `Storage Blob Data Reader` on the storage account to read log files from the Blob container and `Storage Queue Data Contributor` to read and delete pointer messages from the Storage Queue.
 
 Refer to the Microsoft documentation on [Azure roles for Microsoft Sentinel](https://learn.microsoft.com/en-us/azure/sentinel/roles) and [Azure roles for storage](https://learn.microsoft.com/en-us/azure/storage/blobs/assign-azure-role-data-access) for details.
 

--- a/src/content/docs/analytics/analytics-integrations/sentinel.mdx
+++ b/src/content/docs/analytics/analytics-integrations/sentinel.mdx
@@ -17,8 +17,8 @@ Cloudflare has integrations with Microsoft Sentinel to make analyzing your Cloud
 
 **[Sentinel Function Based Connector](https://azuremarketplace.microsoft.com/en-us/marketplace/apps/cloudflare.cloudflare_sentinel?tab=Overview)**: The Cloudflare connector for Microsoft Sentinel uses [Azure Functions](https://azure.microsoft.com/en-us/products/functions) to process security logs from Cloudflare's Logpush service and ingest them directly into the SIEM platform.
 
-:::note[Legacy connector deprecated]
-The Azure Function-based Cloudflare solution has been deprecated and is no longer listed in the Microsoft Sentinel Content Hub. New deployments should use the CCF connector documented below. Existing Function-based deployments continue to operate, but Cloudflare recommends migrating to the CCF connector to benefit from ongoing schema updates and the Sentinel Data Lake integration.
+:::caution[Legacy connector deprecation — action required by 2026-09-14]
+Microsoft is deprecating the Azure Monitor HTTP Data Collector API on 2026-09-14. As a result, Cloudflare will no longer maintain the Azure Functions-based Microsoft Sentinel connector after that date. Cloudflare Enterprise customers using the Function-based connector must migrate to the CCF connector documented below by 2026-09-14. Refer to the [deprecation changelog entry](/changelog/2026-08-26-sentinel-functions-connector-deprecation/) for details.
 :::
 
 This guide provides clear, step-by-step instructions for integrating Cloudflare logs with the CCF connector for Microsoft Sentinel using Azure Blob Storage. By following these steps, you will be able to securely collect, store, and analyze your Cloudflare logs within Microsoft Sentinel, enhancing your organization's security monitoring and incident response capabilities.

--- a/src/content/docs/analytics/analytics-integrations/sentinel.mdx
+++ b/src/content/docs/analytics/analytics-integrations/sentinel.mdx
@@ -53,7 +53,7 @@ Alternatively, run the following Azure CLI commands:
 
 ```sh
 az provider register --namespace Microsoft.EventGrid --subscription <subscription-id>
-az provider show --namespace Microsoft.EventGrid --query "registrationState"
+az provider show --namespace Microsoft.EventGrid --subscription <subscription-id> --query "registrationState"
 ```
 
 The registration state should report `Registered` before you continue.

--- a/src/content/docs/analytics/analytics-integrations/sentinel.mdx
+++ b/src/content/docs/analytics/analytics-integrations/sentinel.mdx
@@ -262,7 +262,7 @@ ZoneID<br />
 <Details header="Workbook fields">
 
 ClientDeviceType<br />
-ClientIP<br />
+SrcIpAddr<br />
 ClientIPClass<br />
 ClientRequestProtocol<br />
 ClientRequestReferer<br />
@@ -272,7 +272,6 @@ EdgePathingOp<br />
 EdgePathingSrc<br />
 EdgePathingStatus<br />
 EdgeResponseContentType<br />
-EdgeResponseStatus<br />
 HttpRequestMethod<br />
 HttpStatusCode<br />
 TimeGenerated<br />

--- a/src/content/docs/analytics/analytics-integrations/sentinel.mdx
+++ b/src/content/docs/analytics/analytics-integrations/sentinel.mdx
@@ -39,7 +39,7 @@ Before you begin, make sure the following prerequisites are met.
 
 The CCF connector authenticates to Azure using a service principal that belongs to the Cloudflare CCF connector application, registered as a multi-tenant Microsoft Entra application. The ARM template that deploys the connector assigns the required roles to this service principal automatically.
 
-The deploying user must have **Microsoft Sentinel Contributor** (or `Contributor` / `Owner`) on the Microsoft Sentinel workspace and **Owner** or **EventGrid Contributor** on the storage account, so that the deployment can create the Event Grid system topic and subscription.
+The deploying user must have **Microsoft Sentinel Contributor**, `Contributor`, or `Owner` on the Microsoft Sentinel workspace to deploy the connector resources. Because the ARM template creates role assignments for the service principal, the user must also have `Owner` or `User Access Administrator` at the storage account scope. `Contributor` and **Microsoft Sentinel Contributor** alone cannot create role assignments.
 
 At deployment time, the Cloudflare CCF connector service principal receives `Storage Blob Data Reader` on the storage account to read log files from the Blob container and `Storage Queue Data Contributor` to read and delete pointer messages from the Storage Queue.
 

--- a/src/content/docs/analytics/analytics-integrations/sentinel.mdx
+++ b/src/content/docs/analytics/analytics-integrations/sentinel.mdx
@@ -30,7 +30,7 @@ Before you begin, make sure the following prerequisites are met.
 ### Azure resources
 
 - **Azure subscription** with permission to create and manage resources (`Contributor` or `Owner` role recommended).
-- **Azure Storage account** with [Azure Data Lake Storage Gen2 enabled](https://learn.microsoft.com/en-us/azure/storage/blobs/create-data-lake-storage-account) (hierarchical namespace on). This account holds the Cloudflare log files pushed by Logpush.
+- **Azure Storage account** with [Azure Data Lake Storage Gen2 enabled](https://learn.microsoft.com/en-us/azure/storage/blobs/create-data-lake-storage-account) (hierarchical namespace on). Logpush writes the Cloudflare log files to this account.
 - **Azure Blob container** inside the storage account, dedicated to receiving Cloudflare Logpush files. The CCF connector monitors this container for new files via Event Grid.
 - **Microsoft Sentinel workspace** already deployed on top of a Log Analytics workspace. The connector's Data Collection Rule (DCR) and Data Collection Endpoint (DCE) are tied to this Log Analytics workspace, and all ingested Cloudflare log records land in tables within it.
 - **Cloudflare account** with access to the domain or account whose logs you want to export, and permission to configure Logpush jobs.
@@ -149,7 +149,7 @@ To resolve the error:
 
 1. **Verify co-location**: in the Azure portal, open both the storage account and the Microsoft Sentinel workspace (or its underlying Log Analytics workspace) and confirm that **Resource group** and **Subscription** match on the **Overview** blade. If they differ, move the storage account into the resource group that hosts Sentinel, or create a new storage account in that resource group.
 2. **Verify network access**: confirm that public network access is enabled on the storage account, or that a Network Security Perimeter is configured as described in [Prerequisites](#network-access-configuration). Selected network limits using IPv4 CIDR addresses are not supported.
-3. **Retry the deployment**: once the resources are aligned, re-run the ARM template deployment. The `CreateDataFlowResources` error should not recur.
+3. **Retry the deployment**: after you align the resources, re-run the ARM template deployment. The `CreateDataFlowResources` error should not recur.
 
 For the full list of storage-related failure modes and mitigations, refer to Microsoft's [Azure Storage Blob connector troubleshooting guide](https://learn.microsoft.com/en-us/azure/sentinel/azure-storage-blob-connector-troubleshoot).
 

--- a/src/content/docs/analytics/analytics-integrations/sentinel.mdx
+++ b/src/content/docs/analytics/analytics-integrations/sentinel.mdx
@@ -17,18 +17,66 @@ Cloudflare has integrations with Microsoft Sentinel to make analyzing your Cloud
 
 **[Sentinel Function Based Connector](https://azuremarketplace.microsoft.com/en-us/marketplace/apps/cloudflare.cloudflare_sentinel?tab=Overview)**: The Cloudflare connector for Microsoft Sentinel uses [Azure Functions](https://azure.microsoft.com/en-us/products/functions) to process security logs from Cloudflare's Logpush service and ingest them directly into the SIEM platform.
 
-This guide provides clear, step-by-step instructions for integrating Cloudflare logs with the new CCF connector for Microsoft Sentinel using Azure Blob Storage. By following these steps, you will be able to securely collect, store, and analyse your Cloudflare logs within Microsoft Sentinel, enhancing your organisation's security monitoring and incident response capabilities.
+:::note[Legacy connector deprecated]
+The Azure Function-based Cloudflare solution has been deprecated and is no longer listed in the Microsoft Sentinel Content Hub. New deployments should use the CCF connector documented below. Existing Function-based deployments continue to operate, but Cloudflare recommends migrating to the CCF connector to benefit from ongoing schema updates and the Sentinel Data Lake integration.
+:::
+
+This guide provides clear, step-by-step instructions for integrating Cloudflare logs with the CCF connector for Microsoft Sentinel using Azure Blob Storage. By following these steps, you will be able to securely collect, store, and analyze your Cloudflare logs within Microsoft Sentinel, enhancing your organization's security monitoring and incident response capabilities.
 
 ## Step 1: Prerequisites
 
-- Azure Subscription with permission to create and manage resources (Contributor/Owner role recommended).
-- Microsoft Sentinel Workspace already set up in your Azure environment.
-- Azure Storage Account with a Blob container for storing Cloudflare logs.
-- Cloudflare Account with access to the domain whose logs you wish to export, and permission to configure Logpush jobs.
-- The Azure Storage account needs to be set to public network access.
-- The Azure Storage account needs to be in the same subscription as the Microsoft Sentinel Workspace. 
+Before you begin, make sure the following prerequisites are met.
 
-## Step 2: Set up a logpush job
+### Azure resources
+
+- **Azure subscription** with permission to create and manage resources (`Contributor` or `Owner` role recommended).
+- **Azure Storage account** with [Azure Data Lake Storage Gen2 enabled](https://learn.microsoft.com/en-us/azure/storage/blobs/create-data-lake-storage-account) (hierarchical namespace on). This account holds the Cloudflare log files pushed by Logpush.
+- **Azure Blob container** inside the storage account, dedicated to receiving Cloudflare Logpush files. The CCF connector monitors this container for new files via Event Grid.
+- **Microsoft Sentinel workspace** already deployed on top of a Log Analytics workspace. The connector's Data Collection Rule (DCR) and Data Collection Endpoint (DCE) are tied to this Log Analytics workspace, and all ingested Cloudflare log records land in tables within it.
+- **Cloudflare account** with access to the domain or account whose logs you want to export, and permission to configure Logpush jobs.
+
+### RBAC roles
+
+The CCF connector authenticates to Azure using a service principal that is managed by Microsoft Sentinel. The ARM template that deploys the connector assigns the required roles automatically, so you only need to make sure that the deploying user has enough privileges:
+
+- **Microsoft Sentinel Contributor** (or `Contributor` / `Owner`) on the Microsoft Sentinel workspace.
+- **Owner** or **EventGrid Contributor** on the storage account, so that the deployment can create the Event Grid system topic and subscription.
+
+For reference, the connector's service principal receives the following roles on the storage account at deployment time:
+
+- `Storage Blob Data Reader` on the storage account, to read log files from the Blob container.
+- `Storage Queue Data Contributor` on the storage account, to read and delete pointer messages from the Storage Queue.
+
+Refer to the Microsoft documentation on [Azure roles for Microsoft Sentinel](https://learn.microsoft.com/en-us/azure/sentinel/roles) and [Azure roles for storage](https://learn.microsoft.com/en-us/azure/storage/blobs/assign-azure-role-data-access) for details.
+
+### Event Grid resource provider
+
+The `Microsoft.EventGrid` resource provider must be registered in the subscription that hosts the storage account. Verify the registration state in the Azure portal under **Subscriptions** > select the subscription > **Settings** > **Resource providers** > search for `Microsoft.EventGrid`.
+
+Alternatively, run the following Azure CLI commands:
+
+```sh
+az provider register --namespace Microsoft.EventGrid --subscription <subscription-id>
+az provider show --namespace Microsoft.EventGrid --query "registrationState"
+```
+
+The registration state should report `Registered` before you continue.
+
+### Network access configuration
+
+By default, the storage account must allow public network access so that the connector's managed resources can reach both the Blob container endpoint and the Storage Queue endpoint.
+
+- If you are not restricting access with a Network Security Perimeter (NSP), open the storage account's **Networking** blade and set **Public network access** to **Enabled from all networks**.
+- Restricting access using selected virtual networks or IPv4 CIDR ranges is not supported for this connector, because of Azure Storage firewall limitations around IP ranges and caller region affinity.
+- If network restrictions are required for compliance, use an [Azure Network Security Perimeter (NSP)](https://learn.microsoft.com/en-us/azure/private-link/network-security-perimeter-concepts) instead. Include the Sentinel service tag inbound ranges in the NSP rules and configure the Event Grid system topic subscription to use system-assigned managed identity delivery.
+
+Refer to Microsoft's guidance on [enabling storage network security for Sentinel](https://learn.microsoft.com/en-us/azure/sentinel/enable-storage-network-security) for the full options.
+
+### Storage account and Sentinel co-location
+
+The Azure Blob Storage account and the Microsoft Sentinel workspace must live in the **same Azure subscription and the same resource group**. Deployments where these resources are split across subscriptions or resource groups fail during ARM template validation. Refer to [Troubleshooting](#troubleshooting) for details.
+
+## Step 2: Set up a Logpush job
 
 1. Log in to the [Cloudflare dashboard](https://dash.cloudflare.com/), and select your account and domain.
 2. Go to **Analytics** > **Logs** and select **Logpush**.
@@ -43,49 +91,71 @@ This guide provides clear, step-by-step instructions for integrating Cloudflare 
 
 For complete details, refer to the [Cloudflare Logpush to Azure documentation](/logs/logpush/logpush-job/enable-destinations/azure/).
 
-## Step 3: Configure Azure and deploy the Data Connector in Microsoft Sentinel
+## Step 3: Install the Cloudflare CCF solution
 
-1. Log in to the Azure Portal and go to your **Microsoft Sentinel** workspace.
-2. Select **Content Hub** in the navigation bar and search for **Cloudflare**.
-3. Select the **Cloudflare** solution from the results.
-4. Select **Install** in the right pane.
-5. In your **Sentinel workspace**, go to **Data connectors**.
-6. Search for the **Cloudflare connector** (may appear as **Cloudflare (using Azure Blob Storage)**).
-7. Select the connector to configure it.
+1. Log in to the Azure portal and open your Microsoft Sentinel workspace. If you do not have one yet, follow Microsoft's [onboarding guide](https://learn.microsoft.com/en-us/azure/sentinel/quickstart-onboard) to create a Log Analytics workspace and enable Microsoft Sentinel on it.
+2. In the left navigation pane, under **Content management**, select **Content hub**. If the page appears empty, refresh and wait for the content list to load.
+3. In the search bar, enter `Cloudflare` and press **Enter**.
+4. Select the **Cloudflare CCF** solution and select **Install**.
+5. Once the solution is installed, select **Manage**.
+6. Select **Cloudflare (Using Blob Container) (via Codeless Connector Framework)** and select **Open connector page**.
 
 ![Azure portal](~/assets/images/analytics/azure-portal.png)
 
-## Step 4: Fill out required fields
+## Step 4: Configure the CCF connector
 
-When configuring the Cloudflare data connector, you will need to provide the following information:
+On the connector page, fill in the following fields:
 
-- Blob container URL
+- **Service Principal ID**: this field is prepopulated with the object ID of the Microsoft-managed service principal used by the connector. If it is empty, ensure that admin consent has been granted for the Microsoft Sentinel application in your Entra ID tenant, then reload the page. Refer to Microsoft's [admin consent workflow](https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/configure-admin-consent-workflow) for details.
+- **Blob Container URL**: in the Azure portal, open the storage account that receives Cloudflare logs. Under **Data storage** > **Containers**, open the target container, go to **Properties**, and copy the URL.
+- **Storage Account Resource Group Name**, **Storage Account Location**, and **Storage Account Subscription ID**: available on the storage account's **Overview** page.
+- **Event Grid System Topic Name**: leave this field blank on the first deployment. The ARM template creates the topic automatically. If you are reconfiguring an existing deployment, open **Event Grid** > **System topics** in the Azure portal, filter by location, and copy the name of the topic whose **Source** matches your storage account.
 
-To obtain the container URL within your Azure storage account, access the Azure Portal and navigate to your storage account. Under **Data Storage**, select **Containers**, then choose the relevant container receiving logs from Cloudflare. The container properties section will display the URL link.
-
-- Resource group name for the storage account
-- Storage account location
-- Subscription ID
-- Event grid topic name (only if reconfiguring; not needed for initial setup)
-
-After entering all information, select **Connect**.
-
-Ensure all fields are correctly filled to enable seamless log ingestion.
+Select **Connect** to start the deployment. When the deployment completes, the Azure portal shows a `Deployment succeeded` notification and the button changes to **Disconnect**.
 
 ![Configuration fields](~/assets/images/analytics/configuration.png)
 
-## Step 5: Complete deployment
+## Step 5: Verify log ingestion
 
-1. Select **Apply changes** or **Connect** to finalise the connector setup.
-2. Monitor the Data connectors page in Sentinel to confirm that the Cloudflare connector status is **Connected**.
-3. Verify that Cloudflare logs are appearing in your Sentinel workspace under **Log Analytics** > **Logs**.
-4. If logs are not appearing, review your Blob Storage permissions, Cloudflare Logpush configuration, and Sentinel connector settings.
+1. In the Azure portal, open the Log Analytics workspace backing your Sentinel instance.
+2. In the left navigation pane, select **Logs**.
+3. Enter the following query in the editor and select **Run**:
+
+   ```kusto
+   CloudflareV2_CL
+   | take 10
+   ```
+
+4. Confirm that Cloudflare log records are returned.
+
+:::note[Note]
+Data usually starts appearing in the workspace within 20 to 30 minutes of the connector reporting a successful deployment. If logs do not appear after that window, review your storage account permissions, Cloudflare Logpush configuration, Event Grid subscription, and Sentinel connector settings.
+:::
 
 ![Data connectors](~/assets/images/analytics/data-connectors.png)
 
-By following these steps, you have successfully integrated Cloudflare logs with Microsoft Sentinel using Azure Blob Storage. This integration enables advanced security analytics and incident response capabilities for your Cloudflare-protected environments. If you encounter issues, review each configuration step, check permissions, and review Microsoft's official documentation.
-
 ![Cloudflare traffic overview](~/assets/images/analytics/traffic-overview.png)
+
+## Troubleshooting
+
+### `CreateDataFlowResources` deployment error
+
+The ARM template deployment fails with an error similar to:
+
+```txt
+InvalidTemplate: Deployment template validation failed:
+'The resource 'Microsoft.Resources/deployments/CreateDataFlowResources' is not defined in the template.'
+```
+
+The CCF connector's ARM template operates within a single resource group scope and cross-references the storage account, Blob container, Event Grid system topic, Storage Queue, Data Collection Rule (DCR), Data Collection Endpoint (DCE), and Microsoft Sentinel workspace as co-located resources. If any of those resources live outside the deployment scope, the template cannot resolve the references and validation fails before anything is created.
+
+To resolve the error:
+
+1. **Verify co-location**: in the Azure portal, open both the storage account and the Microsoft Sentinel workspace (or its underlying Log Analytics workspace) and confirm that **Resource group** and **Subscription** match on the **Overview** blade. If they differ, move the storage account into the resource group that hosts Sentinel, or create a new storage account in that resource group.
+2. **Verify network access**: confirm that public network access is enabled on the storage account, or that a Network Security Perimeter is configured as described in [Prerequisites](#network-access-configuration). Selected network limits using IPv4 CIDR addresses are not supported.
+3. **Retry the deployment**: once the resources are aligned, re-run the ARM template deployment. The `CreateDataFlowResources` error should not recur.
+
+For the full list of storage-related failure modes and mitigations, refer to Microsoft's [Azure Storage Blob connector troubleshooting guide](https://learn.microsoft.com/en-us/azure/sentinel/azure-storage-blob-connector-troubleshoot).
 
 ## Supported Logs
 

--- a/src/content/docs/analytics/analytics-integrations/sentinel.mdx
+++ b/src/content/docs/analytics/analytics-integrations/sentinel.mdx
@@ -93,7 +93,7 @@ For complete details, refer to the [Cloudflare Logpush to Azure documentation](/
 2. In the left navigation pane, under **Content management**, select **Content hub**. If the page appears empty, refresh and wait for the content list to load.
 3. In the search bar, enter `Cloudflare` and press **Enter**.
 4. Select the **Cloudflare CCF** solution and select **Install**.
-5. Once the solution is installed, select **Manage**.
+5. After you install the solution, select **Manage**.
 6. Select **Cloudflare (Using Blob Container) (via Codeless Connector Framework)** and select **Open connector page**.
 
 ![Azure portal](~/assets/images/analytics/azure-portal.png)

--- a/src/content/docs/analytics/analytics-integrations/sentinel.mdx
+++ b/src/content/docs/analytics/analytics-integrations/sentinel.mdx
@@ -17,8 +17,8 @@ Cloudflare has integrations with Microsoft Sentinel to make analyzing your Cloud
 
 **[Sentinel Function Based Connector](https://azuremarketplace.microsoft.com/en-us/marketplace/apps/cloudflare.cloudflare_sentinel?tab=Overview)**: The Cloudflare connector for Microsoft Sentinel uses [Azure Functions](https://azure.microsoft.com/en-us/products/functions) to process security logs from Cloudflare's Logpush service and ingest them directly into the SIEM platform.
 
-:::caution[Legacy connector deprecation — action required by 2026-09-14]
-Microsoft is deprecating the Azure Monitor HTTP Data Collector API on 2026-09-14. As a result, Cloudflare will no longer maintain the Azure Functions-based Microsoft Sentinel connector after that date. Cloudflare Enterprise customers using the Function-based connector must migrate to the CCF connector documented in this guide by 2026-09-14. Refer to the [deprecation changelog entry](/changelog/2026-08-26-sentinel-functions-connector-deprecation/) for details.
+:::caution[Legacy connector deprecation]
+Microsoft is deprecating the Azure Monitor HTTP Data Collector API. As a result, Cloudflare will no longer maintain the Azure Functions-based Microsoft Sentinel connector after the API end-of-support date. Cloudflare Enterprise customers using the Function-based connector must migrate to the CCF connector documented in this guide. Refer to the [deprecation changelog entry](/changelog/2026-08-26-sentinel-functions-connector-deprecation/) for the exact end-of-support date and migration details.
 :::
 
 This guide provides clear, step-by-step instructions for integrating Cloudflare logs with the CCF connector for Microsoft Sentinel using Azure Blob Storage. By following these steps, you will be able to securely collect, store, and analyze your Cloudflare logs within Microsoft Sentinel, enhancing your organization's security monitoring and incident response capabilities.

--- a/src/content/docs/analytics/analytics-integrations/splunk.mdx
+++ b/src/content/docs/analytics/analytics-integrations/splunk.mdx
@@ -96,15 +96,15 @@ You can also manually configure Data Models by going to **Settings** > **Data mo
 
 Create the Logpush job by following [Enable Logpush to Splunk](/logs/logpush/logpush-job/enable-destinations/splunk/). When you fill in the Splunk destination:
 
-- Use the endpoint you built in [Task 1 - step 9](#task-1---install-and-configure-the-cloudflare-app-for-splunk) for **Splunk HEC URL**, including the `/services/collector/raw` path.
-- Use the HEC token you saved in [Task 1 - step 7](#task-1---install-and-configure-the-cloudflare-app-for-splunk) for **Auth Token**, prefixed with `Splunk` (for example, `Splunk 12345678-1234-1234-1234-1234567890ab`).
+- Use the endpoint you configured in [Task 1](#task-1---install-and-configure-the-cloudflare-app-for-splunk) for **Splunk HEC URL**, including the `/services/collector/raw` path.
+- Use the HEC token you created in [Task 1](#task-1---install-and-configure-the-cloudflare-app-for-splunk) for **Auth Token**, prefixed with `Splunk` (for example, `Splunk 12345678-1234-1234-1234-1234567890ab`).
 - Set **Source Type** to the value that matches the dataset you want to push, so the Cloudflare App for Splunk parses events correctly:
   - HTTP requests, Firewall events, Spectrum events, and most zone-scoped datasets: `cloudflare:json`
-  - DNS logs: `cloudflare:dns`
+  - DNS logs, including Zero Trust Gateway DNS: `cloudflare:dns`
   - Audit logs: `cloudflare:audit`
   - Access requests: `cloudflare:access`
   - CASB findings, Zero Trust Gateway HTTP, and Zero Trust Gateway Network: `cloudflare:json`
-- Only turn on **Use insecure skip verify option** if your Splunk instance uses a self-signed certificate, as noted in [Task 1 - step 8](#task-1---install-and-configure-the-cloudflare-app-for-splunk).
+- Only turn on **Use insecure skip verify option** if your Splunk instance uses a self-signed certificate, as noted in [Task 1](#task-1---install-and-configure-the-cloudflare-app-for-splunk).
 
 Under **Send the following fields**, keep the defaults or refer to the [Dashboard section](#task-3---view-the-dashboards) to select the fields required to fully populate the Cloudflare App for Splunk dashboards.
 
@@ -208,9 +208,11 @@ Available Filters:
 
 ## Splunk CIM field mappings
 
-The Cloudflare App for Splunk maps Cloudflare log fields to [Splunk Common Information Model (CIM)](https://docs.splunk.com/Documentation/CIM/latest/User/Overview) field names, so that Cloudflare data can be searched, correlated, and accelerated alongside other CIM-compliant sources in your Splunk deployment. The following tables list the mappings the app applies per Cloudflare Logpush dataset.
+The Cloudflare App for Splunk maps Cloudflare log fields to [Splunk Common Information Model (CIM)](https://docs.splunk.com/Documentation/CIM/latest/User/Overview) field names, so that you can search, correlate, and accelerate Cloudflare data alongside other CIM-compliant sources in your Splunk deployment. The following tables list the mappings the app applies per Cloudflare Logpush dataset.
 
 ### HTTP requests
+
+The app applies the following mappings:
 
 | Cloudflare field           | Splunk CIM field    |
 | -------------------------- | ------------------- |
@@ -233,6 +235,8 @@ The Cloudflare App for Splunk maps Cloudflare log fields to [Splunk Common Infor
 
 ### CASB findings
 
+The app applies the following mappings:
+
 | Cloudflare field         | Splunk CIM field |
 | ------------------------ | ---------------- |
 | `AssetDisplayName`       | `dest`           |
@@ -243,6 +247,8 @@ The Cloudflare App for Splunk maps Cloudflare log fields to [Splunk Common Infor
 | `InstanceID`             | `signature_id`   |
 
 ### Zero Trust Gateway DNS
+
+The app applies the following mappings:
 
 | Cloudflare field | Splunk CIM field |
 | ---------------- | ---------------- |
@@ -257,6 +263,8 @@ The Cloudflare App for Splunk maps Cloudflare log fields to [Splunk Common Infor
 
 ### Audit logs
 
+The app applies the following mappings:
+
 | Cloudflare field | Splunk CIM field |
 | ---------------- | ---------------- |
 | `ActionResult`   | `status`         |
@@ -267,6 +275,8 @@ The Cloudflare App for Splunk maps Cloudflare log fields to [Splunk Common Infor
 | `OwnerID`        | `src_user`       |
 
 ### Access requests
+
+The app applies the following mappings:
 
 | Cloudflare field               | Splunk CIM field         |
 | ------------------------------ | ------------------------ |
@@ -280,11 +290,13 @@ The Cloudflare App for Splunk maps Cloudflare log fields to [Splunk Common Infor
 
 ### Zero Trust Gateway HTTP
 
+The app applies the following mappings:
+
 | Cloudflare field | Splunk CIM field  |
 | ---------------- | ----------------- |
 | `Action`         | `action`          |
 | `DestinationIP`  | `dest`            |
-| `DestinationPort`| `dest_port`       |
+| `DestinationPort` | `dest_port`       |
 | `HTTPMethod`     | `http_method`     |
 | `Referer`        | `http_referrer`   |
 | `SourceIP`       | `src`             |
@@ -293,6 +305,8 @@ The Cloudflare App for Splunk maps Cloudflare log fields to [Splunk Common Infor
 | `UserID`         | `user`            |
 
 ### Zero Trust Gateway Network
+
+The app applies the following mappings:
 
 | Cloudflare field  | Splunk CIM field       |
 | ----------------- | ---------------------- |
@@ -303,7 +317,7 @@ The Cloudflare App for Splunk maps Cloudflare log fields to [Splunk Common Infor
 | `OverrideIP`      | `dest_translated_ip`   |
 | `OverridePort`    | `dest_translated_port` |
 | `PolicyID`        | `rule`                 |
-| `SessionID`       | `ssid`                 |
+| `SessionID`       | `session_id`           |
 | `SourceIP`        | `src_ip`               |
 | `SourcePort`      | `src_port`             |
 | `Transport`       | `transport`            |

--- a/src/content/docs/analytics/analytics-integrations/splunk.mdx
+++ b/src/content/docs/analytics/analytics-integrations/splunk.mdx
@@ -205,6 +205,110 @@ Available Filters:
 
 - Client Request Method
 
+## Splunk CIM field mappings
+
+The Cloudflare App for Splunk maps Cloudflare log fields to [Splunk Common Information Model (CIM)](https://docs.splunk.com/Documentation/CIM/latest/User/Overview) field names, so that Cloudflare data can be searched, correlated, and accelerated alongside other CIM-compliant sources in your Splunk deployment. The tables below list the mappings the app applies per Cloudflare Logpush dataset.
+
+### HTTP requests
+
+| Cloudflare field           | Splunk CIM field    |
+| -------------------------- | ------------------- |
+| `ClientIP`                 | `src_ip`            |
+| `ClientRequestBytes`       | `bytes_in`          |
+| `ClientRequestHost`        | `dest_host`         |
+| `ClientRequestMethod`      | `http_method`       |
+| `ClientRequestPath`        | `uri_path`          |
+| `ClientRequestReferer`     | `http_referer`      |
+| `ClientRequestURI`         | `uri`               |
+| `ClientRequestUserAgent`   | `http_user_agent`   |
+| `ClientSrcPort`            | `src_port`          |
+| `ClientSSLProtocol`        | `ssl_protocol`      |
+| `EdgeRateLimitAction`      | `action`            |
+| `EdgeResponseBytes`        | `bytes_out`         |
+| `EdgeResponseContentType`  | `http_content_type` |
+| `EdgeResponseStatus`       | `status`            |
+| `OriginIP`                 | `dest_ip`           |
+| `OriginResponseTime`       | `response_time`     |
+
+### CASB findings
+
+| Cloudflare field         | Splunk CIM field |
+| ------------------------ | ---------------- |
+| `AssetDisplayName`       | `dest`           |
+| `AssetLink`              | `url`            |
+| `FindingTypeDisplayName` | `category`       |
+| `FindingTypeID`          | `category_id`    |
+| `FindingTypeSeverity`    | `severity`       |
+| `InstanceID`             | `signature_id`   |
+
+### DNS logs
+
+| Cloudflare field | Splunk CIM field |
+| ---------------- | ---------------- |
+| `DstIP`          | `dest`           |
+| `DstPort`        | `dest_port`      |
+| `Protocol`       | `transport`      |
+| `QueryName`      | `query`          |
+| `QuerySize`      | `query_count`    |
+| `QueryTypeName`  | `query_type`     |
+| `RCode`          | `reply_code`     |
+| `SrcIP`          | `src`            |
+| `SrcPort`        | `src_port`       |
+
+### Audit logs
+
+| Cloudflare field | Splunk CIM field |
+| ---------------- | ---------------- |
+| `ActionResult`   | `status`         |
+| `ActionType`     | `action`         |
+| `ActorID`        | `user`           |
+| `ActorIP`        | `src`            |
+| `ActorType`      | `user_category`  |
+| `OwnerID`        | `src_user`       |
+
+### Access requests
+
+| Cloudflare field               | Splunk CIM field         |
+| ------------------------------ | ------------------------ |
+| `Action`                       | `action`                 |
+| `AppDomain`                    | `app`                    |
+| `Connection`                   | `authentication_service` |
+| `IPAddress`                    | `src`                    |
+| `PurposeJustificationResponse` | `reason`                 |
+| `RayID`                        | `signature_id`           |
+| `UserUID`                      | `user_id`                |
+
+### Zero Trust Gateway HTTP
+
+| Cloudflare field | Splunk CIM field  |
+| ---------------- | ----------------- |
+| `Action`         | `action`          |
+| `DestinationIP`  | `dest`            |
+| `DestinationPort`| `dest_port`       |
+| `HTTPMethod`     | `http_method`     |
+| `Referer`        | `http_referrer`   |
+| `SourceIP`       | `src`             |
+| `URL`            | `url`             |
+| `UserAgent`      | `http_user_agent` |
+| `UserID`         | `user`            |
+
+### Zero Trust Gateway Network
+
+| Cloudflare field  | Splunk CIM field       |
+| ----------------- | ---------------------- |
+| `Action`          | `action`               |
+| `DestinationIP`   | `dest_ip`              |
+| `DestinationPort` | `dest_port`            |
+| `DeviceName`      | `dvc`                  |
+| `OverrideIP`      | `dest_translated_ip`   |
+| `OverridePort`    | `dest_translated_port` |
+| `PolicyID`        | `rule`                 |
+| `SessionID`       | `ssid`                 |
+| `SourceIP`        | `src_ip`               |
+| `SourcePort`      | `src_port`             |
+| `Transport`       | `transport`            |
+| `UserID`          | `user`                 |
+
 ## Debugging tips
 
 ### Incomplete dashboards

--- a/src/content/docs/analytics/analytics-integrations/splunk.mdx
+++ b/src/content/docs/analytics/analytics-integrations/splunk.mdx
@@ -45,15 +45,20 @@ To install the [Cloudflare App for Splunk](https://splunkbase.splunk.com/app/450
    1. Open the setup screen by clicking the **Settings** dropdown, then click **Indexes**.
    2. Select **New Index**. Note that the **Indexes** page also gives you the status of all your existing indexes so that you can see whether you're about to use up your licensed amount of space.
    3. Name the index **cloudflare**, which is the default index that the Cloudflare App will use.
+   4. Set **Index Data Type** to **Events**, then select **Save**.
 
 7. Set up the HTTP Event Collector (HEC) on Splunk. To create an HEC:
    1. Click the **Settings** dropdown and select **Data inputs**.
-   2. Click **+Add new** and follow the wizard. When prompted, submit the following responses:
+   2. Click **+Add new** next to **HTTP Event Collector** and follow the wizard. When prompted, submit the following responses:
       - Name: Cloudflare
-      - Source Type: Select > "cloudflare:json"
+      - Source Type: Select > `cloudflare:json`
       - App Context: Cloudflare App for Splunk (cloudflare)
       - Index: cloudflare
    3. At the end of the wizard you will see a **Token Value**. This token authorizes the Cloudflare Logpush job to send data to your Splunk instance. If you forget to copy it now, Splunk allows you to get the value at any time.
+
+   :::note[Enable HEC and SSL]
+   After creating the token, go to **Settings** > **Data inputs** > **HTTP Event Collector** > **Global Settings** and confirm that **All Tokens** is set to **Enabled** and that **Enable SSL** is selected, then select **Save**. Verify that the status of your new HEC token is **Enabled** in the token list. Refer to the [Splunk HEC documentation](https://docs.splunk.com/Documentation/Splunk/latest/Data/UsetheHTTPEventCollector) for details.
+   :::
 
 8. Verify whether Splunk is using a self-signed certificate. You'll need this information when creating the Logpush job.
 
@@ -87,17 +92,28 @@ Enable or disable acceleration after the initial configuration by accessing the 
 
 You can also manually configure Data Models by going to **Settings** > **Data models**. Learn more about data model acceleration in the [Splunk documentation](https://docs.splunk.com/Documentation/Splunk/latest/Knowledge/Acceleratedatamodels).
 
-## Task 2 - Make the API call to create the Logpush job
+## Task 2 - Create the Cloudflare Logpush job to Splunk
 
-Create the Logpush job by following the instructions on [Enable Logpush to Splunk](/logs/logpush/logpush-job/enable-destinations/splunk/). The API call creates a Logpush job but does not enable it.
+Create the Logpush job by following [Enable Logpush to Splunk](/logs/logpush/logpush-job/enable-destinations/splunk/). When you fill in the Splunk destination:
 
-Enable the Logpush job through the Cloudflare dashboard or through the API by following the instructions on [Enable Logpush to Splunk](/logs/logpush/logpush-job/enable-destinations/splunk/). To enable through the dashboard:
+- Use the endpoint you built in [Task 1 - step 9](#task-1---install-and-configure-the-cloudflare-app-for-splunk) for **Splunk HEC URL**, including the `/services/collector/raw` path.
+- Use the HEC token you saved in [Task 1 - step 7](#task-1---install-and-configure-the-cloudflare-app-for-splunk) for **Auth Token**, prefixed with `Splunk` (for example, `Splunk 12345678-1234-1234-1234-1234567890ab`).
+- Set **Source Type** to the value that matches the dataset you want to push, so the Cloudflare App for Splunk parses events correctly:
+  - HTTP requests, Firewall events, Spectrum events, and most zone-scoped datasets: `cloudflare:json`
+  - DNS logs: `cloudflare:dns`
+  - Audit logs: `cloudflare:audit`
+  - Access requests: `cloudflare:access`
+- Only enable **Use insecure skip verify option** if your Splunk instance uses a self-signed certificate, as noted in [Task 1 - step 8](#task-1---install-and-configure-the-cloudflare-app-for-splunk).
 
-1. Navigate to the Cloudflare dashboard and select **Analytics & Logs** > **Logs**.
-2. Select **Edit** and select the fields referenced in the Dashboard section below to fully populate all tables and graphs.
-3. Enable the Logpush job by toggling on the switch next to the Edit link. Data takes a few minutes to populate.
+Under **Send the following fields**, keep the defaults or refer to the [Dashboard section](#task-3---view-the-dashboards) below to select the fields required to fully populate the Cloudflare App for Splunk dashboards.
 
-To validate that you are receiving data, search `index=cloudflare` in Splunk.
+Once the job is created, enable it to start sending logs. To confirm end-to-end delivery, run the following search in Splunk:
+
+```txt
+index="cloudflare"
+```
+
+Cloudflare sends two system confirmation events to verify connectivity and delivery setup as soon as the job is enabled. Regular Cloudflare logs start streaming shortly afterward. Data can take a few minutes to appear.
 
 ## Task 3 - View the Dashboards
 

--- a/src/content/docs/analytics/analytics-integrations/splunk.mdx
+++ b/src/content/docs/analytics/analytics-integrations/splunk.mdx
@@ -103,7 +103,9 @@ Create the Logpush job by following [Enable Logpush to Splunk](/logs/logpush/log
   - DNS logs, including Zero Trust Gateway DNS: `cloudflare:dns`
   - Audit logs: `cloudflare:audit`
   - Access requests: `cloudflare:access`
-  - CASB findings, Zero Trust Gateway HTTP, and Zero Trust Gateway Network: `cloudflare:json`
+  - CASB findings: `cloudflare:casb`
+  - Zero Trust Gateway HTTP: `cloudflare:http`
+  - Zero Trust Gateway Network: `cloudflare:network`
 - Only turn on **Use insecure skip verify option** if your Splunk instance uses a self-signed certificate, as noted in [Task 1](#task-1---install-and-configure-the-cloudflare-app-for-splunk).
 
 Under **Send the following fields**, keep the defaults or refer to the [Dashboard section](#task-3---view-the-dashboards) to select the fields required to fully populate the Cloudflare App for Splunk dashboards.

--- a/src/content/docs/analytics/analytics-integrations/splunk.mdx
+++ b/src/content/docs/analytics/analytics-integrations/splunk.mdx
@@ -92,7 +92,7 @@ Enable or disable acceleration after the initial configuration by accessing the 
 
 You can also manually configure Data Models by going to **Settings** > **Data models**. Learn more about data model acceleration in the [Splunk documentation](https://docs.splunk.com/Documentation/Splunk/latest/Knowledge/Acceleratedatamodels).
 
-## Task 2 - Create the Cloudflare Logpush job to Splunk
+## Task 2 - create the Cloudflare Logpush job to Splunk
 
 Create the Logpush job by following [Enable Logpush to Splunk](/logs/logpush/logpush-job/enable-destinations/splunk/). When you fill in the Splunk destination:
 

--- a/src/content/docs/analytics/analytics-integrations/splunk.mdx
+++ b/src/content/docs/analytics/analytics-integrations/splunk.mdx
@@ -103,6 +103,7 @@ Create the Logpush job by following [Enable Logpush to Splunk](/logs/logpush/log
   - DNS logs: `cloudflare:dns`
   - Audit logs: `cloudflare:audit`
   - Access requests: `cloudflare:access`
+  - CASB findings, Zero Trust Gateway HTTP, and Zero Trust Gateway Network: `cloudflare:json`
 - Only turn on **Use insecure skip verify option** if your Splunk instance uses a self-signed certificate, as noted in [Task 1 - step 8](#task-1---install-and-configure-the-cloudflare-app-for-splunk).
 
 Under **Send the following fields**, keep the defaults or refer to the [Dashboard section](#task-3---view-the-dashboards) to select the fields required to fully populate the Cloudflare App for Splunk dashboards.

--- a/src/content/docs/analytics/analytics-integrations/splunk.mdx
+++ b/src/content/docs/analytics/analytics-integrations/splunk.mdx
@@ -49,7 +49,7 @@ To install the [Cloudflare App for Splunk](https://splunkbase.splunk.com/app/450
 
 7. Set up the HTTP Event Collector (HEC) on Splunk. To create an HEC:
    1. Click the **Settings** dropdown and select **Data inputs**.
-   2. Click **+Add new** next to **HTTP Event Collector** and follow the wizard. When prompted, submit the following responses:
+   2. Select **+Add new** next to **HTTP Event Collector** and follow the wizard. When prompted, submit the following responses:
       - Name: Cloudflare
       - Source Type: Select > `cloudflare:json`
       - App Context: Cloudflare App for Splunk (cloudflare)
@@ -57,7 +57,7 @@ To install the [Cloudflare App for Splunk](https://splunkbase.splunk.com/app/450
    3. At the end of the wizard you will see a **Token Value**. This token authorizes the Cloudflare Logpush job to send data to your Splunk instance. If you forget to copy it now, Splunk allows you to get the value at any time.
 
    :::note[Enable HEC and SSL]
-   After creating the token, go to **Settings** > **Data inputs** > **HTTP Event Collector** > **Global Settings** and confirm that **All Tokens** is set to **Enabled** and that **Enable SSL** is selected, then select **Save**. Verify that the status of your new HEC token is **Enabled** in the token list. Refer to the [Splunk HEC documentation](https://docs.splunk.com/Documentation/Splunk/latest/Data/UsetheHTTPEventCollector) for details.
+   After creating the token, go to **Settings** > **Data inputs** > **HTTP Event Collector** > **Global Settings** and confirm that **All Tokens** is turned on and that **Enable SSL** is selected, then select **Save**. Verify that the status of your new HEC token is enabled in the token list. Refer to the [Splunk HEC documentation](https://docs.splunk.com/Documentation/Splunk/latest/Data/UsetheHTTPEventCollector) for details.
    :::
 
 8. Verify whether Splunk is using a self-signed certificate. You'll need this information when creating the Logpush job.
@@ -103,9 +103,9 @@ Create the Logpush job by following [Enable Logpush to Splunk](/logs/logpush/log
   - DNS logs: `cloudflare:dns`
   - Audit logs: `cloudflare:audit`
   - Access requests: `cloudflare:access`
-- Only enable **Use insecure skip verify option** if your Splunk instance uses a self-signed certificate, as noted in [Task 1 - step 8](#task-1---install-and-configure-the-cloudflare-app-for-splunk).
+- Only turn on **Use insecure skip verify option** if your Splunk instance uses a self-signed certificate, as noted in [Task 1 - step 8](#task-1---install-and-configure-the-cloudflare-app-for-splunk).
 
-Under **Send the following fields**, keep the defaults or refer to the [Dashboard section](#task-3---view-the-dashboards) below to select the fields required to fully populate the Cloudflare App for Splunk dashboards.
+Under **Send the following fields**, keep the defaults or refer to the [Dashboard section](#task-3---view-the-dashboards) to select the fields required to fully populate the Cloudflare App for Splunk dashboards.
 
 Once the job is created, enable it to start sending logs. To confirm end-to-end delivery, run the following search in Splunk:
 

--- a/src/content/docs/analytics/analytics-integrations/splunk.mdx
+++ b/src/content/docs/analytics/analytics-integrations/splunk.mdx
@@ -207,7 +207,7 @@ Available Filters:
 
 ## Splunk CIM field mappings
 
-The Cloudflare App for Splunk maps Cloudflare log fields to [Splunk Common Information Model (CIM)](https://docs.splunk.com/Documentation/CIM/latest/User/Overview) field names, so that Cloudflare data can be searched, correlated, and accelerated alongside other CIM-compliant sources in your Splunk deployment. The tables below list the mappings the app applies per Cloudflare Logpush dataset.
+The Cloudflare App for Splunk maps Cloudflare log fields to [Splunk Common Information Model (CIM)](https://docs.splunk.com/Documentation/CIM/latest/User/Overview) field names, so that Cloudflare data can be searched, correlated, and accelerated alongside other CIM-compliant sources in your Splunk deployment. The following tables list the mappings the app applies per Cloudflare Logpush dataset.
 
 ### HTTP requests
 

--- a/src/content/docs/analytics/analytics-integrations/splunk.mdx
+++ b/src/content/docs/analytics/analytics-integrations/splunk.mdx
@@ -107,13 +107,13 @@ Create the Logpush job by following [Enable Logpush to Splunk](/logs/logpush/log
 
 Under **Send the following fields**, keep the defaults or refer to the [Dashboard section](#task-3---view-the-dashboards) to select the fields required to fully populate the Cloudflare App for Splunk dashboards.
 
-Once the job is created, enable it to start sending logs. To confirm end-to-end delivery, run the following search in Splunk:
+After you create the job, enable it to start sending logs. To confirm end-to-end delivery, run the following search in Splunk:
 
 ```txt
 index="cloudflare"
 ```
 
-Cloudflare sends two system confirmation events to verify connectivity and delivery setup as soon as the job is enabled. Regular Cloudflare logs start streaming shortly afterward. Data can take a few minutes to appear.
+Cloudflare sends two system confirmation events to verify connectivity and delivery setup as soon as you enable the job. Regular Cloudflare logs start streaming shortly afterward. Data can take a few minutes to appear.
 
 ## Task 3 - View the Dashboards
 

--- a/src/content/docs/analytics/analytics-integrations/splunk.mdx
+++ b/src/content/docs/analytics/analytics-integrations/splunk.mdx
@@ -218,7 +218,7 @@ The Cloudflare App for Splunk maps Cloudflare log fields to [Splunk Common Infor
 | `ClientRequestHost`        | `dest_host`         |
 | `ClientRequestMethod`      | `http_method`       |
 | `ClientRequestPath`        | `uri_path`          |
-| `ClientRequestReferer`     | `http_referer`      |
+| `ClientRequestReferer`     | `http_referrer`     |
 | `ClientRequestURI`         | `uri`               |
 | `ClientRequestUserAgent`   | `http_user_agent`   |
 | `ClientSrcPort`            | `src_port`          |
@@ -241,7 +241,7 @@ The Cloudflare App for Splunk maps Cloudflare log fields to [Splunk Common Infor
 | `FindingTypeSeverity`    | `severity`       |
 | `InstanceID`             | `signature_id`   |
 
-### DNS logs
+### Zero Trust Gateway DNS
 
 | Cloudflare field | Splunk CIM field |
 | ---------------- | ---------------- |
@@ -249,7 +249,6 @@ The Cloudflare App for Splunk maps Cloudflare log fields to [Splunk Common Infor
 | `DstPort`        | `dest_port`      |
 | `Protocol`       | `transport`      |
 | `QueryName`      | `query`          |
-| `QuerySize`      | `query_count`    |
 | `QueryTypeName`  | `query_type`     |
 | `RCode`          | `reply_code`     |
 | `SrcIP`          | `src`            |


### PR DESCRIPTION
### Summary

**What:** Expand `analytics/analytics-integrations/sentinel` and `analytics/analytics-integrations/splunk` with the setup and operations details customers have been asking for.

Sentinel:
- Detailed prerequisites: ADLS Gen2, RBAC roles, Event Grid resource provider, DCR/DCE, network access rules, and required storage/Sentinel co-location.
- Refreshed Content hub and CCF connector-field walkthrough.
- Log Analytics KQL verification query and expected ingestion window.
- Troubleshooting entry for the `InvalidTemplate: CreateDataFlowResources` ARM error.
- Deprecation notice for the legacy Azure Function-based solution.

Splunk:
- HEC Global Settings guidance (enable All Tokens, Enable SSL).
- Dataset-to-sourcetype mapping (`cloudflare:json`, `cloudflare:dns`, `cloudflare:audit`, `cloudflare:access`).
- Confirmation-events note when validating a new Logpush job.

**Why:** Customers deploying these integrations were missing prerequisites, connector-field detail, and the troubleshooting path for the most common ARM template failure. No screenshots are added; steps link out to the relevant Microsoft and Splunk docs.

DEE-3779

### Documentation checklist

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry — not applicable, this is a docs enhancement to existing pages.
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [x] No file has been renamed or relocated, so no redirects are needed.