### PR TITLE
Fix hardware-backed registration MDM example

### DIFF
--- a/src/content/docs/cloudflare-one/team-and-resources/devices/cloudflare-one-client/deployment/mdm-deployment/hardware-backed-registration.mdx
+++ b/src/content/docs/cloudflare-one/team-and-resources/devices/cloudflare-one-client/deployment/mdm-deployment/hardware-backed-registration.mdx
@@ -87,6 +87,8 @@ The following example turns on hardware-backed registration for the `example-tea
     <dict>
       <key>organization</key>
       <string>example-team</string>
+      <key>display_name</key>
+      <string>Example team</string>
     </dict>
   </array>
 </dict>


### PR DESCRIPTION
Adds the required display_name field to the hardware-backed registration MDM example so it matches the configs parameter requirements.

Internal source: https://chat.google.com/room/AAAAUdh_23M/fHGO1Bqjew8