### PR TITLE
[Learning Paths] remove Customer Success Manager references

### DIFF
--- a/src/content/docs/learning-paths/surge-readiness/concepts/index.mdx
+++ b/src/content/docs/learning-paths/surge-readiness/concepts/index.mdx
@@ -12,7 +12,7 @@ products:
 
 import { DashButton } from "~/components";
 
-Reach out to your Customer Success Manager at least 30 days prior to the expected traffic surge to schedule a Security Optimization walkthrough with your Customer Solution Engineer.
+Reach out to your account team at least 30 days prior to the expected traffic surge to schedule a Security Optimization walkthrough with your Customer Solution Engineer.
 
 To learn more about our service offerings, refer to [Customer Success offerings](https://www.cloudflare.com/success-offerings/).
 


### PR DESCRIPTION
Replace occurrences of "Customer Success Manager" with "account team" in public-facing documentation.

DEE-3828