### PR TITLE
docs(cache): document Always Online limitation for Custom Hostnames

### DIFF
--- a/src/content/docs/cache/troubleshooting/always-online.mdx
+++ b/src/content/docs/cache/troubleshooting/always-online.mdx
@@ -18,6 +18,7 @@ Observe the following best practices when enabling Always Online with Internet A
 
 Do not use Always Online with:
 
+- A [Custom Hostname (Cloudflare for SaaS)](/cloudflare-for-platforms/cloudflare-for-saas/) domain. Always Online is not supported for Custom Hostnames and can result in [Error 1001](/support/troubleshooting/http-status-codes/cloudflare-1xxx-errors/error-1001/).
 - API traffic.
 - An [IP Access rule](/waf/tools/ip-access-rules/) or a [WAF custom rule](/waf/custom-rules/) that blocks the United States or
 - Bypass Cache cache rules. Always Online ignores Bypass Cache cache rules and serves Always Online cached assets.


### PR DESCRIPTION
## Summary

Document that Always Online is not supported for Custom Hostnames (Cloudflare for SaaS), and that enabling it can result in Error 1001.

## Rationale

The existing [Error 1001 troubleshooting page](https://developers.cloudflare.com/support/troubleshooting/http-status-codes/cloudflare-1xxx-errors/error-1001/#common-causes) identifies Always Online enabled on a Custom Hostname as a common cause and advises disabling it. This adds the same limitation to the Always Online troubleshooting page, where users evaluate feature compatibility.

## Changes

- Add Custom Hostnames (Cloudflare for SaaS) to the "Do not use Always Online with" list.
- Link to the Error 1001 troubleshooting guidance.

No product behavior changes.