### PR TITLE
[SSL] document Enterprise opt-out process for backup certificates

### DIFF
--- a/src/content/docs/ssl/edge-certificates/backup-certificates.mdx
+++ b/src/content/docs/ssl/edge-certificates/backup-certificates.mdx
@@ -23,3 +23,7 @@ For additional details, refer to the [introductory blog post](https://blog.cloud
 | - | - | - | - | - |
 | Availability | Yes | Yes | Yes | Yes |
 | Can opt out? | No | No | No | Yes |
+
+## Opt out
+
+Enterprise customers can request to opt out of backup certificates by opening a support case. Opting out removes the backup-certificate redundancy for your domain.


### PR DESCRIPTION
Adds an `## Opt out` section to the backup certificates page explaining that Enterprise customers need to contact Cloudflare Support to disable backup certificates.

DEE-3827