### PR TITLE
[MCP Portals] Raise documented server limit

### DIFF
--- a/src/content/docs/cloudflare-one/access-controls/ai-controls/mcp-portals.mdx
+++ b/src/content/docs/cloudflare-one/access-controls/ai-controls/mcp-portals.mdx
@@ -1054,7 +1054,7 @@ MCP server portals have the following known limitations:
 - **Some MCP servers block proxy-based clients.** Certain MCP servers reject requests from proxy-based clients like MCP server portals, returning a `403` error on the registration endpoint. These servers are not compatible with MCP server portals until those providers add Cloudflare as a supported MCP client.
 - **Manual OAuth capabilities are captured during the first user authorization.** Servers configured with [manual OAuth credentials](#configure-manual-oauth-credentials) remain in **Waiting** status until a user completes upstream OAuth. Cloudflare stores the tools and prompts returned during that connection. Background and manual capability synchronization do not refresh them.
 - **Admin OAuth tokens can expire silently.** The admin credential used to [authenticate an MCP server](#reauthenticate-the-mcp-server) is subject to the upstream provider's token expiration policy. When the token expires, the server status changes to **Error** or **Sync Required** and the server will not appear in the portal for end users. Admins are not notified when this happens. Periodically check the [server status](#server-status) and [reauthenticate](#reauthenticate-the-mcp-server) servers that show an error.
-- **Each portal supports up to 40 MCP servers.** If you need to aggregate more than 40 servers into a single portal, contact your Cloudflare account team to request a higher limit. The dashboard displays a warning as you approach the limit.
+- **Each portal supports up to 80 MCP servers.**
 
 ## Policy limitations
 

--- a/src/content/docs/cloudflare-one/account-limits.mdx
+++ b/src/content/docs/cloudflare-one/account-limits.mdx
@@ -30,7 +30,7 @@ This page lists the default account limits for rules, applications, fields, and 
 | Domains per application  | 50    |
 | Infrastructure targets   | 5,000 |
 | MCP portals              | 20    |
-| MCP servers per portal   | 40    |
+| MCP servers per portal   | 80    |
 | Custom domains per MCP portal | 5 |
 | MCP portal session inactivity timeout | 24 hours |
 


### PR DESCRIPTION
## Summary

- update the MCP servers-per-portal limit from 40 to 80
- remove the stale higher-limit request and dashboard warning guidance

## Testing

- checked against MAX_GATEWAY_SERVERS and its API validation test
- git diff --check