### PR TITLE
[DNS] remove Customer Success Manager references

### DIFF
--- a/src/content/docs/dns/zone-setups/troubleshooting/cannot-add-domain.mdx
+++ b/src/content/docs/dns/zone-setups/troubleshooting/cannot-add-domain.mdx
@@ -85,7 +85,7 @@ If Cloudflare has temporary or permanent restrictions on a domain, you will rece
   - **Cause**: You may have entered a subdomain (`www.example.com`) instead of the apex domain (also known as "root domain", e.g. `example.com`).
   - **Resolution**: Verify that you are entering the apex domain. If you are and still experience issues, contact [Cloudflare Support](/support/contacting-cloudflare-support/).
 - **Error 1097**
-  - **Message**: `This web property cannot be added to Cloudflare at this time. If you are an Enterprise customer, contact your Customer Success Manager. Otherwise, email abusereply@cloudflare.com with a detailed explanation of your association with this zone. (Code: 1097)`
+  - **Message**: `This web property cannot be added to Cloudflare at this time. If you are an Enterprise customer, contact your account team. Otherwise, email abusereply@cloudflare.com with a detailed explanation of your association with this zone. (Code: 1097)`
   - **Resolution**: Contact [abusereply@cloudflare.com](mailto:abusereply@cloudflare.com) with a detailed explanation of your association with this zone.
 - **Error: Cannot be found** OR **`<your domain>` is not a registered domain (code: 1049)**
   - This can happen if the domain has not been registered yet. Some domains, like `.gov` domains, have special requirements that require the domain be added first.


### PR DESCRIPTION
Replace occurrences of "Customer Success Manager" with "account team" in public-facing documentation.

DEE-3828