### PR TITLE
[Gateway] Document dedicated egress IPs for resolver policies

### DIFF
--- a/src/content/docs/cloudflare-one/traffic-policies/egress-policies/dedicated-egress-ips.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/egress-policies/dedicated-egress-ips.mdx
@@ -78,7 +78,7 @@ Each dedicated egress IP supports up to 40,000 concurrent connections per unique
 
 Dedicated egress IPs do not apply to the following traffic types. These connections use the default shared IPs because Cloudflare identifies them by other means (for example, tunnel ID or account context) rather than source IP.
 
-- DNS queries resolved through Gateway (unless you enable [dedicated egress on a resolver policy](/cloudflare-one/traffic-policies/resolver-policies/#dedicated-egress-ips-for-resolver-policies))
+- DNS queries resolved through Gateway. DNS queries are only forwarded through dedicated egress IPs when [dedicated egress is enabled in a resolver policy](/cloudflare-one/traffic-policies/resolver-policies/#dedicated-egress-ips-for-resolver-policies).
 - Private networks connected to Zero Trust via Cloudflare Tunnel
 - Traffic destined for private networks connected to Zero Trust via [Cloudflare WAN](/cloudflare-wan/)
 - ICMP traffic (for example, `ping`)

--- a/src/content/docs/cloudflare-one/traffic-policies/egress-policies/dedicated-egress-ips.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/egress-policies/dedicated-egress-ips.mdx
@@ -78,10 +78,11 @@ Each dedicated egress IP supports up to 40,000 concurrent connections per unique
 
 Dedicated egress IPs do not apply to the following traffic types. These connections use the default shared IPs because Cloudflare identifies them by other means (for example, tunnel ID or account context) rather than source IP.
 
-- DNS queries resolved through Gateway. DNS queries are only forwarded through dedicated egress IPs when [dedicated egress is enabled in a resolver policy](/cloudflare-one/traffic-policies/resolver-policies/#send-dns-queries-sourced-from-dedicated-egress-ips).
 - Private networks connected to Zero Trust via Cloudflare Tunnel
 - Traffic destined for private networks connected to Zero Trust via [Cloudflare WAN](/cloudflare-wan/)
 - ICMP traffic (for example, `ping`)
+
+By default, DNS queries that Gateway sends to custom resolvers use shared Cloudflare source IP addresses. You can [configure a resolver policy to send these queries from dedicated egress IPs](/cloudflare-one/traffic-policies/resolver-policies/#send-dns-queries-sourced-from-dedicated-egress-ips).
 
 ### Traffic resilience
 

--- a/src/content/docs/cloudflare-one/traffic-policies/egress-policies/dedicated-egress-ips.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/egress-policies/dedicated-egress-ips.mdx
@@ -78,7 +78,7 @@ Each dedicated egress IP supports up to 40,000 concurrent connections per unique
 
 Dedicated egress IPs do not apply to the following traffic types. These connections use the default shared IPs because Cloudflare identifies them by other means (for example, tunnel ID or account context) rather than source IP.
 
-- DNS queries resolved through Gateway. DNS queries are only forwarded through dedicated egress IPs when [dedicated egress is enabled in a resolver policy](/cloudflare-one/traffic-policies/resolver-policies/#dedicated-egress-ips-for-resolver-policies).
+- DNS queries resolved through Gateway. DNS queries are only forwarded through dedicated egress IPs when [dedicated egress is enabled in a resolver policy](/cloudflare-one/traffic-policies/resolver-policies/#send-dns-queries-sourced-from-dedicated-egress-ips).
 - Private networks connected to Zero Trust via Cloudflare Tunnel
 - Traffic destined for private networks connected to Zero Trust via [Cloudflare WAN](/cloudflare-wan/)
 - ICMP traffic (for example, `ping`)

--- a/src/content/docs/cloudflare-one/traffic-policies/egress-policies/dedicated-egress-ips.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/egress-policies/dedicated-egress-ips.mdx
@@ -78,7 +78,7 @@ Each dedicated egress IP supports up to 40,000 concurrent connections per unique
 
 Dedicated egress IPs do not apply to the following traffic types. These connections use the default shared IPs because Cloudflare identifies them by other means (for example, tunnel ID or account context) rather than source IP.
 
-- DNS queries resolved through Gateway
+- DNS queries resolved through Gateway (unless you enable [dedicated egress on a resolver policy](/cloudflare-one/traffic-policies/resolver-policies/#dedicated-egress-ips-for-resolver-policies))
 - Private networks connected to Zero Trust via Cloudflare Tunnel
 - Traffic destined for private networks connected to Zero Trust via [Cloudflare WAN](/cloudflare-wan/)
 - ICMP traffic (for example, `ping`)

--- a/src/content/docs/cloudflare-one/traffic-policies/resolver-policies.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/resolver-policies.mdx
@@ -107,12 +107,12 @@ For more information on creating a DNS policy, refer to [DNS policies](/cloudfla
 Available in closed beta for Enterprise accounts with [dedicated egress IPs](/cloudflare-one/traffic-policies/egress-policies/dedicated-egress-ips/). Contact your account team to request access.
 :::
 
-By default, DNS requests that Gateway sends to your custom resolvers use shared Cloudflare IP addresses. If your upstream resolver restricts access by source IP, you can configure a resolver policy to send those requests from your [dedicated egress IPs](/cloudflare-one/traffic-policies/egress-policies/dedicated-egress-ips/) instead.
+By default, DNS requests that Gateway sends to your custom resolvers use shared Cloudflare source IP addresses. If your upstream resolver restricts access by source IP, you can configure a resolver policy to send those requests from your [dedicated egress IPs](/cloudflare-one/traffic-policies/egress-policies/dedicated-egress-ips/) instead.
 
 ### Prerequisites
 
 - Your account must have dedicated egress IPs provisioned.
-- The resolver policy must include at least one public resolver. Dedicated egress cannot be used when all resolvers route through private networks.
+- The resolver policy must include at least one public resolver. Dedicated egress IPs cannot be used when all resolvers route through private networks.
 
 ### Enable dedicated egress on a resolver policy
 

--- a/src/content/docs/cloudflare-one/traffic-policies/resolver-policies.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/resolver-policies.mdx
@@ -116,7 +116,7 @@ By default, DNS requests that Gateway sends to your custom resolvers use shared 
 
 ### Enable dedicated egress on a resolver policy
 
-1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Traffic policies** > **Resolver policies**.
+1. In the [Cloudflare One dashboard](https://dash.cloudflare.com/one), go to **Traffic policies** > **Resolver policies**.
 2. Create or edit a resolver policy that uses custom DNS resolvers.
 3. Under the custom resolver configuration, turn on **Use dedicated egress IPs for DNS requests to custom resolvers**.
 4. Select a **Primary IPv4**, **IPv6**, and optionally a **Secondary IPv4** address from the available dedicated egress IPs.

--- a/src/content/docs/cloudflare-one/traffic-policies/resolver-policies.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/resolver-policies.mdx
@@ -101,6 +101,48 @@ For more information on creating a DNS policy, refer to [DNS policies](/cloudfla
 
 <Render file="gateway/terraform-precedence-warning" product="cloudflare-one" />
 
+## Dedicated egress IPs for resolver policies <Badge text="Closed beta" variant="caution"/>
+
+:::note
+Available in closed beta for Enterprise accounts with [dedicated egress IPs](/cloudflare-one/traffic-policies/egress-policies/dedicated-egress-ips/). Contact your account team to request access.
+:::
+
+By default, DNS requests that Gateway sends to your custom resolvers use shared Cloudflare IP addresses. If your upstream resolver restricts access by source IP, you can configure a resolver policy to send those requests from your [dedicated egress IPs](/cloudflare-one/traffic-policies/egress-policies/dedicated-egress-ips/) instead.
+
+### Prerequisites
+
+- Your account must have dedicated egress IPs provisioned.
+- The resolver policy must include at least one public resolver. Dedicated egress cannot be used when all resolvers route through private networks.
+
+### Enable dedicated egress on a resolver policy
+
+1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Traffic policies** > **Resolver policies**.
+2. Create or edit a resolver policy that uses custom DNS resolvers.
+3. Under the custom resolver configuration, turn on **Use dedicated egress IPs for DNS requests to custom resolvers**.
+4. Select a **Primary IPv4**, **IPv6**, and optionally a **Secondary IPv4** address from the available dedicated egress IPs.
+5. Save the policy.
+
+### API configuration
+
+To configure dedicated egress on a resolver policy via the API, add an `egress` object to `rule_settings`:
+
+```json
+{
+	"rule_settings": {
+		"dns_resolvers": {
+			"ipv4": [{ "ip": "198.51.100.1" }]
+		},
+		"egress": {
+			"ipv4": "104.30.133.232",
+			"ipv6": "2a09:bac0:1000:3ec::/64",
+			"ipv4_fallback": "104.30.134.156"
+		}
+	}
+}
+```
+
+The `egress` object uses the same schema as [egress policies](/cloudflare-one/traffic-policies/egress-policies/).
+
 ## Selectors
 
 ### Content Categories

--- a/src/content/docs/cloudflare-one/traffic-policies/resolver-policies.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/resolver-policies.mdx
@@ -101,7 +101,7 @@ For more information on creating a DNS policy, refer to [DNS policies](/cloudfla
 
 <Render file="gateway/terraform-precedence-warning" product="cloudflare-one" />
 
-## Dedicated egress IPs for resolver policies <Badge text="Closed beta" variant="caution"/>
+## Send DNS queries sourced from dedicated egress IPs <Badge text="Closed beta" variant="caution"/>
 
 :::note
 Available in closed beta for Enterprise accounts with [dedicated egress IPs](/cloudflare-one/traffic-policies/egress-policies/dedicated-egress-ips/). Contact your account team to request access.


### PR DESCRIPTION
Adds documentation for configuring dedicated egress IPs on resolver policies (SHIP-12697 / ONEUX-1106).

## Changes

- **resolver-policies.mdx**: New "Dedicated egress IPs for resolver policies" section with Closed beta badge, prerequisites, dashboard steps, and API configuration example.
- **dedicated-egress-ips.mdx**: Updated the "Unsupported traffic" list to note that DNS queries can now use dedicated egress when configured on a resolver policy.

The feature is gated behind a feature flag (`dns_forward_dedicated_egress`), so it is marked as Closed beta with a note to contact the account team for access.