### PR TITLE
[Pages] remove Customer Success Manager references

### DIFF
--- a/src/content/docs/pages/functions/pricing.mdx
+++ b/src/content/docs/pages/functions/pricing.mdx
@@ -18,7 +18,7 @@ Pages supports the [Standard usage model](/workers/platform/pricing/#example-pri
 
 :::note
 
-Workers Enterprise accounts are billed based on the usage model specified in their contract. To switch to the Standard usage model, reach out to your Customer Success Manager (CSM). Some Workers Enterprise customers maintain the ability to [change usage models](/workers/platform/pricing/#how-to-switch-usage-models).
+Workers Enterprise accounts are billed based on the usage model specified in their contract. To switch to the Standard usage model, reach out to your account team. Some Workers Enterprise customers maintain the ability to [change usage models](/workers/platform/pricing/#how-to-switch-usage-models).
 
 :::
 


### PR DESCRIPTION
Replace occurrences of "Customer Success Manager" with "account team" in public-facing documentation.

DEE-3828