### PR TITLE
DEE-3138: Enterprise self-serve Max Upload Size up to 5 GB

### DIFF
--- a/src/content/docs/cache/concepts/default-cache-behavior.mdx
+++ b/src/content/docs/cache/concepts/default-cache-behavior.mdx
@@ -93,6 +93,10 @@ Cloudflare’s CDN provides several cache customization options:
 
 Customers can adjust the **Maximum Upload Size** from the zone's **Network** page. Enterprise customers can self-serve any value up to 5 GB. Uploads larger than 5 GB require additional configuration — contact your account team.
 
+:::note
+Very large uploads take longer to transfer. Requests that exceed the connection or read timeout can fail mid-upload before reaching the size limit — a failure that may look unrelated to **Maximum Upload Size**. If you raise the limit substantially, make sure your clients and origin allow enough time for the full transfer.
+:::
+
 If you require a larger upload, you can group requests into smaller chunks, upload the full resource through a [DNS-only (unproxied) DNS record](/dns/proxy-status/) or [upgrade your plan](/billing/manage/change-plan/).
 
 ### Cacheable size limits

--- a/src/content/docs/cache/concepts/default-cache-behavior.mdx
+++ b/src/content/docs/cache/concepts/default-cache-behavior.mdx
@@ -91,7 +91,7 @@ Cloudflare’s CDN provides several cache customization options:
 | Availability | Yes | Yes | Yes | Yes |
 | Max upload size | 100 MB | 100 MB | 200 MB | Up to 5 GB |
 
-Customers can adjust the **Maximum Upload Size** from the zone's **Network** page. Enterprise customers can self-serve any value up to 5 GB. Uploads larger than 5 GB require additional configuration — contact your account team.
+Customers can adjust the **Maximum Upload Size** from the zone's **Network** page. Enterprise customers can self-serve any value up to 5 GB. Uploads larger than 5 GB require additional configuration — contact your account team or [Cloudflare Support](/support/contacting-cloudflare-support/).
 
 :::note
 Very large uploads take longer to transfer. Requests that exceed the connection or read timeout can fail mid-upload before reaching the size limit — a failure that may look unrelated to **Maximum Upload Size**. If you raise the limit substantially, make sure your clients and origin allow enough time for the full transfer.
@@ -104,7 +104,7 @@ If you require a larger upload, you can group requests into smaller chunks, uplo
 Cloudflare cacheable file limits:
 
 * Free, Pro and Business customers have a limit of 512 MB.
-* For Enterprise customers the default maximum cacheable file size is 5 GB. Contact your account team to request a limit increase.
+* For Enterprise customers the default maximum cacheable file size is 5 GB. Contact your account team or [Cloudflare Support](/support/contacting-cloudflare-support/) to request a limit increase.
 
 ## When does Cloudflare cache successfully?
 

--- a/src/content/docs/cache/concepts/default-cache-behavior.mdx
+++ b/src/content/docs/cache/concepts/default-cache-behavior.mdx
@@ -89,9 +89,9 @@ Cloudflare’s CDN provides several cache customization options:
 |  | Free | Pro | Business | Enterprise |
 | - | - | - | - | - |
 | Availability | Yes | Yes | Yes | Yes |
-| Max upload size | 100 MB | 100 MB | 200 MB | 500+ MB |
+| Max upload size | 100 MB | 100 MB | 200 MB | Up to 5 GB |
 
-Customers can reduce the **Maximum Upload Size** from the zone's **Network** page.
+Customers can adjust the **Maximum Upload Size** from the zone's **Network** page. Enterprise customers can self-serve any value up to 5 GB. Uploads larger than 5 GB require additional configuration — contact your account team.
 
 If you require a larger upload, you can group requests into smaller chunks, upload the full resource through a [DNS-only (unproxied) DNS record](/dns/proxy-status/) or [upgrade your plan](/billing/manage/change-plan/).
 

--- a/src/content/docs/support/troubleshooting/http-status-codes/4xx-client-error/error-413.mdx
+++ b/src/content/docs/support/troubleshooting/http-status-codes/4xx-client-error/error-413.mdx
@@ -26,8 +26,8 @@ The upload limit for the Cloudflare API depends on your plan. If you exceed this
 |  | Free | Pro | Business | Enterprise |
 | - | - | - | - | - |
 | Availability | Yes | Yes | Yes | Yes |
-| Max upload size | 100 MB | 100 MB | 200 MB | 500+ MB |
+| Max upload size | 100 MB | 100 MB | 200 MB | Up to 5 GB |
 
-Keep in mind, customers can reduce the **Maximum Upload Size** from the zone's **Network** page which can cause a `413`.
+Keep in mind, customers can adjust the **Maximum Upload Size** from the zone's **Network** page. Enterprise customers can self-serve any value up to 5 GB; uploads larger than 5 GB require additional configuration — contact your account team. Setting the limit below the size of an incoming request causes a `413`.
 
 If you require a larger upload, break up requests into smaller chunks, change your DNS record to [DNS-only](/dns/proxy-status/#dns-only-records), or [upgrade your plan](/billing/manage/change-plan/).

--- a/src/content/docs/workers/platform/limits.mdx
+++ b/src/content/docs/workers/platform/limits.mdx
@@ -57,9 +57,9 @@ Request body size limits depend on your Cloudflare account plan, not your Worker
 | Free            | 100 MB                    |
 | Pro             | 100 MB                    |
 | Business        | 200 MB                    |
-| Enterprise      | 500 MB (by default)       |
+| Enterprise      | Up to 5 GB (self-serve)   |
 
-Enterprise customers can contact their account team or [Cloudflare Support](/support/contacting-cloudflare-support/) for a higher request body limit.
+Enterprise customers can adjust the maximum request body size up to 5 GB themselves from the zone's **Network** page (**Maximum Upload Size**). For limits above 5 GB, contact your account team or [Cloudflare Support](/support/contacting-cloudflare-support/).
 
 Cloudflare does not enforce response body size limits. [CDN cache limits](/cache/concepts/default-cache-behavior/) apply: 512 MB for Free, Pro, and Business plans, and 5 GB for Enterprise.
 


### PR DESCRIPTION
## What
Update docs to reflect that **Enterprise** customers can now self-serve the Cache **Maximum Upload Size** up to **5 GB** from the zone's **Network** page (previously 500 MB, account-team only). Part of DEE-3138.

## Changes
- `cache/concepts/default-cache-behavior` — upload-limits table Enterprise cell `500+ MB` → `Up to 5 GB`; clarify Enterprise self-serve up to 5 GB and that >5 GB needs the account team.
- `workers/platform/limits` — request-body-size table Enterprise row `500 MB (by default)` → `Up to 5 GB (self-serve)`; update the accompanying sentence.

## Dependency
Ships with the product change (cf-www API + Network app UI). Merge once the feature is live.

Ref: DEE-3138 (internal)