### PR TITLE
[API Shield] remove Customer Success Manager references

### DIFF
--- a/src/content/docs/api-shield/reference/classic-schema-validation.mdx
+++ b/src/content/docs/api-shield/reference/classic-schema-validation.mdx
@@ -31,7 +31,7 @@ If you are in the Schema validation 2.0, you can make changes to your settings b
 
 :::note
 
-This feature is only available for customers on an Enterprise plan. Contact your Cloudflare Customer Success Manager to get access.
+This feature is only available for customers on an Enterprise plan. Contact your account team to get access.
 :::
 
 ## Create an API Shield with Schema validation


### PR DESCRIPTION
Replace occurrences of "Customer Success Manager" with "account team" in public-facing documentation.

DEE-3828