### PR TITLE
[Stream] fix: Update max frame rate Stream encoding output

### DIFF
--- a/src/content/docs/stream/uploading-videos/index.mdx
+++ b/src/content/docs/stream/uploading-videos/index.mdx
@@ -54,6 +54,6 @@ Files must be less than 30 GB, and content should be encoded and uploaded in the
 
 ## Frame rates
 
-Stream accepts video uploads at any frame rate. During encoding, Stream re-encodes videos for a maximum of 70 FPS playback. If the original video has a frame rate lower than 70 FPS, Stream re-encodes at the original frame rate.
+Stream accepts video uploads at any frame rate. During encoding, Stream re-encodes videos for a maximum of 90 FPS playback. If the original video has a frame rate lower than 90 FPS, Stream re-encodes at the original frame rate.
 
 For variable frame rate content, Stream drops extra frames. For example, if there is more than one frame within a 1/30 second window, Stream drops the extra frames within that period.


### PR DESCRIPTION
### Summary

This has been 90 FPS for a while, but the docs were never updated.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).