### PR TITLE
Added new working Wrangler configurations in breakpoints.mdx

### DIFF
--- a/src/content/docs/workers/observability/dev-tools/breakpoints.mdx
+++ b/src/content/docs/workers/observability/dev-tools/breakpoints.mdx
@@ -30,7 +30,7 @@ To setup VS Code for breakpoint debugging in your Worker project:
 {
 	"configurations": [
 		{
-			"name": "Wrangler",
+			"name": "Listen Wrangler",
 			"type": "node",
 			"request": "attach",
 			"port": 9229,
@@ -39,6 +39,14 @@ To setup VS Code for breakpoint debugging in your Worker project:
 			"attachExistingChildren": false,
 			"autoAttachChildProcesses": false,
 			"sourceMaps": true // works with or without this line
+		},
+		{
+			"name": "Launch Wrangler",
+			"command": "npm run dev",
+			"type": "node-terminal",
+			"request": "launch",
+			"console": "integratedTerminal",
+			"sourceMaps": true
 		}
 	]
 }


### PR DESCRIPTION
Unclear why previously supplied configuration does not work, or when it should, no clear information about context is present. The new Launch Wrangler always works for breakpoints, in Wrangler, under Vite, and Astro.

node attach Wrangler configuration appears to have environment restrictions in place that aren't clarified in documentation. node-terminal launched Wrangler configuration appears to always work, regardless of the aforementioned unknown environmental restriction.

Added small Launch Wrangler configuration to relevant documentation page to cover edge cases.