### PR TITLE
Reframe Realtime SFU around application outcomes

### DIFF
--- a/src/content/docs/realtime/index.mdx
+++ b/src/content/docs/realtime/index.mdx
@@ -13,7 +13,6 @@ products:
 
 import {
 	Description,
-	LinkButton,
 	RelatedProduct,
 	CardGrid,
 	LinkTitleCard,
@@ -21,7 +20,7 @@ import {
 
 <Description>
 
-Cloudflare Realtime is a comprehensive suite of products designed to help you build powerful, scalable real-time applications.
+Build live audio, video, and data applications with managed Realtime products.
 
 </Description>
 
@@ -33,9 +32,11 @@ It sits on top of the Realtime SFU, abstracting away the heavy lifting of media 
 
 ### Realtime SFU
 
-The [Realtime SFU (Selective Forwarding Unit)](/realtime/sfu/) is a powerful media server that efficiently routes video and audio. The Realtime SFU runs on [Cloudflare's global cloud network](https://www.cloudflare.com/network/) in hundreds of cities worldwide.
+The [Realtime SFU (Selective Forwarding Unit)](/realtime/sfu/) routes WebRTC audio, video, and DataChannels between application endpoints.
 
-For developers with WebRTC expertise, the SFU can be used independently to build highly custom applications that require full control over media streams. This is recommended only for those who want to leverage Cloudflare's network with their own WebRTC logic.
+Use Realtime SFU when your application needs custom media routing, signaling, state, permissions, or user interfaces. Common topologies include custom calls, interactive broadcasts, AI media pipelines, cloud gaming, device control, and media processing.
+
+Your application backend keeps the Realtime SFU credentials and decides which sessions can publish, subscribe, or control resources.
 
 ### TURN Service
 
@@ -45,17 +46,14 @@ The [TURN service](/realtime/turn/) is a managed service that acts as a relay fo
 
 Use this comparison table to quickly find the right Realtime product for your needs:
 
-|                               | **RealtimeKit**                                                                                                                 | **Realtime SFU**                                                                                                                                             | **TURN Service**                                                                                                        |
-| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------- |
-| **What is it**                | High-level SDKs and APIs with pre-built UI components for video/voice integration. Built on top of Realtime SFU.                | Low-level WebRTC media server (Selective Forwarding Unit) that routes audio/video/data streams between participants.                                         | Managed relay service for WebRTC traffic that ensures connectivity through restrictive firewalls and NATs.              |
-| **Who is it for**             | Developers who want to quickly add video/voice features without handling WebRTC complexities.                                   | Developers with WebRTC expertise who need full control over media streams and want to build highly custom applications.                                      | Any WebRTC application needing reliable connectivity in restrictive network environments.                               |
-| **Effort to get started**     | Low - Just a few lines of code with UI Kit and Core SDK.                                                                        | High - Requires deep WebRTC knowledge. No SDK provided (unopinionated). You manage sessions, tracks, and presence protocol. Works with every WebRTC library. | Low - Automatically used by WebRTC libraries (browser WebRTC, Pion, libwebrtc). No additional code needed.              |
-| **WebRTC expertise required** | None - Abstracts away WebRTC complexities.                                                                                      | Expert - You handle all WebRTC logic yourself.                                                                                                               | None - Used transparently by WebRTC libraries.                                                                          |
-| **Primitives**                | Meetings, Sessions, Participants, Presets (roles), Stage, Waiting Room                                                          | Sessions (PeerConnections), Tracks (MediaStreamTracks), pub/sub model - no rooms concept                                                                     | TURN allocations, relayed transport addresses, protocols (UDP/TCP/TLS)                                                  |
-| **Key use cases**             | Team meetings, virtual classrooms, webinars, live streaming with interactive features, social video chat                        | Highly custom real-time apps, unique WebRTC architectures that don't fit standard patterns, leveraging Cloudflare's network with custom logic                | Ensuring connectivity for all users regardless of firewall/NAT configuration, used alongside SFU or peer-to-peer WebRTC |
-| **Key features**              | Pre-built UI components, automatic track management, recording, chat, polls, breakout rooms, virtual backgrounds, transcription | Unopinionated architecture, no lock-in, globally scalable, full control over media routing, programmable "switchboard"                                       | Anycast routing to nearest location, multiple protocol options                                                          |
-| **Pricing**                   | Pricing by minute [view details](https://workers.cloudflare.com/pricing#media)                                                  | $0.05/GB egress                                                                                                                                              | Free when used with Realtime SFU, otherwise $0.05/GB egress                                                             |
-| **Free tier**                 | None                                                                                                                            | First 1,000 GB free each month                                                                                                                               | First 1,000 GB free each month                                                                                          |
+|                              | **RealtimeKit**                                                                | **Realtime SFU**                                                                                        | **TURN Service**                                                            |
+| ---------------------------- | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| **Choose it when**           | You want meeting SDKs, participant management, and pre-built UI components.    | You want to compose WebRTC media and data into a custom application topology.                           | You need a relay for peer-to-peer or self-hosted WebRTC connections.        |
+| **Provides**                 | Meetings, participants, presets, stage management, and UI components.          | Sessions, media tracks, DataChannels, and programmable publish and subscribe operations.                | TURN allocations and relayed UDP, TCP, or TLS transport.                    |
+| **Your application manages** | Product integration, branding, and application-specific behavior.              | Authentication, authorization, signaling, presence, state, and track discovery.                         | Peer connections, signaling, media routing, and application state.          |
+| **Example outcomes**         | Meetings, classrooms, webinars, and social video.                              | Custom calls, interactive broadcasts, AI pipelines, cloud gaming, device control, and media processing. | Connectivity through restrictive firewalls and network address translation. |
+| **Pricing**                  | Pricing by minute [view details](https://workers.cloudflare.com/pricing#media) | $0.05/GB egress                                                                                         | Free when used with Realtime SFU, otherwise $0.05/GB egress                 |
+| **Free tier**                | None                                                                           | First 1,000 GB free each month                                                                          | First 1,000 GB free each month                                              |
 
 ## Related products
 
@@ -85,12 +83,11 @@ Cloudflare Stream lets you or your end users upload, store, encode, and deliver 
 </LinkTitleCard>
 
 <LinkTitleCard
-	title="Use cases"
-	href="/realtime/realtimekit/#build-with-realtimekit"
+	title="Build with Realtime SFU"
+	href="/realtime/sfu/#what-you-can-build"
 	icon="document"
 >
-	Learn how you can build and deploy ambitious Realtime applications to
-	Cloudflare's global network.
+	Explore custom media and data application topologies.
 </LinkTitleCard>
 
 <LinkTitleCard

--- a/src/content/docs/realtime/sfu/index.mdx
+++ b/src/content/docs/realtime/sfu/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Realtime SFU
-description: Build real-time serverless video, audio, and data applications with Cloudflare Realtime SFU.
+description: Build custom audio, video, and data applications from WebRTC primitives with Cloudflare Realtime SFU.
 pcx_content_type: overview
 sidebar:
   order: 2
@@ -11,27 +11,79 @@ products:
   - realtime
 ---
 
-import { Description, LinkButton } from "~/components";
+import { CardGrid, Description, LinkButton, LinkTitleCard } from "~/components";
 
 <Description>
 
-Build real-time serverless video, audio and data applications.
+Compose real-time audio, video, and data applications from WebRTC primitives.
 
 </Description>
 
-Cloudflare Realtime SFU is infrastructure for real-time audio/video/data applications. It allows you to build real-time apps without worrying about scaling or regions. It can act as a selective forwarding unit (WebRTC SFU), as a fanout delivery system for broadcasting (WebRTC CDN) or anything in between.
+Cloudflare Realtime SFU routes WebRTC media tracks and DataChannels between browser, native, server, and external media endpoints. Your application controls who publishes, who subscribes, and how participants discover each other.
 
 Cloudflare Realtime SFU runs on [Cloudflare's global cloud network](https://www.cloudflare.com/network/) in hundreds of cities worldwide.
 
-<LinkButton variant="primary" href="/realtime/sfu/get-started/">
-	Get started
+## What you can build
+
+<CardGrid>
+	<LinkTitleCard
+		title="Custom calls and rooms"
+		href="/realtime/sfu/example-architecture/"
+		icon="ph:video-camera"
+	>
+		Build your own signaling, presence, permissions, and user interface.
+	</LinkTitleCard>
+	<LinkTitleCard
+		title="Interactive broadcasts"
+		href="/realtime/sfu/sessions-tracks/"
+		icon="ph:broadcast"
+	>
+		Publish media once and choose which sessions receive each track.
+	</LinkTitleCard>
+	<LinkTitleCard
+		title="Cloud gaming and device control"
+		href="/realtime/sfu/datachannels/"
+		icon="ph:game-controller"
+	>
+		Send media downstream and low-latency control data upstream.
+	</LinkTitleCard>
+	<LinkTitleCard
+		title="AI and media processing"
+		href="/realtime/sfu/media-transport-adapters/"
+		icon="ph:waveform"
+	>
+		Connect WebRTC tracks to AI services and external media systems.
+	</LinkTitleCard>
+</CardGrid>
+
+## Application architecture
+
+Each client creates a WebRTC PeerConnection. Your backend stores the application
+secret and uses the Realtime SFU API to create the corresponding session. It
+also authenticates users, authorizes publish and subscribe operations, and
+shares session or track identifiers through your application state.
+
+Realtime SFU forwards the selected media or data. It does not define rooms,
+participants, roles, or presence for your application.
+
+## Explore examples
+
+Use the [Realtime Examples repository](https://github.com/cloudflare/realtime-examples)
+to choose a starting point for what you want to build. Each example identifies
+its status, credential boundary, and known limitations.
+
+<LinkButton
+	variant="primary"
+	href="https://github.com/cloudflare/realtime-examples"
+>
+	Browse Realtime examples
+</LinkButton>
+<LinkButton variant="secondary" href="/realtime/sfu/get-started/">
+	Create an SFU application
 </LinkButton>
 <LinkButton
 	variant="secondary"
 	href="https://dash.cloudflare.com/?to=/:account/calls"
 >
 	Realtime dashboard
-</LinkButton>
-<LinkButton variant="secondary" href="https://github.com/cloudflare/orange">
-	Orange Meets demo app
 </LinkButton>


### PR DESCRIPTION
### Summary

This updates the Realtime overview and SFU landing page so developers can see what they can build before diving into the API primitives.

- Presents Realtime SFU as programmable WebRTC media and data infrastructure.
- Adds custom calls, interactive broadcasts, AI pipelines, cloud gaming, device control, and media processing as example outcomes.
- Clarifies that the backend creates SFU sessions, keeps credentials, and owns authentication, authorization, signaling, and application state.
- Links directly to the Realtime Examples repository.
- Does not claim that the in-progress blueprints are available or change the existing quickstart.

This should merge after the Realtime Examples foundation PR (https://github.com/cloudflare/realtime-examples/pull/30) so the repository link opens the new catalog and safety guidance.

### Screenshots

Changes to the SFU overview page should greatly improved clarify for developers:

<img width="1898" height="1219" alt="Screenshot 2026-08-27 at 12 34 11 PM" src="https://github.com/user-attachments/assets/a2fcabec-e1ee-4245-8d9d-23adc9dd3961" />

### Documentation checklist

<!-- Remove items that do not apply -->

- [X] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).

No changelog is needed because this documents existing capabilities and does not announce new product behavior.
