### PR TITLE
Remove 'DNS' tab mention from zone analytics

### DIFF
--- a/src/content/docs/analytics/account-and-zone-analytics/zone-analytics.mdx
+++ b/src/content/docs/analytics/account-and-zone-analytics/zone-analytics.mdx
@@ -29,7 +29,7 @@ To view metrics for your website, in the Cloudflare dashboard, go to the **Analy
 
 <DashButton url="/?to=/:account/:zone/analytics/traffic" />
 
-Once it loads, you can find tabs for **Traffic**, **Security**, **Performance**, **DNS**, **Workers**, and **Logs** (Enterprise domains only). To understand the various metrics available, refer to _Review your website metrics_ below.
+Once it loads, you can find tabs for **Traffic**, **Security**, **Performance**, **Workers**, and **Logs** (Enterprise domains only). To understand the various metrics available, refer to _Review your website metrics_ below.
 
 ---
 


### PR DESCRIPTION
DNS analytics have moved under the DNS section (quite some time ago).

Probably worth redoing this entire page, since the Analytics and Logs sections have changed significantly since this page got created.