### PR TITLE
[LOGPUSH] Update ZeroTrust Network Session SourceInternalIP wording

### DIFF
--- a/src/content/docs/logs/logpush/logpush-job/datasets/account/zero_trust_network_sessions.md
+++ b/src/content/docs/logs/logpush/logpush-job/datasets/account/zero_trust_network_sessions.md
@@ -243,7 +243,7 @@ Source IP of the network session.
 
 Type: `string`
 
-Local LAN IP of the device. Only available when connected via a GRE/IPsec tunnel on-ramp.
+Internal IP of the device. For WARP client traffic, this is the WARP CGNAT address, typically in the `100.96.0.0/12` range. For GRE/IPsec tunnel [on-ramps](/cloudflare-one/networks/connectivity-options/), this may represent the local/private source IP behind the tunnel.
 
 ## SourcePort
 


### PR DESCRIPTION
Updating the SourceInternalIP field description because the current wording says it is only available for GRE/IPsec tunnel on-ramps and represents the local LAN IP. A customer confirmed this is also populated for WARP client (device_client) traffic, where the value represents the WARP CGNAT/internal address rather than the device’s local LAN IP. This change clarifies the field behavior across on-ramp types and avoids customers assuming the field should be empty for WARP traffic.

Fix per merge for Fix Gateway analytics IPv4 byte order