### PR TITLE
[Logs] Update Logpush dataset field definitions (2026-09-01)

### DIFF
--- a/src/content/docs/logs/logpush/logpush-job/datasets/account/gateway_http.md
+++ b/src/content/docs/logs/logpush/logpush-job/datasets/account/gateway_http.md
@@ -307,7 +307,7 @@ Country code of the source IP of the request (for example, 'US').
 
 Type: `string`
 
-Local LAN IP of the device. Only available when connected via a GRE/IPsec tunnel on-ramp.
+Internal IP of the device. For WARP client traffic, this is the WARP CGNAT address. For GRE/IPsec on-ramps, this is the source IP behind the tunnel.
 
 ## SourcePort
 

--- a/src/content/docs/logs/logpush/logpush-job/datasets/account/gateway_network.md
+++ b/src/content/docs/logs/logpush/logpush-job/datasets/account/gateway_network.md
@@ -169,7 +169,7 @@ Country code of the source IP of the network session (for example, 'US').
 
 Type: `string`
 
-Local LAN IP of the device. Only available when connected via a GRE/IPsec tunnel on-ramp.
+Internal IP of the device. For WARP client traffic, this is the WARP CGNAT address. For GRE/IPsec on-ramps, this is the source IP behind the tunnel.
 
 ## SourcePort
 

--- a/src/content/docs/logs/logpush/logpush-job/datasets/account/zero_trust_network_sessions.md
+++ b/src/content/docs/logs/logpush/logpush-job/datasets/account/zero_trust_network_sessions.md
@@ -243,7 +243,7 @@ Source IP of the network session.
 
 Type: `string`
 
-Local LAN IP of the device. Only available when connected via a GRE/IPsec tunnel on-ramp.
+Internal IP of the device. For WARP client traffic, this is the WARP CGNAT address. For GRE/IPsec on-ramps, this is the source IP behind the tunnel.
 
 ## SourcePort
 


### PR DESCRIPTION
## Summary

Automated sync of Logpush dataset field definitions from [data/entities](https://gitlab.cfdata.org/cloudflare/data/entities).

### Files changed
- `src/content/docs/logs/logpush/logpush-job/datasets/account/` — dataset pages

### Documentation checklist
- [ ] Changelog entry — not applicable (no field additions or removals)
- [x] Content generated by code generator (DO NOT EDIT manually)
