### PR TITLE
[client-side security] expand PCI DSS compliance page

### DIFF
--- a/src/content/docs/client-side-security/reference/pci-dss.mdx
+++ b/src/content/docs/client-side-security/reference/pci-dss.mdx
@@ -35,7 +35,7 @@ Requirement 11.6.1 requires a mechanism that detects unauthorized modifications 
 
 | Control objective | What it requires | How client-side security addresses it |
 | --- | --- | --- |
-| Tamper detection | Detect unauthorized changes to HTTP security headers and payment page content | Alerts fire when scripts, connections, or cookies on a monitored payment page change. Cloudflare's detection runs continuously — no manual scheduling is required. Refer to the [PCI DSS v4.0 Evaluation](https://cfl.re/4dhk8Gx) whitepaper for the full requirement mapping |
+| Tamper detection | Detect unauthorized changes to monitored client-side resources on payment pages | Alerts can identify changes to monitored client-side resources on payment pages. Cloudflare's detection runs continuously — no manual scheduling is required. Refer to the [PCI DSS v4.0 Evaluation](https://cfl.re/4dhk8Gx) whitepaper for the full requirement mapping |
 
 ## Get started
 

--- a/src/content/docs/client-side-security/reference/pci-dss.mdx
+++ b/src/content/docs/client-side-security/reference/pci-dss.mdx
@@ -1,1 +1,52 @@
-H@ë·µq®7õÿuãÇºÓ‡·÷Ÿi¾µoÆºAˆ6Ê.­Ç
+---
+title: Client-side security and PCI DSS compliance
+pcx_content_type: reference
+description: Use Cloudflare's client-side security to meet PCI DSS v4.0 requirements 6.4.3 and 11.6.1 for payment page script management and tamper detection.
+products:
+  - client-side-security
+sidebar:
+  order: 4
+  label: PCI DSS compliance
+tags:
+  - Compliance
+---
+
+PCI DSS v4.0 introduced two requirements that apply to scripts running in the consumer's browser on payment pages. Cloudflare's client-side security helps you meet both.
+
+:::note
+Client-Side Security Advanced is required to meet PCI DSS requirements 6.4.3 and 11.6.1. Refer to [Availability](/client-side-security/#availability) for plan details.
+:::
+
+## Requirements
+
+### Requirement 6.4.3 â€” Payment page script management
+
+Requirement 6.4.3 applies to all scripts that a payment page loads into the consumer's browser, regardless of whether those scripts are first-party or third-party.
+
+| Control objective | What it requires | How client-side security addresses it |
+| --- | --- | --- |
+| Script inventory | A documented inventory of all scripts loaded to a payment page | The **Monitor resources** view lists every script loaded on monitored pages, including third-party scripts |
+| Business justification | A written justification (business or technical) for each script | You can review scripts in the dashboard and export the inventory for annotation to document each script's purpose |
+| Authorization method | A method to confirm that each script is authorized | Content security rules block or report scripts that are not explicitly allowed |
+
+### Requirement 11.6.1 â€” Tamper detection for payment pages
+
+Requirement 11.6.1 requires a mechanism that detects unauthorized modifications to your payment pages and their security headers.
+
+| Control objective | What it requires | How client-side security addresses it |
+| --- | --- | --- |
+| Tamper detection | Detect unauthorized changes to HTTP security headers and payment page content | Alerts fire when scripts, connections, or cookies on a monitored payment page change. Cloudflare's detection runs continuously â€” no manual scheduling is required. Refer to the [PCI DSS v4.0 Evaluation](https://cfl.re/4dhk8Gx) whitepaper for the full requirement mapping |
+
+## Get started
+
+1. Follow [Get started with client-side security](/client-side-security/get-started/) to enable monitoring on your payment pages.
+2. Use [Monitor resources and cookies](/client-side-security/detection/monitor-connections-scripts/) to review the full inventory of scripts and connections detected on those pages.
+3. Classify and approve each script to build your authorized inventory for requirement 6.4.3.
+4. Configure [alerts](/client-side-security/alerts/) to receive notifications when unauthorized changes are detected (requirement 11.6.1).
+5. Deploy [rules](/client-side-security/rules/) to enforce your script policy and block unauthorized scripts.
+
+For a detailed mapping of client-side security features to PCI DSS v4.0 controls, refer to the [PCI DSS v4.0 Evaluation](https://cfl.re/4dhk8Gx) whitepaper.
+
+## Related resources
+
+For related resources, refer to the [PCI DSS compliance](/ssl/reference/compliance-and-vulnerabilities/) guide to configure TLS version and cipher suites to meet PCI DSS requirement 4.2.1, and the [Cloudflare Trust Hub](https://www.cloudflare.com/trust-hub/compliance-resources/pci-dss/) to obtain Cloudflare's Attestation of Compliance (AOC) for your QSA.

--- a/src/content/docs/client-side-security/reference/pci-dss.mdx
+++ b/src/content/docs/client-side-security/reference/pci-dss.mdx
@@ -1,20 +1,1 @@
----
-title: Client-side security and PCI DSS compliance
-pcx_content_type: reference
-description: Use client-side security to meet PCI DSS v4 requirements 6.4.3 and 11.6.1.
-products:
-  - client-side-security
-sidebar:
-  order: 4
-  label: PCI DSS compliance
-tags:
-  - Compliance
----
-
-You can use Cloudflare's client-side security for PCI DSS v4's client-side security requirements (items 6.4.3 and 11.6.1).
-
-Refer to the [PCI DSS v.4.0 Evaluation](https://cfl.re/4dhk8Gx) whitepaper for details on how you can use Cloudflare's client-side security to meet the new v4 requirements.
-
-:::note
-To help with PCI DSS requirements, you must have Client-Side Security Advanced. Refer to [Availability](/client-side-security/#availability) for details on what is included in each package.
-:::
+H@ë·µq®7õÿuãÇºÓ‡·÷Ÿi¾µoÆºAˆ6Ê.­Ç


### PR DESCRIPTION
Expands the client-side security PCI DSS documentation to meet requirements 6.4.3 and 11.6.1 introduced in PCI DSS v4.0.

DEE-3623

**Changes**
- `/client-side-security/reference/pci-dss/`: expanded from a one-paragraph stub to a full requirements mapping table for PCI DSS v4.0 req 6.4.3 (payment page script management) and 11.6.1 (tamper detection), with setup steps and cross-links to the SSL PCI DSS guide and Cloudflare Trust Hub