### PR TITLE
[DNS] Add ZEROLAG nameserver instructions

### DIFF
--- a/src/content/partials/dns/ns-update-providers.mdx
+++ b/src/content/partials/dns/ns-update-providers.mdx
@@ -40,3 +40,4 @@ This is not an exhaustive list of provider-specific instructions, but the follow
 * [Site5](https://kb.site5.com/dns-2/custom-nameservers/)
 * [Softlayer](https://cloud.ibm.com/docs/dns?topic=dns-add-edit-or-delete-custom-name-servers-for-a-domain)
 * [Yola](https://helpcenter.yola.com/hc/articles/360012492660-Changing-your-name-servers)
+* [ZEROLAG](https://zerolag.ro/index.php?rp=/knowledgebase/393/Cum-schimbi-nameserverele-unui-domeniu-inregistrat-la-ZEROLAG.html)


### PR DESCRIPTION
### Summary

Adds ZEROLAG to the provider-specific nameserver instructions list, linking to the official ZEROLAG nameserver update guide:

https://zerolag.ro/index.php?rp=/knowledgebase/393/Cum-schimbi-nameserverele-unui-domeniu-inregistrat-la-ZEROLAG.html

### Documentation checklist

- [x] The change adheres to the documentation style guide.