### PR TITLE
[Stream] remove Customer Success Manager references

### DIFF
--- a/src/content/docs/stream/faq.mdx
+++ b/src/content/docs/stream/faq.mdx
@@ -35,7 +35,7 @@ The limit to the number of videos only applies to videos being uploaded to Cloud
 
 Limits apply to Direct Creator Uploads at the time of upload URL creation.
 
-Uploads over these limits will receive a [429 (Too Many Requests)](/support/troubleshooting/http-status-codes/4xx-client-error/error-429/) or [413 (Payload too large)](/support/troubleshooting/http-status-codes/4xx-client-error/error-413/) HTTP status codes with more information in the response body. Please write to Cloudflare support or your customer success manager for higher limits.
+Uploads over these limits will receive a [429 (Too Many Requests)](/support/troubleshooting/http-status-codes/4xx-client-error/error-429/) or [413 (Payload too large)](/support/troubleshooting/http-status-codes/4xx-client-error/error-413/) HTTP status codes with more information in the response body. For higher limits, [contact Cloudflare support](/support/contacting-cloudflare-support/) or your account team.
 
 ### Can I embed videos on Stream even if my domain is not on Cloudflare?
 


### PR DESCRIPTION
Replace occurrences of "Customer Success Manager" with "account team" in public-facing documentation.

DEE-3828