### PR TITLE
[R2] Use list_objects_v2 in Ruby example

### DIFF
--- a/src/content/docs/r2/examples/aws/aws-sdk-ruby.mdx
+++ b/src/content/docs/r2/examples/aws/aws-sdk-ruby.mdx
@@ -49,18 +49,17 @@ puts @r2.list_buckets
 #=> }
 
 # List the first 20 items in a bucket
-puts @r2.list_objects(bucket:"your-bucket", max_keys:20)
+puts @r2.list_objects_v2(bucket: "your-bucket", max_keys: 20)
 
 #=> {
 #=>   :is_truncated => false,
-#=>   :marker => nil,
-#=>   :next_marker => nil,
 #=>   :name => "your-bucket",
 #=>   :prefix => nil,
-#=>   :delimiter =>nil,
+#=>   :delimiter => nil,
 #=>   :max_keys => 20,
 #=>   :common_prefixes => [],
-#=>   :encoding_type => nil
+#=>   :encoding_type => nil,
+#=>   :key_count => 3,
 #=>   :contents => [
 #=>     …,
 #=>     …,


### PR DESCRIPTION
### Summary
<!-- Add context such as the type of documentation being updated or added -->

Updates the Ruby R2 example to use `list_objects_v2` instead of `list_objects`.

AWS recommends using `ListObjectsV2` for application development. This PR also updates the example response accordingly and fixes minor formatting issues in the same code block.

### Documentation checklist
<!-- Remove items that do not apply -->

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).

