### PR TITLE
Document BYOIP dedicated egress assignment

### DIFF
--- a/src/content/changelog/gateway/2025-08-21-byoip-dedicated-egress-ip.mdx
+++ b/src/content/changelog/gateway/2025-08-21-byoip-dedicated-egress-ip.mdx
@@ -10,7 +10,7 @@ Enterprise Gateway users can now use Bring Your Own IP (BYOIP) for dedicated egr
 
 Admins can now onboard and use their own IPv4 or IPv6 prefixes to egress traffic from Cloudflare, delivering greater control, flexibility, and compliance for network traffic.
 
-Get started by following the [BYOIP onboarding process](/cloudflare-one/traffic-policies/egress-policies/dedicated-egress-ips/#bring-your-own-ip-address-byoip). Once your IPs are onboarded, go to **Gateway** > **Egress policies** and select or create an egress policy. In **Select an egress IP**, choose _Use dedicated egress IPs (Cloudflare or BYOIP)_, then select your BYOIP address from the dropdown menu.
+Get started by completing the [BYOIP onboarding process](/cloudflare-one/traffic-policies/egress-policies/dedicated-egress-ips/#bring-your-own-ip-address-byoip). Then, contact your account team to have the IP address manually assigned to your Zero Trust organization. The address appears in the egress policy options only after this assignment. Go to **Gateway** > **Egress policies** and select or create an egress policy. In **Select an egress IP**, choose _Use dedicated egress IPs (Cloudflare or BYOIP)_, then select your BYOIP address from the dropdown menu.
 
 ![Screenshot of a dropdown menu adding a BYOIP IPv4 address as a dedicated egress IP in a Gateway egress policy](~/assets/images/gateway/Gateway-byoip-dedicated-egress-ips.png)
 

--- a/src/content/docs/cloudflare-one/traffic-policies/egress-policies/dedicated-egress-ips.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/egress-policies/dedicated-egress-ips.mdx
@@ -52,7 +52,7 @@ When testing against another origin, you may see either an IPv4 or IPv6 address.
 
 If your organization already owns IPv4 or IPv6 addresses from a regional Internet registry, you can use them as dedicated egress IPs instead of Cloudflare-provided addresses. To obtain an IPv6 range, refer to [American Registry for Internet Numbers (ARIN)](https://www.arin.net/resources/guide/ipv6/first_request/) or [Regional Internet Registry for Europe, Middle East and Central Asia (RIPE NCC)](https://www.ripe.net/manage-ips-and-asns/ipv6/request-ipv6/).
 
-After you onboard your IP addresses, they appear as options when you create an [egress policy](/cloudflare-one/traffic-policies/egress-policies/) and choose **Use dedicated egress IPs (Cloudflare or BYOIP)** as the [egress method](/cloudflare-one/traffic-policies/egress-policies/#egress-methods). BYOIP dedicated egress IPs do not support [IP geolocation](#ip-geolocation).
+After you complete the general BYOIP onboarding process, contact your account team to have the IP address manually assigned to your Zero Trust organization. The IP address does not appear as an option when you create an [egress policy](/cloudflare-one/traffic-policies/egress-policies/) and choose **Use dedicated egress IPs (Cloudflare or BYOIP)** as the [egress method](/cloudflare-one/traffic-policies/egress-policies/#egress-methods) until this assignment is complete. BYOIP dedicated egress IPs do not support [IP geolocation](#ip-geolocation).
 
 For more information, refer to [Cloudflare BYOIP](/byoip/) or contact your account team.
 


### PR DESCRIPTION
Clarifies the setup required after general BYOIP onboarding. Customers must ask their account team to assign the address to their Zero Trust organization before it appears in egress policy options.

Internal source: https://chat.google.com/room/AAAAUdh_23M/4rFswCpeNko