### PR TITLE
AI Search: add GLM-5.3 Flash support

### DIFF
--- a/src/content/changelog/ai-search/2026-08-30-glm-5.3-flash.mdx
+++ b/src/content/changelog/ai-search/2026-08-30-glm-5.3-flash.mdx
@@ -1,0 +1,12 @@
+---
+title: AI Search now supports GLM-5.3 Flash
+description: AI Search now supports the Workers AI GLM-5.3 Flash model for text generation.
+products:
+  - ai-search
+date: 2026-08-30
+publish_future_dated_entry: true
+---
+
+[AI Search](/ai-search/) now supports [`@cf/zai-org/glm-5.3-flash`](/workers-ai/models/glm-5.3-flash/) for text generation. The model has a 1,048,576-token context window and runs on Workers AI.
+
+To configure the model for an AI Search instance, refer to [Supported models](/ai-search/configuration/models/supported-models/).

--- a/src/content/docs/ai-search/configuration/models/supported-models.mdx
+++ b/src/content/docs/ai-search/configuration/models/supported-models.mdx
@@ -20,34 +20,35 @@ Production models are the actively supported and recommended models that are sta
 
 ### Text generation
 
-| Provider             | Alias                                         | Context window (tokens) |
-| -------------------- | --------------------------------------------- | ----------------------- |
-| **Anthropic**        | `anthropic/claude-3-7-sonnet`                 | 200,000                 |
-|                      | `anthropic/claude-sonnet-4`                   | 200,000                 |
-|                      | `anthropic/claude-opus-4`                     | 200,000                 |
-|                      | `anthropic/claude-3-5-haiku`                  | 200,000                 |
-| **Cerebras**         | `cerebras/gpt-oss-120b`                       | 131,072                 |
-|                      | `cerebras/gemma-4-31b`                        | 131,072                 |
-| **Google AI Studio** | `google-ai-studio/gemini-2.5-flash`           | 1,048,576               |
-|                      | `google-ai-studio/gemini-2.5-pro`             | 1,048,576               |
-| **Grok (x.ai)**      | `grok/grok-4`                                 | 256,000                 |
-| **Groq**             | `groq/llama-3.3-70b-versatile`                | 131,072                 |
-|                      | `groq/llama-3.1-8b-instant`                   | 131,072                 |
-| **OpenAI**           | `openai/gpt-5`                                | 400,000                 |
-|                      | `openai/gpt-5-mini`                           | 400,000                 |
-|                      | `openai/gpt-5-nano`                           | 400,000                 |
-| **Workers AI**       | `@cf/meta/llama-3.3-70b-instruct-fp8-fast`    | 24,000                  |
-|                      | `@cf/meta/llama-3.1-8b-instruct-fast`         | 60,000                  |
-|                      | `@cf/meta/llama-3.1-8b-instruct-fp8`          | 32,000                  |
-|                      | `@cf/meta/llama-4-scout-17b-16e-instruct`     | 131,000                 |
-|                      | `@cf/deepseek-ai/deepseek-v4-flash-0731`      | 1,048,576               |
-|                      | `@cf/deepseek-ai/deepseek-v4-pro-0813`        | 1,048,576               |
-|                      | `@cf/openai/gpt-oss-120b`                     | 128,000                 |
-|                      | `@cf/openai/gpt-oss-20b`                      | 128,000                 |
-|                      | `@cf/qwen/qwen3.8-27b`                        | 262,144                 |
-|                      | `@cf/moonshotai/kimi-k2.7-code`               | 262,144                 |
-|                      | `@cf/zai-org/glm-4.7-flash`                   | 131,072                 |
-|                      | `@cf/qwen/qwen3-30b-a3b-fp8`                  | 32,000                  |
+| Provider             | Alias                                      | Context window (tokens) |
+| -------------------- | ------------------------------------------ | ----------------------- |
+| **Anthropic**        | `anthropic/claude-3-7-sonnet`              | 200,000                 |
+|                      | `anthropic/claude-sonnet-4`                | 200,000                 |
+|                      | `anthropic/claude-opus-4`                  | 200,000                 |
+|                      | `anthropic/claude-3-5-haiku`               | 200,000                 |
+| **Cerebras**         | `cerebras/gpt-oss-120b`                    | 131,072                 |
+|                      | `cerebras/gemma-4-31b`                     | 131,072                 |
+| **Google AI Studio** | `google-ai-studio/gemini-2.5-flash`        | 1,048,576               |
+|                      | `google-ai-studio/gemini-2.5-pro`          | 1,048,576               |
+| **Grok (x.ai)**      | `grok/grok-4`                              | 256,000                 |
+| **Groq**             | `groq/llama-3.3-70b-versatile`             | 131,072                 |
+|                      | `groq/llama-3.1-8b-instant`                | 131,072                 |
+| **OpenAI**           | `openai/gpt-5`                             | 400,000                 |
+|                      | `openai/gpt-5-mini`                        | 400,000                 |
+|                      | `openai/gpt-5-nano`                        | 400,000                 |
+| **Workers AI**       | `@cf/meta/llama-3.3-70b-instruct-fp8-fast` | 24,000                  |
+|                      | `@cf/meta/llama-3.1-8b-instruct-fast`      | 60,000                  |
+|                      | `@cf/meta/llama-3.1-8b-instruct-fp8`       | 32,000                  |
+|                      | `@cf/meta/llama-4-scout-17b-16e-instruct`  | 131,000                 |
+|                      | `@cf/deepseek-ai/deepseek-v4-flash-0731`   | 1,048,576               |
+|                      | `@cf/deepseek-ai/deepseek-v4-pro-0813`     | 1,048,576               |
+|                      | `@cf/openai/gpt-oss-120b`                  | 128,000                 |
+|                      | `@cf/openai/gpt-oss-20b`                   | 128,000                 |
+|                      | `@cf/qwen/qwen3.8-27b`                     | 262,144                 |
+|                      | `@cf/moonshotai/kimi-k2.7-code`            | 262,144                 |
+|                      | `@cf/zai-org/glm-4.7-flash`                | 131,072                 |
+|                      | `@cf/zai-org/glm-5.3-flash`                | 1,048,576               |
+|                      | `@cf/qwen/qwen3-30b-a3b-fp8`               | 32,000                  |
 
 ### Embedding
 


### PR DESCRIPTION
## Changes
- Add GLM-5.3 Flash to AI Search supported text-generation models.
- Add the AI Search changelog entry.