### PR TITLE
Warn that `cloudflared service install <TOKEN>` exposes the token in the process list

### DIFF
--- a/src/content/docs/tunnel/advanced/tunnel-tokens.mdx
+++ b/src/content/docs/tunnel/advanced/tunnel-tokens.mdx
@@ -67,6 +67,14 @@ Rotate tokens regularly to reduce the risk of compromise. For tunnels with multi
 	sudo cloudflared service install <NEW_TOKEN>
 	```
 
+	`cloudflared service install <TOKEN>` writes the token into the generated service definition, so the token appears in the process command line. On Linux, `/proc/<pid>/cmdline` is world-readable, so any local user can recover the token with `ps`. To keep the token out of the process list, write it to a root-owned file and use `--token-file` (or the `TUNNEL_TOKEN_FILE` environment variable) instead:
+
+	```sh
+	sudo install -o root -g root -m 600 /dev/null /etc/cloudflared/tunnel.token
+	# Write the new token into /etc/cloudflared/tunnel.token, then run:
+	# cloudflared --no-autoupdate tunnel run --token-file /etc/cloudflared/tunnel.token
+	```
+
 <Details header="Rotate a compromised token">
 
 If your tunnel token is compromised, immediately [rotate the token](#rotate-a-token), then force-disconnect all existing connections:
@@ -76,6 +84,6 @@ If your tunnel token is compromised, immediately [rotate the token](#rotate-a-to
 	method="DELETE"
 />
 
-Then reinstall the `cloudflared` service on all replicas using the new token.
+Then reinstall the `cloudflared` service on all replicas using the new token. Use `--token-file` rather than passing the new token on the command line, so that the replacement token is not exposed in the process list to the same local users who could have read the compromised one.
 
 </Details>


### PR DESCRIPTION
## Summary

The tunnel token rotation steps end with:

```sh
sudo cloudflared service uninstall
sudo cloudflared service install <NEW_TOKEN>
```

`cloudflared service install <TOKEN>` writes the token into the generated service
definition, so the token appears in the process command line. On Linux
`/proc/<pid>/cmdline` is world-readable, so any local user can recover the token,
even though `cloudflared` itself runs as root:

```
$ stat -c "%n mode=%a owner=%U" /proc/$PID/cmdline /proc/$PID/environ
/proc/536/cmdline mode=444 owner=root
/proc/536/environ mode=400 owner=root

$ id -un
jamin                                 # unprivileged
$ tr '\0' ' ' < /proc/536/cmdline     # succeeds — token recovered
$ cat /proc/536/environ               # Permission denied
```

`/proc` is mounted without `hidepid` by default on most distributions, so this
applies to a stock install.

This is most consequential in the **Rotate a compromised token** section, which
repeats the same instruction. A reader rotating *because the token leaked* is
told to place the replacement token in front of exactly the same local users who
could have read the original one.

## What this changes

Two prose additions to `tunnel-tokens.mdx`. No behaviour change is being
requested of `cloudflared` — it already supports both `--token-file` and
`$TUNNEL_TOKEN_FILE`:

```
--token value       The Tunnel token ... [$TUNNEL_TOKEN]
--token-file value  Filepath at which to read the tunnel token. [$TUNNEL_TOKEN_FILE]
```

so this documents an existing safer option at the point where readers are most
likely to need it.

Verified on a live remotely-managed tunnel: after switching the unit to
`--token-file`, the connector registered normally (four QUIC connections) and the
token was no longer present in argv.

## Related

Related to cloudflare/cloudflared#1539 and cloudflare/cloudflared#802, which
propose changing the default in `service install`. This PR is independent of
those — whatever happens to the default, the rotation steps currently point the
reader at the less safe option.

No new components or imports; uses only what the page already imports.
