### PR TITLE
Docs/lb pool sets

### DIFF
--- a/src/content/changelog/load-balancing/2026-08-31-pool-sets.mdx
+++ b/src/content/changelog/load-balancing/2026-08-31-pool-sets.mdx
@@ -1,0 +1,35 @@
+---
+title: Load Balancing now supports pool sets
+description: Pool sets combine geographic matching with location-specific steering policies, weights, pools, and fallback behavior.
+products:
+  - load-balancing
+date: 2026-08-31
+---
+
+Cloudflare Load Balancing now supports pool sets through the API. Pool sets combine geographic matching with location-specific traffic steering. One load balancer can now use different routing behavior for different locations.
+
+Each pool set can match a Cloudflare data center, country, or region. It then supplies the candidate pools and can apply its own steering policy, pool weights, and fallback pool. Cloudflare evaluates pool sets in array order and applies the first matching pool set.
+
+For example, this pool set uses Dynamic Latency steering for traffic from Germany:
+
+```json
+{
+	"pool_sets": [
+		{
+			"name": "germany-lowest-latency",
+			"match": { "topology": { "countries": ["DE"] } },
+			"overrides": {
+				"pools": [
+					"0930eec54a4c7ae6616985b79f678210",
+					"c8b4f5a6d7e84910a2b3c4d5e6f70819"
+				],
+				"steering_policy": "dynamic_latency"
+			}
+		}
+	]
+}
+```
+
+Use pool sets for active-active traffic distribution, location-specific failover, and regional routing policies. For proxied traffic, a pool set can also return a fixed HTTP response instead of selecting a pool.
+
+For configuration details and more examples, refer to [Pool sets](/load-balancing/understand-basics/traffic-steering/pool-sets/).

--- a/src/content/docs/load-balancing/additional-options/load-balancing-rules/actions.mdx
+++ b/src/content/docs/load-balancing/additional-options/load-balancing-rules/actions.mdx
@@ -67,6 +67,11 @@ This table lists the actions available for Load Balancing rules. For a walkthrou
     </tr>
     <tr>
       <td><em>Override</em></td>
+      <td><em>Country pools</em></td>
+      <td>Update the <a href="/load-balancing/understand-basics/traffic-steering/steering-policies/geo-steering/">country pools</a> associated with your load balancer.</td>
+    </tr>
+    <tr>
+      <td><em>Override</em></td>
       <td><em>Terminates</em></td>
       <td>Stop processing Load Balancing rules and apply the current load balancing logic to the request.</td>
     </tr>

--- a/src/content/docs/load-balancing/additional-options/load-balancing-rules/index.mdx
+++ b/src/content/docs/load-balancing/additional-options/load-balancing-rules/index.mdx
@@ -34,3 +34,5 @@ By default, non-Enterprise customers have **one** Load Balancing rule **per load
 At the moment, you cannot use Load Balancing rules with [Cloudflare Spectrum](/spectrum/about/load-balancer/).
 
 Custom load balancing rules are incompatible with [Geo steering](/load-balancing/understand-basics/traffic-steering/steering-policies/geo-steering/). As a result, any custom rule applied to Geo-steered load balancers will not function as expected.
+
+Custom rules do work alongside [pool sets](/load-balancing/understand-basics/traffic-steering/pool-sets/). Cloudflare evaluates pool sets first, then applies custom rule overrides on top of the result. A pool set that returns a fixed response is the complete response, so custom rules are not evaluated for that request.

--- a/src/content/docs/load-balancing/additional-options/load-balancing-rules/index.mdx
+++ b/src/content/docs/load-balancing/additional-options/load-balancing-rules/index.mdx
@@ -33,6 +33,6 @@ By default, non-Enterprise customers have **one** Load Balancing rule **per load
 
 At the moment, you cannot use Load Balancing rules with [Cloudflare Spectrum](/spectrum/about/load-balancer/).
 
-Custom load balancing rules are incompatible with [Geo steering](/load-balancing/understand-basics/traffic-steering/steering-policies/geo-steering/). As a result, any custom rule applied to Geo-steered load balancers will not function as expected.
+Custom rules can override [Geo steering](/load-balancing/understand-basics/traffic-steering/steering-policies/geo-steering/) pool mappings for matched requests. Specify different region, country, or data center pools in the rule. Changing only the steering policy does not disable Geo steering. Cloudflare still resolves pools from the configured topology before applying that policy.
 
 Custom rules do work alongside [pool sets](/load-balancing/understand-basics/traffic-steering/pool-sets/). Cloudflare evaluates pool sets first, then applies custom rule overrides on top of the result. A pool set that returns a fixed response is the complete response, so custom rules are not evaluated for that request.

--- a/src/content/docs/load-balancing/pools/create-pool.mdx
+++ b/src/content/docs/load-balancing/pools/create-pool.mdx
@@ -76,7 +76,7 @@ To update specific settings without having to resubmit the entire configuration,
 
 ## Delete a pool
 
-You cannot delete pools that are in use by load balancers. This includes [geo steering regions](/load-balancing/understand-basics/traffic-steering/steering-policies/geo-steering/#region-steering) pools as well as [fallback pools](/load-balancing/understand-basics/health-details/#fallback-pools).
+You cannot delete pools that are in use by load balancers. This includes [geo steering regions](/load-balancing/understand-basics/traffic-steering/steering-policies/geo-steering/#region-steering) pools, pools referenced by a [pool set](/load-balancing/understand-basics/traffic-steering/pool-sets/), as well as [fallback pools](/load-balancing/understand-basics/health-details/#fallback-pools).
 
 If you get an error when trying to delete a pool, consider the hostnames listed in the error and [edit the respective load balancers](/load-balancing/load-balancers/create-load-balancer/), making sure to remove all references to the pool.
 

--- a/src/content/docs/load-balancing/troubleshooting/common-error-codes.mdx
+++ b/src/content/docs/load-balancing/troubleshooting/common-error-codes.mdx
@@ -284,11 +284,13 @@ Cloudflare now restricts configured [endpoint host headers](/load-balancing/addi
 
 ### Cause
 
-You will receive this error when you attempt to delete a pool that is referenced by a load balancer [geo steering](/load-balancing/understand-basics/traffic-steering/steering-policies/geo-steering/) region.
+You will receive this error when you attempt to delete a pool that is referenced by a load balancer [geo steering](/load-balancing/understand-basics/traffic-steering/steering-policies/geo-steering/) region, or by a [pool set](/load-balancing/understand-basics/traffic-steering/pool-sets/).
 
 ### Solution
 
-Remove the pool from the load balancer's geo steering configuration. If your load balancer no longer uses geo steering, you will need to [re-enable geo steering](/load-balancing/understand-basics/traffic-steering/steering-policies/geo-steering/) and then remove the pool.
+For a geo steering reference, remove the pool from the load balancer's geo steering configuration. If your load balancer no longer uses geo steering, you will need to [re-enable geo steering](/load-balancing/understand-basics/traffic-steering/steering-policies/geo-steering/) and then remove the pool.
+
+For a pool set reference, remove the pool from every pool set that references it, including any `overrides.pool_weights` and `overrides.fallback_pool` entries.
 
 ***
 

--- a/src/content/docs/load-balancing/understand-basics/adaptive-routing.mdx
+++ b/src/content/docs/load-balancing/understand-basics/adaptive-routing.mdx
@@ -22,6 +22,8 @@ When there are no healthy endpoints in the same pool, failover across pools exte
 When using [geo-steering](/load-balancing/understand-basics/traffic-steering/steering-policies/geo-steering/), failover across pools only considers pools within the same geographic grouping. If your NA pool becomes unhealthy, traffic will **not** automatically fail over to your EU pool — it will go to the global fallback pool instead.
 
 To enable cross-region failover, include the desired fallback pool as an additional pool within each region's pool list.
+
+Alternatively, [pool sets](/load-balancing/understand-basics/traffic-steering/pool-sets/) accept a fallback pool for each location, so traffic that exhausts the pools for one location fails over to a pool you choose for that location instead of the global fallback pool.
 :::
 
 ### Enable failover across pools

--- a/src/content/docs/load-balancing/understand-basics/traffic-steering/index.mdx
+++ b/src/content/docs/load-balancing/understand-basics/traffic-steering/index.mdx
@@ -9,10 +9,11 @@ sidebar:
 
 ---
 
-When requests come to your load balancer, it distributes them across your pools and endpoints according to three factors:
+When requests come to your load balancer, it distributes them across your pools and endpoints according to four factors:
 
 1. [Pool and endpoint health](/load-balancing/understand-basics/health-details/): Traffic decisions start with which pools and endpoints are available and should receive traffic.
-2. [Global traffic steering](/load-balancing/understand-basics/traffic-steering/steering-policies/): Policies set on your [load balancer](/load-balancing/load-balancers/) that route traffic to attached and available pools.
-3. [Local traffic steering](/load-balancing/understand-basics/traffic-steering/origin-level-steering/): These are policies set on each [pool](/load-balancing/pools/) that route traffic to available endpoints within the pool.
+2. [Pool sets](/load-balancing/understand-basics/traffic-steering/pool-sets/): Optional location-matched pool selections that, when one matches, replace the pool selection for that request and supply their own steering policy, weights, and fallback pool.
+3. [Global traffic steering](/load-balancing/understand-basics/traffic-steering/steering-policies/): Policies set on your [load balancer](/load-balancing/load-balancers/) that route traffic to attached and available pools.
+4. [Local traffic steering](/load-balancing/understand-basics/traffic-steering/origin-level-steering/): These are policies set on each [pool](/load-balancing/pools/) that route traffic to available endpoints within the pool.
 
 When a pool or endpoint becomes unhealthy, your load balancer and pools redistribute traffic according to these same policies.

--- a/src/content/docs/load-balancing/understand-basics/traffic-steering/index.mdx
+++ b/src/content/docs/load-balancing/understand-basics/traffic-steering/index.mdx
@@ -12,7 +12,7 @@ sidebar:
 When requests come to your load balancer, it distributes them across your pools and endpoints according to four factors:
 
 1. [Pool and endpoint health](/load-balancing/understand-basics/health-details/): Traffic decisions start with which pools and endpoints are available and should receive traffic.
-2. [Pool sets](/load-balancing/understand-basics/traffic-steering/pool-sets/): Optional location-matched pool selections that, when one matches, replace the pool selection for that request and supply their own steering policy, weights, and fallback pool.
+2. [Pool sets](/load-balancing/understand-basics/traffic-steering/pool-sets/): The preferred way to define new API-managed location routing. A matched pool set can replace pool selection and provide its own steering policy, weights, and fallback pool.
 3. [Global traffic steering](/load-balancing/understand-basics/traffic-steering/steering-policies/): Policies set on your [load balancer](/load-balancing/load-balancers/) that route traffic to attached and available pools.
 4. [Local traffic steering](/load-balancing/understand-basics/traffic-steering/origin-level-steering/): These are policies set on each [pool](/load-balancing/pools/) that route traffic to available endpoints within the pool.
 

--- a/src/content/docs/load-balancing/understand-basics/traffic-steering/origin-level-steering/index.mdx
+++ b/src/content/docs/load-balancing/understand-basics/traffic-steering/origin-level-steering/index.mdx
@@ -5,7 +5,7 @@ products:
   - load-balancing
 title: Local traffic steering
 sidebar:
-  order: 2
+  order: 3
 ---
 
 import { DirectoryListing, Render } from "~/components";

--- a/src/content/docs/load-balancing/understand-basics/traffic-steering/pool-sets.mdx
+++ b/src/content/docs/load-balancing/understand-basics/traffic-steering/pool-sets.mdx
@@ -1,6 +1,6 @@
 ---
 pcx_content_type: concept
-description: Pair a location match with its own pool list, steering policy, weights, and fallback pool using pool sets.
+description: Use pool sets to define location-specific pools, steering policies, weights, and fallback behavior through the API.
 products:
   - load-balancing
 title: Pool sets
@@ -11,16 +11,18 @@ head:
     content: Pool sets
 ---
 
-A **pool set** pairs a match condition with the routing behavior to apply when that condition succeeds. Each pool set carries its own pool list, steering policy, pool weights, and fallback pool.
+A **pool set** pairs a match condition with routing behavior. For new API-managed configurations that route traffic by location, use pool sets.
 
-Pool sets address two limits of [Geo steering](/load-balancing/understand-basics/traffic-steering/steering-policies/geo-steering/). Geo steering assigns a list of pools to each location and uses them in failover order only, so you cannot split traffic across pools within one location or pick the lowest-latency pool there. Geo steering also has a single global fallback pool, so when every pool in a location becomes unhealthy, traffic can move to a distant data center.
+Use [Geo steering](/load-balancing/understand-basics/traffic-steering/steering-policies/geo-steering/) for simple geographic failover configured in the dashboard. Use pool sets when you need per-location steering policies, weights, fallback pools, or custom rules.
+
+Geo steering assigns pools to each location in failover order. It cannot split traffic across pools within one location. It also cannot select the lowest-latency pool within that location. Geo steering uses one global fallback pool. When every pool for a location is unhealthy, traffic may move to a distant data center.
 
 With pool sets you can:
 
 - Apply any supported steering policy within a single location
 - Set pool weights that apply only to that location
 - Assign a fallback pool for that location instead of the global fallback pool
-- Return a fixed response for a location instead of routing to pools
+- Return a fixed HTTP response for matched proxied traffic
 
 :::note
 Pool sets are available to Enterprise customers who have purchased Traffic Steering, and are configurable through the API only.
@@ -117,7 +119,7 @@ Omitting `steering_policy` leaves the pool set using failover order.
 
 ### Fixed responses
 
-Instead of `overrides.pools`, a pool set can return a `fixed_response`. This is useful when you want a location to receive a specific status code or redirect rather than reach an origin:
+For proxied zone load balancers, a pool set can return a `fixed_response` instead of using `overrides.pools`. Use this option to return an HTTP status or redirect for a matched location:
 
 ```json
 {
@@ -134,6 +136,8 @@ Instead of `overrides.pools`, a pool set can return a `fixed_response`. This is 
 	]
 }
 ```
+
+Do not use `fixed_response` with DNS-only load balancers. DNS responses cannot carry HTTP status, body, or redirect fields. A matching fixed response returns `NOERROR` with no records.
 
 A pool set must specify either `overrides.pools` or `fixed_response`. A pool set with neither is rejected, because it would match traffic and then have nowhere to send it.
 
@@ -159,11 +163,19 @@ Pool sets work on:
 - DNS-only (gray-clouded) zone load balancers
 - Account load balancers
 
-On DNS-only load balancers, two behaviors differ.
+Available steering behavior differs by load balancer type.
 
-Country matching resolves the client location from the EDNS Client Subnet when the request carries one, and from the DNS resolver address otherwise. A request without EDNS Client Subnet therefore matches the location of the resolver rather than the client. To control how this location is chosen, refer to [EDNS Client Subnet (ECS) support](/load-balancing/understand-basics/traffic-steering/steering-policies/#edns-client-subnet-ecs-support).
+### DNS-only load balancers
 
-An `overrides.steering_policy` of `least_outstanding_requests` is supported only in a no-operation form, because all pool outstanding request counts are considered to be zero at the DNS layer. For more information, refer to [Least Outstanding Requests steering](/load-balancing/understand-basics/traffic-steering/steering-policies/least-outstanding-requests/).
+Country matching depends on the top-level steering policy and `location_strategy`. With a configured strategy, Geo and Proximity steering can use EDNS Client Subnet (ECS), the resolver IP address, or the responding Cloudflare data center. Without a configured strategy, Proximity uses ECS when available, while Geo uses the responding data center. Other top-level policies use the responding data center.
+
+A pool set applies `overrides.steering_policy` after evaluating its match. The override therefore cannot change the location used for country matching. For more information, refer to [EDNS Client Subnet (ECS) support](/load-balancing/understand-basics/traffic-steering/steering-policies/#edns-client-subnet-ecs-support).
+
+`least_outstanding_requests` does not provide counter-based selection for DNS-only load balancers. All pool outstanding request counts are treated as zero. Use a different policy when selection must reflect active requests.
+
+### Account load balancers
+
+`least_outstanding_requests` and `least_connections` do not provide counter-based selection for account load balancers. Account lookups do not use live request or connection counters. Use a different policy when you require counter-based routing.
 
 ## Limits
 

--- a/src/content/docs/load-balancing/understand-basics/traffic-steering/pool-sets.mdx
+++ b/src/content/docs/load-balancing/understand-basics/traffic-steering/pool-sets.mdx
@@ -5,17 +5,13 @@ products:
   - load-balancing
 title: Pool sets
 sidebar:
-  order: 3
+  order: 1
 head:
   - tag: title
     content: Pool sets
 ---
 
-A **pool set** pairs a match condition with routing behavior. For new API-managed configurations that route traffic by location, use pool sets.
-
-Use [Geo steering](/load-balancing/understand-basics/traffic-steering/steering-policies/geo-steering/) for simple geographic failover configured in the dashboard. Use pool sets when you need per-location steering policies, weights, fallback pools, or custom rules.
-
-Geo steering assigns pools to each location in failover order. It cannot split traffic across pools within one location. It also cannot select the lowest-latency pool within that location. Geo steering uses one global fallback pool. When every pool for a location is unhealthy, traffic may move to a distant data center.
+Pool sets allow you to combine geographic steering with other traffic steering policies. For example, you can apply Dynamic Latency steering within a specific region or country. For load balancers managed through the API, pool sets can replace Geo steering.
 
 With pool sets you can:
 
@@ -25,16 +21,16 @@ With pool sets you can:
 - Return a fixed HTTP response for matched proxied traffic
 
 :::note
-Pool sets are available to Enterprise customers who have purchased Traffic Steering, and are configurable through the API only.
+Use [Geo steering](/load-balancing/understand-basics/traffic-steering/steering-policies/geo-steering/) for simple, dashboard-managed geographic failover. Geo steering evaluates each location's pools in failover order and uses one global fallback pool. It cannot split traffic across pools within a location.
 :::
 
 ## How pool sets are evaluated
 
 Pool sets are stored as an ordered array on the load balancer. Cloudflare evaluates them in array order and stops at the first pool set whose `match` succeeds. That pool set then supplies the pools, steering policy, weights, and fallback pool for the request.
 
-Array position is the only precedence mechanism. A pool set matching a single data center does not automatically take priority over one matching a whole region — order the array from most specific to least specific yourself.
+Pool sets are evaluated in array order, and the first matching pool set wins. A pool set matching a single data center does not automatically take priority over one matching a region. Order the array from most specific to least specific.
 
-Place a catch-all pool set last so requests that match no location still have a destination:
+Place a default pool set last by setting `match.default` to `true`. The `default` match applies to every request. Since pool sets use first-match wins, this pool set handles requests that did not match an earlier pool set:
 
 ```json
 {
@@ -45,7 +41,7 @@ Place a catch-all pool set last so requests that match no location still have a 
 			"overrides": { "pools": ["17b5962d775c646f3f9725cbc7a53df4"] }
 		},
 		{
-			"name": "catch-all",
+			"name": "default",
 			"match": { "default": true },
 			"overrides": { "pools": ["ff02c959d17f7bb2b1184a202e3c0af7"] }
 		}
@@ -155,27 +151,11 @@ Pool sets are evaluated before [custom rules](/load-balancing/additional-options
 
 A pool set that returns a `fixed_response` is the complete response, so custom rules are not evaluated for that request.
 
-## Supported load balancer types
-
-Pool sets work on:
-
-- Proxied (orange-clouded) zone load balancers
-- DNS-only (gray-clouded) zone load balancers
-- Account load balancers
-
-Available steering behavior differs by load balancer type.
-
-### DNS-only load balancers
+## DNS-only load balancers
 
 Country matching depends on the top-level steering policy and `location_strategy`. With a configured strategy, Geo and Proximity steering can use EDNS Client Subnet (ECS), the resolver IP address, or the responding Cloudflare data center. Without a configured strategy, Proximity uses ECS when available, while Geo uses the responding data center. Other top-level policies use the responding data center.
 
 A pool set applies `overrides.steering_policy` after evaluating its match. The override therefore cannot change the location used for country matching. For more information, refer to [EDNS Client Subnet (ECS) support](/load-balancing/understand-basics/traffic-steering/steering-policies/#edns-client-subnet-ecs-support).
-
-`least_outstanding_requests` does not provide counter-based selection for DNS-only load balancers. All pool outstanding request counts are treated as zero. Use a different policy when selection must reflect active requests.
-
-### Account load balancers
-
-`least_outstanding_requests` and `least_connections` do not provide counter-based selection for account load balancers. Account lookups do not use live request or connection counters. Use a different policy when you require counter-based routing.
 
 ## Limits
 
@@ -193,7 +173,7 @@ Duplicate entries within a single `pops`, `countries`, or `regions` list are rej
 A pool referenced by a pool set cannot be [deleted](/load-balancing/pools/create-pool/#delete-a-pool) until you remove it from every pool set that references it. This applies to pools in `overrides.pools`, `overrides.pool_weights`, and `overrides.fallback_pool`.
 :::
 
-## Update pool sets
+## Configure pool sets via the API
 
 Pool sets are managed through the `pool_sets` field on the [Update Load Balancer](/api/resources/load_balancers/methods/edit/) endpoint. When you send a `PATCH` request:
 
@@ -201,13 +181,17 @@ Pool sets are managed through the `pool_sets` field on the [Update Load Balancer
 - Sending `"pool_sets": []` removes all pool sets
 - Sending `"pool_sets": null` makes no change
 
-## Example
+### Example request
 
-This load balancer splits North American traffic across two pools by weight with a regional fallback pool, sends German traffic to a single pool by lowest latency, and routes everything else to a default pool:
+Before using this example, create the referenced pools. Replace each example pool ID with an ID from your account.
+
+This request splits Western North American traffic across two pools by weight and uses a regional fallback pool. It selects the lowest-latency pool for German traffic. A default pool set handles all remaining traffic. The load balancer uses a separate global fallback pool.
+
+Send a `PATCH` request to `/zones/{zone_id}/load_balancers/{load_balancer_id}` with the following body:
 
 ```json title="Request"
-// PATCH /zones/{zone_id}/load_balancers/{load_balancer_id}
 {
+	"fallback_pool": "6f1ed002ab5595859014ebf0951522d9",
 	"pool_sets": [
 		{
 			"name": "wnam-active-active",
@@ -229,12 +213,15 @@ This load balancer splits North American traffic across two pools by weight with
 			"name": "de-lowest-latency",
 			"match": { "topology": { "countries": ["DE"] } },
 			"overrides": {
-				"pools": ["0930eec54a4c7ae6616985b79f678210"],
+				"pools": [
+					"0930eec54a4c7ae6616985b79f678210",
+					"c8b4f5a6d7e84910a2b3c4d5e6f70819"
+				],
 				"steering_policy": "dynamic_latency"
 			}
 		},
 		{
-			"name": "catch-all",
+			"name": "default",
 			"match": { "default": true },
 			"overrides": {
 				"pools": ["ff02c959d17f7bb2b1184a202e3c0af7"],
@@ -245,17 +232,29 @@ This load balancer splits North American traffic across two pools by weight with
 }
 ```
 
-## Error codes
+### Resulting behavior
 
-| Code                            | Cause                                                               |
-| ------------------------------- | ------------------------------------------------------------------- |
-| `POOL_SETS_TOO_LARGE`           | More than 1,000 pool sets on one load balancer                      |
-| `POOL_SET_NO_INTENT`            | A pool set specifies neither `overrides.pools` nor `fixed_response` |
-| `POOL_SET_EMPTY_MATCH`          | A `match` object is present but sets no condition                   |
-| `POOL_SET_DEFAULT_WITH_MATCH`   | A `match` combines `default` with `topology`                        |
-| `POOL_SET_EMPTY_TOPOLOGY`       | A `topology` sets none of `pops`, `countries`, or `regions`         |
-| `POOL_SET_TOPOLOGY_TOO_LARGE`   | A `topology` list exceeds 1,000 entries                             |
-| `POOL_SET_POP_ENTITLEMENT`      | The account is not entitled to data center steering                 |
-| `POOL_SET_REGION_ENTITLEMENT`   | The account is not entitled to region steering                      |
-| `POOL_SET_COUNTRY_ENTITLEMENT`  | The account is not entitled to country steering                     |
-| `POOL_SET_STEERING_ENTITLEMENT` | The account has not purchased Traffic Steering                      |
+After the request completes, the load balancer routes traffic with this configuration:
+
+| Order | Match                         | Pools                                                                      | Steering policy  | Fallback pool                              |
+| ----- | ----------------------------- | -------------------------------------------------------------------------- | ---------------- | ------------------------------------------ |
+| 1     | Western North America (`WNAM`) | `17b5962d775c646f3f9725cbc7a53df4`, `9290f38c5d07c2e2f4df57b1f61d4196` | Random, 50% each | `2a28d35d1c00f000540fe739a04b3230`         |
+| 2     | Germany (`DE`)                | `0930eec54a4c7ae6616985b79f678210`, `c8b4f5a6d7e84910a2b3c4d5e6f70819` | Dynamic Latency  | Global fallback                            |
+| 3     | All remaining traffic         | `ff02c959d17f7bb2b1184a202e3c0af7`                                       | Failover order   | Global fallback                            |
+
+The global fallback pool is `6f1ed002ab5595859014ebf0951522d9`.
+
+## Validation errors
+
+Invalid Pool Sets configurations return HTTP status `400` and API error code `1002`. The error message explains the problem and can include one of these identifiers:
+
+| Message identifier             | Cause                                                               |
+| ------------------------------ | ------------------------------------------------------------------- |
+| `POOL_SETS_TOO_LARGE`          | More than 1,000 pool sets on one load balancer                      |
+| `POOL_SET_NO_INTENT`           | A pool set specifies neither `overrides.pools` nor `fixed_response` |
+| `POOL_SET_DEFAULT_WITH_MATCH`  | A `match` combines `default` with `topology`                        |
+| `POOL_SET_EMPTY_TOPOLOGY`      | A `topology` sets none of `pops`, `countries`, or `regions`         |
+| `POOL_SET_TOPOLOGY_TOO_LARGE`  | A `topology` list exceeds 1,000 entries                             |
+| `POOL_SET_POP_ENTITLEMENT`     | The account is not entitled to data center steering                 |
+| `POOL_SET_REGION_ENTITLEMENT`  | The account is not entitled to region steering                      |
+| `POOL_SET_COUNTRY_ENTITLEMENT` | The account is not entitled to country steering                     |

--- a/src/content/docs/load-balancing/understand-basics/traffic-steering/pool-sets.mdx
+++ b/src/content/docs/load-balancing/understand-basics/traffic-steering/pool-sets.mdx
@@ -76,6 +76,22 @@ Entries within a single field are combined with OR. A request from Germany match
 Fields are combined with AND, not OR. A `topology` that sets both `"countries": ["US"]` and `"regions": ["WNAM"]` matches only requests that are in the United States **and** in the WNAM region. To match either location, use two separate pool sets.
 :::
 
+For example, this topology sets multiple values in all three fields:
+
+```json
+{
+	"match": {
+		"topology": {
+			"pops": ["SJC", "IAD"],
+			"countries": ["US", "CA"],
+			"regions": ["WNAM", "ENAM"]
+		}
+	}
+}
+```
+
+A request matches when its data center is `SJC` or `IAD`, its country is `US` or `CA`, **and** its region hierarchy includes `WNAM` or `ENAM`.
+
 Set one field per `topology` unless you specifically want that AND behavior.
 
 A `regions` entry matches if it appears anywhere in the request's region hierarchy, so a broader region code can match a request from a narrower one.
@@ -84,7 +100,7 @@ Country matching uses the location resolved for the request. When the client loc
 
 ## Overrides
 
-The `overrides` object holds the routing behavior applied on a match. All fields are optional.
+The `overrides` object holds the routing behavior applied on a match. Its fields are optional, but a pool set without `fixed_response` must set `overrides.pools`.
 
 | Field                 | Description                                                                                     |
 | --------------------- | ----------------------------------------------------------------------------------------------- |
@@ -121,12 +137,11 @@ For proxied zone load balancers, a pool set can return a `fixed_response` instea
 {
 	"pool_sets": [
 		{
-			"name": "unavailable-region",
+			"name": "redirect-region",
 			"match": { "topology": { "countries": ["US"] } },
 			"fixed_response": {
-				"status_code": 403,
-				"content_type": "text/plain",
-				"message_body": "This service is not available in your region."
+				"status_code": 302,
+				"location": "https://example.com/service-unavailable"
 			}
 		}
 	]

--- a/src/content/docs/load-balancing/understand-basics/traffic-steering/pool-sets.mdx
+++ b/src/content/docs/load-balancing/understand-basics/traffic-steering/pool-sets.mdx
@@ -1,0 +1,249 @@
+---
+pcx_content_type: concept
+description: Pair a location match with its own pool list, steering policy, weights, and fallback pool using pool sets.
+products:
+  - load-balancing
+title: Pool sets
+sidebar:
+  order: 3
+head:
+  - tag: title
+    content: Pool sets
+---
+
+A **pool set** pairs a match condition with the routing behavior to apply when that condition succeeds. Each pool set carries its own pool list, steering policy, pool weights, and fallback pool.
+
+Pool sets address two limits of [Geo steering](/load-balancing/understand-basics/traffic-steering/steering-policies/geo-steering/). Geo steering assigns a list of pools to each location and uses them in failover order only, so you cannot split traffic across pools within one location or pick the lowest-latency pool there. Geo steering also has a single global fallback pool, so when every pool in a location becomes unhealthy, traffic can move to a distant data center.
+
+With pool sets you can:
+
+- Apply any supported steering policy within a single location
+- Set pool weights that apply only to that location
+- Assign a fallback pool for that location instead of the global fallback pool
+- Return a fixed response for a location instead of routing to pools
+
+:::note
+Pool sets are available to Enterprise customers who have purchased Traffic Steering, and are configurable through the API only.
+:::
+
+## How pool sets are evaluated
+
+Pool sets are stored as an ordered array on the load balancer. Cloudflare evaluates them in array order and stops at the first pool set whose `match` succeeds. That pool set then supplies the pools, steering policy, weights, and fallback pool for the request.
+
+Array position is the only precedence mechanism. A pool set matching a single data center does not automatically take priority over one matching a whole region — order the array from most specific to least specific yourself.
+
+Place a catch-all pool set last so requests that match no location still have a destination:
+
+```json
+{
+	"pool_sets": [
+		{
+			"name": "sjc-only",
+			"match": { "topology": { "pops": ["SJC"] } },
+			"overrides": { "pools": ["17b5962d775c646f3f9725cbc7a53df4"] }
+		},
+		{
+			"name": "catch-all",
+			"match": { "default": true },
+			"overrides": { "pools": ["ff02c959d17f7bb2b1184a202e3c0af7"] }
+		}
+	]
+}
+```
+
+A pool set with `disabled` set to `true` is skipped.
+
+## Match conditions
+
+The `match` object decides which requests a pool set applies to. Set either `default` or `topology` — the two cannot be combined. A pool set with no `match` at all applies to every request.
+
+| Field      | Description                                                                   |
+| ---------- | ----------------------------------------------------------------------------- |
+| `default`  | When `true`, matches every request. Cannot be combined with `topology`.        |
+| `topology` | Matches by location. Requires at least one of `pops`, `countries`, `regions`. |
+
+### Topology matching
+
+Within `topology`, each field takes a list of location codes:
+
+| Field       | Values                                                                                                                |
+| ----------- | --------------------------------------------------------------------------------------------------------------------- |
+| `pops`      | Cloudflare data center codes, matched against the data center handling the request                                     |
+| `countries` | ISO 3166-1 alpha-2 country codes                                                                                      |
+| `regions`   | Cloudflare [region codes](/load-balancing/reference/region-mapping-api/#list-of-load-balancer-regions), such as `WNAM` |
+
+Entries within a single field are combined with OR. A request from Germany matches `"countries": ["FR", "DE", "GB"]`.
+
+:::caution
+Fields are combined with AND, not OR. A `topology` that sets both `"countries": ["US"]` and `"regions": ["WNAM"]` matches only requests that are in the United States **and** in the WNAM region. To match either location, use two separate pool sets.
+:::
+
+Set one field per `topology` unless you specifically want that AND behavior.
+
+A `regions` entry matches if it appears anywhere in the request's region hierarchy, so a broader region code can match a request from a narrower one.
+
+Country matching uses the location resolved for the request. When the client location cannot be resolved, country matching falls back to the country of the Cloudflare data center handling the request.
+
+## Overrides
+
+The `overrides` object holds the routing behavior applied on a match. All fields are optional.
+
+| Field                 | Description                                                                                     |
+| --------------------- | ----------------------------------------------------------------------------------------------- |
+| `pools`               | Pool IDs to route to. Replaces the load balancer's pool selection entirely for this request.     |
+| `pool_weights`        | Per-pool weights, applied only within this pool set                                             |
+| `pool_default_weight` | Weight for any pool in `pools` without an entry in `pool_weights`                                |
+| `fallback_pool`       | Pool of last resort for this pool set. When omitted, the load balancer's fallback pool is used. |
+| `steering_policy`     | Steering policy applied to `pools`                                                               |
+
+`pools` is a flat list rather than a map of locations to pools. The matched pool set defines the whole set of candidate pools for the request.
+
+### Steering policies within a pool set
+
+These steering policies are supported within a pool set:
+
+| Policy                       | Behavior within the pool set                                     |
+| ---------------------------- | ---------------------------------------------------------------- |
+| `off`                        | Use `pools` in failover order                                    |
+| `random`                     | Select a pool at random, honoring `pool_weights`                 |
+| `dynamic_latency`            | Select the pool with the lowest round trip time                  |
+| `proximity`                  | Select the pool closest to the request by latitude and longitude |
+| `least_outstanding_requests` | Select a pool by weights and outstanding request counts          |
+| `least_connections`          | Select a pool by weights and open connection counts              |
+
+`pool_weights` and `pool_default_weight` apply to `random`, `least_outstanding_requests`, and `least_connections`. These weights are separate from the load balancer's `random_steering` weights, so each pool set can weight its pools independently.
+
+Omitting `steering_policy` leaves the pool set using failover order.
+
+### Fixed responses
+
+Instead of `overrides.pools`, a pool set can return a `fixed_response`. This is useful when you want a location to receive a specific status code or redirect rather than reach an origin:
+
+```json
+{
+	"pool_sets": [
+		{
+			"name": "unavailable-region",
+			"match": { "topology": { "countries": ["US"] } },
+			"fixed_response": {
+				"status_code": 403,
+				"content_type": "text/plain",
+				"message_body": "This service is not available in your region."
+			}
+		}
+	]
+}
+```
+
+A pool set must specify either `overrides.pools` or `fixed_response`. A pool set with neither is rejected, because it would match traffic and then have nowhere to send it.
+
+## Relationship to other steering settings
+
+Pool sets are independent of the standard steering fields. Adding pool sets does not read from or write to `default_pools`, `region_pools`, `country_pools`, `pop_pools`, `steering_policy`, `random_steering`, or `fallback_pool`, and configuring those fields does not create pool sets.
+
+Because a matched pool set replaces pool selection for the request, the standard fields have no effect on requests that a pool set matches. Requests that match no pool set fall through to your standard steering configuration.
+
+`default_pools` remains required on every load balancer, even when you expect every request to match a pool set. It is the destination for requests that match no pool set.
+
+### Custom rules
+
+Pool sets are evaluated before [custom rules](/load-balancing/additional-options/load-balancing-rules/). A matched pool set establishes the routing decision, and custom rules then apply their overrides on top of it.
+
+A pool set that returns a `fixed_response` is the complete response, so custom rules are not evaluated for that request.
+
+## Supported load balancer types
+
+Pool sets work on:
+
+- Proxied (orange-clouded) zone load balancers
+- DNS-only (gray-clouded) zone load balancers
+- Account load balancers
+
+On DNS-only load balancers, two behaviors differ.
+
+Country matching resolves the client location from the EDNS Client Subnet when the request carries one, and from the DNS resolver address otherwise. A request without EDNS Client Subnet therefore matches the location of the resolver rather than the client. To control how this location is chosen, refer to [EDNS Client Subnet (ECS) support](/load-balancing/understand-basics/traffic-steering/steering-policies/#edns-client-subnet-ecs-support).
+
+An `overrides.steering_policy` of `least_outstanding_requests` is supported only in a no-operation form, because all pool outstanding request counts are considered to be zero at the DNS layer. For more information, refer to [Least Outstanding Requests steering](/load-balancing/understand-basics/traffic-steering/steering-policies/least-outstanding-requests/).
+
+## Limits
+
+Pool sets are subject to the following limits:
+
+| Limit                                              | Value |
+| -------------------------------------------------- | ----- |
+| Pool sets per load balancer                        | 1,000 |
+| Characters in `name`                               | 200   |
+| Entries per `pops`, `countries`, or `regions` list | 1,000 |
+
+Duplicate entries within a single `pops`, `countries`, or `regions` list are rejected.
+
+:::caution
+A pool referenced by a pool set cannot be [deleted](/load-balancing/pools/create-pool/#delete-a-pool) until you remove it from every pool set that references it. This applies to pools in `overrides.pools`, `overrides.pool_weights`, and `overrides.fallback_pool`.
+:::
+
+## Update pool sets
+
+Pool sets are managed through the `pool_sets` field on the [Update Load Balancer](/api/resources/load_balancers/methods/edit/) endpoint. When you send a `PATCH` request:
+
+- Omitting `pool_sets` leaves existing pool sets unchanged
+- Sending `"pool_sets": []` removes all pool sets
+- Sending `"pool_sets": null` makes no change
+
+## Example
+
+This load balancer splits North American traffic across two pools by weight with a regional fallback pool, sends German traffic to a single pool by lowest latency, and routes everything else to a default pool:
+
+```json title="Request"
+// PATCH /zones/{zone_id}/load_balancers/{load_balancer_id}
+{
+	"pool_sets": [
+		{
+			"name": "wnam-active-active",
+			"match": { "topology": { "regions": ["WNAM"] } },
+			"overrides": {
+				"pools": [
+					"17b5962d775c646f3f9725cbc7a53df4",
+					"9290f38c5d07c2e2f4df57b1f61d4196"
+				],
+				"pool_weights": {
+					"17b5962d775c646f3f9725cbc7a53df4": 0.5,
+					"9290f38c5d07c2e2f4df57b1f61d4196": 0.5
+				},
+				"steering_policy": "random",
+				"fallback_pool": "2a28d35d1c00f000540fe739a04b3230"
+			}
+		},
+		{
+			"name": "de-lowest-latency",
+			"match": { "topology": { "countries": ["DE"] } },
+			"overrides": {
+				"pools": ["0930eec54a4c7ae6616985b79f678210"],
+				"steering_policy": "dynamic_latency"
+			}
+		},
+		{
+			"name": "catch-all",
+			"match": { "default": true },
+			"overrides": {
+				"pools": ["ff02c959d17f7bb2b1184a202e3c0af7"],
+				"steering_policy": "off"
+			}
+		}
+	]
+}
+```
+
+## Error codes
+
+| Code                            | Cause                                                               |
+| ------------------------------- | ------------------------------------------------------------------- |
+| `POOL_SETS_TOO_LARGE`           | More than 1,000 pool sets on one load balancer                      |
+| `POOL_SET_NO_INTENT`            | A pool set specifies neither `overrides.pools` nor `fixed_response` |
+| `POOL_SET_EMPTY_MATCH`          | A `match` object is present but sets no condition                   |
+| `POOL_SET_DEFAULT_WITH_MATCH`   | A `match` combines `default` with `topology`                        |
+| `POOL_SET_EMPTY_TOPOLOGY`       | A `topology` sets none of `pops`, `countries`, or `regions`         |
+| `POOL_SET_TOPOLOGY_TOO_LARGE`   | A `topology` list exceeds 1,000 entries                             |
+| `POOL_SET_POP_ENTITLEMENT`      | The account is not entitled to data center steering                 |
+| `POOL_SET_REGION_ENTITLEMENT`   | The account is not entitled to region steering                      |
+| `POOL_SET_COUNTRY_ENTITLEMENT`  | The account is not entitled to country steering                     |
+| `POOL_SET_STEERING_ENTITLEMENT` | The account has not purchased Traffic Steering                      |

--- a/src/content/docs/load-balancing/understand-basics/traffic-steering/pool-sets.mdx
+++ b/src/content/docs/load-balancing/understand-basics/traffic-steering/pool-sets.mdx
@@ -28,7 +28,7 @@ Use [Geo steering](/load-balancing/understand-basics/traffic-steering/steering-p
 
 Pool sets are stored as an ordered array on the load balancer. Cloudflare evaluates them in array order and stops at the first pool set whose `match` succeeds. That pool set then supplies the pools, steering policy, weights, and fallback pool for the request.
 
-Pool sets are evaluated in array order, and the first matching pool set wins. A pool set matching a single data center does not automatically take priority over one matching a region. Order the array from most specific to least specific.
+A pool set matching a single data center does not automatically take priority over one matching a region. Order the array from most specific to least specific.
 
 Place a default pool set last by setting `match.default` to `true`. The `default` match applies to every request. Since pool sets use first-match wins, this pool set handles requests that did not match an earlier pool set:
 

--- a/src/content/docs/load-balancing/understand-basics/traffic-steering/steering-policies/geo-steering.mdx
+++ b/src/content/docs/load-balancing/understand-basics/traffic-steering/steering-policies/geo-steering.mdx
@@ -20,7 +20,7 @@ import { TabItem, Tabs } from "~/components";
 This option is extremely useful when you want site visitors to access the endpoint closest to them, which improves page-loading performance.
 
 :::note
-For new API-managed location routing, use [pool sets](/load-balancing/understand-basics/traffic-steering/pool-sets/). Pool sets support per-location steering policies, weights, fallback pools, and custom rules. Use Geo steering for simple geographic failover configured in the dashboard.
+For new API-managed location-specific routing, use [pool sets](/load-balancing/understand-basics/traffic-steering/pool-sets/). Pool sets support per-location steering policies, weights, fallback pools, and custom rules. Use Geo steering for simple geographic failover configured in the dashboard.
 
 :::
 

--- a/src/content/docs/load-balancing/understand-basics/traffic-steering/steering-policies/geo-steering.mdx
+++ b/src/content/docs/load-balancing/understand-basics/traffic-steering/steering-policies/geo-steering.mdx
@@ -20,9 +20,9 @@ import { TabItem, Tabs } from "~/components";
 This option is extremely useful when you want site visitors to access the endpoint closest to them, which improves page-loading performance.
 
 :::note
-Custom load balancing rules are incompatible with Geo steering. As a result, any custom rule applied to Geo-steered Load Balancers will not function as expected.
+Use Geo steering for simple geographic failover configured in the dashboard. For new API-managed location routing, use [pool sets](/load-balancing/understand-basics/traffic-steering/pool-sets/). Pool sets support per-location steering policies, weights, fallback pools, and custom rules.
 
-[Pool sets](/load-balancing/understand-basics/traffic-steering/pool-sets/) do work alongside custom rules. Cloudflare evaluates pool sets first, then applies custom rule overrides on top of the result.
+Custom load balancing rules are incompatible with Geo steering. Cloudflare evaluates pool sets before applying custom rule overrides.
 :::
 
 ## Pool assignment

--- a/src/content/docs/load-balancing/understand-basics/traffic-steering/steering-policies/geo-steering.mdx
+++ b/src/content/docs/load-balancing/understand-basics/traffic-steering/steering-policies/geo-steering.mdx
@@ -21,11 +21,17 @@ This option is extremely useful when you want site visitors to access the endpoi
 
 :::note
 Custom load balancing rules are incompatible with Geo steering. As a result, any custom rule applied to Geo-steered Load Balancers will not function as expected.
+
+[Pool sets](/load-balancing/understand-basics/traffic-steering/pool-sets/) do work alongside custom rules. Cloudflare evaluates pool sets first, then applies custom rule overrides on top of the result.
 :::
 
 ## Pool assignment
 
 You can assign multiple pools to the same area and the load balancer will use them in failover order. Any options not explicitly defined — whether in data centers, countries, or regions — will fall back to using default pools and failover.
+
+:::note
+Geo steering uses failover order within each area and a single global fallback pool. To apply a steering policy such as weighted random or dynamic latency within one area, or to set a fallback pool per area, refer to [Pool sets](/load-balancing/understand-basics/traffic-steering/pool-sets/).
+:::
 
 ### Region steering
 

--- a/src/content/docs/load-balancing/understand-basics/traffic-steering/steering-policies/geo-steering.mdx
+++ b/src/content/docs/load-balancing/understand-basics/traffic-steering/steering-policies/geo-steering.mdx
@@ -20,18 +20,13 @@ import { TabItem, Tabs } from "~/components";
 This option is extremely useful when you want site visitors to access the endpoint closest to them, which improves page-loading performance.
 
 :::note
-Use Geo steering for simple geographic failover configured in the dashboard. For new API-managed location routing, use [pool sets](/load-balancing/understand-basics/traffic-steering/pool-sets/). Pool sets support per-location steering policies, weights, fallback pools, and custom rules.
+For new API-managed location routing, use [pool sets](/load-balancing/understand-basics/traffic-steering/pool-sets/). Pool sets support per-location steering policies, weights, fallback pools, and custom rules. Use Geo steering for simple geographic failover configured in the dashboard.
 
-Custom load balancing rules are incompatible with Geo steering. Cloudflare evaluates pool sets before applying custom rule overrides.
 :::
 
 ## Pool assignment
 
 You can assign multiple pools to the same area and the load balancer will use them in failover order. Any options not explicitly defined — whether in data centers, countries, or regions — will fall back to using default pools and failover.
-
-:::note
-Geo steering uses failover order within each area and a single global fallback pool. To apply a steering policy such as weighted random or dynamic latency within one area, or to set a fallback pool per area, refer to [Pool sets](/load-balancing/understand-basics/traffic-steering/pool-sets/).
-:::
 
 ### Region steering
 

--- a/src/content/docs/load-balancing/understand-basics/traffic-steering/steering-policies/index.mdx
+++ b/src/content/docs/load-balancing/understand-basics/traffic-steering/steering-policies/index.mdx
@@ -5,7 +5,7 @@ products:
   - load-balancing
 title: Global traffic steering
 sidebar:
-  order: 1
+  order: 2
 head:
   - tag: title
     content: Global traffic steering policies


### PR DESCRIPTION
### Summary

Adds a new Pool sets guide for API-managed Cloudflare Load Balancing. The page documents location matching, per-location pools and steering policies, weights, fallback behavior, fixed responses, first-match evaluation, limits, API update semantics, configuration examples, and validation errors.

Adds a Pool sets changelog entry and updates eight related Load Balancing pages. These supporting edits link to the new guide, clarify when Pool sets can replace Geo steering, document interactions with custom rules and other features, improve related error guidance, and reorder the traffic steering navigation.

### Screenshots

Not applicable — this PR contains documentation-only changes.

### Documentation checklist

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))?
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change — such as adding a new page — an issue has been opened for incorrect or outdated information fixed by this PR.
- [ ] Files that changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).