### PR TITLE
[Cache] Document selected header matching

### DIFF
--- a/src/content/docs/cache/how-to/cache-keys.mdx
+++ b/src/content/docs/cache/how-to/cache-keys.mdx
@@ -110,6 +110,10 @@ In the **Include headers and selected values** section, you can add header names
   * `referer`
   * `user-agent`
 
+:::caution
+For custom and restricted headers, selected values use case-sensitive substring matching. For example, `text/plain` matches an `Accept` header value of `text/plain, foo/bar`. It can also match the unintended value `text/plaintext`, but not `Text/Plain`.
+:::
+
 To check for the presence of a header without including its actual value, use the **Check presence of** option.
 
 Currently, you can only exclude the `Origin` header. The `Origin` header is always included unless explicitly excluded. Including the [Origin header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Origin) in the Cache Key is important to enforce [CORS](https://developer.mozilla.org/en-US/docs/Glossary/CORS).


### PR DESCRIPTION
### Summary

Clarifies that selected values for custom and restricted cache-key headers use case-sensitive substring matching. Includes examples of a comma-separated header value, a longer value, and a case difference.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
