### PR TITLE
[Cloudflare for SaaS] Document RSA 4096 key support

### DIFF
--- a/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/custom-certificates/index.mdx
+++ b/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/custom-certificates/index.mdx
@@ -35,4 +35,6 @@ Cloudflare also only accepts publicly trusted certificates of these types:
 - `SHA1WithRSA`
 - `ECDSAWithSHA256`
 
+For uploaded custom certificates, Cloudflare accepts 2,048-bit and 4,096-bit RSA private keys.
+
 If you attempt to upload another type of certificate or a certificate that has been self-signed, it will be rejected.


### PR DESCRIPTION
### Summary

Clarifies that Cloudflare for SaaS accepts 2,048-bit and 4,096-bit RSA private keys for uploaded custom certificates. This keeps upload requirements distinct from the `rsa2048` option for Cloudflare-generated CSRs.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
