### PR TITLE
[DNS] Add MonoVM to nameserver update provider list

### DIFF
--- a/src/content/partials/dns/ns-update-providers.mdx
+++ b/src/content/partials/dns/ns-update-providers.mdx
@@ -29,6 +29,7 @@ This is not an exhaustive list of provider-specific instructions, but the follow
 * [iPage](https://www.ipage.com/help/article/domain-management-how-to-update-nameservers)
 * [MelbourneIT](https://support.melbourneit.au/docs/how-do-i-manage-my-dns-on-cpanel)
 * [Moniker](https://support.moniker.com/hc/en-gb/articles/10101271418653-How-to-update-Nameservers-for-a-domain)
+* [MonoVM](https://monovm.com/blog/how-to-use-and-manage-the-domain-control-panel/)
 * [Name.com](https://www.name.com/support/articles/205934457-registering-custom-nameservers)
 * [Namecheap](https://www.namecheap.com/support/knowledgebase/article.aspx/767/10/how-can-i-change-the-nameservers-for-my-domain)
 * [Network Solutions](https://www.networksolutions.com/manage-it/edit-nameservers.jsp)


### PR DESCRIPTION
Adds a link to MonoVM's domain control panel guide in the provider-specific nameserver instructions partial, which is rendered on the "Onboard a domain" page and the Update nameservers page.


Claude-Session: https://claude.ai/code/session_01PLeuHCD3evBk39zd4rLTmC

### Summary

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
