### PR TITLE
[Fundamentals] remove Customer Success Manager references

### DIFF
--- a/src/content/docs/fundamentals/manage-domains/remove-domain.mdx
+++ b/src/content/docs/fundamentals/manage-domains/remove-domain.mdx
@@ -58,7 +58,7 @@ Please also note that domains in the `Initializing (Finish setup)` or `Pending` 
 2. On the domain **Overview** page, find **Advanced Actions** and then select **Remove from Cloudflare**.
 
    :::note
-   If you are using an Enterprise domain, [change your domain plan](/billing/manage/change-plan/#change-plan-type) to **Free**, which will give you access to **Remove from Cloudflare**.<br/><br/>If this does not work, contact your Customer Success Manager.
+   If you are using an Enterprise domain, [change your domain plan](/billing/manage/change-plan/#change-plan-type) to **Free**, which will give you access to **Remove from Cloudflare**.<br/><br/>If this does not work, contact your account team.
    :::
 
 3. Select **Confirm**.

--- a/src/content/docs/fundamentals/user-profiles/change-password-or-email.mdx
+++ b/src/content/docs/fundamentals/user-profiles/change-password-or-email.mdx
@@ -51,7 +51,7 @@ For added account security, consider changing your [API tokens](/fundamentals/ap
 
 :::note
 
-If you are an Enterprise customer and forgot the email address associated with your account, contact your Customer Success Manager.
+If you are an Enterprise customer and forgot the email address associated with your account, contact your account team.
 :::
 
 If you forget the email address associated with your application:


### PR DESCRIPTION
Replace occurrences of "Customer Success Manager" with "account team" in public-facing documentation.

DEE-3828