### PR TITLE
Tunnel: Clarify path forwarding and reverse proxy boundary

### DIFF
--- a/src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/do-more-with-tunnels/local-management/configuration-file.mdx
+++ b/src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/do-more-with-tunnels/local-management/configuration-file.mdx
@@ -86,6 +86,14 @@ You can use wildcards to match traffic to multiple subdomains. For example, if y
 
 You can also enter regular expressions for the `path` key. For example, if `hostname` is `static.example.com` and `path` is `\.(jpg|png|css|js)$`, matching URLs could include `https://static.example.com/data.js`, `http://static.example.com/images/photo.jpg`, and so on. Cloudflare parses the path regex using the [Go `syntax` package](https://pkg.go.dev/regexp/syntax).
 
+:::note[Path forwarding]
+`cloudflared` matches request paths to evaluate rules, but it forwards the full request path to your service without modifying or stripping it.
+
+For example, if an ingress rule matches `path: /api`, a request to `https://example.com/api/users` is sent to your service as `http://localhost:8000/api/users`.
+
+If your application requires path stripping or URL rewriting, you can rewrite the URL at the Cloudflare edge using [URL Rewrite Rules](/rules/transform/url-rewrite/), or forward traffic from `cloudflared` to a local reverse proxy (such as Nginx or Traefik) configured to strip path prefixes before reaching your application.
+:::
+
 ### Services
 
 In addition to HTTP, `cloudflared` supports protocols like SSH, RDP, arbitrary TCP services, and Unix sockets. You can also route traffic to the built-in `hello_world` test server or respond to traffic with an HTTP status. For a full list of supported service types, refer to <a href="/cloudflare-one/networks/connectors/cloudflare-tunnel/routing-to-tunnel/protocols/">Protocols for published applications</a>.

--- a/src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/get-started/tunnel-useful-terms.mdx
+++ b/src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/get-started/tunnel-useful-terms.mdx
@@ -28,6 +28,8 @@ A tunnel name is a unique, user-friendly identifier that you choose for a tunnel
 
 The connector, referred to as `cloudflared`, establishes connectivity from your origin server to the Cloudflare global network. Each `cloudflared` instance creates four long-lived connections to at least two distinct data centers within Cloudflare's global network. This built-in redundancy means that if an individual connection, server, or data center goes down, your origin remains available.
 
+`cloudflared` operates as a secure connector daemon rather than a local reverse proxy. It forwards requests directly to the configured local service without altering request URI paths or performing local load balancing.
+
 ## Replica
 
 A replica is an additional instance of `cloudflared` running the same tunnel on a different host. You can create and configure a tunnel once, then run it through multiple replicas for redundancy. DNS records and Cloudflare Load Balancers continue to point to the tunnel (`UUID.cfargotunnel.com`), while Cloudflare distributes traffic across the available replicas. There is no guarantee about which replica will be chosen — Cloudflare routes to the geographically closest one. Replicas are typically deployed to keep a tunnel available if a host running `cloudflared` goes offline.

--- a/src/content/docs/tunnel/advanced/local-management/configuration-file.mdx
+++ b/src/content/docs/tunnel/advanced/local-management/configuration-file.mdx
@@ -74,6 +74,14 @@ You can use wildcards to match traffic to multiple subdomains. For example, if y
 
 You can also enter regular expressions for the `path` key. For example, if `hostname` is `static.example.com` and `path` is `\.(jpg|png|css|js)$`, matching URLs could include `https://static.example.com/data.js`, `http://static.example.com/images/photo.jpg`, and so on. Cloudflare parses the path regex using the [Go `syntax` package](https://pkg.go.dev/regexp/syntax).
 
+:::note[Path forwarding]
+`cloudflared` matches request paths to evaluate rules, but it forwards the full request path to your service without modifying or stripping it.
+
+For example, if an ingress rule matches `path: /api`, a request to `https://example.com/api/users` is sent to your service as `http://localhost:8000/api/users`.
+
+If your application requires path stripping or URL rewriting, you can rewrite the URL at the Cloudflare edge using [URL Rewrite Rules](/rules/transform/url-rewrite/), or forward traffic from `cloudflared` to a local reverse proxy (such as Nginx or Traefik) configured to strip path prefixes before reaching your application.
+:::
+
 ### Services
 
 In addition to HTTP, `cloudflared` supports protocols like SSH, RDP, arbitrary TCP services, and Unix sockets. You can also route traffic to the built-in `hello_world` test server or respond to traffic with an HTTP status. For a full list of supported service types, refer to <a href="/tunnel/routing/#supported-protocols">Protocols for published applications</a>.

--- a/src/content/partials/cloudflare-one/tunnel/add-published-application.mdx
+++ b/src/content/partials/cloudflare-one/tunnel/add-published-application.mdx
@@ -18,6 +18,10 @@ After creating your tunnel, add a published application route:
 	If you add a multi-level subdomain (more than one level of subdomain), you must [order an Advanced Certificate for the hostname](/cloudflare-one/networks/connectors/cloudflare-tunnel/troubleshoot-tunnels/common-errors/#i-see-this-site-cant-provide-a-secure-connection).
 	:::
 
+	:::note[Path routing]
+	Specifying a path routes matching requests to the service URL, but does not strip or rewrite the path. The service receives the complete request path. To strip or rewrite paths, configure [URL Rewrite Rules](/rules/transform/url-rewrite/) at the Cloudflare edge or use a local reverse proxy.
+	:::
+
 4. In **Service URL**, enter the protocol and address of your application (for example, `http://localhost:8000`). Refer to [supported protocols](/cloudflare-one/networks/connectors/cloudflare-tunnel/routing-to-tunnel/protocols/) for available options.
 
 5. Select **Save**.

--- a/src/content/partials/cloudflare-one/tunnel/locally-managed/local-tunnel-terms.mdx
+++ b/src/content/partials/cloudflare-one/tunnel/locally-managed/local-tunnel-terms.mdx
@@ -32,4 +32,4 @@ This file is created when you run `cloudflared tunnel create <NAME>`. It stores 
 
 ## Ingress rule
 
-Ingress rules let you specify which local services traffic should be proxied to. If a rule does not specify a path, all paths will be matched. Ingress rules can be listed in your <a href={props.configFileURL}>configuration file</a> or when running `cloudflared tunnel ingress`.
+Ingress rules let you specify which local services traffic should be proxied to. If a rule does not specify a path, all paths will be matched. `cloudflared` forwards the full request path to the service without stripping or rewriting it. Ingress rules can be listed in your <a href={props.configFileURL}>configuration file</a> or when running `cloudflared tunnel ingress`.


### PR DESCRIPTION
### Summary

Clarifies the architectural boundary between `cloudflared` (as a secure connector daemon) and local reverse proxies across Cloudflare Tunnel documentation.

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
