### PR TITLE
[AI Gateway] Add OpenCode setup guide

### DIFF
--- a/src/content/docs/ai-gateway/integrations/coding-agents/index.mdx
+++ b/src/content/docs/ai-gateway/integrations/coding-agents/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Coding agents
-description: Route Claude Code, Claude Desktop, GitHub Copilot CLI, OpenAI Codex, and Pi through AI Gateway for observability, caching, rate limiting, and cost tracking.
+description: Route Claude Code, Claude Desktop, GitHub Copilot CLI, OpenAI Codex, OpenCode, and Pi through AI Gateway for observability and control.
 pcx_content_type: navigation
 sidebar:
   order: 5
@@ -30,6 +30,7 @@ Follow the setup guide for your coding agent:
 - [Claude Desktop](/ai-gateway/integrations/coding-agents/claude-desktop/)
 - [GitHub Copilot CLI](/ai-gateway/integrations/coding-agents/github-copilot-cli/)
 - [OpenAI Codex](/ai-gateway/integrations/coding-agents/openai-codex/)
+- [OpenCode](/ai-gateway/integrations/coding-agents/opencode/)
 - [Pi](/ai-gateway/integrations/coding-agents/pi/)
 
 ## Protect sensitive code with DLP

--- a/src/content/docs/ai-gateway/integrations/coding-agents/index.mdx
+++ b/src/content/docs/ai-gateway/integrations/coding-agents/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Coding agents
-description: Route Claude Code, Claude Desktop, GitHub Copilot CLI, OpenAI Codex, OpenCode, and Pi through AI Gateway for observability and control.
+description: Route Claude Code, Claude Desktop, GitHub Copilot CLI, OpenAI Codex, OpenCode, and Pi through AI Gateway for observability, caching, rate limiting, and cost tracking.
 pcx_content_type: navigation
 sidebar:
   order: 5

--- a/src/content/docs/ai-gateway/integrations/coding-agents/opencode.mdx
+++ b/src/content/docs/ai-gateway/integrations/coding-agents/opencode.mdx
@@ -1,0 +1,150 @@
+---
+title: OpenCode
+description: Connect OpenCode to an Access-protected AI Gateway custom domain with shared provider configuration.
+pcx_content_type: configuration
+sidebar:
+  order: 5
+products:
+  - ai-gateway
+---
+
+import { Steps } from "~/components";
+
+[OpenCode](https://opencode.ai/) can discover shared configuration from an AI Gateway custom domain. Users run one login command to authenticate with Cloudflare Access and load shared provider defaults.
+
+This setup hosts two JSON files at public HTTPS URLs. The files contain configuration, but no credentials. A Single Redirect sends `/.well-known/opencode` requests from your AI Gateway custom domain to the discovery file.
+
+:::caution
+OpenCode executes the `auth.command` from the discovery file. Only host these files on infrastructure that you control. Protect the configuration host and its DNS from unauthorized changes.
+:::
+
+Users can override remote configuration in their global or project configuration. To enforce organization-wide settings, refer to [OpenCode managed settings](https://opencode.ai/docs/config/#managed-settings).
+
+## Prerequisites
+
+Before you start, you need:
+
+- An AI Gateway with a [custom domain](/ai-gateway/configuration/custom-domains/).
+- [Cloudflare Access configured](/ai-gateway/configuration/cloudflare-access/) on the gateway.
+- [Unified Billing](/ai-gateway/features/unified-billing/) or stored [provider keys](/ai-gateway/configuration/bring-your-own-keys/) for each provider.
+- A public HTTPS location for the configuration files. You can use an [R2 bucket with a custom domain](/r2/buckets/public-buckets/#custom-domains).
+- OpenCode and [`cloudflared`](/cloudflare-one/networks/connectors/cloudflare-tunnel/downloads/) installed on each user's device.
+
+## Set up OpenCode discovery
+
+The following example uses `ai.example.com` for the AI Gateway domain and `config.example.com` for the configuration host. Replace both hostnames with your own values.
+
+<Steps>
+
+1. Create an `opencode.json` file with the shared provider configuration:
+
+   ```json title="opencode.json"
+   {
+     "$schema": "https://opencode.ai/config.json",
+     "share": "disabled",
+     "disabled_providers": ["opencode"],
+     "enabled_providers": ["anthropic", "openai", "google", "xai"],
+     "provider": {
+       "anthropic": {
+         "name": "Anthropic through Cloudflare AI Gateway",
+         "options": {
+           "baseURL": "https://ai.example.com/anthropic",
+           "apiKey": "",
+           "headers": {
+             "cf-access-token": "{env:TOKEN}",
+             "X-Requested-With": "XMLHttpRequest"
+           }
+         }
+       },
+       "openai": {
+         "name": "OpenAI through Cloudflare AI Gateway",
+         "options": {
+           "baseURL": "https://ai.example.com/openai",
+           "apiKey": "",
+           "headers": {
+             "cf-access-token": "{env:TOKEN}",
+             "X-Requested-With": "XMLHttpRequest"
+           }
+         }
+       },
+       "google": {
+         "name": "Google AI Studio through Cloudflare AI Gateway",
+         "options": {
+           "baseURL": "https://ai.example.com/google-ai-studio/v1beta",
+           "apiKey": "",
+           "headers": {
+             "cf-access-token": "{env:TOKEN}",
+             "X-Requested-With": "XMLHttpRequest"
+           }
+         }
+       },
+       "xai": {
+         "name": "xAI through Cloudflare AI Gateway",
+         "options": {
+           "baseURL": "https://ai.example.com/grok",
+           "apiKey": "",
+           "headers": {
+             "cf-access-token": "{env:TOKEN}",
+             "X-Requested-With": "XMLHttpRequest"
+           }
+         }
+       }
+     }
+   }
+   ```
+
+   Leave each `apiKey` value empty. AI Gateway supplies provider credentials through Unified Billing or your stored provider keys. Remove providers that you do not use. For more configuration options, refer to [OpenCode providers](https://opencode.ai/docs/providers/).
+
+2. Create an `opencode` discovery file. Set `remote_config.url` to the public URL of the `opencode.json` file:
+
+   ```json title="opencode"
+   {
+     "auth": {
+       "command": [
+         "cloudflared",
+         "access",
+         "login",
+         "--no-verbose",
+         "-app=https://ai.example.com/"
+       ],
+       "env": "TOKEN"
+     },
+     "remote_config": {
+       "url": "https://config.example.com/opencode.json"
+     }
+   }
+   ```
+
+   OpenCode runs the authentication command and makes its output available as `{env:TOKEN}`. It then substitutes that value into the remote provider configuration.
+
+3. Upload `opencode.json` and `opencode` to your public HTTPS host. Confirm that both URLs return the expected JSON without authentication.
+
+   If you use R2, upload both objects to the bucket and [connect a custom domain](/r2/buckets/public-buckets/#custom-domains). The example files should be available at `https://config.example.com/opencode.json` and `https://config.example.com/opencode`.
+
+4. In the zone for your AI Gateway custom domain, [create a Single Redirect](/rules/url-forwarding/single-redirects/create-dashboard/) with these settings:
+
+   - **Rule name**: `OpenCode discovery`
+   - **Custom filter expression**: `(http.host eq "ai.example.com" and http.request.uri.path eq "/.well-known/opencode")`
+   - **Target URL**: `https://config.example.com/opencode`
+   - **Status code**: `302`
+   - **Preserve query string**: Off
+
+5. In a browser without an active Access session, open `https://ai.example.com/.well-known/opencode`. Confirm that the request returns the discovery JSON without an Access prompt.
+
+6. To connect OpenCode, run:
+
+   ```sh
+   opencode auth login https://ai.example.com
+   ```
+
+   Complete the Access login flow when prompted. OpenCode stores the resulting credential locally and loads the remote configuration. Run the command again when the Access session expires.
+
+7. Start OpenCode and select a configured provider and model:
+
+   ```sh
+   opencode
+   ```
+
+</Steps>
+
+To confirm traffic reaches AI Gateway, refer to [Verify it works](/ai-gateway/integrations/coding-agents/#verify-it-works).

--- a/src/content/docs/ai-gateway/integrations/coding-agents/opencode.mdx
+++ b/src/content/docs/ai-gateway/integrations/coding-agents/opencode.mdx
@@ -1,6 +1,6 @@
 ---
 title: OpenCode
-description: Connect OpenCode to an Access-protected AI Gateway custom domain with shared provider configuration.
+description: Route OpenCode model requests through AI Gateway using a gateway token or an Access-protected custom domain.
 pcx_content_type: configuration
 sidebar:
   order: 5
@@ -8,35 +8,46 @@ products:
   - ai-gateway
 ---
 
-import { Steps } from "~/components";
+import { Steps, Tabs, TabItem } from "~/components";
 
-[OpenCode](https://opencode.ai/) can discover shared configuration from an AI Gateway custom domain. Users run one login command to authenticate with Cloudflare Access and load shared provider defaults.
-
-This setup hosts two JSON files at public HTTPS URLs. The files contain configuration, but no credentials. A Single Redirect sends `/.well-known/opencode` requests from your AI Gateway custom domain to the discovery file.
-
-:::caution
-OpenCode executes the `auth.command` from the discovery file. Only host these files on infrastructure that you control. Protect the configuration host and its DNS from unauthorized changes.
-:::
-
-Users can override remote configuration in their global or project configuration. To enforce organization-wide settings, refer to [OpenCode managed settings](https://opencode.ai/docs/config/#managed-settings).
+[OpenCode](https://opencode.ai/) is an open source coding agent that supports custom provider configuration. Point its built-in providers at AI Gateway to observe and control model requests from OpenCode.
 
 ## Prerequisites
 
 Before you start, you need:
 
-- An AI Gateway with a [custom domain](/ai-gateway/configuration/custom-domains/).
-- [Cloudflare Access configured](/ai-gateway/configuration/cloudflare-access/) on the gateway.
-- [Unified Billing](/ai-gateway/features/unified-billing/) or stored [provider keys](/ai-gateway/configuration/bring-your-own-keys/) for each provider.
-- A public HTTPS location for the configuration files. You can use an [R2 bucket with a custom domain](/r2/buckets/public-buckets/#custom-domains).
-- OpenCode and [`cloudflared`](/cloudflare-one/networks/connectors/cloudflare-tunnel/downloads/) installed on each user's device.
+- An AI Gateway and its gateway slug.
+- [Sufficient Unified Billing credits](/ai-gateway/features/unified-billing/#load-credits) or a stored [provider key](/ai-gateway/configuration/bring-your-own-keys/) with the `default` alias for each provider.
+- [OpenCode installed](https://opencode.ai/docs/).
 
-## Set up OpenCode discovery
+## Connect with a gateway token
 
-The following example uses `ai.example.com` for the AI Gateway domain and `config.example.com` for the configuration host. Replace both hostnames with your own values.
+To use this method, you also need an [authenticated gateway](/ai-gateway/configuration/authentication/) and its gateway token. The token must have `Run` permissions. You also need your Cloudflare account ID. To find it, refer to [Find your account and zone IDs](/fundamentals/account/find-account-and-zone-ids/).
 
 <Steps>
 
-1. Create an `opencode.json` file with the shared provider configuration:
+1. Set your gateway token as the `CF_AIG_TOKEN` environment variable. The following commands set it for the current session. To persist it, add it to your shell profile.
+
+   Replace `<CF_AIG_TOKEN>` with your gateway token.
+
+   <Tabs syncKey="os">
+   <TabItem label="macOS / Linux">
+
+   ```sh
+   export CF_AIG_TOKEN="<CF_AIG_TOKEN>"
+   ```
+
+   </TabItem>
+   <TabItem label="Windows (PowerShell)">
+
+   ```powershell
+   $env:CF_AIG_TOKEN = "<CF_AIG_TOKEN>"
+   ```
+
+   </TabItem>
+   </Tabs>
+
+2. In your project root, create an `opencode.json` file. Replace `<ACCOUNT_ID>` and `<GATEWAY_ID>` with your account ID and gateway slug:
 
    ```json title="opencode.json"
    {
@@ -48,44 +59,40 @@ The following example uses `ai.example.com` for the AI Gateway domain and `confi
        "anthropic": {
          "name": "Anthropic through Cloudflare AI Gateway",
          "options": {
-           "baseURL": "https://ai.example.com/anthropic",
+           "baseURL": "https://gateway.ai.cloudflare.com/v1/<ACCOUNT_ID>/<GATEWAY_ID>/anthropic/v1",
            "apiKey": "",
            "headers": {
-             "cf-access-token": "{env:TOKEN}",
-             "X-Requested-With": "XMLHttpRequest"
+             "cf-aig-authorization": "Bearer {env:CF_AIG_TOKEN}"
            }
          }
        },
        "openai": {
          "name": "OpenAI through Cloudflare AI Gateway",
          "options": {
-           "baseURL": "https://ai.example.com/openai",
+           "baseURL": "https://gateway.ai.cloudflare.com/v1/<ACCOUNT_ID>/<GATEWAY_ID>/openai",
            "apiKey": "",
            "headers": {
-             "cf-access-token": "{env:TOKEN}",
-             "X-Requested-With": "XMLHttpRequest"
+             "cf-aig-authorization": "Bearer {env:CF_AIG_TOKEN}"
            }
          }
        },
        "google": {
          "name": "Google AI Studio through Cloudflare AI Gateway",
          "options": {
-           "baseURL": "https://ai.example.com/google-ai-studio/v1beta",
+           "baseURL": "https://gateway.ai.cloudflare.com/v1/<ACCOUNT_ID>/<GATEWAY_ID>/google-ai-studio/v1beta",
            "apiKey": "",
            "headers": {
-             "cf-access-token": "{env:TOKEN}",
-             "X-Requested-With": "XMLHttpRequest"
+             "cf-aig-authorization": "Bearer {env:CF_AIG_TOKEN}"
            }
          }
        },
        "xai": {
          "name": "xAI through Cloudflare AI Gateway",
          "options": {
-           "baseURL": "https://ai.example.com/grok",
+           "baseURL": "https://gateway.ai.cloudflare.com/v1/<ACCOUNT_ID>/<GATEWAY_ID>/grok/v1",
            "apiKey": "",
            "headers": {
-             "cf-access-token": "{env:TOKEN}",
-             "X-Requested-With": "XMLHttpRequest"
+             "cf-aig-authorization": "Bearer {env:CF_AIG_TOKEN}"
            }
          }
        }
@@ -93,9 +100,61 @@ The following example uses `ai.example.com` for the AI Gateway domain and `confi
    }
    ```
 
-   Leave each `apiKey` value empty. AI Gateway supplies provider credentials through Unified Billing or your stored provider keys. Remove providers that you do not use. For more configuration options, refer to [OpenCode providers](https://opencode.ai/docs/providers/).
+   Leave each `apiKey` value empty. AI Gateway supplies provider credentials through Unified Billing or your stored provider keys. To use a stored key without the `default` alias, add the [`cf-aig-byok-alias` header](/ai-gateway/configuration/bring-your-own-keys/#key-aliases) to that provider's `headers` object. Remove providers that you do not use. For more configuration options, refer to [OpenCode providers](https://opencode.ai/docs/providers/).
 
-2. Create an `opencode` discovery file. Set `remote_config.url` to the public URL of the `opencode.json` file:
+3. Start OpenCode and select a configured provider and model:
+
+   ```sh
+   opencode
+   ```
+
+</Steps>
+
+To confirm traffic reaches AI Gateway, refer to [Verify it works](/ai-gateway/integrations/coding-agents/#verify-it-works).
+
+## Use with Cloudflare Access
+
+If your gateway is protected by [Cloudflare Access](/ai-gateway/configuration/cloudflare-access/), OpenCode can authenticate with a short-lived Access token instead of a gateway token. You can also host the configuration centrally so users connect with one login command.
+
+This setup requires an AI Gateway [custom domain](/ai-gateway/configuration/custom-domains/), [`cloudflared`](/cloudflare-one/networks/connectors/cloudflare-tunnel/downloads/) on each user's device, and a public HTTPS location for two configuration files. You can use an [R2 bucket with a custom domain](/r2/buckets/public-buckets/#custom-domains).
+
+The files contain configuration, but no credentials. A Single Redirect sends `/.well-known/opencode` requests from your AI Gateway custom domain to the discovery file.
+
+:::caution
+OpenCode executes the `auth.command` from the discovery file. Only host these files on infrastructure that you control. Protect the configuration host and its DNS from unauthorized changes.
+:::
+
+Users can override remote configuration in their global or project configuration. To enforce organization-wide settings, refer to [OpenCode managed settings](https://opencode.ai/docs/config/#managed-settings).
+
+The following example uses `ai.example.com` for the AI Gateway domain and `config.example.com` for the configuration host. Replace both hostnames with your own values.
+
+<Steps>
+
+1. Outside any OpenCode project, create a copy of the `opencode.json` file from [Connect with a gateway token](#connect-with-a-gateway-token). Replace each provider `baseURL` with the corresponding value:
+
+   | Provider  | Base URL                                         |
+   | --------- | ------------------------------------------------ |
+   | Anthropic | `https://ai.example.com/anthropic/v1`            |
+   | OpenAI    | `https://ai.example.com/openai`                  |
+   | Google    | `https://ai.example.com/google-ai-studio/v1beta` |
+   | xAI       | `https://ai.example.com/grok/v1`                 |
+
+   Replace each provider's `headers` object with the following value:
+
+   ```json
+   {
+     "cf-access-token": "{env:TOKEN}",
+     "X-Requested-With": "XMLHttpRequest"
+   }
+   ```
+
+2. Upload `opencode.json` to your public HTTPS host. Confirm that its URL returns the expected JSON without authentication.
+
+   If you use R2, upload the object to the bucket and [connect a custom domain](/r2/buckets/public-buckets/#custom-domains). The example file should be available at `https://config.example.com/opencode.json`.
+
+   Do not keep another copy in a project or global OpenCode configuration. Local configuration takes precedence over remote configuration and would prevent later hosted updates from applying.
+
+3. Create an `opencode` discovery file. Set `remote_config.url` to the public URL of the `opencode.json` file:
 
    ```json title="opencode"
    {
@@ -117,11 +176,9 @@ The following example uses `ai.example.com` for the AI Gateway domain and `confi
 
    OpenCode runs the authentication command and makes its output available as `{env:TOKEN}`. It then substitutes that value into the remote provider configuration.
 
-3. Upload `opencode.json` and `opencode` to your public HTTPS host. Confirm that both URLs return the expected JSON without authentication.
+4. Upload `opencode` to your public HTTPS host. Confirm that `https://config.example.com/opencode` returns the discovery JSON without authentication.
 
-   If you use R2, upload both objects to the bucket and [connect a custom domain](/r2/buckets/public-buckets/#custom-domains). The example files should be available at `https://config.example.com/opencode.json` and `https://config.example.com/opencode`.
-
-4. In the zone for your AI Gateway custom domain, [create a Single Redirect](/rules/url-forwarding/single-redirects/create-dashboard/) with these settings:
+5. In the zone for your AI Gateway custom domain, [create a Single Redirect](/rules/url-forwarding/single-redirects/create-dashboard/) with these settings:
 
    - **Rule name**: `OpenCode discovery`
    - **Custom filter expression**: `(http.host eq "ai.example.com" and http.request.uri.path eq "/.well-known/opencode")`
@@ -129,9 +186,9 @@ The following example uses `ai.example.com` for the AI Gateway domain and `confi
    - **Status code**: `302`
    - **Preserve query string**: Off
 
-5. In a browser without an active Access session, open `https://ai.example.com/.well-known/opencode`. Confirm that the request returns the discovery JSON without an Access prompt.
+6. In a browser without an active Access session, open `https://ai.example.com/.well-known/opencode`. Confirm that the request returns the discovery JSON without an Access prompt.
 
-6. To connect OpenCode, run:
+7. To connect OpenCode, run:
 
    ```sh
    opencode auth login https://ai.example.com
@@ -139,12 +196,10 @@ The following example uses `ai.example.com` for the AI Gateway domain and `confi
 
    Complete the Access login flow when prompted. OpenCode stores the resulting credential locally and loads the remote configuration. Run the command again when the Access session expires.
 
-7. Start OpenCode and select a configured provider and model:
+8. Start OpenCode and select a configured provider and model:
 
    ```sh
    opencode
    ```
 
 </Steps>
-
-To confirm traffic reaches AI Gateway, refer to [Verify it works](/ai-gateway/integrations/coding-agents/#verify-it-works).

--- a/src/content/docs/ai-gateway/integrations/coding-agents/opencode.mdx
+++ b/src/content/docs/ai-gateway/integrations/coding-agents/opencode.mdx
@@ -12,6 +12,10 @@ import { Steps, Tabs, TabItem } from "~/components";
 
 [OpenCode](https://opencode.ai/) is an open source coding agent that supports custom provider configuration. Point its built-in providers at AI Gateway to observe and control model requests from OpenCode.
 
+:::note
+This custom setup is intended for organizations that need more control and want to distribute configuration to a team. For individual use, OpenCode's standard [Cloudflare AI Gateway provider setup](https://opencode.ai/docs/providers/#cloudflare-ai-gateway) is usually sufficient.
+:::
+
 ## Prerequisites
 
 Before you start, you need:

--- a/src/content/docs/ai-gateway/integrations/coding-agents/pi.mdx
+++ b/src/content/docs/ai-gateway/integrations/coding-agents/pi.mdx
@@ -3,7 +3,7 @@ title: Pi
 description: Route the Pi coding agent through AI Gateway using its built-in Cloudflare AI Gateway provider.
 pcx_content_type: configuration
 sidebar:
-  order: 5
+  order: 6
 products:
   - ai-gateway
 ---


### PR DESCRIPTION
### Summary

Adds a general OpenCode integration guide for AI Gateway. It covers the standard gateway-token setup and an alternative using Cloudflare Access, custom domains, centrally hosted configuration, and OpenCode discovery through a Single Redirect.

### Screenshots (optional)

<!-- TODO: add screenshots before requesting review -->

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
