### PR TITLE
[Load Balancing] Clarify endpoint address uniqueness

### DIFF
--- a/src/content/docs/load-balancing/pools/create-pool.mdx
+++ b/src/content/docs/load-balancing/pools/create-pool.mdx
@@ -34,7 +34,7 @@ For more background information on pools, refer to [Pools](/load-balancing/pools
 
 ## Endpoint address uniqueness
 
-Within a single pool, each endpoint must be unique. Endpoints can share the same IP address as long as they are differentiated by port or by [virtual network](/load-balancing/private-network/) — a common pattern for private endpoints reachable on the same IP across different internal networks.
+Within a single pool, each endpoint address must be unique. Endpoints cannot share the same IP address, even when they use different ports or virtual networks. To use overlapping IP addresses, assign the endpoints to different pools.
 
 ---
 


### PR DESCRIPTION
Corrects the pool documentation to state that endpoint IP addresses must be unique within a pool.

Files touched:
- src/content/docs/load-balancing/pools/create-pool.mdx: Clarify the endpoint address uniqueness restriction.

Diagrams:
- No diagram changes

Validated locally:
- pnpm run check: PASS
- pnpm run build: PASS
- pnpm run lint: PASS
- pnpm run format:core:check: PASS

### Summary

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
