### PR TITLE
Document cloudflared log rotation

### DIFF
--- a/src/content/partials/cloudflare-one/tunnel/logs/view-logs-on-server.mdx
+++ b/src/content/partials/cloudflare-one/tunnel/logs/view-logs-on-server.mdx
@@ -5,11 +5,12 @@ params:
   - runParametersURL
 ---
 
-If you have access to the origin server, you can use the <a href={props.loglevelURL}>`--loglevel` flag</a> to enable logging when you start the tunnel. By default, `cloudflared` prints logs to stdout and does not store logs on the server. You can optionally use the <a href={props.logfileURL}>`--logfile` flag</a> to write your logs to a file.
+If you have access to the origin server, you can use the <a href={props.loglevelURL}>`--loglevel` flag</a> to enable logging when you start the tunnel. By default, `cloudflared` prints logs to stdout and does not store logs on the server.
 
-To enable logs, <a href={props.runParametersURL}>run the tunnel</a> using the `--loglevel info` and `--logfile <PATH>` flags. For example,
+For routine persistent logging, <a href={props.runParametersURL + "#log-directory"}>run the tunnel</a> with `--log-directory <PATH>`. This flag writes logs to `cloudflared.log` in the specified directory, rotates the file when it reaches 1 MB, and keeps up to five backups. It does not remove logs based on age.
 
 ```sh
-cloudflared tunnel --loglevel info --logfile cloudflared.log run <UUID>
+cloudflared tunnel --loglevel info --log-directory <PATH> run <UUID>
 ```
 
+Use the <a href={props.logfileURL}>`--logfile` flag</a> instead for short troubleshooting sessions or when another tool manages rotation. `cloudflared` does not rotate the file specified by `--logfile`. If you set both flags, `--logfile` takes precedence.

--- a/src/content/partials/cloudflare-one/tunnel/run-parameters.mdx
+++ b/src/content/partials/cloudflare-one/tunnel/run-parameters.mdx
@@ -213,13 +213,23 @@ The value `auto` relies on the host operating system to determine which IP versi
 
 When `cloudflared` receives SIGINT/SIGTERM it will stop accepting new requests, wait for in-progress requests to terminate, then shut down. Waiting for in-progress requests will timeout after this grace period, or when a second SIGTERM/SIGINT is received.
 
+### `log-directory`
+
+| Syntax                                                        | Environment Variable  |
+| ------------------------------------------------------------- | --------------------- |
+| `cloudflared tunnel --log-directory <PATH> run <UUID or NAME>` | `TUNNEL_LOGDIRECTORY` |
+
+Writes logs to a file named `cloudflared.log` in the specified directory. When the file reaches 1 MB, `cloudflared` rotates it and keeps up to five backup files. Rotation is based on file size; there is no age-based retention.
+
+Use `log-directory` for routine persistent logging. If you also specify [`logfile`](#logfile), `logfile` takes precedence.
+
 ### `logfile`
 
 | Syntax                                                   | Environment Variable |
 | -------------------------------------------------------- | -------------------- |
 | `cloudflared tunnel --logfile <PATH> run <UUID or NAME>` | `TUNNEL_LOGFILE`     |
 
-Saves application log to this file. Mainly useful for reporting issues. For more details on what information you need when contacting Cloudflare support, refer to <a href={props.faqURL}>this guide</a>.
+Saves the application log to this file. `cloudflared` does not rotate this file. Use `logfile` for short troubleshooting sessions or when another tool manages log rotation. If you also specify [`log-directory`](#log-directory), `logfile` takes precedence. For more details on what information you need when contacting Cloudflare support, refer to <a href={props.faqURL}>this guide</a>.
 
 ### `loglevel`
 


### PR DESCRIPTION
Documents the built-in rotation behavior of --log-directory and its environment variable. Also explains when to use --log-directory or --logfile, including precedence when both are set.

Internal source: https://chat.google.com/room/AAAAUdh_23M/Hj13X5Dec-I