### PR TITLE
docs(d1): add D1 Migration Guard to community projects

### DIFF
--- a/src/content/docs/d1/reference/community-projects.mdx
+++ b/src/content/docs/d1/reference/community-projects.mdx
@@ -75,6 +75,12 @@ Instead of running the `wrangler d1 execute` command in your terminal every time
 
 * [GitHub](https://github.com/isaac-mcfadyen/d1-console)
 
+### D1 Migration Guard
+
+`d1-migration-guard` is a free, zero-dependency CLI that runs three safety checks against your D1 migrations before you run `wrangler d1 migrations apply`: migration filename ordering/duplicate-number detection, `wrangler.toml` `database_id` validation, and a pattern scan for destructive SQL (`DROP TABLE`, `DROP COLUMN`, unfiltered `DELETE`). It reads local files only and never calls `wrangler` or touches a live database.
+
+* [GitHub](https://github.com/MattBridges/d1-migration-guard)
+
 ### L1
 
 `L1` is a package that brings some Cloudflare Worker ecosystem bindings into PHP and Laravel via the Cloudflare API. It provides interaction with D1 via PDO, KV and Queues, with more services to add in the future, making PHP integration with Cloudflare a real breeze.


### PR DESCRIPTION
## Summary

Adds `d1-migration-guard` to the D1 community projects reference page, alongside the other community CLI tools (e.g. `d1-console`).

`d1-migration-guard` is a free, MIT-licensed, zero-dependency CLI that checks D1 migrations for three common footguns before you run `wrangler d1 migrations apply`:

- Migration filename ordering / duplicate or gapped numeric prefixes
- Missing or placeholder `database_id` in `wrangler.toml`
- Destructive SQL patterns (`DROP TABLE`, `DROP COLUMN`, unfiltered `DELETE`)

It reads local files only — it never calls `wrangler` and never touches a live database.

Repo: https://github.com/MattBridges/d1-migration-guard

## Disclosure

I'm the author of this tool. Following the existing entries' format (short factual description + GitHub link, no marketing copy).