### PR TITLE
fix: stop expand dialog from shrinking tall Mermaid diagrams

### DIFF
--- a/src/scripts/mermaid.client.ts
+++ b/src/scripts/mermaid.client.ts
@@ -70,7 +70,14 @@ function openDiagram(container: HTMLElement) {
 
 	const svg = clone.querySelector("svg");
 	if (svg) {
-		svg.removeAttribute("style");
+		// A taller-than-wide diagram must keep its natural-width cap, otherwise
+		// the dialog stretches it to full width and the content shrinks to
+		// letterbox inside the viewport-bounded body. Wide diagrams stretch.
+		const [, , vbW = 0, vbH = 0] = (svg.getAttribute("viewBox") ?? "")
+			.trim()
+			.split(/[\s,]+/)
+			.map(Number);
+		if (!(vbH > vbW)) svg.removeAttribute("style");
 		svg.setAttribute("width", "100%");
 		svg.setAttribute("height", "auto");
 	}

--- a/src/styles/markdown-pipeline.css
+++ b/src/styles/markdown-pipeline.css
@@ -217,13 +217,13 @@ pre.mermaid:not([data-processed]) {
 	overflow: hidden;
 }
 
-/* Scale the SVG larger in the dialog */
+/* The dialog body scrolls, so diagrams render at their natural size instead
+   of shrinking to fit the viewport height. */
 .mermaid-dialog-body pre.mermaid[data-processed] {
 	padding: 3rem;
 }
 
 .mermaid-dialog-body pre.mermaid[data-processed] svg {
-	max-height: calc(92vh - 120px);
 	width: 100%;
 }
 


### PR DESCRIPTION
### Summary

Fixes the expand-to-dialog view of Mermaid diagrams so taller-than-wide diagrams render at their natural size instead of shrinking dramatically.

The dialog forced the SVG into a wide, viewport-height-bounded box (`width: 100%` plus `max-height: calc(92vh - 120px)`). With the default `preserveAspectRatio: xMidYMid meet`, a diagram whose viewBox is taller than wide (e.g. a `flowchart TD` decision tree) letterboxed into that box and rendered at a small fraction of its natural scale — nodes were legible on the page but appeared scattered and tiny inside the dialog, in a mostly empty canvas.

The dialog body already scrolls (`overflow: auto`), so the height cap was removed and the clone now keeps Mermaid's natural-width `max-width` cap for taller-than-wide diagrams. Wide diagrams keep the previous stretch-to-fill behavior.

| Diagram shape | Before | After |
| --- | --- | --- |
| Taller than wide (`flowchart TD` trees, long sequence diagrams) | letterboxed at ~0.26x in a 92vh-bounded box | natural size (1x), body scrolls |
| Wider than tall (most `flowchart LR` diagrams) | stretched to fill dialog width | unchanged |

Measured on the affected dialog path: a 792x1574 viewBox diagram rendered at meet-scale 0.261 before this change and 1.0 after. Found while reviewing #33123, whose new decision-tree diagram triggered it; the behavior predates and is unrelated to the recent Mermaid version bump.

### Screenshots (optional)

<!-- TODO: add screenshots before requesting review -->

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
