### PR TITLE
Add Arize AX to AI Gateway OTEL backends

### DIFF
--- a/src/content/docs/ai-gateway/observability/otel-integration.mdx
+++ b/src/content/docs/ai-gateway/observability/otel-integration.mdx
@@ -103,6 +103,7 @@ When these headers are provided, the AI Gateway span will use them to link with 
 AI Gateway's OTEL integration works with any OpenTelemetry-compatible backend, including:
 
 - [Honeycomb](https://www.honeycomb.io/)
+- [Arize AX](https://arize.com/docs/ax/integrations/llm-providers/cloudflare-ai-gateway/cloudflare-ai-gateway-tracing)
 - [Braintrust](https://www.braintrust.dev/docs/integrations/sdk-integrations/opentelemetry)
 - [Langfuse](https://langfuse.com/integrations/native/opentelemetry)
 - [Datadog](https://docs.datadoghq.com/opentelemetry/setup/agentless/)


### PR DESCRIPTION
## Summary
- Add Arize AX to the common OpenTelemetry backends listed for AI Gateway trace export.
- Link to the Arize AX Cloudflare AI Gateway setup guide, which includes the OTLP endpoint, protobuf content type, and required authentication headers.

## Notes
This is a docs-only update to the existing OpenTelemetry backend list. AI Gateway already supports exporting to any OTLP-compatible backend; this adds an AI observability backend with Cloudflare-specific setup instructions.

## Testing
- `git diff --check`