### PR TITLE
Clarify legacy Access destination limits

### DIFF
--- a/src/content/docs/cloudflare-one/account-limits.mdx
+++ b/src/content/docs/cloudflare-one/account-limits.mdx
@@ -14,25 +14,27 @@ This page lists the default account limits for rules, applications, fields, and 
 
 ## Access
 
-| Feature                  | Limit |
-| ------------------------ | ----- |
-| Applications             | 500   |
-| Audit Logpush jobs       | 5     |
-| Email addresses per rule | 1,000 |
-| Rule groups              | 300   |
-| Rules per rule group     | 1,000 |
-| IP addresses per rule    | 1,000 |
-| mTLS root certificates   | 50    |
-| Service tokens           | 50    |
-| Identity providers       | 50    |
-| Reusable policies        | 500   |
-| Rules per application    | 1,000 |
-| Domains per application  | 50    |
-| Infrastructure targets   | 5,000 |
-| MCP portals              | 20    |
-| MCP servers per portal   | 40    |
-| Custom domains per MCP portal | 5 |
-| MCP portal session inactivity timeout | 24 hours |
+| Feature                                  | Limit    |
+| ---------------------------------------- | -------- |
+| Applications                             | 500      |
+| Audit Logpush jobs                       | 5        |
+| Email addresses per rule                 | 1,000    |
+| Rule groups                              | 300      |
+| Rules per rule group                     | 1,000    |
+| IP addresses per rule                    | 1,000    |
+| mTLS root certificates                   | 50       |
+| Service tokens                           | 50       |
+| Identity providers                       | 50       |
+| Reusable policies                        | 500      |
+| Rules per application                    | 1,000    |
+| Destinations per self-hosted application | 50       |
+| Infrastructure targets                   | 5,000    |
+| MCP portals                              | 20       |
+| MCP servers per portal                   | 40       |
+| Custom domains per MCP portal            | 5        |
+| MCP portal session inactivity timeout    | 24 hours |
+
+Some legacy accounts may enforce a lower destination limit. Contact your account team or [Cloudflare Support](/cloudflare-one/troubleshooting/contact-support/) for review.
 
 ## Gateway
 


### PR DESCRIPTION
## Summary

- Rename the Access limit to destinations per self-hosted application.
- Keep the documented limit at 50.
- Note that some legacy accounts may have a lower limit and can request a review.

Internal source: https://chat.google.com/room/AAAAUdh_23M/uihANyiAmTw