### PR TITLE
[Workers] Recommend Zod 4.5.0 for memory errors

### DIFF
--- a/src/content/docs/workers/platform/limits.mdx
+++ b/src/content/docs/workers/platform/limits.mdx
@@ -136,7 +136,8 @@ To resolve a memory limit error:
 
 1. **Stream request and response bodies** — Use [`TransformStream`](/workers/runtime-apis/streams/transformstream/) or [`node:stream`](/workers/runtime-apis/nodejs/streams/) instead of buffering entire payloads in memory.
 2. **Avoid large in-memory objects** — Store large data in [KV](/kv/), [R2](/r2/), or [D1](/d1/) instead of holding it in Worker memory.
-3. **Profile memory usage** — Use [memory profiling with DevTools](/workers/observability/dev-tools/memory-usage/) locally to identify leaks and high-memory allocations.
+3. **Update Zod** — If your Worker uses Zod, use [version 4.5.0 or later](https://github.com/colinhacks/zod/releases/tag/v4.5.0). Earlier versions use substantially more memory per schema.
+4. **Profile memory usage** — Use [memory profiling with DevTools](/workers/observability/dev-tools/memory-usage/) locally to identify leaks and high-memory allocations.
 
 To view memory errors in the dashboard:
 


### PR DESCRIPTION
### Summary

Updates the Workers memory-limit troubleshooting guidance to recommend Zod 4.5.0 or later. Zod 4.5 reduced retained heap per schema by up to 9.8x compared with Zod 4.4.3.

Source: https://github.com/colinhacks/zod/releases/tag/v4.5.0

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
