### PR TITLE
[Cache] remove Customer Success Manager references

### DIFF
--- a/src/content/docs/cache/how-to/configure-cache-status-code.mdx
+++ b/src/content/docs/cache/how-to/configure-cache-status-code.mdx
@@ -16,7 +16,7 @@ Setting cache TTL based on response status overrides the [default cache behavior
 
 ## Caching limits
 
-The maximum caching limit for Free, Pro, and Business customers is 512 MB per file, and the maximum caching limit for Enterprise customers is 5 GB per file. If you need to raise the limits, contact your Customer Success Manager.
+The maximum caching limit for Free, Pro, and Business customers is 512 MB per file, and the maximum caching limit for Enterprise customers is 5 GB per file. If you need to raise the limits, contact your account team.
 
 <Render
   file="edge-ttl"


### PR DESCRIPTION
Replace occurrences of "Customer Success Manager" with "account team" in public-facing documentation.

DEE-3828