### PR TITLE
[Cloudflare One] Improve Mesh and headless client setup docs

### DIFF
--- a/src/content/docs/cloudflare-one/networks/connectors/cloudflare-mesh/client-devices.mdx
+++ b/src/content/docs/cloudflare-one/networks/connectors/cloudflare-mesh/client-devices.mdx
@@ -85,7 +85,7 @@ if (-not (curl.exe --silent https://www.cloudflare.com/cdn-cgi/trace | Select-St
 </TabItem>
 </Tabs>
 
-In Include mode, `warp=off` is expected for destinations that are not in the include list. Use the successful connection to an included Mesh IP as the data-path check. Do not rely only on the success message from `warp-cli`: Mesh connectivity requires Traffic and DNS mode. In DNS-only mode, use `warp-cli registration show` only to verify enrollment. DNS-only mode cannot carry Mesh traffic.
+In Include mode, expect `warp=off` for destinations that are not in the include list. Use the successful connection to an included Mesh IP as the data-path check. Do not rely only on the success message from `warp-cli`: Mesh connectivity requires Traffic and DNS mode. In DNS-only mode, use `warp-cli registration show` only to verify enrollment. DNS-only mode cannot carry Mesh traffic.
 
 ## What devices can reach
 
@@ -103,7 +103,7 @@ For client devices to reach Mesh IPs, the Mesh IP range must route through Cloud
 
 ### Exclude mode (default)
 
-Current default profiles route the Mesh IP range through Cloudflare. Existing or customized profiles may contain a broad CGNAT exclusion. Verify that `100.96.0.0/12` (or your custom device IP range) is not in the exclude list that applies to the device.
+The Mesh setup wizard updates the default device profile to route the Mesh IP range through Cloudflare. If you did not use the wizard, or if another profile applies to the device, verify that `100.96.0.0/12` (or your custom device IP range) is not in the exclude list or contained by a broader exclusion.
 
 Depending on your Cloudflare networking configuration, you may need to remove additional IPs from your exclude list. For a list of IPs to check, refer to [Reserved IP addresses](/cloudflare-one/networks/routes/reserved-ips/).
 

--- a/src/content/docs/cloudflare-one/networks/connectors/cloudflare-mesh/client-devices.mdx
+++ b/src/content/docs/cloudflare-one/networks/connectors/cloudflare-mesh/client-devices.mdx
@@ -13,7 +13,7 @@ head:
     content: Connect client devices to Cloudflare Mesh
 ---
 
-import { Details, Render } from "~/components";
+import { Render, TabItem, Tabs } from "~/components";
 
 Client devices — laptops, phones, and desktops — join your Mesh network by installing the [Cloudflare One Client](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/) and enrolling. Each device receives a [Mesh IP](/cloudflare-one/networks/connectors/cloudflare-mesh/#mesh-ips) and can immediately communicate with every other enrolled device and Mesh node.
 
@@ -33,17 +33,59 @@ Connect a laptop or phone to your Mesh network:
 
 <Render file="warp/enroll-ios-android" product="cloudflare-one" />
 
+### Headless Windows, macOS, and Linux devices
+
+Do not use interactive CLI enrollment on a device without a browser. Instead, [create a Service Auth enrollment policy](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/deployment/device-enrollment/#check-for-service-token). Configure the [`organization`](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/deployment/mdm-deployment/parameters/#organization), [`auth_client_id`](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/deployment/mdm-deployment/parameters/#auth_client_id), and [`auth_client_secret`](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/deployment/mdm-deployment/parameters/#auth_client_secret) managed deployment parameters.
+
+For platform-specific installation methods and configuration file locations, refer to [Managed deployment](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/deployment/mdm-deployment/). For a complete Linux example, refer to [Deploy the Cloudflare One Client on headless Linux machines](/cloudflare-one/tutorials/deploy-client-headless-linux/).
+
+This method works on [supported Windows, macOS, and Linux systems](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/download/). Service-token devices use the shared identity `non_identity@<team-name>.cloudflareaccess.com`. Policies based on identity provider users or groups do not apply to these devices. To assign device profiles, use the expression `identity.service_token_uuid == "<SERVICE_TOKEN_ID>"`, where `<SERVICE_TOKEN_ID>` is the service token resource UUID (`id`), not its `auth_client_id`. Place this [Service Token selector](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/device-profiles/#service-token) before broader OS or email profiles. Use the shared non-identity email only when all Service Auth devices should match the profile.
+
 After enrollment, the device receives a Mesh IP and connects to your Mesh network.
 
 ## 2. Verify connectivity
 
-Test that the device can reach a Mesh node or another client device:
+From a Windows, macOS, or Linux device, test TCP connectivity to a Mesh node or another client device. For example, test SSH:
+
+<Tabs syncKey="os">
+<TabItem label="macOS / Linux">
 
 ```sh
-ping <MESH-IP>
+nc -vz <MESH-IP> 22
 ```
 
-Replace `<MESH-IP>` with the Mesh IP of a node (visible on the [Mesh overview page](https://dash.cloudflare.com/?to=/:account/mesh)) or another enrolled device. Any TCP, UDP, or ICMP traffic works — you can SSH, connect to databases, call APIs, or run any protocol over Mesh IPs.
+</TabItem>
+<TabItem label="Windows (PowerShell)">
+
+```powershell
+Test-NetConnection <MESH-IP> -Port 22
+```
+
+</TabItem>
+</Tabs>
+
+Replace `<MESH-IP>` with the Mesh IP of a node (visible on the [Mesh overview page](https://dash.cloudflare.com/?to=/:account/mesh)) or another enrolled device. Replace port `22` with the port used by your service. You can test HTTP services from a mobile browser. If you turned on the ICMP Gateway proxy, you can also run `ping <MESH-IP>` as a diagnostic check.
+
+If the device profile routes `www.cloudflare.com` through WARP, verify the data path:
+
+<Tabs syncKey="os">
+<TabItem label="macOS / Linux">
+
+```sh
+curl --silent https://www.cloudflare.com/cdn-cgi/trace | grep '^warp=on$'
+```
+
+</TabItem>
+<TabItem label="Windows (PowerShell)">
+
+```powershell
+if (-not (curl.exe --silent https://www.cloudflare.com/cdn-cgi/trace | Select-String '^warp=on$')) { exit 1 }
+```
+
+</TabItem>
+</Tabs>
+
+In Include mode, `warp=off` is expected for destinations that are not in the include list. Use the successful connection to an included Mesh IP as the data-path check. Do not rely only on the success message from `warp-cli`: Mesh connectivity requires Traffic and DNS mode. In DNS-only mode, use `warp-cli registration show` only to verify enrollment. DNS-only mode cannot carry Mesh traffic.
 
 ## What devices can reach
 
@@ -61,9 +103,7 @@ For client devices to reach Mesh IPs, the Mesh IP range must route through Cloud
 
 ### Exclude mode (default)
 
-In Exclude mode, the CGNAT range (`100.64.0.0/10`) is excluded from Cloudflare by default. Remove the CGNAT range from your exclude list so that Mesh IP traffic routes through Cloudflare.
-
-If you used the [Mesh setup wizard](/cloudflare-one/networks/connectors/cloudflare-mesh/get-started/#1-run-the-setup-wizard), the wizard creates a device profile in **Include mode** for Mesh nodes. However, your client devices may still use the default profile with Exclude mode. Verify that `100.96.0.0/12` (or your custom device IP range) is not in the exclude list.
+Current default profiles route the Mesh IP range through Cloudflare. Existing or customized profiles may contain a broad CGNAT exclusion. Verify that `100.96.0.0/12` (or your custom device IP range) is not in the exclude list that applies to the device.
 
 Depending on your Cloudflare networking configuration, you may need to remove additional IPs from your exclude list. For a list of IPs to check, refer to [Reserved IP addresses](/cloudflare-one/networks/routes/reserved-ips/).
 

--- a/src/content/docs/cloudflare-one/networks/connectors/cloudflare-mesh/containers.mdx
+++ b/src/content/docs/cloudflare-one/networks/connectors/cloudflare-mesh/containers.mdx
@@ -49,23 +49,36 @@ Before starting the container, create a Mesh node and copy its token.
 
 </TabItem> <TabItem label="API">
 
-Create a node via the [Cloudflare API](/api/resources/zero_trust/subresources/tunnels/subresources/warp_connector/methods/create/):
+With an API token that has either `Cloudflare One Connectors Write` or `Cloudflare One Connector: WARP Write` permission, create a node and retrieve its connector token:
 
-```sh
-curl -X POST "https://api.cloudflare.com/client/v4/accounts/{account_id}/warp_connector" \
-  -H "Authorization: Bearer {api_token}" \
-  -H "Content-Type: application/json" \
-  -d '{"name": "k8s-gateway"}'
+```bash
+set -euo pipefail
+
+NODE_RESPONSE=$(
+	curl --fail-with-body --silent --show-error \
+		"https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/warp_connector" \
+		--request POST \
+		--header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+		--header "Content-Type: application/json" \
+		--data '{"name":"k8s-gateway"}'
+)
+
+jq -e '.success == true and (.result.id | type == "string")' \
+	<<< "$NODE_RESPONSE" > /dev/null
+NODE_ID=$(jq -r '.result.id' <<< "$NODE_RESPONSE")
+
+TOKEN_RESPONSE=$(
+	curl --fail-with-body --silent --show-error \
+		"https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/warp_connector/$NODE_ID/token" \
+		--header "Authorization: Bearer $CLOUDFLARE_API_TOKEN"
+)
+
+MESH_NODE_TOKEN=$(jq -er \
+	'select(.success == true) | .result | select(type == "string" and length > 0)' \
+	<<< "$TOKEN_RESPONSE")
 ```
 
-Then retrieve the token:
-
-```sh
-curl "https://api.cloudflare.com/client/v4/accounts/{account_id}/warp_connector/{node_id}/token" \
-  -H "Authorization: Bearer {api_token}"
-```
-
-The response contains the token string. Pass it to the container as `MESH_NODE_TOKEN`.
+Install `jq`, then set `ACCOUNT_ID` and `CLOUDFLARE_API_TOKEN` before running the commands. The commands stop on an HTTP or API error. Do not continue until they return zero and set `NODE_ID` and `MESH_NODE_TOKEN`. If token retrieval fails after node creation, retry only the token request with the existing `NODE_ID`. Do not rerun the node creation request. Pass `MESH_NODE_TOKEN` to the container.
 
 :::note
 Mesh nodes can also be managed with Terraform using the [`cloudflare_zero_trust_tunnel_warp_connector`](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zero_trust_tunnel_warp_connector) resource. To manage node configuration, use [`cloudflare_zero_trust_tunnel_warp_connector_config`](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zero_trust_tunnel_warp_connector_config).
@@ -73,7 +86,7 @@ Mesh nodes can also be managed with Terraform using the [`cloudflare_zero_trust_
 
 </TabItem> </Tabs>
 
-If this is your first Mesh node, the dashboard runs a [setup wizard](/cloudflare-one/networks/connectors/cloudflare-mesh/get-started/#what-the-wizard-configures) that configures your account for Mesh networking.
+If this is your first Mesh node, configure the [required account settings](/cloudflare-one/networks/connectors/cloudflare-mesh/get-started/#required-account-settings). You can use the dashboard wizard, APIs, or Terraform.
 
 :::caution
 Do not commit Mesh node tokens to source control. Use environment variables, `.env` files excluded from version control, or a secrets manager.

--- a/src/content/docs/cloudflare-one/networks/connectors/cloudflare-mesh/get-started.mdx
+++ b/src/content/docs/cloudflare-one/networks/connectors/cloudflare-mesh/get-started.mdx
@@ -13,31 +13,56 @@ head:
     content: Get started with Cloudflare Mesh
 ---
 
-import { DashButton, Details, Tabs, TabItem, Render } from "~/components";
+import {
+	DashButton,
+	Details,
+	Render,
+	Steps,
+	TabItem,
+	Tabs,
+} from "~/components";
 
 Set up Cloudflare Mesh so your devices and servers can reach each other by private IP.
 
 ## Prerequisites
 
 - A [Cloudflare account](https://dash.cloudflare.com/sign-up)
+- A [Zero Trust organization](/cloudflare-one/setup/#2-create-a-zero-trust-organization) with an active subscription, including the Free plan
 - A laptop or phone to connect as a client device
 - (Optional) A Linux server to deploy a Mesh node
 
-	<Details header="Linux server requirements">
+  <Details header="Linux server requirements">
 
-	<Render file="warp/system-requirements/linux" product="cloudflare-one" />
+  <Render file="warp/system-requirements/linux" product="cloudflare-one" />
 
-	</Details>
+  </Details>
 
-	:::note[Mesh nodes are optional]
-	Client-to-client connectivity works without any Mesh nodes. Two enrolled laptops can reach each other directly by Mesh IP. Mesh nodes are for running the client in headless mode on a server — either to make that server reachable by its Mesh IP, or to [route traffic to a private subnet](/cloudflare-one/networks/connectors/cloudflare-mesh/routes/) behind it. You still need to complete the setup wizard to configure your account — you can skip the Mesh node installation step and connect the node later.
-	:::
+  :::note[Mesh nodes are optional]
+  Client-to-client connectivity works without any Mesh nodes. Two enrolled laptops can reach each other directly by Mesh IP. Mesh nodes are for running the client in headless mode on a server — either to make that server reachable by its Mesh IP, or to [route traffic to a private subnet](/cloudflare-one/networks/connectors/cloudflare-mesh/routes/) behind it. Configure the [required account settings](#required-account-settings) before connecting participants. You can use the dashboard wizard, APIs, or Terraform.
+  :::
 
 Cloudflare Mesh requires that the Mesh node's [device profile](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/device-profiles/) is configured to use [MASQUE](/cloudflare-one/networks/connectors/cloudflare-mesh/#protocol-requirement). Hostname routes, IPv6 CIDR routes, and high availability do not work if the device profile uses WireGuard instead.
 
-## 1. Run the setup wizard
+## Choose a participant type
 
-The setup wizard [configures your account for Mesh networking](#what-the-wizard-configures) and optionally guides you through creating a Mesh node. This is a one-time setup.
+Choose an enrollment method based on what you want to connect:
+
+| Goal | Participant type | Enrollment method | Browser required |
+| --- | --- | --- | --- |
+| Run a service or route a subnet from Linux | [Mesh node](#1-configure-mesh) | Connector token | No |
+| Connect an unattended Windows, macOS, or Linux device | [Headless client device](/cloudflare-one/networks/connectors/cloudflare-mesh/client-devices/#headless-windows-macos-and-linux-devices) | Service token and managed deployment parameters | No |
+| Connect a user device with identity | [Client device](#2-connect-a-client-device) | Interactive identity provider enrollment | Yes |
+
+## 1. Configure Mesh
+
+Choose the dashboard wizard or API and Terraform resources.
+
+<Tabs syncKey="dashPlusAPI">
+<TabItem label="Dashboard">
+
+The setup wizard [configures your account for Mesh networking](#required-account-settings) and optionally guides you through creating a Mesh node. This is a one-time setup.
+
+<Steps>
 
 1. In the Cloudflare dashboard, go to **Networking** > **Mesh**.
 
@@ -56,7 +81,94 @@ The setup wizard [configures your account for Mesh networking](#what-the-wizard-
 
 6. Select **View node details** to complete the setup wizard.
 
+</Steps>
+
 If you installed the node, it should appear as **Online** on the Mesh overview page along with its assigned **Mesh IP**. If the node does not come online, refer to [Troubleshooting](#troubleshooting).
+
+</TabItem>
+<TabItem label="API / Terraform">
+
+The dashboard wizard is not required. After account bootstrap, APIs and Terraform can automate the supported Mesh resources. You will need your [account ID](/fundamentals/account/find-account-and-zone-ids/), Zero Trust team name, `jq`, and an [API token](/fundamentals/api/get-started/create-token/) with permissions for the resources you configure.
+
+:::note[Initial API token]
+You must create the initial API token in the dashboard. An authorized token can [create subsequent user-owned or account-owned tokens through the API](/fundamentals/api/how-to/create-via-api/).
+:::
+
+Before continuing, configure every item in [Required account settings](#required-account-settings). The examples in this section configure the Mesh node device profile, node, and connector token. You must configure device enrollment and global settings separately. **Allow all Cloudflare One traffic to reach enrolled devices** and the ICMP Gateway proxy require dashboard configuration.
+
+Before connecting a node, create a safe Include-mode profile. This request requires the `Zero Trust Write` permission. It matches Mesh nodes, uses MASQUE in Traffic and DNS mode, and routes only the Mesh IP range through Cloudflare:
+
+```bash
+set -euo pipefail
+
+PROFILE_RESPONSE=$(
+	curl --fail-with-body --silent --show-error \
+		"https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/devices/policy" \
+		--request POST \
+		--header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+		--header "Content-Type: application/json" \
+		--data "$(jq -n \
+			--arg match "identity.email == \"warp_connector@$TEAM_NAME.cloudflareaccess.com\"" \
+			'{
+				name: "Cloudflare Mesh nodes",
+				description: "Route Mesh IP traffic through Cloudflare",
+				enabled: true,
+				precedence: 100,
+				match: $match,
+				service_mode_v2: {mode: "warp"},
+				tunnel_protocol: "masque",
+				include: [{address: "100.96.0.0/12", description: "Cloudflare Mesh IPs"}]
+			}')"
+)
+
+jq -e '.success == true and (.result.id | type == "string")' \
+	<<< "$PROFILE_RESPONSE" > /dev/null
+PROFILE_ID=$(jq -r '.result.id' <<< "$PROFILE_RESPONSE")
+```
+
+Set `ACCOUNT_ID`, `TEAM_NAME`, and `CLOUDFLARE_API_TOKEN` in the shell before running the command. Use an unused `precedence` value that places this profile before broader profiles. Do not add an `exclude` field. A device profile cannot contain both `include` and `exclude`.
+
+The API response uses the standard `success`, `errors`, `messages`, and `result` fields. A non-2xx response causes `curl` to fail. A response with `success: false` or without `result.id` causes `jq` to fail. Do not continue until the command returns zero and `PROFILE_ID` is set.
+
+The following requests require an API token with either `Cloudflare One Connectors Write` or `Cloudflare One Connector: WARP Write` permission. To create a Mesh node and retrieve its connector token:
+
+```bash
+set -euo pipefail
+
+NODE_RESPONSE=$(
+	curl --fail-with-body --silent --show-error \
+		"https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/warp_connector" \
+		--request POST \
+		--header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+		--header "Content-Type: application/json" \
+		--data '{"name":"web-server"}'
+)
+
+jq -e '.success == true and (.result.id | type == "string")' \
+	<<< "$NODE_RESPONSE" > /dev/null
+NODE_ID=$(jq -r '.result.id' <<< "$NODE_RESPONSE")
+
+TOKEN_RESPONSE=$(
+	curl --fail-with-body --silent --show-error \
+		"https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/warp_connector/$NODE_ID/token" \
+		--header "Authorization: Bearer $CLOUDFLARE_API_TOKEN"
+)
+
+MESH_NODE_TOKEN=$(jq -er \
+	'select(.success == true) | .result | select(type == "string" and length > 0)' \
+	<<< "$TOKEN_RESPONSE")
+```
+
+The commands stop on an HTTP or API error. Do not continue until they return zero and set `NODE_ID` and `MESH_NODE_TOKEN`. If token retrieval fails after node creation, retry only the token request with the existing `NODE_ID`. Do not rerun the node creation request.
+
+Install the node and replace `<TOKEN>` with the value of `MESH_NODE_TOKEN`:
+
+<Render file="mesh/install-node" product="cloudflare-one" />
+
+You can also manage nodes with the [`cloudflare_zero_trust_tunnel_warp_connector`](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zero_trust_tunnel_warp_connector) resource. Use [`cloudflare_zero_trust_tunnel_warp_connector_config`](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zero_trust_tunnel_warp_connector_config) to manage node configuration.
+
+</TabItem>
+</Tabs>
 
 ## 2. Connect a client device
 
@@ -74,46 +186,78 @@ Once you see a **Connected** status, your device is on the mesh and receives its
 
 ## 3. Test connectivity
 
-From your client device, verify you can reach a Mesh node or another enrolled device:
+From a Windows, macOS, or Linux client device, verify TCP connectivity to a Mesh node or another enrolled device. For example, test SSH:
+
+<Tabs syncKey="os">
+<TabItem label="macOS / Linux">
 
 ```sh
-ping <MESH-IP>
+nc -vz <MESH-IP> 22
 ```
 
-Replace `<MESH-IP>` with the Mesh IP of a node or another device (visible on the Mesh overview page). You can also SSH, connect to a database, or call an API — any TCP, UDP, or ICMP traffic works.
+</TabItem>
+<TabItem label="Windows (PowerShell)">
+
+```powershell
+Test-NetConnection <MESH-IP> -Port 22
+```
+
+</TabItem>
+</Tabs>
+
+Replace `<MESH-IP>` with the Mesh IP shown on the Mesh overview page. Replace port `22` with the port used by your service. You can test HTTP services from a mobile browser. A connected client or healthy connector status does not verify peer connectivity. Verify the application protocol you intend to use. If you turned on the ICMP Gateway proxy, you can also run `ping <MESH-IP>` as a diagnostic check.
 
 ## Logs
 
 Traffic from Mesh nodes appears in [Gateway activity logs](/cloudflare-one/insights/logs/dashboard-logs/gateway-logs/) with the identity `warp_connector@<your-team-name>.cloudflareaccess.com`. Client device traffic appears in Gateway activity logs under the enrolled user's identity.
 
-## What the wizard configures
+## Required account settings
 
-When you create your first Mesh node, the setup wizard automatically provisions several Cloudflare One settings so you do not have to configure them manually:
+Mesh requires the following Cloudflare One settings. The dashboard wizard configures them automatically for new deployments. Non-wizard deployments must configure the same settings.
 
-| Setting                                                                                                                                                              | What it does                                                                                                                                                                                    |
-| -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [Device enrollment policy](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/deployment/device-enrollment/)                                                  | Allows devices to enroll into your Cloudflare One account using email-based [one-time PIN](/cloudflare-one/integrations/identity-providers/one-time-pin/). Only created if you do not already have an existing device enrollment policy in your account.                                                                                         |
-| [Device profile](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/device-profiles/)                                          | Creates a profile configured with [Split Tunnels](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/route-traffic/split-tunnels/) in **Include mode**, so only Mesh traffic routes through Cloudflare. This prevents disrupting existing network connectivity on your server. Only created if you do not already have an active Mesh node (formerly WARP Connector) in your account. |
-| [Allow all Cloudflare One traffic to reach enrolled devices](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/settings/#allow-all-cloudflare-one-traffic-to-reach-enrolled-devices) and [Assign a unique IP address to each device](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/settings/#assign-a-unique-ip-address-to-each-device) | Enables device-to-device connectivity for Mesh networking. |
-| [Gateway proxy](/cloudflare-one/traffic-policies/proxy/) | Enables the TCP, UDP, and ICMP traffic proxy for Mesh communication.                                     |
+| Setting                                                                                                                                                                                                                                                                                                                                                                                       | What it does                                                                                                                                                                                                                                                                                                                                                                                                  |
+| --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [Device enrollment policy](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/deployment/device-enrollment/)                                                                                                                                                                                                                                                                    | Allows devices to enroll into your Cloudflare One account using email-based [one-time PIN](/cloudflare-one/integrations/identity-providers/one-time-pin/). Only created if you do not already have an existing device enrollment policy in your account.                                                                                                                                                      |
+| [Device profile](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/device-profiles/)                                                                                                                                                                                                                                                                                 | Creates a profile configured with [Split Tunnels](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/route-traffic/split-tunnels/) in **Include mode**, so only Mesh traffic routes through Cloudflare. This prevents disrupting existing network connectivity on your server. Only created if you do not already have an active Mesh node (formerly WARP Connector) in your account. |
+| [Allow all Cloudflare One traffic to reach enrolled devices](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/settings/#allow-all-cloudflare-one-traffic-to-reach-enrolled-devices) and [Assign a unique IP address to each device](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/settings/#assign-a-unique-ip-address-to-each-device) | Enables device-to-device connectivity for Mesh networking.                                                                                                                                                                                                                                                                                                                                                    |
+| [Gateway proxy](/cloudflare-one/traffic-policies/proxy/)                                                                                                                                                                                                                                                                                                                                      | Enables TCP and UDP proxying for Mesh services. ICMP proxying is optional and supports diagnostics such as `ping` and `traceroute`.                                                                                                                                                                                                                                                                           |
+
+For automated deployments, the device profile documentation includes API and Terraform examples. Set `service_mode_v2 = { mode = "warp" }`, replace the generic example's `wireguard` protocol with `tunnel_protocol = "masque"`, and configure Split Tunnels to route `100.96.0.0/12` through Cloudflare. Match Mesh nodes with `identity.email == "warp_connector@<TEAM_NAME>.cloudflareaccess.com"`, and place this profile before broader profiles. The device enrollment documentation includes the Terraform enrollment-policy flow.
+
+### Automated settings
+
+The [`cloudflare_zero_trust_device_settings`](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zero_trust_device_settings) resource supports unique device IPs and the TCP and UDP Gateway proxies:
+
+```tf
+resource "cloudflare_zero_trust_device_settings" "mesh" {
+	account_id                        = var.cloudflare_account_id
+	use_zt_virtual_ip                 = true
+	gateway_proxy_enabled             = true
+	gateway_udp_proxy_enabled         = true
+}
+```
+
+### Human-only settings
+
+The Terraform resource does not configure **Allow all Cloudflare One traffic to reach enrolled devices** or the ICMP Gateway proxy. Before connecting participants, turn on enrolled-device reachability in the dashboard. Turn on ICMP only if you require `ping`, `traceroute`, or another ICMP-based workflow.
 
 ### Existing Cloudflare One accounts
 
 If your account already has a Cloudflare One deployment, the setup wizard will not overwrite your existing configuration. Verify the following settings are enabled for Mesh to work:
 
 - [ ] **Device enrollment** — At least one [enrollment rule](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/deployment/device-enrollment/) must exist so that devices and nodes can register with your account.
-- [ ] **Device profile for Mesh nodes** — Your Mesh nodes need a [device profile](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/route-traffic/split-tunnels/) that uses **Include mode** with the Mesh IP range (`100.96.0.0/12`) included. If your nodes use Exclude mode instead, remove `100.64.0.0/10` (the default CGNAT exclusion) from the exclude list.
+- [ ] **Device profile for Mesh nodes** — Your Mesh nodes need a [device profile](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/route-traffic/split-tunnels/) that routes the Mesh IP range (`100.96.0.0/12`) through Cloudflare. In Include mode, add the Mesh range. In Exclude mode, verify that no custom or legacy entry contains the Mesh range.
 - [ ] **Mesh connectivity** — In your device profile settings, enable [Allow all Cloudflare One traffic to reach enrolled devices](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/settings/#allow-all-cloudflare-one-traffic-to-reach-enrolled-devices).
 - [ ] **Unique device IPs** — Enable [Assign a unique IP address to each device](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/settings/#assign-a-unique-ip-address-to-each-device) so that each participant gets a routable Mesh IP.
 - [ ] **Client mode** — Mesh nodes must run in [Traffic and DNS mode](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/modes/). DNS-only or proxy-only modes are not supported.
-- [ ] **Traffic proxying** — Enable the [Gateway proxy](/cloudflare-one/traffic-policies/proxy/) for TCP, UDP, and ICMP so that Mesh traffic can flow between devices.
+- [ ] **Traffic proxying** — Enable the [Gateway proxy](/cloudflare-one/traffic-policies/proxy/) for the protocols you use. TCP and UDP carry Mesh services. ICMP supports diagnostic tools such as `ping` and `traceroute`.
 
 ## Troubleshooting
 
 - **Node shows as Offline** — On the server, run `warp-cli status`. If the output does not show `Status update: Connected`:
-    - Run `warp-cli connect`.
-    - If your private network uses a firewall to restrict Internet traffic, ensure that it allows the [WARP ports and IPs](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/deployment/firewall/).
-    - Review your [WARP daemon logs](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/troubleshooting/diagnostic-logs/) for information about why the connection is failing.
+  - Run `warp-cli connect`.
+  - If your private network uses a firewall to restrict Internet traffic, ensure that it allows the [WARP ports and IPs](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/deployment/firewall/).
+  - Review your [WARP daemon logs](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/troubleshooting/diagnostic-logs/) for information about why the connection is failing.
 - **Client device cannot reach Mesh IPs** — Verify that your Split Tunnel configuration routes the Mesh IP range (`100.96.0.0/12`) through Cloudflare. For details, refer to [Connect client devices](/cloudflare-one/networks/connectors/cloudflare-mesh/client-devices/).
 - **Windows firewall blocks Mesh traffic** — Windows Firewall blocks inbound traffic from `100.96.0.0/12` by default. Add a firewall rule that allows incoming requests from this range for your desired protocols and ports.
 

--- a/src/content/docs/cloudflare-one/networks/connectors/cloudflare-mesh/get-started.mdx
+++ b/src/content/docs/cloudflare-one/networks/connectors/cloudflare-mesh/get-started.mdx
@@ -213,7 +213,7 @@ Traffic from Mesh nodes appears in [Gateway activity logs](/cloudflare-one/insig
 
 ## Required account settings
 
-Mesh requires the following Cloudflare One settings. The dashboard wizard configures them automatically for new deployments. Non-wizard deployments must configure the same settings.
+The dashboard wizard configures the following Cloudflare One settings automatically for new deployments. Non-wizard deployments must configure the same settings:
 
 | Setting                                                                                                                                                                                                                                                                                                                                                                                       | What it does                                                                                                                                                                                                                                                                                                                                                                                                  |
 | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -250,7 +250,7 @@ If your account already has a Cloudflare One deployment, the setup wizard will n
 - [ ] **Mesh connectivity** — In your device profile settings, enable [Allow all Cloudflare One traffic to reach enrolled devices](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/settings/#allow-all-cloudflare-one-traffic-to-reach-enrolled-devices).
 - [ ] **Unique device IPs** — Enable [Assign a unique IP address to each device](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/settings/#assign-a-unique-ip-address-to-each-device) so that each participant gets a routable Mesh IP.
 - [ ] **Client mode** — Mesh nodes must run in [Traffic and DNS mode](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/modes/). DNS-only or proxy-only modes are not supported.
-- [ ] **Traffic proxying** — Enable the [Gateway proxy](/cloudflare-one/traffic-policies/proxy/) for the protocols you use. TCP and UDP carry Mesh services. ICMP supports diagnostic tools such as `ping` and `traceroute`.
+- [ ] **Traffic proxying** — Turn on the [Gateway proxy](/cloudflare-one/traffic-policies/proxy/) for the protocols you use. TCP and UDP carry Mesh services. ICMP supports diagnostic tools such as `ping` and `traceroute`.
 
 ## Troubleshooting
 

--- a/src/content/docs/cloudflare-one/networks/routes/reserved-ips.mdx
+++ b/src/content/docs/cloudflare-one/networks/routes/reserved-ips.mdx
@@ -80,7 +80,7 @@ For deployments that use the [Cloudflare One Client](/cloudflare-one/team-and-re
 
 ### Exclude mode (default)
 
-Current default profiles route the device IP range (`100.96.0.0/12`) through Cloudflare. Existing or customized profiles may still exclude the entire CGNAT range (`100.64.0.0/10`). In these profiles, delete or narrow any exclude entry that contains a reserved range required by your deployment.
+In **Exclude IPs and domains** mode, default device profiles exclude the CGNAT range (`100.64.0.0/10`) from Cloudflare. To route a reserved range within CGNAT space through Cloudflare, delete or narrow the CGNAT exclusion. The Mesh setup wizard does this automatically for the device IP range used by Mesh.
 
 [Gateway initial resolved IPs](#gateway-initial-resolved-ips) are the exception: the default range (`172.64.128.0/20`) is public Cloudflare address space, not CGNAT, so it is **not** excluded by default in Exclude mode. The Cloudflare One Client also automatically removes this range, along with the entire `2606:4700:0cf1::/48` IPv6 range (which also covers [device IPs](#device-ips) and [Cloudflare source IPs](#cloudflare-source-ips) on IPv6), from any exclusions you configure — refer to [Automatically managed ranges](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/route-traffic/split-tunnels/#automatically-managed-ranges). No Split Tunnel changes are required for these ranges. This only applies to the default IPv4 range: if you configured a custom initial resolved IP range within CGNAT space, treat it the same as the other CGNAT-based ranges below.
 

--- a/src/content/docs/cloudflare-one/networks/routes/reserved-ips.mdx
+++ b/src/content/docs/cloudflare-one/networks/routes/reserved-ips.mdx
@@ -80,13 +80,13 @@ For deployments that use the [Cloudflare One Client](/cloudflare-one/team-and-re
 
 ### Exclude mode (default)
 
-In **Exclude IPs and domains** mode, the Cloudflare One Client excludes the CGNAT range (`100.64.0.0/10`) from its routing by default. You must delete the reserved IP ranges that fall within CGNAT space from your Split Tunnels exclude list, or the associated features will stop working.
+Current default profiles route the device IP range (`100.96.0.0/12`) through Cloudflare. Existing or customized profiles may still exclude the entire CGNAT range (`100.64.0.0/10`). In these profiles, delete or narrow any exclude entry that contains a reserved range required by your deployment.
 
 [Gateway initial resolved IPs](#gateway-initial-resolved-ips) are the exception: the default range (`172.64.128.0/20`) is public Cloudflare address space, not CGNAT, so it is **not** excluded by default in Exclude mode. The Cloudflare One Client also automatically removes this range, along with the entire `2606:4700:0cf1::/48` IPv6 range (which also covers [device IPs](#device-ips) and [Cloudflare source IPs](#cloudflare-source-ips) on IPv6), from any exclusions you configure — refer to [Automatically managed ranges](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/route-traffic/split-tunnels/#automatically-managed-ranges). No Split Tunnel changes are required for these ranges. This only applies to the default IPv4 range: if you configured a custom initial resolved IP range within CGNAT space, treat it the same as the other CGNAT-based ranges below.
 
-Cloudflare recommends adding back the IPs that are not explicitly used for Cloudflare One services. This reduces the risk of conflicts with existing private network configurations that may use CGNAT address space.
+Cloudflare recommends excluding CGNAT IPs that are not used for Cloudflare One services. This reduces the risk of conflicts with private network configurations that use CGNAT address space.
 
-Use the following calculator to determine which IP ranges to add back based on the Cloudflare One features you use. For example, if your deployment requires [Cloudflare source IPs](#cloudflare-source-ips) (`100.64.0.0/12`) and [device IPs](#device-ips) (`100.96.0.0/12`), delete `100.64.0.0/10` from Split Tunnels and add back `100.80.0.0/12` and `100.112.0.0/12`.
+Use the following calculator to determine which ranges you can exclude based on the Cloudflare One features you use. For example, if your deployment requires [Cloudflare source IPs](#cloudflare-source-ips) (`100.64.0.0/12`) and [device IPs](#device-ips) (`100.96.0.0/12`), exclude `100.80.0.0/12` and `100.112.0.0/12`.
 
 <SubtractIPCalculator
 	client:load

--- a/src/content/docs/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/route-traffic/split-tunnels.mdx
+++ b/src/content/docs/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/route-traffic/split-tunnels.mdx
@@ -67,6 +67,10 @@ In [Traffic only mode](/cloudflare-one/team-and-resources/devices/cloudflare-one
 - `104.19.194.29`
 - `104.19.195.29`
 
+## Device IP ranges
+
+Current default device profiles route the default [device IP range](/cloudflare-one/networks/routes/reserved-ips/#device-ips) (`100.96.0.0/12`) through Cloudflare. Existing or customized profiles may still exclude the entire CGNAT range (`100.64.0.0/10`). Verify that the profile applied to your device does not exclude the device IP range or a parent range that contains it.
+
 ## Automatically managed ranges
 
 The Cloudflare One Client automatically includes the following ranges in Include mode, and automatically removes them from any exclusions configured in Exclude mode. This happens at runtime on the device: the ranges are not stored in your device profile, do not appear in the Split Tunnels list in the dashboard, and do not need to be added manually.

--- a/src/content/docs/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/route-traffic/split-tunnels.mdx
+++ b/src/content/docs/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/route-traffic/split-tunnels.mdx
@@ -69,7 +69,7 @@ In [Traffic only mode](/cloudflare-one/team-and-resources/devices/cloudflare-one
 
 ## Device IP ranges
 
-Current default device profiles route the default [device IP range](/cloudflare-one/networks/routes/reserved-ips/#device-ips) (`100.96.0.0/12`) through Cloudflare. Existing or customized profiles may still exclude the entire CGNAT range (`100.64.0.0/10`). Verify that the profile applied to your device does not exclude the device IP range or a parent range that contains it.
+In Exclude mode, default device profiles exclude the CGNAT range (`100.64.0.0/10`), which contains the default [device IP range](/cloudflare-one/networks/routes/reserved-ips/#device-ips) (`100.96.0.0/12`). The Mesh setup wizard updates the default profile to route the device IP range through Cloudflare. If you did not use the wizard, or if another profile applies to the device, verify that the profile does not exclude the device IP range or a parent range that contains it.
 
 ## Automatically managed ranges
 

--- a/src/content/docs/cloudflare-one/team-and-resources/devices/cloudflare-one-client/deployment/manual-deployment.mdx
+++ b/src/content/docs/cloudflare-one/team-and-resources/devices/cloudflare-one-client/deployment/manual-deployment.mdx
@@ -129,7 +129,7 @@ To enroll your device using the terminal:
    </TabItem>
    </Tabs>
 
-   In Include mode, `warp=off` is expected for destinations that are not in the include list. Test an included destination instead. In DNS-only mode, use the registration output from step 7 to verify enrollment; DNS-only mode cannot carry network traffic.
+   In Include mode, expect `warp=off` for destinations that are not in the include list. Test an included destination instead. In DNS-only mode, use the registration output from step 7 to verify enrollment. DNS-only mode cannot carry network traffic.
 
 </Steps>
 

--- a/src/content/docs/cloudflare-one/team-and-resources/devices/cloudflare-one-client/deployment/manual-deployment.mdx
+++ b/src/content/docs/cloudflare-one/team-and-resources/devices/cloudflare-one-client/deployment/manual-deployment.mdx
@@ -10,12 +10,20 @@ tags:
   - CLI
 ---
 
-import { Details, GlossaryTooltip, Render } from "~/components";
+import {
+	Details,
+	GlossaryTooltip,
+	Render,
+	Steps,
+	TabItem,
+	Tabs,
+} from "~/components";
 
 If you plan to direct your users to manually download and configure the Cloudflare One Client (formerly WARP), users will need to connect the client to your organization's Cloudflare Zero Trust instance.
 
 ## Prerequisites
 
+- Complete [Zero Trust organization setup](/cloudflare-one/setup/#2-create-a-zero-trust-organization), including subscription activation.
 - [Set device enrollment permissions](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/deployment/device-enrollment/) to specify which users can connect.
 
 ## Windows, macOS, and Linux
@@ -30,50 +38,100 @@ The device is now protected by your organization's Zero Trust policies.
 
 To enroll your device using the terminal:
 
+<Steps>
+
 1. [Download](https://pkg.cloudflareclient.com/) and install the Cloudflare One Client package.
 
 2. Open a terminal window. Ensure that you are logged into the terminal as the current user and not as root.
 
-3. Enroll into Cloudflare Zero Trust using your organization's <GlossaryTooltip term="team name">team name</GlossaryTooltip>:
+3. (Optional) Validate your organization's <GlossaryTooltip term="team name">team name</GlossaryTooltip>:
+
+   <Tabs syncKey="os">
+   <TabItem label="macOS / Linux">
+
+   ```sh
+   curl --fail --silent --show-error \
+     "https://<YOUR_TEAM_NAME>.cloudflareaccess.com/cdn-cgi/access/certs" \
+     > /dev/null
+   ```
+
+   </TabItem>
+   <TabItem label="Windows (PowerShell)">
+
+   ```powershell
+   Invoke-WebRequest -UseBasicParsing "https://<YOUR_TEAM_NAME>.cloudflareaccess.com/cdn-cgi/access/certs" | Out-Null
+   ```
+
+   </TabItem>
+   </Tabs>
+
+   A successful request confirms that the team domain exists and is reachable. It does not confirm enrollment eligibility. Compare the value with the team name in your Zero Trust settings.
+
+4. Enroll into Cloudflare Zero Trust using your team name:
 
    ```sh
    warp-cli registration new <your-team-name>
    ```
 
-4. In the browser window that opens, complete the authentication steps required by your organization.
+5. In the browser window that opens, complete the authentication steps required by your organization.
 
    Once authenticated, you will see a success page and a dialog prompting you to open a link.
 
-5. Select **Open Link**.
+6. Select **Open Link**.
 
-6. Verify the registration in the terminal:
+7. Verify the registration in the terminal:
 
    ```sh
    warp-cli registration show
    ```
 
-<Details header="Troubleshoot missing registration">
+   <Details header="Troubleshoot missing registration">
 
-The registration process may take a few minutes to complete. If the registration continues to be missing, then manually copy the authentication token from the browser to the Cloudflare One Client:
+   The `warp-cli registration new` success message does not prove that organization enrollment completed. If the browser reports an invalid enrollment request while the CLI reports success, treat the enrollment as failed. Inspect the enrollment endpoint HTTP response in browser developer tools. You can also collect [diagnostic logs](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/troubleshooting/diagnostic-logs/) with `warp-diag`.
 
-1. On the success page, right-click and select **View Page Source**.
-2. Find the HTML metadata tag that contains the token. For example, `<meta http-equiv="refresh" content"=0;url=com.cloudflare.warp://<your-team-name>.cloudflareaccess.com/auth?token=yeooilknmasdlfnlnsadfojDSFJndf_kjnasdf..." />`
-3. Copy the URL field: `com.cloudflare.warp://<your-team-name>.cloudflareaccess.com/auth?token=<your-token>`
-4. In the terminal, run the following command using the URL obtained in the previous step.
+   Do not open the bare `https://<YOUR_TEAM_NAME>.cloudflareaccess.com/warp` URL as a fallback. It does not contain the active enrollment session. If the registration continues to be missing, manually copy the authentication token from the browser to the Cloudflare One Client:
 
-   ```sh
-   warp-cli registration token "com.cloudflare.warp://<your-team-name>.cloudflareaccess.com/auth?token=<your-token>"
-   ```
+   1. On the success page, right-click and select **View Page Source**.
+   2. Find the HTML metadata tag that contains the token. For example, `<meta http-equiv="refresh" content"=0;url=com.cloudflare.warp://<your-team-name>.cloudflareaccess.com/auth?token=yeooilknmasdlfnlnsadfojDSFJndf_kjnasdf..." />`
+   3. Copy the URL field: `com.cloudflare.warp://<your-team-name>.cloudflareaccess.com/auth?token=<your-token>`
+   4. In the terminal, run the following command using the URL obtained in the previous step.
 
-If you get a `401` error, then the token has expired. Generate a new one by refreshing the web page and quickly grab the new token from the page source.
+      ```sh
+      warp-cli registration token "com.cloudflare.warp://<your-team-name>.cloudflareaccess.com/auth?token=<your-token>"
+      ```
 
-</Details>
+   If you get a `401` error, then the token has expired. Generate a new one by refreshing the web page and quickly grab the new token from the page source.
 
-7. If you did not configure the client to [auto-connect](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/settings/#auto-connect), manually connect:
+   </Details>
+
+8. If you did not configure the client to [auto-connect](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/settings/#auto-connect), manually connect:
 
    ```sh
    warp-cli connect
    ```
+
+9. If the device profile routes `www.cloudflare.com` through WARP, verify the data path:
+
+   <Tabs syncKey="os">
+   <TabItem label="macOS / Linux">
+
+   ```sh
+   curl --silent https://www.cloudflare.com/cdn-cgi/trace | grep '^warp=on$'
+   ```
+
+   </TabItem>
+   <TabItem label="Windows (PowerShell)">
+
+   ```powershell
+   if (-not (curl.exe --silent https://www.cloudflare.com/cdn-cgi/trace | Select-String '^warp=on$')) { exit 1 }
+   ```
+
+   </TabItem>
+   </Tabs>
+
+   In Include mode, `warp=off` is expected for destinations that are not in the include list. Test an included destination instead. In DNS-only mode, use the registration output from step 7 to verify enrollment; DNS-only mode cannot carry network traffic.
+
+</Steps>
 
 The device is now protected by your organization's Zero Trust policies. For more information on all available commands, run `warp-cli --help`.
 

--- a/src/content/docs/cloudflare-one/tutorials/deploy-client-headless-linux.mdx
+++ b/src/content/docs/cloudflare-one/tutorials/deploy-client-headless-linux.mdx
@@ -12,7 +12,7 @@ tags:
   - Linux
 ---
 
-import { Render, GlossaryTooltip } from "~/components";
+import { GlossaryTooltip, Render, Steps } from "~/components";
 
 This tutorial explains how to deploy the [Cloudflare One Client](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/) on Linux devices using a service token and an installation script. This deployment workflow is designed for headless servers - that is, servers which do not have access to a browser for identity provider logins - and for situations where you want to fully automate the onboarding process. Because devices will not register through an identity provider, [identity-based policies](/cloudflare-one/traffic-policies/identity-selectors/) and logging will be unavailable.
 
@@ -23,6 +23,9 @@ This tutorial focuses on deploying the Cloudflare One Client as an endpoint devi
 ## Prerequisites
 
 - [Cloudflare Zero Trust account](/cloudflare-one/setup/#2-create-a-zero-trust-organization)
+- Root or `sudo` access on a supported Linux device
+- Zero Trust team name
+- Service token Client ID and Client Secret
 
 ## 1. Create a service token
 
@@ -38,6 +41,8 @@ Device enrollment permissions determine the users and devices that can register 
 
 To allow devices to enroll using a service token:
 
+<Steps>
+
 1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Team & Resources** > **Devices**. Select the **Management** tab.
 2. In **Device enrollment permissions**, select **Manage**.
 3. In the **Policies** tab, select **Create new policy**. A new tab will open with the policy creation page.
@@ -52,12 +57,19 @@ To allow devices to enroll using a service token:
 7. Go back to **Device enrollment permissions** and add the newly created policy to your permissions.
 8. Select **Save**.
 
+</Steps>
+
+To configure service-token enrollment with Terraform, refer to [Check for a service token](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/deployment/device-enrollment/#check-for-service-token).
+
 ## 3. Create an installation script
 
 You can use a shell script to automate WARP installation and registration. The following example shows how to deploy the Cloudflare One Client on Ubuntu 24.04.
 
+<Steps>
+
 1.  In a terminal, create a new `.sh` file using a text editor. For example:
     ```sh
+    umask 077
     vim install_warp.sh
     ```
 2.  Press `i` to enter insert mode and add the following lines:
@@ -76,13 +88,13 @@ You can use a shell script to automate WARP installation and registration. The f
 
         # Create an MDM file with your Cloudflare One Client deployment parameters
         function mdm() {
-        	sudo touch /var/lib/cloudflare-warp/mdm.xml
-        	cat > /var/lib/cloudflare-warp/mdm.xml << "EOF"
+                sudo install -m 600 /dev/null /var/lib/cloudflare-warp/mdm.xml
+                sudo tee /var/lib/cloudflare-warp/mdm.xml > /dev/null << "EOF"
         <dict>
-        		<key>auth_client_id</key>
-        		<string>88bf3b6d86161464f6509f7219099e57.access</string>
-        		<key>auth_client_secret</key>
-        		<string>cfast_EqN8f9vx3sKOSY4mwCMCbZYb02L4OvfAkacLAqTZ63a435a7</string>
+                <key>auth_client_id</key>
+                <string>YOUR_CLIENT_ID</string>
+                <key>auth_client_secret</key>
+                <string>YOUR_CLIENT_SECRET</string>
         		<key>auto_connect</key>
         		<integer>1</integer>
         		<key>onboarding</key>
@@ -98,30 +110,59 @@ You can use a shell script to automate WARP installation and registration. The f
         #main program
         warp
         mdm
+        sudo systemctl restart warp-svc
         ```
 
 3.  If you are using Debian or RHEL / CentOS, modify the `warp()` function so that it installs the correct [WARP package](https://pkg.cloudflareclient.com/) for your OS.
-
 4.  Modify the values in the `mdm()` function:
     1. For `auth_client_id` and `auth_client_secret`, replace the string values with the Client ID and Client Secret of your [service token](/cloudflare-one/tutorials/deploy-client-headless-linux/#1-create-a-service-token).
     2. For `organization`, replace `your-team-name` with your Zero Trust <GlossaryTooltip term="team name">team name</GlossaryTooltip>.
     3. (Optional) Add or modify other [Cloudflare One Client deployment parameters](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/deployment/mdm-deployment/parameters/) according to your preferences.
-
 5.  Press `esc`, then type `:x` and press `Enter` to save and exit.
+
+</Steps>
 
 ## 4. Install WARP
 
 To install the Cloudflare One Client using the example script:
 
+<Steps>
+
 1. Make the script executable:
 
    ```sh
-   chmod +x install_warp.sh
+   chmod 700 install_warp.sh
    ```
 
 2. Run the script:
    ```sh
    sudo ./install_warp.sh
    ```
+3. Delete the script because it contains the service token secret:
 
-The Cloudflare One Client is now deployed with the configuration parameters stored in `/var/lib/cloudflare-warp/mdm.xml`. Assuming [`auto_connect`](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/deployment/mdm-deployment/parameters/#auto_connect) is configured, the Cloudflare One Client will automatically connect to your Zero Trust organization. Once connected, the device will appear in the [Cloudflare dashboard](https://dash.cloudflare.com/) under **Zero Trust** > **Team & Resources** > **Devices** with the email `non_identity@<team-name>.cloudflareaccess.com`.
+   ```sh
+   rm install_warp.sh
+   ```
+
+</Steps>
+
+The Cloudflare One Client is now deployed with the configuration parameters stored in the root-only `/var/lib/cloudflare-warp/mdm.xml`. Assuming [`auto_connect`](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/deployment/mdm-deployment/parameters/#auto_connect) is configured, the Cloudflare One Client will automatically connect to your Zero Trust organization.
+
+Verify registration and connection:
+
+```sh
+sudo warp-cli --accept-tos registration show
+sudo warp-cli --accept-tos status
+```
+
+Successful enrollment creates a device in **Zero Trust** > **Team & Resources** > **Devices** with the email `non_identity@<team-name>.cloudflareaccess.com`. Verify that `status` reports `Connected`. A command completion or HTTP redirect alone does not prove registration or connectivity.
+
+The registration and status commands verify enrollment and the connection to Cloudflare. To verify end-to-end traffic, connect to an included destination using the protocol you intend to use. For Cloudflare Mesh, follow [Verify connectivity](/cloudflare-one/networks/connectors/cloudflare-mesh/client-devices/#2-verify-connectivity).
+
+If the client reports `Registration Missing due to: Does not exist in API`, or the `warp-svc` logs show an HTTP `400` enrollment response, enrollment failed. Confirm that the service token policy uses the _Service Auth_ action, the policy is attached to device enrollment permissions, and the MDM team name and token values are correct. After correcting or confirming the configuration, restart the service and repeat both verification commands:
+
+```sh
+sudo systemctl restart warp-svc
+sudo warp-cli --accept-tos registration show
+sudo warp-cli --accept-tos status
+```

--- a/src/content/partials/cloudflare-one/mesh/install-node.mdx
+++ b/src/content/partials/cloudflare-one/mesh/install-node.mdx
@@ -4,19 +4,24 @@
 
 import { Tabs, TabItem } from "~/components";
 
+IP forwarding is not required to reach the node by its Mesh IP. If the node will advertise [CIDR routes](/cloudflare-one/networks/connectors/cloudflare-mesh/routes/), enable persistent forwarding before connecting it:
+
+```sh
+printf 'net.ipv4.ip_forward = 1\nnet.ipv6.conf.all.forwarding = 1\nnet.ipv6.conf.all.accept_ra = 2\n' | sudo tee /etc/sysctl.d/99-zzz-cloudflare-warp-connector.conf &&
+sudo sysctl --system
+```
+
 <Tabs>
 <TabItem label="Debian / Ubuntu">
 
 ```sh
 curl -fsSL https://pkg.cloudflareclient.com/pubkey.gpg | sudo gpg --yes --dearmor -o /usr/share/keyrings/cloudflare-warp-archive-keyring.gpg &&
 echo "deb [signed-by=/usr/share/keyrings/cloudflare-warp-archive-keyring.gpg] https://pkg.cloudflareclient.com/ $(. /etc/os-release && echo $VERSION_CODENAME) main" | sudo tee /etc/apt/sources.list.d/cloudflare-client.list &&
-sudo apt-get update -qq && sudo apt-get install -y -qq cloudflare-warp &&
-printf 'net.ipv4.ip_forward = 1\nnet.ipv6.conf.all.forwarding = 1\nnet.ipv6.conf.all.accept_ra = 2\n' | sudo tee /etc/sysctl.d/99-zzz-cloudflare-warp-connector.conf &&
-sudo sysctl --system
+sudo apt-get update -qq && sudo apt-get install -y -qq cloudflare-warp
 ```
 
 ```sh
-sudo warp-cli connector new <TOKEN> && sudo warp-cli connect
+sudo warp-cli --accept-tos connector new <TOKEN> && sudo warp-cli --accept-tos connect
 ```
 
 </TabItem>
@@ -32,13 +37,11 @@ Then install the package:
 
 ```sh
 curl -fsSl https://pkg.cloudflareclient.com/cloudflare-warp-ascii.repo | sudo tee /etc/yum.repos.d/cloudflare-warp.repo &&
-sudo yum install -y cloudflare-warp &&
-printf 'net.ipv4.ip_forward = 1\nnet.ipv6.conf.all.forwarding = 1\nnet.ipv6.conf.all.accept_ra = 2\n' | sudo tee /etc/sysctl.d/99-zzz-cloudflare-warp-connector.conf &&
-sudo sysctl --system
+sudo yum install -y cloudflare-warp
 ```
 
 ```sh
-sudo warp-cli connector new <TOKEN> && sudo warp-cli connect
+sudo warp-cli --accept-tos connector new <TOKEN> && sudo warp-cli --accept-tos connect
 ```
 
 </TabItem>

--- a/src/content/partials/cloudflare-one/tunnel/cgnat-split-tunnels.mdx
+++ b/src/content/partials/cloudflare-one/tunnel/cgnat-split-tunnels.mdx
@@ -2,7 +2,7 @@
 
 ---
 
-In your device profile, configure [Split Tunnels](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/route-traffic/split-tunnels/) so that traffic to your [device IPs](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/device-ips/) goes through the WARP tunnel. Configuration depends on your [Split Tunnels mode](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/route-traffic/split-tunnels/#change-split-tunnels-mode). For example, if your devices use the default `100.96.0.0/12` range:
+Current default device profiles route the default [device IP range](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/device-ips/) (`100.96.0.0/12`) through the WARP tunnel. Existing or customized profiles may require changes. Configuration depends on your [Split Tunnels mode](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/route-traffic/split-tunnels/#change-split-tunnels-mode):
 
-- **Exclude mode**: Delete `100.64.0.0/10` from your Split Tunnels list. We recommend [adding back the IP ranges](/cloudflare-one/networks/routes/reserved-ips/#split-tunnel-configuration) that are not explicitly used for Cloudflare One services. This reduces the risk of conflicts with existing private network configurations that may use the CGNAT address space.
+- **Exclude mode**: Delete or narrow any exclusion that contains `100.96.0.0/12`. You can [exclude the remaining CGNAT ranges](/cloudflare-one/networks/routes/reserved-ips/#split-tunnel-configuration) that your deployment does not use.
 - **Include mode**: Add `100.96.0.0/12` to your Split Tunnels list.

--- a/src/content/partials/cloudflare-one/tunnel/cgnat-split-tunnels.mdx
+++ b/src/content/partials/cloudflare-one/tunnel/cgnat-split-tunnels.mdx
@@ -2,7 +2,7 @@
 
 ---
 
-Current default device profiles route the default [device IP range](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/device-ips/) (`100.96.0.0/12`) through the WARP tunnel. Existing or customized profiles may require changes. Configuration depends on your [Split Tunnels mode](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/route-traffic/split-tunnels/#change-split-tunnels-mode):
+In Exclude mode, default device profiles exclude the CGNAT range (`100.64.0.0/10`), which contains the default [device IP range](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/device-ips/) (`100.96.0.0/12`). The Mesh setup wizard updates the default profile to route the device IP range through Cloudflare. If you did not use the wizard, or if another profile applies to the device, configure [Split Tunnels](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/route-traffic/split-tunnels/#change-split-tunnels-mode) as follows:
 
 - **Exclude mode**: Delete or narrow any exclusion that contains `100.96.0.0/12`. You can [exclude the remaining CGNAT ranges](/cloudflare-one/networks/routes/reserved-ips/#split-tunnel-configuration) that your deployment does not use.
 - **Include mode**: Add `100.96.0.0/12` to your Split Tunnels list.


### PR DESCRIPTION
### Summary

- Distinguish the guided Mesh wizard from API and Terraform setup, including dashboard-only settings.
- Add fail-fast Mesh node and connector token examples with explicit permissions, response validation, and retry guidance.
- Document browserless service-token enrollment, independent connectivity checks, and safer secret handling.
- Align Split Tunnel guidance with current device profile defaults and clarify subnet forwarding requirements.

### Screenshots (optional)

Not applicable.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [x] No files changed name or location, so redirects are not required.

### Validation

- `git diff --check origin/production...HEAD`
- Full local docs checks not run; GitHub CI will validate the MDX and links.