### PR TITLE
[Audit Logs] Document CMB support

### DIFF
--- a/src/content/docs/data-localization/metadata-boundary/logpush-datasets.mdx
+++ b/src/content/docs/data-localization/metadata-boundary/logpush-datasets.mdx
@@ -28,7 +28,8 @@ If you enable CMB for a region where a dataset is not available (marked ✘ in t
 | ------------------------------------------- | ------- | ------------ | ---------------------------- | ---------------------------- |
 | Access Requests                             | Account | ✅           | ✅                           | ✅                           |
 | AI Gateway Events                           | Account | ✅           | ✅                           | ✅                           |
-| Audit Logs                                  | Account | ✘            | ✅                           | ✘                            |
+| Audit Logs v1                               | Account | ✘            | ✅                           | ✘                            |
+| Audit Logs v2                               | Account | ✅           | ✅                           | ✅                           |
 | Browser Isolation User Actions              | Account | ✅           | ✅                           | ✅                           |
 | CASB Findings                               | Account | ✘            | ✅                           | ✘                            |
 | Client-side security (formerly Page Shield) | Zone    | ✅           | ✅                           | ✅                           |

--- a/src/content/docs/fundamentals/account/account-security/audit-logs.mdx
+++ b/src/content/docs/fundamentals/account/account-security/audit-logs.mdx
@@ -46,6 +46,12 @@ Audit Logs (version 2) provide a unified and standardized system for tracking an
 Approximately 30 days of logs from the Beta period (back to ~February 8, 2026) are available at GA. These Beta logs will expire on ~April 9, 2026. Logs generated after GA will be retained for the full 18 months. Older logs remain available in Audit Logs v1.
 :::
 
+## Customer Metadata Boundary
+
+Audit Logs v2 supports [Customer Metadata Boundary (CMB)](/data-localization/metadata-boundary/). The account-level CMB preference automatically applies to Audit Logs v2. For example, if you select `eu`, Audit Logs v2 uses the EU metadata boundary. You do not need to configure Audit Logs separately.
+
+To configure CMB in the Cloudflare dashboard or via the `/accounts/{account_id}/logs/control/cmb/config` API, refer to [Get started with Customer Metadata Boundary](/data-localization/metadata-boundary/get-started/). CMB is part of the Data Localization Suite. Contact your account team if CMB is not enabled for your account.
+
 ## Access Audit Logs
 
 You can retrieve audit logs using the Cloudflare dashboard, the API, or Logpush.


### PR DESCRIPTION
## Summary

- document Customer Metadata Boundary support for Audit Logs v2
- clarify that account-level CMB preferences apply automatically
- distinguish Audit Logs v1 and v2 in the CMB Logpush compatibility table

## Tests

- `pnpm exec astro check --minimumFailingSeverity=error`
- verified both updated pages locally