### PR TITLE
[Tunnel] Document JSON log output

### DIFF
--- a/src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/deployment-guides/kubernetes.mdx
+++ b/src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/deployment-guides/kubernetes.mdx
@@ -270,6 +270,8 @@ To run the Cloudflare Tunnel in Kubernetes:
                - --no-autoupdate
                - --loglevel
                - info
+               - --output
+               - json
                - --metrics
                - 0.0.0.0:2000
                - run
@@ -290,7 +292,11 @@ To run the Cloudflare Tunnel in Kubernetes:
    kubectl create -f tunnel.yaml
    ```
 
-   Kubernetes will install the `cloudflared` image on two pods and run the tunnel using the command `cloudflared tunnel --no-autoupdate --loglevel info --metrics 0.0.0.0:2000 run`. `cloudflared` will consume the tunnel token from the `TUNNEL_TOKEN` environment variable.
+   Kubernetes will install the `cloudflared` image on two pods and run the tunnel using the command `cloudflared tunnel --no-autoupdate --loglevel info --output json --metrics 0.0.0.0:2000 run`.
+
+   The `--output json` flag formats each console log line as a JSON object. This format is useful for log collection systems that consume JSON.
+
+   `cloudflared` will consume the tunnel token from the `TUNNEL_TOKEN` environment variable.
 
 3. Check the status of your cluster:
 
@@ -328,14 +334,8 @@ To print logs for a `cloudflared` instance:
 kubectl logs pod/cloudflared-deployment-6d5f9f9666-85l5w
 ```
 
-```sh output
-2025-06-11T22:00:47Z INF Starting tunnel tunnelID=64c359b6-e111-40ec-a3a9-199c2a656613
-2025-06-11T22:00:47Z INF Version 2025.6.0 (Checksum 72f233bb55199093961bf099ad62d491db58819df34b071ab231f622deff33ce)
-2025-06-11T22:00:47Z INF GOOS: linux, GOVersion: go1.24.2, GoArch: amd64
-2025-06-11T22:00:47Z INF Settings: map[loglevel:debug metrics:0.0.0.0:2000 no-autoupdate:true token:*****]
-2025-06-11T22:00:47Z INF Generated Connector ID: aff7c4a0-85a3-4ac9-8475-1e0aa1af8d94
-2025-06-11T22:00:47Z DBG Fetched protocol: quic
-2025-06-11T22:00:47Z INF Initial protocol quic
+```txt output
+{"level":"info","message":"Starting tunnel","time":"2025-06-20T22:00:47Z","tunnelID":"64c359b6-e111-40ec-a3a9-199c2a656613"}
 ...
 ```
 

--- a/src/content/partials/cloudflare-one/tunnel/logs/view-logs-on-server.mdx
+++ b/src/content/partials/cloudflare-one/tunnel/logs/view-logs-on-server.mdx
@@ -7,6 +7,14 @@ params:
 
 If you have access to the origin server, you can use the <a href={props.loglevelURL}>`--loglevel` flag</a> to enable logging when you start the tunnel. By default, `cloudflared` prints logs to stdout and does not store logs on the server.
 
+To format each log line as a JSON object, add `--output json` before `run`:
+
+```sh
+cloudflared tunnel --output json run <UUID>
+```
+
+This format is useful for Kubernetes deployments and log collection systems that consume JSON.
+
 For routine persistent logging, <a href={props.runParametersURL + "#log-directory"}>run the tunnel</a> with `--log-directory <PATH>`. This flag writes logs to `cloudflared.log` in the specified directory, rotates the file when it reaches 1 MB, and keeps up to five backups. It does not remove logs based on age.
 
 ```sh

--- a/src/content/partials/cloudflare-one/tunnel/logs/view-logs-on-server.mdx
+++ b/src/content/partials/cloudflare-one/tunnel/logs/view-logs-on-server.mdx
@@ -5,7 +5,11 @@ params:
   - runParametersURL
 ---
 
-If you have access to the origin server, you can use the <a href={props.loglevelURL}>`--loglevel` flag</a> to enable logging when you start the tunnel. By default, `cloudflared` prints logs to stdout and does not store logs on the server.
+If you have access to the origin server, you can use the <a href={props.loglevelURL}>`--loglevel` flag</a> to enable logging when you start the tunnel. By default, `cloudflared` writes logs to standard error (`stderr`) and does not store logs on the server.
+
+:::note
+Requires `cloudflared` version 2025.6.1 or later.
+:::
 
 To format each log line as a JSON object, add `--output json` before `run`:
 

--- a/src/content/partials/cloudflare-one/tunnel/run-parameters.mdx
+++ b/src/content/partials/cloudflare-one/tunnel/run-parameters.mdx
@@ -261,6 +261,20 @@ This parameter does not apply when `cloudflared` runs on Windows, was installed 
 
 Disables automatic `cloudflared` updates. To change the automatic update interval instead, refer to [`autoupdate-freq`](#autoupdate-freq). For manual update methods and options to minimize downtime, refer to [Update `cloudflared`](/cloudflare-one/networks/connectors/cloudflare-tunnel/downloads/update-cloudflared/).
 
+### `output`
+
+:::note
+Requires `cloudflared` version 2025.6.1 or later.
+:::
+
+| Syntax                                                    | Default   | Environment variables                              |
+| --------------------------------------------------------- | --------- | -------------------------------------------------- |
+| `cloudflared tunnel --output <FORMAT> run <UUID or NAME>` | `default` | `TUNNEL_LOG_OUTPUT`<br/>`TUNNEL_MANAGEMENT_OUTPUT` |
+
+Specifies the console log format. Available values are `default` and `json`.
+
+The `json` value formats each log line as a JSON object. This format is useful for Kubernetes deployments and log collection systems that consume JSON.
+
 ### `origincert`
 
 :::note


### PR DESCRIPTION
### Summary

Documents the `cloudflared --output json` option for Kubernetes deployments and log collection systems that consume JSON.

### Screenshots (optional)
<img width="1712" height="1008" alt="image" src="https://github.com/user-attachments/assets/e9e26ac8-62dc-46aa-a0aa-31bd76195b5a" />
<img width="819" height="323" alt="image" src="https://github.com/user-attachments/assets/7db41f36-d1c1-47ca-bfcf-67bb6c966ea2" />

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
