### PR TITLE
[SaaS] Update O2O enablement details for Render customers

### DIFF
--- a/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/saas-customers/provider-guides/render.mdx
+++ b/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/saas-customers/provider-guides/render.mdx
@@ -29,6 +29,8 @@ For additional detail about how traffic routes when O2O is enabled, refer to [Ho
 
 ## Enable
 
+Render customers can enable O2O on any Cloudflare zone plan.
+
 To enable O2O for a specific hostname within a Cloudflare zone, [create](/dns/manage-dns-records/how-to/create-dns-records/#create-dns-records) a Proxied `CNAME` DNS record with your Render site name as the target. Render's domain addition setup will walk you through other validation steps.
 
 | Type    | Name              | Target                                                     | Proxy status |

--- a/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/saas-customers/provider-guides/render.mdx
+++ b/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/saas-customers/provider-guides/render.mdx
@@ -29,8 +29,6 @@ For additional detail about how traffic routes when O2O is enabled, refer to [Ho
 
 ## Enable
 
-Render customers can enable O2O on any Cloudflare zone plan. Cloudflare support for O2O setups is only available for Enterprise customers.
-
 To enable O2O for a specific hostname within a Cloudflare zone, [create](/dns/manage-dns-records/how-to/create-dns-records/#create-dns-records) a Proxied `CNAME` DNS record with your Render site name as the target. Render's domain addition setup will walk you through other validation steps.
 
 | Type    | Name              | Target                                                     | Proxy status |


### PR DESCRIPTION
Removed confusing statement about O2O.
From https://community.cloudflare.com/t/zone-wide-caching-completely-broken-cf-cache-status-dynamic-on-everything-all-s/951794/2

