### PR TITLE
fix: serve original images in local dev

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -281,11 +281,8 @@ export default defineConfig({
 	},
 	markdown,
 	image: {
-		// Cloudflare Image Resizing (/cdn-cgi/image/) is only available on the
-		// edge, so in dev serve the original images directly (no resizing — the
-		// full files are already local). The production build still uses the
-		// Cloudflare service to keep image processing off the build (fixes
-		// rolldown OOM) and mirror what's served in production.
+		// /cdn-cgi/image/ only exists on Cloudflare's edge, so dev serves
+		// originals directly; production keeps edge resizing.
 		service:
 			process.env.NODE_ENV === "production"
 				? { entrypoint: "@astrojs/cloudflare/image-service" }

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -1,7 +1,7 @@
 import { readdir, readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { defineConfig } from "astro/config";
+import { defineConfig, passthroughImageService } from "astro/config";
 import react from "@astrojs/react";
 import tailwindcss from "@tailwindcss/vite";
 import skills from "astro-skills";
@@ -281,9 +281,15 @@ export default defineConfig({
 	},
 	markdown,
 	image: {
-		service: {
-			entrypoint: "@astrojs/cloudflare/image-service",
-		},
+		// Cloudflare Image Resizing (/cdn-cgi/image/) is only available on the
+		// edge, so in dev serve the original images directly (no resizing — the
+		// full files are already local). The production build still uses the
+		// Cloudflare service to keep image processing off the build (fixes
+		// rolldown OOM) and mirror what's served in production.
+		service:
+			process.env.NODE_ENV === "production"
+				? { entrypoint: "@astrojs/cloudflare/image-service" }
+				: passthroughImageService(),
 	},
 	server: {
 		port: 1111,


### PR DESCRIPTION
### Summary

Fixes images 404ing under `astro dev`. The `@astrojs/cloudflare/image-service` emits `/cdn-cgi/image/...` URLs, which only exist on Cloudflare's edge — locally the request falls through to the `[...slug]` catch-all and returns 404.

Switches the dev image service to `passthroughImageService()` (original images are already local, no resizing needed), keeping `@astrojs/cloudflare/image-service` for production builds so image processing stays off the build. This mirrors the documented local-dev pattern in the Cloudflare Images framework loader docs.

Closes https://github.com/cloudflare/cloudflare-docs/issues/33003

### Images
<img width="1728" height="1031" alt="Screenshot 2026-08-28 at 8 49 57 AM" src="https://github.com/user-attachments/assets/bc7adc3e-50dc-4656-bb64-e109c2f648f8" />

