### PR TITLE
[Audit Logs] Document account analytics

### DIFF
--- a/src/content/docs/fundamentals/account/account-security/audit-logs.mdx
+++ b/src/content/docs/fundamentals/account/account-security/audit-logs.mdx
@@ -108,6 +108,23 @@ To access audit logs in the Cloudflare dashboard, go to **Manage Account** > **A
 The Audit Logs v2 is shown by default. You can switch between Audit Logs v2 and v1 as needed.
 :::
 
+#### Account analytics
+
+The account-level Audit Logs v2 dashboard includes analytics for the selected time range. The **Actions over time** chart separates successful and failed actions. The summary cards show **Total actions**, **Unique actors**, **Products impacted**, and **Failure rate**.
+
+Select a summary card to view more details:
+
+- **Total actions**: Action types and authentication methods
+- **Unique actors**: Actors with the most actions
+- **Products impacted**: Products with the most actions
+- **Failure rate**: Failed actions and their HTTP status codes
+
+To focus the analytics and audit log table on a value, select **Filter** or **Exclude** from a detail panel. The analytics, table, filters, and time range remain synchronized.
+
+:::note
+Account analytics are available for account-level audit logs. They are not available for organization-level audit logs.
+:::
+
 ### Logpush
 
 :::note


### PR DESCRIPTION
## Summary

- Document account-level analytics in the Audit Logs v2 dashboard.
- Describe the activity chart, summary cards, detail panels, and filtering behavior.
- Clarify that analytics are not available for organization-level audit logs.

## Tests

- `pnpm run check:astro`

## Related

- Changelog: #33081