### PR TITLE
[Browser Run] Add Kitesurf free unlimited concurrency note to pricing

### DIFF
--- a/src/content/docs/browser-run/kitesurf.mdx
+++ b/src/content/docs/browser-run/kitesurf.mdx
@@ -14,7 +14,7 @@ products:
 For common agentic tasks like screenshots and HTML extraction, Kitesurf uses significantly less CPU and memory than Chromium, which means you can run more sessions and scale better for bursty, AI-driven workloads.
 
 :::note[Pricing]
-Kitesurf is in beta and available for free, behind per-account [limits](/browser-run/limits/).
+Kitesurf is in beta and available for free.
 :::
 
 ## When to use Kitesurf

--- a/src/content/docs/browser-run/limits.mdx
+++ b/src/content/docs/browser-run/limits.mdx
@@ -61,6 +61,10 @@ The limits below are defaults for Workers Paid users. If you need to scale beyon
 
 [^3]: If you exceed the per-second rate limit, you will receive a `429` response. Refer to [troubleshooting the `429 Too many requests` error](#error-429-too-many-requests).
 
+## Kitesurf limits
+
+Kitesurf is limited to 100 requests per 10 seconds per account, per colo.
+
 ## FAQ
 
 <Render file="manage-concurrency-faq" product="browser-run" />

--- a/src/content/docs/browser-run/pricing.mdx
+++ b/src/content/docs/browser-run/pricing.mdx
@@ -28,6 +28,10 @@ To view or change your plan, go to the **Workers plans** page in the Cloudflare 
 
 <DashButton url="/?to=/:account/workers/plans" />
 
+## Use Kitesurf for free, unlimited concurrency
+
+If you want unlimited concurrency at no extra cost, use [Kitesurf](/browser-run/kitesurf/). Kitesurf is free while in beta and does not count against Browser Run browser-hour or concurrent-browser limits. The only limits that apply are your [Cloudflare Workers plan limits](/workers/platform/pricing/).
+
 ## Examples of Workers Paid pricing
 
 #### Example: Quick Actions pricing

--- a/src/content/docs/browser-run/pricing.mdx
+++ b/src/content/docs/browser-run/pricing.mdx
@@ -28,9 +28,9 @@ To view or change your plan, go to the **Workers plans** page in the Cloudflare 
 
 <DashButton url="/?to=/:account/workers/plans" />
 
-## Use Kitesurf for free, unlimited concurrency
+## Use Kitesurf without concurrent-browser charges
 
-If you want unlimited concurrency at no extra cost, use [Kitesurf](/browser-run/kitesurf/). Kitesurf is free while in beta and does not count against Browser Run browser-hour or concurrent-browser limits. The only limits that apply are your [Cloudflare Workers plan limits](/workers/platform/pricing/).
+If you want to avoid concurrent-browser charges, use [Kitesurf](/browser-run/kitesurf/). Kitesurf is free while in beta and does not count against Browser Run concurrent-browser limits. Kitesurf Quick Actions are still billed for browser hours, and Kitesurf requests are subject to per-account, per-colo rate limits. For details, refer to [Browser Run limits](/browser-run/limits/).
 
 ## Examples of Workers Paid pricing
 


### PR DESCRIPTION
Adds Kitesurf callouts to the Browser Run pricing and limits pages.

Changes:
- Highlights that Kitesurf is free while in beta and not subject to Browser Run concurrent-browser limits.
- Clarifies that Kitesurf Quick Actions still incur browser-hour charges.
- Adds a Kitesurf limits section with the per-account, per-colo rate limit.