### PR TITLE
docs: add 10-rules-per-ruleset limit for account-level rate limiting

### DIFF
--- a/src/content/docs/waf/account/rate-limiting-rulesets/index.mdx
+++ b/src/content/docs/waf/account/rate-limiting-rulesets/index.mdx
@@ -16,6 +16,7 @@ Account-level rate limiting rulesets allow you to define rate limiting rules onc
 
 :::note
 This feature requires an Enterprise plan.
+Account-level rate limiting rulesets support a maximum of 10 rules per ruleset.
 :::
 
 To apply a rate limiting ruleset at the account level:


### PR DESCRIPTION
Account-level rate limiting rulesets page was missing the 10-rules-per-ruleset cap. Added a note to match the level of detail shown in the zone-level rate limiting docs. Flagged by a Premium customer.

### Summary

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
