### PR TITLE
[Sandbox] Rewrite backup and restore docs

### DIFF
--- a/src/content/changelog/agents/2026-02-23-sandbox-backup-restore-api.mdx
+++ b/src/content/changelog/agents/2026-02-23-sandbox-backup-restore-api.mdx
@@ -35,14 +35,14 @@ await env.KV.put(`backup:${userId}`, JSON.stringify(backup));
 await sandbox.restoreBackup(backup);
 ```
 
-Backups are stored in [R2](/r2/). The SDK rejects expired backups at restore time. To delete objects from the bucket, use [R2 object lifecycle rules](/sandbox/guides/backup-restore/#set-a-name-and-ttl).
+Backups are stored in [R2](/r2) and can take advantage of [R2 object lifecycle rules](/sandbox/guides/backup-restore/#configure-r2-lifecycle-rules-for-automatic-cleanup) to ensure they do not persist forever.
 
 Key capabilities:
 
 - **Persist and reuse across sandbox sessions** — Easily store backup handles in KV, D1, or Durable Object storage for use in subsequent sessions
 - **Usable across multiple instances** — Fork a backup across many sandboxes for parallel work
 - **Named backups** — Provide optional human-readable labels for easier management
-- **TTLs** — Set time-to-live durations. Expired backups cannot be restored. They remain in R2 until you delete them or a lifecycle rule removes them.
+- **TTLs** — Set time-to-live durations so backups are automatically removed from storage once they are no longer needed
 
 :::note
 Backup and restore currently uses a FUSE overlay. Soon, native snapshotting at a lower level will be added to Containers and Sandboxes, improving speed and ergonomics. The current backup functionality provides a significant speed improvement over manually recreating a file system, but it will be further optimized in the future. The new snapshotting system will use a similar API, so changing to this system will be simple once it is available.

--- a/src/content/changelog/agents/2026-02-23-sandbox-backup-restore-api.mdx
+++ b/src/content/changelog/agents/2026-02-23-sandbox-backup-restore-api.mdx
@@ -35,14 +35,14 @@ await env.KV.put(`backup:${userId}`, JSON.stringify(backup));
 await sandbox.restoreBackup(backup);
 ```
 
-Backups are stored in [R2](/r2) and can take advantage of [R2 object lifecycle rules](/sandbox/guides/backup-restore/#configure-r2-lifecycle-rules-for-automatic-cleanup) to ensure they do not persist forever.
+Backups are stored in [R2](/r2/). The SDK rejects expired backups at restore time. To delete objects from the bucket, use [R2 object lifecycle rules](/sandbox/guides/backup-restore/#set-a-name-and-ttl).
 
 Key capabilities:
 
 - **Persist and reuse across sandbox sessions** — Easily store backup handles in KV, D1, or Durable Object storage for use in subsequent sessions
 - **Usable across multiple instances** — Fork a backup across many sandboxes for parallel work
 - **Named backups** — Provide optional human-readable labels for easier management
-- **TTLs** — Set time-to-live durations so backups are automatically removed from storage once they are no longer needed
+- **TTLs** — Set time-to-live durations. Expired backups cannot be restored. They remain in R2 until you delete them or a lifecycle rule removes them.
 
 :::note
 Backup and restore currently uses a FUSE overlay. Soon, native snapshotting at a lower level will be added to Containers and Sandboxes, improving speed and ergonomics. The current backup functionality provides a significant speed improvement over manually recreating a file system, but it will be further optimized in the future. The new snapshotting system will use a similar API, so changing to this system will be simple once it is available.

--- a/src/content/docs/sandbox/api/backups.mdx
+++ b/src/content/docs/sandbox/api/backups.mdx
@@ -81,7 +81,7 @@ Configure a `BACKUP_BUCKET` R2 binding in `wrangler.jsonc` before using backup m
 :::
 
 :::caution[Path permissions]
-`mksquashfs` must read every file and subdirectory in `dir`. Restrictive permissions fail with `BackupCreateError`. The message includes `mksquashfs failed` and the archiver output. Refer to [Fix path permissions](/sandbox/guides/backup-restore/#fix-path-permissions).
+`mksquashfs` must read every file and subdirectory in `dir`. Restrictive permissions fail with `BackupCreateError`. Refer to [Fix path permissions](/sandbox/guides/backup-restore/#fix-path-permissions).
 :::
 
 :::caution[Partial writes]

--- a/src/content/docs/sandbox/api/backups.mdx
+++ b/src/content/docs/sandbox/api/backups.mdx
@@ -1,6 +1,6 @@
 ---
 title: Backups
-description: Create point-in-time snapshots of sandbox directories and restore them with copy-on-write overlays.
+description: Create and restore point-in-time snapshots of sandbox directories.
 pcx_content_type: concept
 sidebar:
   order: 5
@@ -10,13 +10,15 @@ products:
 
 import { TypeScriptExample } from "~/components";
 
-Create point-in-time snapshots of sandbox directories and restore them with copy-on-write overlays.
+Create point-in-time snapshots of sandbox directories and restore them from R2.
+
+For setup, restore workflows, and generated-cache exclusions, refer to [Backup and restore](/sandbox/guides/backup-restore/). For overlay semantics, refer to [Directory backups](/sandbox/concepts/backup-restore/).
 
 ## Methods
 
 ### `createBackup()`
 
-Create a point-in-time snapshot of a directory and upload it to R2 storage.
+Create a snapshot of a directory and upload it to R2.
 
 ```ts
 await sandbox.createBackup(options: BackupOptions): Promise<DirectoryBackup>
@@ -25,16 +27,20 @@ await sandbox.createBackup(options: BackupOptions): Promise<DirectoryBackup>
 **Parameters**:
 
 - `options` - Backup configuration (see [`BackupOptions`](#backupoptions)):
-  - `dir` (required) - Absolute path to the directory to back up (for example, `"/workspace"`)
-  - `name` (optional) - Human-readable name for the backup. Maximum 256 characters, no control characters.
-  - `ttl` (optional) - Time-to-live in seconds until the backup expires. Default: `259200` (3 days). Must be a positive number.
-  - `useGitignore` (optional) - When `true`, excludes files matching `.gitignore` rules from the backup. Default: `false`. If the directory is not inside a git repository, no exclusions are applied. Requires `git` to be available in the container.
-  - `localBucket` (optional) - When `true`, uses the `BACKUP_BUCKET` R2 binding directly instead of presigned URLs. Intended for use with `wrangler dev`. Default: `false`.
+  - `dir` (required) - Absolute path to back up. Must be under `/workspace`, `/home`, `/tmp`, `/var/tmp`, or `/app`.
+  - `name` (optional) - Human-readable name. Maximum 256 characters. Control characters are rejected.
+  - `ttl` (optional) - Time-to-live in seconds. Default: `259200` (3 days). Must be a positive number.
+  - `gitignore` (optional) - When `true`, exclude paths matching `.gitignore` rules if `dir` is inside a git repository. Default: `false`. If the directory is not in a git repository, no git exclusions apply. If `git` is not installed, the SDK logs a warning and continues without git-based exclusions.
+  - `excludes` (optional) - Glob patterns to omit from the archive. Passed to `mksquashfs` as wildcard excludes. `**` globstars are normalized automatically. Default: `[]`.
+  - `localBucket` (optional) - When `true`, use the `BACKUP_BUCKET` R2 binding instead of presigned URLs. Intended for `wrangler dev`. Default: `false`.
+  - `compression` (optional) - Archive compression. Default format: `lz4`. Default threads: `8`. Format must be `gzip`, `lz4`, or `zstd`. `threads` must be a positive integer.
+  - `multipart` (optional) - Use parallel multipart upload for large archives. Default: `true`.
 
 **Returns**: `Promise<DirectoryBackup>` containing:
 
 - `id` - Unique backup identifier (UUID)
 - `dir` - Directory that was backed up
+- `localBucket` (optional) - Whether the backup used local R2 binding mode
 
 <TypeScriptExample>
 
@@ -43,10 +49,7 @@ import { getSandbox } from "@cloudflare/sandbox";
 
 const sandbox = getSandbox(env.Sandbox, "my-sandbox");
 
-// Create a backup of /workspace
 const backup = await sandbox.createBackup({ dir: "/workspace" });
-
-// Later, restore the backup
 await sandbox.restoreBackup(backup);
 ```
 
@@ -56,40 +59,40 @@ await sandbox.restoreBackup(backup);
 
 In production:
 
-1. The container creates a compressed squashfs archive from the directory.
-2. The container uploads the archive directly to R2 using a presigned URL.
+1. The container creates a compressed squashfs archive.
+2. The container uploads the archive to R2 with a presigned URL.
 3. Metadata is stored alongside the archive in R2.
-4. The local archive is cleaned up.
+4. The local archive is deleted.
 
-With `localBucket: true` (local development):
+With `localBucket: true`:
 
-1. The container creates a compressed squashfs archive from the directory.
-2. The archive is uploaded directly to the `BACKUP_BUCKET` R2 binding.
+1. The container creates a compressed squashfs archive.
+2. The archive is uploaded through the `BACKUP_BUCKET` R2 binding.
 3. Metadata is stored alongside the archive in R2.
-4. The local archive is cleaned up.
+4. The local archive is deleted.
 
 **Throws**:
 
-- `InvalidBackupConfigError` - If `dir` is not absolute, contains `..`, the `BACKUP_BUCKET` binding is missing, or (in production) the R2 presigned URL credentials are not configured
-- `BackupCreateError` - If the container fails to create the archive, the upload to R2 fails, or `useGitignore` is `true` but `git` is not available in the container
+- `InvalidBackupConfigError` - If `dir` is not an allowed absolute path, the `BACKUP_BUCKET` binding is missing, or (in production) R2 presigned URL credentials are not configured
+- `BackupCreateError` - If archive creation or the upload to R2 fails
 
 :::note[R2 binding required]
-You must configure a `BACKUP_BUCKET` R2 binding in your `wrangler.jsonc` before using backup methods. For production, you must also configure R2 presigned URL credentials (`R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, `CLOUDFLARE_ACCOUNT_ID`, `BACKUP_BUCKET_NAME`). Refer to the [backup and restore guide](/sandbox/guides/backup-restore/#prerequisites) for setup details.
+Configure a `BACKUP_BUCKET` R2 binding in `wrangler.jsonc` before using backup methods. Production also requires `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, `CLOUDFLARE_ACCOUNT_ID`, and `BACKUP_BUCKET_NAME`. Refer to [Backup and restore](/sandbox/guides/backup-restore/#prerequisites).
 :::
 
 :::caution[Path permissions]
-The backup process uses `mksquashfs`, which must have read access to every file and subdirectory in the target path. If any file has restrictive permissions (for example, directories owned by a different user), the backup fails with a `BackupCreateError: mksquashfs failed: Could not create destination file: Permission denied` error. Run `chmod -R a+rX` on the target directory before backing up, or refer to the [path permissions guide](/sandbox/guides/backup-restore/#path-permissions) for other options.
+`mksquashfs` must read every file and subdirectory in `dir`. Restrictive permissions fail with `BackupCreateError` and `Permission denied`. Refer to [Fix path permissions](/sandbox/guides/backup-restore/#fix-path-permissions).
 :::
 
 :::caution[Partial writes]
-Partially-written files may not be captured consistently. Only completed writes are guaranteed to be included in the backup.
+Partially written files may not be captured consistently. Completed writes are included.
 :::
 
 ---
 
 ### `restoreBackup()`
 
-Restore a previously created backup into a directory.
+Restore a previously created backup.
 
 ```ts
 await sandbox.restoreBackup(backup: DirectoryBackup): Promise<RestoreBackupResult>
@@ -97,7 +100,7 @@ await sandbox.restoreBackup(backup: DirectoryBackup): Promise<RestoreBackupResul
 
 **Parameters**:
 
-- `backup` - The backup handle returned by `createBackup()`. Contains `id` and `dir`. (see [`DirectoryBackup`](#directorybackup))
+- `backup` - Handle returned by `createBackup()`. Contains `id` and `dir`. Restore writes into `backup.dir`, which may differ from the original backup path. (see [`DirectoryBackup`](#directorybackup))
 
 **Returns**: `Promise<RestoreBackupResult>` containing:
 
@@ -108,15 +111,7 @@ await sandbox.restoreBackup(backup: DirectoryBackup): Promise<RestoreBackupResul
 <TypeScriptExample>
 
 ```ts
-// Create a named backup with 24-hour TTL
-const backup = await sandbox.createBackup({
-	dir: "/workspace",
-	name: "before-refactor",
-	ttl: 86400,
-});
-
-// Store the handle for later use
-await env.KV.put(`backup:${userId}`, JSON.stringify(backup));
+await sandbox.restoreBackup(backup);
 ```
 
 </TypeScriptExample>
@@ -125,135 +120,71 @@ await env.KV.put(`backup:${userId}`, JSON.stringify(backup));
 
 In production:
 
-1. Metadata is downloaded from R2 and the TTL is checked. If expired, an error is thrown (with a 60-second buffer).
-2. The container downloads the archive directly from R2 using a presigned URL.
-3. The container mounts the squashfs archive with FUSE overlayfs.
+1. Metadata is downloaded from R2 and the TTL is checked, with a 60-second buffer. An expired backup throws.
+2. The container downloads the archive from R2 with a presigned URL.
+3. The container mounts the archive with FUSE overlayfs.
 
-With `localBucket: true` (local development):
+With `localBucket: true`:
 
-1. Metadata is downloaded from the `BACKUP_BUCKET` R2 binding and the TTL is checked.
+1. Metadata is downloaded from the `BACKUP_BUCKET` binding and the TTL is checked.
 2. The archive is downloaded from the R2 binding.
-3. The archive is extracted into the target directory using `unsquashfs`.
+3. The archive is extracted with `unsquashfs`.
 
 **Throws**:
 
-- `InvalidBackupConfigError` - If `backup.id` is missing or not a valid UUID, or `backup.dir` is invalid
-- `BackupNotFoundError` - If the backup metadata or archive is not found in R2
-- `BackupExpiredError` - If the backup TTL has elapsed
+- `InvalidBackupConfigError` - If `backup.id` is missing or not a UUID, or `backup.dir` is invalid
+- `BackupNotFoundError` - If the metadata or archive is not in R2
+- `BackupExpiredError` - If the TTL has elapsed
 - `BackupRestoreError` - If the container fails to restore
 
 :::note[Copy-on-write]
-In production, restore uses copy-on-write semantics. The backup is mounted as a read-only lower layer, and new writes go to a writable upper layer. The backup can be restored into a different directory than the original. In local development, the directory is replaced on restore.
+In production, the backup is a read-only lower layer and new writes go to a writable upper layer. In local development, the directory is replaced. For overlay constraints, refer to [Directory backups](/sandbox/concepts/backup-restore/).
 :::
 
 :::caution[Ephemeral mount]
-In production, the FUSE mount is lost when the sandbox sleeps or restarts. Re-restore from the backup handle to recover. Stop processes writing to the target directory before restoring.
+In production, the FUSE mount is lost when the sandbox sleeps or restarts. Restore again from the handle. Stop processes that write to the target directory before restoring.
 :::
-
-## Usage patterns
-
-### Exclude gitignored files
-
-Use `useGitignore` to exclude files matching `.gitignore` rules (such as `node_modules/` or `dist/`) from the backup. This reduces backup size for git repositories.
-
-<TypeScriptExample>
-
-```ts
-const sandbox = getSandbox(env.Sandbox, "my-sandbox");
-
-// Exclude gitignored files from the backup
-const backup = await sandbox.createBackup({
-	dir: "/workspace",
-	useGitignore: true,
-});
-
-// Without useGitignore (default), all files are included
-const fullBackup = await sandbox.createBackup({
-	dir: "/workspace",
-});
-```
-
-</TypeScriptExample>
-
-If the directory is not inside a git repository, `useGitignore` has no effect and all files are included. If `useGitignore` is `true` but `git` is not installed in the container, a `BackupCreateError` is thrown.
-
-### Checkpoint and restore
-
-Use backups as checkpoints before risky operations.
-
-<TypeScriptExample>
-
-```ts
-// Save checkpoint before risky operation
-const checkpoint = await sandbox.createBackup({ dir: "/workspace" });
-
-try {
-	await sandbox.exec("npm install some-experimental-package");
-	await sandbox.exec("npm run build");
-} catch (error) {
-	// Restore to the checkpoint if something goes wrong
-	await sandbox.restoreBackup(checkpoint);
-}
-```
-
-</TypeScriptExample>
-
-### Error handling
-
-<TypeScriptExample>
-
-```ts
-import { getSandbox } from "@cloudflare/sandbox";
-
-const sandbox = getSandbox(env.Sandbox, "my-sandbox");
-
-try {
-	const backup = await sandbox.createBackup({ dir: "/workspace" });
-	console.log(`Backup created: ${backup.id}`);
-} catch (error) {
-	if (error.code === "INVALID_BACKUP_CONFIG") {
-		console.error("Configuration error:", error.message);
-	} else if (error.code === "BACKUP_CREATE_FAILED") {
-		console.error("Backup failed:", error.message);
-	}
-}
-```
-
-</TypeScriptExample>
 
 ## Behavior
 
-- Concurrent backup and restore operations on the same sandbox are automatically serialized.
-- The returned `DirectoryBackup` handle is serializable — store it in KV, D1, or Durable Object storage.
-- Overlapping backups are independent. Restoring a parent directory overwrites subdirectory mounts.
-
-### TTL enforcement
-
-The `ttl` value controls when a backup is considered expired. The SDK enforces this at **restore time only** — when you call `restoreBackup()`, the SDK reads the backup metadata from R2 and checks whether the TTL has elapsed. If it has, the restore is rejected with a `BACKUP_EXPIRED` error.
-
-The TTL does **not** automatically delete objects from R2. Expired backup archives and metadata remain in your R2 bucket until you delete them. To automatically clean up expired objects, configure an [R2 object lifecycle rule](/r2/buckets/object-lifecycles/) on your backup bucket. Without a lifecycle rule, expired backups continue to consume R2 storage.
+- Concurrent backup and restore operations on the same sandbox are serialized.
+- `DirectoryBackup` is serializable. Store it in KV, D1, or Durable Object storage.
+- Overlapping backups are independent. Restoring a parent directory overwrites subdirectory mounts. Restore the parent first when restoring both.
+- `ttl` is enforced at restore time only. Expired objects remain in R2 until you delete them or an [R2 lifecycle rule](/r2/buckets/object-lifecycles/) removes them.
+- Backup objects use `backups/{id}/data.sqsh` and `backups/{id}/meta.json`.
 
 ## Types
 
 ### `BackupOptions`
 
 ```ts
+interface BackupCompressionOptions {
+	format?: "gzip" | "lz4" | "zstd";
+	threads?: number;
+}
+
 interface BackupOptions {
 	dir: string;
 	name?: string;
 	ttl?: number;
-	useGitignore?: boolean;
+	gitignore?: boolean;
+	excludes?: string[];
 	localBucket?: boolean;
+	compression?: BackupCompressionOptions;
+	multipart?: boolean;
 }
 ```
 
 **Fields**:
 
-- `dir` (required) - Absolute path to the directory to back up
-- `name` (optional) - Human-readable backup name. Maximum 256 characters, no control characters.
+- `dir` (required) - Absolute path under `/workspace`, `/home`, `/tmp`, `/var/tmp`, or `/app`
+- `name` (optional) - Human-readable name. Maximum 256 characters. No control characters.
 - `ttl` (optional) - Time-to-live in seconds. Default: `259200` (3 days). Must be a positive number.
-- `useGitignore` (optional) - When `true`, excludes files matching `.gitignore` rules if the directory is inside a git repository. Default: `false`. If the directory is not inside a git repository, no git-based exclusions are applied.
-- `localBucket` (optional) - When `true`, uses the `BACKUP_BUCKET` R2 binding directly instead of presigned URLs. Intended for use with `wrangler dev`. Default: `false`.
+- `gitignore` (optional) - When `true`, exclude `.gitignore` matches if `dir` is inside a git repository. Default: `false`.
+- `excludes` (optional) - Glob patterns to omit. Example: `['node_modules/.cache', '*.log']`. Refer to [Exclude generated caches](/sandbox/guides/backup-restore/#exclude-generated-caches).
+- `localBucket` (optional) - Use the `BACKUP_BUCKET` binding instead of presigned URLs. Default: `false`.
+- `compression` (optional) - `format` defaults to `lz4`. `threads` defaults to `8`.
+- `multipart` (optional) - Parallel multipart upload. Default: `true`.
 
 ### `DirectoryBackup`
 
@@ -261,13 +192,15 @@ interface BackupOptions {
 interface DirectoryBackup {
 	readonly id: string;
 	readonly dir: string;
+	readonly localBucket?: boolean;
 }
 ```
 
 **Fields**:
 
 - `id` - Unique backup identifier (UUID)
-- `dir` - Directory that was backed up
+- `dir` - Directory to restore into
+- `localBucket` (optional) - Whether the backup used local R2 binding mode
 
 ### `RestoreBackupResult`
 
@@ -287,6 +220,8 @@ interface RestoreBackupResult {
 
 ## Related resources
 
+- [Backup and restore](/sandbox/guides/backup-restore/) - Setup and restore workflows
+- [Directory backups](/sandbox/concepts/backup-restore/) - Overlay restore and `EXDEV`
 - [Storage API](/sandbox/api/storage/) - Mount S3-compatible buckets
 - [Files API](/sandbox/api/files/) - Read and write files
 - [Wrangler configuration](/sandbox/configuration/wrangler/) - Configure bindings

--- a/src/content/docs/sandbox/api/backups.mdx
+++ b/src/content/docs/sandbox/api/backups.mdx
@@ -81,7 +81,7 @@ Configure a `BACKUP_BUCKET` R2 binding in `wrangler.jsonc` before using backup m
 :::
 
 :::caution[Path permissions]
-`mksquashfs` must read every file and subdirectory in `dir`. Restrictive permissions fail with `BackupCreateError` and `Permission denied`. Refer to [Fix path permissions](/sandbox/guides/backup-restore/#fix-path-permissions).
+`mksquashfs` must read every file and subdirectory in `dir`. Restrictive permissions fail with `BackupCreateError: mksquashfs failed: Could not create destination file: Permission denied`. Refer to [Fix path permissions](/sandbox/guides/backup-restore/#fix-path-permissions).
 :::
 
 :::caution[Partial writes]

--- a/src/content/docs/sandbox/api/backups.mdx
+++ b/src/content/docs/sandbox/api/backups.mdx
@@ -81,7 +81,7 @@ Configure a `BACKUP_BUCKET` R2 binding in `wrangler.jsonc` before using backup m
 :::
 
 :::caution[Path permissions]
-`mksquashfs` must read every file and subdirectory in `dir`. Restrictive permissions fail with `BackupCreateError: mksquashfs failed: Could not create destination file: Permission denied`. Refer to [Fix path permissions](/sandbox/guides/backup-restore/#fix-path-permissions).
+`mksquashfs` must read every file and subdirectory in `dir`. Restrictive permissions fail with `BackupCreateError`. The message includes `mksquashfs failed` and the archiver output. Refer to [Fix path permissions](/sandbox/guides/backup-restore/#fix-path-permissions).
 :::
 
 :::caution[Partial writes]

--- a/src/content/docs/sandbox/api/index.mdx
+++ b/src/content/docs/sandbox/api/index.mdx
@@ -71,8 +71,7 @@ The Sandbox SDK provides a comprehensive API for executing code, managing files,
 </LinkTitleCard>
 
 <LinkTitleCard title="Backups" href="/sandbox/api/backups/" icon="clock">
-	Create point-in-time snapshots of directories and restore them with
-	copy-on-write overlays. Store backups in R2.
+	Create point-in-time snapshots of directories and restore them from R2.
 </LinkTitleCard>
 
 <LinkTitleCard title="Sessions" href="/sandbox/api/sessions/" icon="seti:plan">

--- a/src/content/docs/sandbox/concepts/backup-restore.mdx
+++ b/src/content/docs/sandbox/concepts/backup-restore.mdx
@@ -31,7 +31,7 @@ With `localBucket: true`, `wrangler dev` extracts the archive with `unsquashfs`.
 
 Overlayfs treats the lower and upper layers as different devices. A rename that moves a directory from the restored lower layer into the writable upper layer can fail with `EXDEV` (`cross-device link not permitted`).
 
-Generated caches that atomically replace a directory trigger this. Vite does this with `node_modules/.vite/deps`. Omit those directories from the backup, or delete them after restore.
+Vite does this with `node_modules/.vite/deps`. Omit that directory from the backup, or delete it after restore.
 
 For the procedure, refer to [Exclude generated caches](/sandbox/guides/backup-restore/#exclude-generated-caches).
 

--- a/src/content/docs/sandbox/concepts/backup-restore.mdx
+++ b/src/content/docs/sandbox/concepts/backup-restore.mdx
@@ -1,0 +1,42 @@
+---
+title: Directory backups
+description: Production restore mounts a copy-on-write overlay. Local restore extracts the archive instead.
+pcx_content_type: concept
+sidebar:
+  order: 8
+products:
+  - sandbox
+---
+
+Backup and restore snapshot a sandbox directory into an R2 archive, then bring that tree back later. The public API is the same in production and in `wrangler dev`. The restore mechanism is not.
+
+Use backups when you want a project directory such as `/workspace` to return later. Use [bucket mounts](/sandbox/guides/mount-buckets/) when a separate storage path such as `/data` should persist independently of the sandbox filesystem.
+
+## Production restore
+
+In production, `restoreBackup()` mounts the squashfs archive with FUSE overlayfs:
+
+- The backup is a read-only lower layer.
+- New writes go to a writable upper layer.
+- The original archive in R2 does not change.
+- Restoring the same handle again discards the upper layer.
+
+The overlay exists only while the container is running. When the sandbox sleeps or the container restarts, the mount is gone and the directory is empty. Store the `DirectoryBackup` handle and restore again.
+
+## Local restore
+
+With `localBucket: true`, `wrangler dev` extracts the archive with `unsquashfs`. The target directory is replaced. There is no overlay, so local restore does not reproduce production FUSE behavior.
+
+## Cross-device renames
+
+Overlayfs treats the lower and upper layers as different devices. A rename that moves a directory from the restored lower layer into the writable upper layer can fail with `EXDEV` (`cross-device link not permitted`).
+
+Generated caches that atomically replace a directory trigger this. Vite does this with `node_modules/.vite/deps`. Omit those directories from the backup, or delete them after restore.
+
+For the procedure, refer to [Exclude generated caches](/sandbox/guides/backup-restore/#exclude-generated-caches).
+
+## Related resources
+
+- [Backup and restore](/sandbox/guides/backup-restore/) - Create, restore, and exclude caches
+- [Backups API](/sandbox/api/backups/) - Method signatures and options
+- [Sandbox lifecycle](/sandbox/concepts/sandboxes/) - What happens when a sandbox sleeps

--- a/src/content/docs/sandbox/concepts/index.mdx
+++ b/src/content/docs/sandbox/concepts/index.mdx
@@ -17,6 +17,7 @@ These pages explain how the Sandbox SDK works, why it's designed the way it is, 
 - [Preview URLs](/sandbox/concepts/preview-urls/) - How to expose sandboxed services on the public internet.
 - [Security model](/sandbox/concepts/security/) - Isolation, validation, and safety mechanisms
 - [Terminal connections](/sandbox/concepts/terminal/) - How browser terminal connections work
+- [Directory backups](/sandbox/concepts/backup-restore/) - Overlay restore, local extract, and cross-device renames
 
 ## Related resources
 

--- a/src/content/docs/sandbox/concepts/sandboxes.mdx
+++ b/src/content/docs/sandbox/concepts/sandboxes.mdx
@@ -197,5 +197,6 @@ See [Dockerfile reference](/sandbox/configuration/dockerfile/) for details on im
 - [Architecture](/sandbox/concepts/architecture/) - How sandboxes fit in the system
 - [Container runtime](/sandbox/concepts/containers/) - What runs inside sandboxes
 - [Session management](/sandbox/concepts/sessions/) - Advanced state isolation
+- [Directory backups](/sandbox/concepts/backup-restore/) - Why restored files do not survive sleep unless you restore again
 - [Lifecycle API](/sandbox/api/lifecycle/) - Create and manage sandboxes
 - [Sessions API](/sandbox/api/sessions/) - Create and manage execution sessions

--- a/src/content/docs/sandbox/guides/backup-restore.mdx
+++ b/src/content/docs/sandbox/guides/backup-restore.mdx
@@ -123,9 +123,7 @@ The restore target is `backup.dir`. You can point that field at a different allo
 
 ## Exclude generated caches
 
-After a production restore, renaming a directory inside the restored tree can fail with `EXDEV` (`cross-device link not permitted`). The restored backup is a read-only lower layer, so the rename is a cross-device move.
-
-Omit disposable generated directories from the backup, or delete them after restore before the process that rewrites them starts. Vite's cache is one such directory:
+After a production restore, renaming a directory inside the restored tree can fail with `EXDEV` (`cross-device link not permitted`). Omit disposable generated directories from the backup, or delete them after restore. Vite's cache is one such directory:
 
 <TypeScriptExample>
 
@@ -147,7 +145,7 @@ await sandbox.exec("rm -rf /workspace/app/node_modules/.vite");
 
 </TypeScriptExample>
 
-`wrangler dev` extracts the archive and does not mount an overlay, so this failure does not appear locally. For overlay restore, refer to [Directory backups](/sandbox/concepts/backup-restore/).
+This failure does not occur in `wrangler dev`, which extracts the archive. For overlay restore, refer to [Directory backups](/sandbox/concepts/backup-restore/).
 
 ## Exclude gitignored files
 
@@ -164,7 +162,7 @@ const backup = await sandbox.createBackup({
 
 </TypeScriptExample>
 
-If the directory is not inside a git repository, `gitignore` has no effect. If `git` is not installed in the container, the SDK logs a warning and continues without git-based exclusions. Nested `.gitignore` files apply because the SDK uses `git ls-files` from the backup directory.
+If the directory is not inside a git repository, `gitignore` has no effect. If `git` is not installed in the container, the SDK logs a warning and continues without git-based exclusions. Nested `.gitignore` files apply.
 
 ## Checkpoint and roll back
 
@@ -272,7 +270,7 @@ await env.BACKUP_BUCKET.delete([
 
 ### Delete backups by age
 
-If you do not have the backup IDs, list objects under `backups/` and delete by upload time:
+List objects under `backups/` and delete by upload time:
 
 <TypeScriptExample>
 
@@ -307,13 +305,13 @@ const result = await sandbox.restoreBackup(backup);
 
 </TypeScriptExample>
 
-Local restore extracts the archive with `unsquashfs`. It replaces the directory instead of mounting an overlay. Local and production backups use the same squashfs archive format. Restore still follows `localBucket` on the stored handle.
+Local restore extracts the archive with `unsquashfs` and replaces the directory. The stored handle's `localBucket` field selects the restore path.
 
 ## Fix path permissions
 
-`createBackup()` must be able to read every file under the target directory. Restrictive modes such as `0600` or directories owned by another user fail with `BackupCreateError`. The message includes `mksquashfs failed` and the archiver output.
+`createBackup()` must read every file under the target directory. Files with mode `0600` or directories owned by another user cause `BackupCreateError`.
 
-Set permissions in the image when you can. `a+rX` grants read on files and traverse on directories. It does not add write access:
+Set permissions in the image when you can. `a+rX` adds read permission on files and execute permission on directories:
 
 ```dockerfile
 RUN mkdir -p /home/sandbox && chmod -R a+rX /home/sandbox

--- a/src/content/docs/sandbox/guides/backup-restore.mdx
+++ b/src/content/docs/sandbox/guides/backup-restore.mdx
@@ -3,26 +3,28 @@ title: Backup and restore
 pcx_content_type: how-to
 sidebar:
   order: 11
-description: Create point-in-time backups and restore sandbox directories.
+description: Snapshot a sandbox directory to R2 and restore it later.
 products:
   - sandbox
 ---
 
 import { TypeScriptExample, WranglerConfig } from "~/components";
 
-Create point-in-time snapshots of sandbox directories and restore them using copy-on-write overlays. Backups are stored in an R2 bucket and use squashfs compression.
+This guide shows you how to snapshot a sandbox directory to R2 and restore it later.
 
-Use backup and restore when you want workspace state, such as `/workspace`, to come back later. This is often a better fit for persistent project directories, while bucket mounts are better suited to separate persisted storage paths. If you mount a bucket over `/workspace`, be aware that it can overlay files seeded by your image in production.
+Use backup and restore when a project directory such as `/workspace` should come back after the sandbox sleeps. For a separate persisted storage path, mount a bucket instead. If you mount a bucket over `/workspace`, the mount overlays files seeded by your image in production.
+
+For why production restore uses an overlay, refer to [Directory backups](/sandbox/concepts/backup-restore/).
 
 ## Prerequisites
 
-1. Create an R2 bucket for storing backups:
+1. Create an R2 bucket:
 
    ```sh
    npx wrangler r2 bucket create my-backup-bucket
    ```
 
-2. Add the `BACKUP_BUCKET` R2 binding and presigned URL credentials to your Wrangler configuration:
+2. Add the `BACKUP_BUCKET` R2 binding and presigned URL settings to your Wrangler configuration:
 
    <WranglerConfig>
 
@@ -67,25 +69,23 @@ Use backup and restore when you want workspace state, such as `/workspace`, to c
 
    </WranglerConfig>
 
-   If your R2 bucket uses a jurisdiction-specific endpoint, you can also add `BACKUP_BUCKET_ENDPOINT` to `vars` to override the default presigned URL endpoint (for example, `https://<ACCOUNT_ID>.eu.r2.cloudflarestorage.com` for an EU-region bucket).
+   If the bucket uses a jurisdiction-specific endpoint, add `BACKUP_BUCKET_ENDPOINT` to `vars`. For an EU bucket, use `https://<ACCOUNT_ID>.eu.r2.cloudflarestorage.com`.
 
-3. Set your R2 API credentials as secrets:
+3. Store R2 API credentials as secrets:
 
    ```sh
    npx wrangler secret put R2_ACCESS_KEY_ID
    npx wrangler secret put R2_SECRET_ACCESS_KEY
    ```
 
-   You can create R2 API tokens in the [Cloudflare dashboard](https://dash.cloudflare.com/) under **R2** > **Overview** > **Manage R2 API Tokens**. The token needs **Object Read & Write** permissions for your backup bucket.
+   Create the token in the [Cloudflare dashboard](https://dash.cloudflare.com/) under **R2** > **Overview** > **Manage R2 API Tokens**. Grant **Object Read & Write** on the backup bucket.
 
 :::note
-The `vars` and API secrets in steps 2 and 3 are only required for production. For local development with `wrangler dev`, only the `BACKUP_BUCKET` R2 binding is required. Refer to [Local development](#local-development) for details.
+The `vars` and API secrets in steps 2 and 3 are required for production. For `wrangler dev`, only the `BACKUP_BUCKET` binding is required. Refer to [Use backup and restore in local development](#use-backup-and-restore-in-local-development).
 :::
 
 ## Create a backup
 
-Use `createBackup()` to snapshot a directory and upload it to R2:
-
 <TypeScriptExample>
 
 ```ts
@@ -93,18 +93,16 @@ import { getSandbox } from "@cloudflare/sandbox";
 
 const sandbox = getSandbox(env.Sandbox, "my-sandbox");
 
-// Create a backup of /workspace
 const backup = await sandbox.createBackup({ dir: "/workspace" });
-console.log(`Backup created: ${backup.id}`);
 ```
 
 </TypeScriptExample>
 
-The SDK creates a compressed squashfs archive of the directory and uploads it directly to your R2 bucket using a presigned URL.
+The directory must be an absolute path under `/workspace`, `/home`, `/tmp`, `/var/tmp`, or `/app`.
 
 ## Restore a backup
 
-Use `restoreBackup()` to restore a directory from a backup:
+Stop processes that write to the target directory, then restore:
 
 <TypeScriptExample>
 
@@ -113,67 +111,74 @@ import { getSandbox } from "@cloudflare/sandbox";
 
 const sandbox = getSandbox(env.Sandbox, "my-sandbox");
 
-// Create a backup
 const backup = await sandbox.createBackup({ dir: "/workspace" });
-
-// Restore the backup
 const result = await sandbox.restoreBackup(backup);
-console.log(`Restored: ${result.success}`);
 ```
 
 </TypeScriptExample>
 
-:::caution[Ephemeral mount]
-In production, the FUSE mount is lost when the sandbox sleeps or the container restarts. Re-restore from the backup handle to recover. This does not apply to local development.
-:::
+In production, restore mounts a copy-on-write overlay. The mount is lost when the sandbox sleeps or the container restarts. Restore again from the stored handle.
 
-## Exclude gitignored files
+The restore target is `backup.dir`. You can point that field at a different allowed directory than the one you originally backed up.
 
-When backing up a directory inside a git repository, set `useGitignore: true` to exclude files matching `.gitignore` rules. This is useful for skipping large generated directories like `node_modules/`, `dist/`, or `build/` that can be recreated.
+## Exclude generated caches
+
+After a production restore, renaming a directory inside the restored tree can fail with `EXDEV` (`cross-device link not permitted`). The restored backup is a read-only lower layer, so the rename is a cross-device move.
+
+Omit disposable generated directories from the backup, or delete them after restore before the process that rewrites them starts. Vite's cache is one such directory:
 
 <TypeScriptExample>
 
 ```ts
-import { getSandbox } from "@cloudflare/sandbox";
-
-const sandbox = getSandbox(env.Sandbox, "my-sandbox");
-
-// Back up only tracked and untracked non-ignored files
 const backup = await sandbox.createBackup({
-	dir: "/workspace",
-	useGitignore: true,
+	dir: "/workspace/app",
+	excludes: ["node_modules/.vite"],
 });
 ```
 
 </TypeScriptExample>
 
-The SDK uses `git ls-files` to resolve which files are ignored. Both root-level and nested `.gitignore` files are respected.
+<TypeScriptExample>
 
-By default, `useGitignore` is `false` and all files in the directory are included in the backup.
+```ts
+await sandbox.restoreBackup(backup);
+await sandbox.exec("rm -rf /workspace/app/node_modules/.vite");
+```
 
-:::note[Requirements]
-`useGitignore` requires `git` to be installed in the container. If `useGitignore` is `true` and `git` is not available, `createBackup()` throws a `BackupCreateError`. If the backup directory is not inside a git repository, the option has no effect and all files are included.
-:::
+</TypeScriptExample>
 
-## Checkpoint and rollback
+`wrangler dev` extracts the archive and does not mount an overlay, so this failure does not appear locally. For overlay restore, refer to [Directory backups](/sandbox/concepts/backup-restore/).
 
-Save state before risky operations and restore if something fails:
+## Exclude gitignored files
+
+To skip `.gitignore` matches such as `node_modules/` or `dist/` in a git repository:
+
+<TypeScriptExample>
+
+```ts
+const backup = await sandbox.createBackup({
+	dir: "/workspace",
+	gitignore: true,
+});
+```
+
+</TypeScriptExample>
+
+If the directory is not inside a git repository, `gitignore` has no effect. If `git` is not installed in the container, the SDK logs a warning and continues without git-based exclusions.
+
+## Checkpoint and roll back
 
 <TypeScriptExample>
 
 ```ts
 const sandbox = getSandbox(env.Sandbox, "my-sandbox");
-
-// Save checkpoint before risky operation
 const checkpoint = await sandbox.createBackup({ dir: "/workspace" });
 
 try {
 	await sandbox.exec("npm install some-experimental-package");
 	await sandbox.exec("npm run build");
 } catch (error) {
-	// Restore to checkpoint if something goes wrong
 	await sandbox.restoreBackup(checkpoint);
-	console.log("Rolled back to checkpoint");
 }
 ```
 
@@ -181,14 +186,11 @@ try {
 
 ## Store backup handles
 
-The `DirectoryBackup` handle is serializable. Persist it to KV, D1, or Durable Object storage for later use:
+`DirectoryBackup` is serializable. Persist it to KV, D1, or Durable Object storage:
 
 <TypeScriptExample>
 
 ```ts
-const sandbox = getSandbox(env.Sandbox, "my-sandbox");
-
-// Create a backup and store the handle in KV
 const backup = await sandbox.createBackup({
 	dir: "/workspace",
 	name: "deploy-v2",
@@ -197,51 +199,28 @@ const backup = await sandbox.createBackup({
 
 await env.KV.put(`backup:${userId}`, JSON.stringify(backup));
 
-// Later, retrieve and restore
 const stored = await env.KV.get(`backup:${userId}`);
 if (stored) {
-	const backupHandle = JSON.parse(stored);
-	await sandbox.restoreBackup(backupHandle);
+	await sandbox.restoreBackup(JSON.parse(stored));
 }
 ```
 
 </TypeScriptExample>
 
-## Use named backups
+## Set a name and TTL
 
-Add a `name` option to identify backups. Names can be up to 256 characters:
-
-<TypeScriptExample>
-
-```ts
-const sandbox = getSandbox(env.Sandbox, "my-sandbox");
-
-const backup = await sandbox.createBackup({
-	dir: "/workspace",
-	name: "before-migration",
-});
-
-console.log(`Backup ID: ${backup.id}`);
-```
-
-</TypeScriptExample>
-
-## Configure TTL
-
-Set a custom time-to-live for backups. The default TTL is 3 days (259200 seconds). The `ttl` value must be a positive number of seconds:
+Names can be up to 256 characters. The default TTL is 3 days (`259200` seconds). The SDK rejects an expired backup at restore time. It does not delete the R2 objects.
 
 <TypeScriptExample>
 
 ```ts
 const sandbox = getSandbox(env.Sandbox, "my-sandbox");
 
-// Short-lived backup for a quick operation
 const shortBackup = await sandbox.createBackup({
 	dir: "/workspace",
 	ttl: 600, // 10 minutes
 });
 
-// Long-lived backup for extended workflows
 const longBackup = await sandbox.createBackup({
 	dir: "/workspace",
 	name: "daily-snapshot",
@@ -251,192 +230,84 @@ const longBackup = await sandbox.createBackup({
 
 </TypeScriptExample>
 
-### How TTL is enforced
+To delete expired objects automatically, add an [R2 object lifecycle rule](/r2/buckets/object-lifecycles/) on the `backups/` prefix. If your longest TTL is 7 days, expire objects older than 7 days.
 
-The TTL is enforced at **restore time**, not at creation time. When you call `restoreBackup()`, the SDK reads the backup metadata from R2 and compares the creation timestamp plus TTL against the current time (with a 60-second buffer to prevent race conditions). If the TTL has elapsed, the restore is rejected with a `BACKUP_EXPIRED` error.
+## Clean up backup objects
 
-The TTL does **not** automatically delete backup objects from R2. Expired backups remain in your bucket and continue to consume storage until you explicitly delete them or configure an automatic cleanup rule.
+Archives live at `backups/{backupId}/data.sqsh` and `backups/{backupId}/meta.json`.
 
-### Configure R2 lifecycle rules for automatic cleanup
-
-To automatically remove expired backup objects from R2, set up an [R2 object lifecycle rule](/r2/buckets/object-lifecycles/) on your backup bucket. This is the recommended way to prevent expired backups from accumulating indefinitely.
-
-For example, if your longest TTL is 7 days, configure a lifecycle rule to delete objects older than 7 days from the `backups/` prefix. This ensures R2 storage does not grow unbounded while giving you a buffer to restore any non-expired backup.
-
-## Local development
-
-You can use backup and restore during local development with `wrangler dev` by passing the `localBucket: true` option to `createBackup()`. This uses the `BACKUP_BUCKET` R2 binding from your Worker environment directly, so no presigned URL credentials are required.
-
-### Configure R2 binding
-
-Add a `BACKUP_BUCKET` R2 binding to your Wrangler configuration:
-
-<WranglerConfig>
-
-```jsonc
-{
-	"r2_buckets": [
-		{
-			"binding": "BACKUP_BUCKET",
-			"bucket_name": "my-backup-bucket"
-		}
-	]
-}
-```
-
-</WranglerConfig>
-
-### Back up and restore with `localBucket`
-
-Pass `localBucket: true` to `createBackup()` to back up and restore using the R2 binding directly:
+### Replace the latest backup
 
 <TypeScriptExample>
 
 ```ts
-const sandbox = getSandbox(env.Sandbox, "my-sandbox");
+if (previousBackup) {
+	await env.BACKUP_BUCKET.delete([
+		`backups/${previousBackup.id}/data.sqsh`,
+		`backups/${previousBackup.id}/meta.json`,
+	]);
+}
 
-// Create a local backup
 const backup = await sandbox.createBackup({
 	dir: "/workspace",
-	localBucket: true,
+	name: "latest",
 });
-
-// Restore the backup
-const result = await sandbox.restoreBackup(backup);
-console.log(`Restored: ${result.success}`);
+await env.KV.put("latest-backup", JSON.stringify(backup));
 ```
 
 </TypeScriptExample>
 
-:::note
-You can use an environment variable to toggle `localBucket` between local development and production. Set an environment variable such as `LOCAL_DEV` in your Wrangler configuration using `vars` for local development, then reference it in your code:
+### Delete a backup by ID
+
+<TypeScriptExample>
+
+```ts
+await env.BACKUP_BUCKET.delete([
+	`backups/${backup.id}/data.sqsh`,
+	`backups/${backup.id}/meta.json`,
+]);
+```
+
+</TypeScriptExample>
+
+## Use backup and restore in local development
+
+Pass `localBucket: true` so `wrangler dev` uses the `BACKUP_BUCKET` binding. Presigned URL credentials are not required.
+
+<TypeScriptExample>
 
 ```ts
 const backup = await sandbox.createBackup({
 	dir: "/workspace",
 	localBucket: Boolean(env.LOCAL_DEV),
 });
-```
 
-When `localBucket` is `true`, presigned URL credentials are not required and the SDK uses the R2 binding directly. For more information on setting environment variables, refer to [Environment variables in Wrangler configuration](/workers/configuration/environment-variables/).
-:::
-
-### Local development considerations
-
-- **No presigned URLs** - The SDK reads and writes backup archives directly through the R2 binding, so no S3-compatible credentials are needed.
-- **No FUSE required** - Local restore extracts the archive using `unsquashfs` instead of mounting with FUSE overlayfs. The backup is not applied as a copy-on-write overlay; the directory is replaced on restore.
-- **Same archive format** - Local backups use the same squashfs archive format as production backups.
-
-:::note
-These considerations apply to local development with `wrangler dev` only. In production, backup and restore use presigned URLs and FUSE overlayfs. Local backup and restore behavior can also differ from local bucket mounting behavior, which uses sync-style updates rather than a production FUSE mount.
-:::
-
-## Clean up backup objects in R2
-
-Backup archives are stored in your R2 bucket under the `backups/` prefix with the structure `backups/{backupId}/data.sqsh` and `backups/{backupId}/meta.json`. You can use the `BACKUP_BUCKET` R2 binding to manage these objects directly.
-
-### Replace the latest backup (delete-then-write)
-
-If you only need the most recent backup, delete the previous one before creating a new one:
-
-<TypeScriptExample>
-
-```ts
-import { getSandbox } from "@cloudflare/sandbox";
-
-const sandbox = getSandbox(env.Sandbox, "my-sandbox");
-
-// Delete the previous backup's R2 objects before creating a new one
-if (previousBackup) {
-	await env.BACKUP_BUCKET.delete(`backups/${previousBackup.id}/data.sqsh`);
-	await env.BACKUP_BUCKET.delete(`backups/${previousBackup.id}/meta.json`);
-}
-
-// Create a fresh backup
-const backup = await sandbox.createBackup({
-	dir: "/workspace",
-	name: "latest",
-});
-
-// Store the handle so you can delete it next time
-await env.KV.put("latest-backup", JSON.stringify(backup));
+const result = await sandbox.restoreBackup(backup);
 ```
 
 </TypeScriptExample>
 
-### List and delete old backups by prefix
+Local restore extracts the archive with `unsquashfs`. It replaces the directory instead of mounting an overlay.
 
-To clean up multiple old backups, list objects under the `backups/` prefix and delete them by key:
+## Fix path permissions
 
-<TypeScriptExample>
+`createBackup()` must be able to read every file under the target directory. Restrictive modes such as `0600` or directories owned by another user cause `BackupCreateError` with `Permission denied`.
 
-```ts
-// List all backup objects in the bucket
-const listed = await env.BACKUP_BUCKET.list({ prefix: "backups/" });
+Set permissions in the image when you can:
 
-for (const object of listed.objects) {
-	// Parse the backup ID from the key (backups/{id}/data.sqsh or backups/{id}/meta.json)
-	const parts = object.key.split("/");
-	const backupId = parts[1];
-
-	// Delete objects older than 7 days
-	const ageMs = Date.now() - object.uploaded.getTime();
-	const sevenDaysMs = 7 * 24 * 60 * 60 * 1000;
-	if (ageMs > sevenDaysMs) {
-		await env.BACKUP_BUCKET.delete(object.key);
-		console.log(`Deleted expired object: ${object.key}`);
-	}
-}
+```dockerfile
+RUN mkdir -p /home/sandbox && chmod -R a+rX /home/sandbox
 ```
 
-</TypeScriptExample>
-
-### Delete a specific backup by ID
-
-If you have the backup ID, delete both its archive and metadata directly:
-
-<TypeScriptExample>
+If a process creates restrictive files at runtime, fix them before the backup:
 
 ```ts
-const backupId = backup.id;
-
-await env.BACKUP_BUCKET.delete(`backups/${backupId}/data.sqsh`);
-await env.BACKUP_BUCKET.delete(`backups/${backupId}/meta.json`);
+await sandbox.exec("chmod -R a+rX /home/sandbox/.claude");
+const backup = await sandbox.createBackup({ dir: "/home/sandbox" });
 ```
-
-</TypeScriptExample>
-
-## Copy-on-write behavior
-
-In production, restore uses FUSE overlayfs to mount the backup as a read-only lower layer. New writes go to a writable upper layer and do not affect the original backup:
-
-<TypeScriptExample>
-
-```ts
-const sandbox = getSandbox(env.Sandbox, "my-sandbox");
-
-// Create a backup
-const backup = await sandbox.createBackup({ dir: "/workspace" });
-
-// Restore the backup
-await sandbox.restoreBackup(backup);
-
-// New writes go to the upper layer — the backup is unchanged
-await sandbox.writeFile(
-	"/workspace/new-file.txt",
-	"This does not modify the backup",
-);
-
-// Restore the same backup again to discard changes
-await sandbox.restoreBackup(backup);
-```
-
-</TypeScriptExample>
 
 ## Handle errors
 
-Backup and restore operations can throw specific errors. Wrap calls in [`try...catch`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/try...catch) blocks:
-
 <TypeScriptExample>
 
 ```ts
@@ -444,20 +315,16 @@ import { getSandbox } from "@cloudflare/sandbox";
 
 const sandbox = getSandbox(env.Sandbox, "my-sandbox");
 
-// Handle backup errors
 try {
 	const backup = await sandbox.createBackup({ dir: "/workspace" });
 } catch (error) {
 	if (error.code === "INVALID_BACKUP_CONFIG") {
-		// Missing BACKUP_BUCKET binding or invalid directory path
 		console.error("Configuration error:", error.message);
 	} else if (error.code === "BACKUP_CREATE_FAILED") {
-		// Archive creation or upload to R2 failed
 		console.error("Backup failed:", error.message);
 	}
 }
 
-// Handle restore errors
 try {
 	await sandbox.restoreBackup(backup);
 } catch (error) {
@@ -473,61 +340,10 @@ try {
 
 </TypeScriptExample>
 
-## Path permissions
-
-The `createBackup()` method uses `mksquashfs` to create a compressed archive of the target directory. This process must be able to read every file and subdirectory within the path you are backing up. If any file or directory has restrictive permissions that prevent the archiver from reading it, the backup fails with a `BackupCreateError` and a "Permission denied" message.
-
-### Common causes
-
-- **Directories owned by other users** — If the target directory contains subdirectories created by a different user or process (for example, `/home/sandbox/.claude`), the archiver may not have read access.
-- **Restrictive file modes** — Files with modes like `0600` or directories with `0700` that belong to a different user than the one running the backup process.
-- **Runtime-generated config directories** — Tools and applications often create configuration directories (such as `.cache`, `.config`, or tool-specific dotfiles) with restrictive permissions.
-
-### Fix permissions at build time
-
-The recommended approach is to set permissions in your Dockerfile so that every container starts with the correct access. This avoids running `chmod` at runtime before every backup:
-
-```dockerfile
-# Ensure the backup target directory is readable
-RUN mkdir -p /home/sandbox && chmod -R a+rX /home/sandbox
-```
-
-The `a+rX` flag grants read access to all files and execute (traverse) access to all directories, without changing write permissions.
-
-### Fix permissions at runtime
-
-If the restrictive permissions come from files created at runtime (for example, a tool that generates config files with `0600` mode), fix them before calling `createBackup()`:
-
-```ts
-await sandbox.exec("chmod -R a+rX /home/sandbox/.claude");
-const backup = await sandbox.createBackup({ dir: "/home/sandbox" });
-```
-
-### Example error
-
-If the backup encounters a permission issue, you will see an error like:
-
-```txt
-BackupCreateError: mksquashfs failed: Could not create destination file: Permission denied
-```
-
-This means `mksquashfs` could not read one or more files inside the directory you passed to `createBackup()`. Check the permissions of all files and subdirectories within that path.
-
-## Best practices
-
-- **Stop writes before restoring** - Stop processes writing to the target directory before calling `restoreBackup()`
-- **Use checkpoints** - Create backups before risky operations like package installations or migrations
-- **Exclude gitignored files** - Set `useGitignore: true` when backing up git repositories to skip generated files like `node_modules/` and reduce backup size
-- **Set appropriate TTLs** - Use short TTLs for temporary checkpoints and longer TTLs for persistent snapshots
-- **Store handles externally** - Persist `DirectoryBackup` handles to KV, D1, or Durable Object storage for cross-request access
-- **Configure R2 lifecycle rules** - Set up [object lifecycle rules](/r2/buckets/object-lifecycles/) to automatically delete expired backups from R2, since TTL is only enforced at restore time
-- **Clean up old backups** - Delete previous backup objects from R2 when you no longer need them, or use the delete-then-write pattern for rolling backups
-- **Handle errors** - Wrap backup and restore calls in `try...catch` blocks
-- **Re-restore after restart** - In production, the FUSE mount is ephemeral, so re-restore from the backup handle after container restarts
-
 ## Related resources
 
-- [Backups API reference](/sandbox/api/backups/) - Full method documentation
-- [Storage API reference](/sandbox/api/storage/) - Mount S3-compatible buckets
-- [R2 documentation](/r2/) - Learn about Cloudflare R2
-- [R2 lifecycle rules](/r2/buckets/object-lifecycles/) - Configure automatic object cleanup
+- [Directory backups](/sandbox/concepts/backup-restore/) - Overlay restore, local extract, and `EXDEV`
+- [Backups API](/sandbox/api/backups/) - Methods, options, and types
+- [Storage API](/sandbox/api/storage/) - Mount S3-compatible buckets
+- [R2 documentation](/r2/) - R2 buckets and credentials
+- [R2 lifecycle rules](/r2/buckets/object-lifecycles/) - Automatic object cleanup

--- a/src/content/docs/sandbox/guides/backup-restore.mdx
+++ b/src/content/docs/sandbox/guides/backup-restore.mdx
@@ -164,7 +164,7 @@ const backup = await sandbox.createBackup({
 
 </TypeScriptExample>
 
-If the directory is not inside a git repository, `gitignore` has no effect. If `git` is not installed in the container, the SDK logs a warning and continues without git-based exclusions.
+If the directory is not inside a git repository, `gitignore` has no effect. If `git` is not installed in the container, the SDK logs a warning and continues without git-based exclusions. Nested `.gitignore` files apply because the SDK uses `git ls-files` from the backup directory.
 
 ## Checkpoint and roll back
 
@@ -270,6 +270,26 @@ await env.BACKUP_BUCKET.delete([
 
 </TypeScriptExample>
 
+### Delete backups by age
+
+If you do not have the backup IDs, list objects under `backups/` and delete by upload time:
+
+<TypeScriptExample>
+
+```ts
+const listed = await env.BACKUP_BUCKET.list({ prefix: "backups/" });
+const sevenDaysMs = 7 * 24 * 60 * 60 * 1000;
+
+for (const object of listed.objects) {
+	const ageMs = Date.now() - object.uploaded.getTime();
+	if (ageMs > sevenDaysMs) {
+		await env.BACKUP_BUCKET.delete(object.key);
+	}
+}
+```
+
+</TypeScriptExample>
+
 ## Use backup and restore in local development
 
 Pass `localBucket: true` so `wrangler dev` uses the `BACKUP_BUCKET` binding. Presigned URL credentials are not required.
@@ -287,13 +307,17 @@ const result = await sandbox.restoreBackup(backup);
 
 </TypeScriptExample>
 
-Local restore extracts the archive with `unsquashfs`. It replaces the directory instead of mounting an overlay.
+Local restore extracts the archive with `unsquashfs`. It replaces the directory instead of mounting an overlay. Local and production backups use the same squashfs archive format. Restore still follows `localBucket` on the stored handle.
 
 ## Fix path permissions
 
-`createBackup()` must be able to read every file under the target directory. Restrictive modes such as `0600` or directories owned by another user cause `BackupCreateError` with `Permission denied`.
+`createBackup()` must be able to read every file under the target directory. Restrictive modes such as `0600` or directories owned by another user fail with:
 
-Set permissions in the image when you can:
+```txt
+BackupCreateError: mksquashfs failed: Could not create destination file: Permission denied
+```
+
+Set permissions in the image when you can. `a+rX` grants read on files and traverse on directories. It does not add write access:
 
 ```dockerfile
 RUN mkdir -p /home/sandbox && chmod -R a+rX /home/sandbox

--- a/src/content/docs/sandbox/guides/backup-restore.mdx
+++ b/src/content/docs/sandbox/guides/backup-restore.mdx
@@ -311,11 +311,7 @@ Local restore extracts the archive with `unsquashfs`. It replaces the directory 
 
 ## Fix path permissions
 
-`createBackup()` must be able to read every file under the target directory. Restrictive modes such as `0600` or directories owned by another user fail with:
-
-```txt
-BackupCreateError: mksquashfs failed: Could not create destination file: Permission denied
-```
+`createBackup()` must be able to read every file under the target directory. Restrictive modes such as `0600` or directories owned by another user fail with `BackupCreateError`. The message includes `mksquashfs failed` and the archiver output.
 
 Set permissions in the image when you can. `a+rX` grants read on files and traverse on directories. It does not add write access:
 

--- a/src/content/docs/sandbox/guides/mount-buckets.mdx
+++ b/src/content/docs/sandbox/guides/mount-buckets.mdx
@@ -450,6 +450,7 @@ await sandbox.exec('cp', { args: ['/workspace/results.json', '/data/results/outp
 ## Related resources
 
 - [Persistent storage tutorial](/sandbox/tutorials/persistent-storage/) - Complete R2 example
+- [Backup and restore](/sandbox/guides/backup-restore/) - Persist a project directory such as `/workspace`
 - [Storage API reference](/sandbox/api/storage/) - Full method documentation
 - [Environment variables](/sandbox/configuration/environment-variables/) - Credential configuration for remote endpoint mounts
 - [Wrangler configuration](/sandbox/configuration/wrangler/) - Configure R2 bindings and compatibility flags


### PR DESCRIPTION
The published backup pages mixed how-to, API reference, and overlay explanation. They named `useGitignore` instead of `gitignore` and omitted `excludes`.

Users who restore a workspace and then run a tool that renames a generated cache directory can hit EXDEV, because production restore is a FUSE overlay. Vite's `node_modules/.vite` is an example.

This PR rewrites those pages so each has one job, matches the public BackupOptions, and documents overlay restore plus the exclude-or-delete workaround for generated caches.
