### PR TITLE
chore: Remove pcx-technical-writing and ax from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,7 +7,6 @@
 /.github/ @cloudflare/content-engineering @kodster28 @mvvmm @colbywhite @ahaywood @MohamedH1998
 /.github/CODEOWNERS @cloudflare/product-owners @cloudflare/content-engineering @kodster28
 /.github/actions/assign-pr/index.js @cloudflare/product-owners @cloudflare/content-engineering @kodster28
-/.github/labeler.yml @cloudflare/pcx-technical-writing
 /src/components/ @cloudflare/content-engineering @kodster28
 *.js @cloudflare/content-engineering @kodster28
 *.ts @cloudflare/content-engineering @kodster28
@@ -24,7 +23,7 @@ package.json @cloudflare/content-engineering
 
 # AI
 
-/src/content/docs/agent-lee/ @kczajkowski @Brayden @cloudflare/ax @cloudflare/product-owners
+/src/content/docs/agent-lee/ @kczajkowski @Brayden @cloudflare/product-owners
 /src/content/docs/agents/ @irvinebroque @rita3ko @cloudflare/product-owners @cloudflare/ai-agents @cloudflare/dev-plat-leads
 /src/content/partials/agents/ @rita3ko @irvinebroque @vy-ton @thomasgauvin @cloudflare/product-owners
 /src/content/docs/ai-gateway/ @abhishekkankani @palashgo @thebongy @roerohan @kathayl @mchenco @zeke @superhighfives @shridhar-cf @adriandlam @mattrothenberg @ethulia @aninibread @kflansburg @cloudflare/product-owners


### PR DESCRIPTION
### Summary

Removes the `@cloudflare/pcx-technical-writing` and `@cloudflare/ax` teams from CODEOWNERS:

- `/.github/labeler.yml` was owned solely by `@cloudflare/pcx-technical-writing`, so its line is removed entirely and the path now falls back to the `/.github/` and default (`*`) ownership rules.
- `@cloudflare/ax` is removed from the `/src/content/docs/agent-lee/` rule, which retains its other owners.
