### PR TITLE
chore: Disable workers.dev preview URL

### DIFF
--- a/wrangler.preview.json
+++ b/wrangler.preview.json
@@ -5,6 +5,7 @@
 	"compatibility_date": "2025-06-02",
 	"compatibility_flags": ["nodejs_compat"],
 	"main": "./worker/index.preview.ts",
+	"workers_dev": false,
 	"rules": [
 		{ "type": "Text", "globs": ["**/__redirects"], "fallthrough": true }
 	],


### PR DESCRIPTION
### Summary

Adds `"workers_dev": false` to `wrangler.preview.json` so the preview Worker does not get a `workers.dev` subdomain URL. Preview deployments will be served through the configured preview routes only.
