### PR TITLE
R2-5119: Data Access Logs

### DIFF
--- a/src/content/changelog/r2/2026-09-04-r2-data-access-logs.mdx
+++ b/src/content/changelog/r2/2026-09-04-r2-data-access-logs.mdx
@@ -1,0 +1,15 @@
+---
+title: R2 Data Access Logs
+description: Record object operations with response status codes below 400 and inspect per-request events in Workers Observability.
+products:
+  - r2
+date: 2026-09-04
+---
+
+R2 Data Access Logs are now generally available. Turn on logging for a bucket to record object read, write, list, multipart upload, and delete operations with response status codes below `400`.
+
+Data Access Logs cover requests made through the S3-compatible API, Cloudflare API and dashboard, Workers bindings, and public buckets through `r2.dev` or custom domains. Events are available in Workers Observability, where you can filter by bucket, operation, interface, actor, and other request fields.
+
+Log delivery is asynchronous and best effort. Events may be delayed or omitted, so do not rely on Data Access Logs as a complete record of bucket activity.
+
+Data Access Logs are available for non-jurisdictional buckets. For setup instructions, supported operations, and the event field reference, refer to [R2 Data Access Logs](/r2/buckets/data-access-logs/).

--- a/src/content/dash-routes/core-manually-defined.json
+++ b/src/content/dash-routes/core-manually-defined.json
@@ -53,5 +53,10 @@
 		"deeplink": "/?to=/:account/:zone/speed/origin-analytics",
 		"name": "Origin Analytics",
 		"parent": ["Speed"]
+	},
+	{
+		"deeplink": "/?to=/:account/r2/:bucket/settings",
+		"name": "Bucket settings",
+		"parent": ["Storage & databases", "R2 object storage"]
 	}
 ]

--- a/src/content/docs/r2/buckets/data-access-logs.mdx
+++ b/src/content/docs/r2/buckets/data-access-logs.mdx
@@ -1,0 +1,129 @@
+---
+title: Data Access Logs
+description: Record object operations with response status codes below 400 and inspect per-request events in Workers Observability.
+pcx_content_type: how-to
+sidebar:
+  order: 4
+products:
+  - r2
+---
+
+import { DashButton, Steps } from "~/components";
+
+R2 Data Access Logs provide per-request records for object operations in a bucket. The logs are generally available for R2 buckets without a [jurisdiction](/r2/reference/data-location/#jurisdictional-restrictions).
+
+Data Access Logs differ from [Audit Logs](/r2/platform/audit-logs/), which record bucket configuration changes. They also differ from [R2 metrics](/r2/platform/metrics-analytics/), which provide aggregated request and storage data.
+
+:::note
+Data Access Logs include requests with HTTP status codes below `400`, including `304 Not Modified`. Log delivery is asynchronous and best effort, and events may be delayed or omitted. Requests with status codes of `400` or greater are excluded. Do not rely on Data Access Logs as a complete record of bucket activity.
+:::
+
+## Supported interfaces
+
+Data Access Logs record requests from these interfaces:
+
+| Interface | Source                                                                                             |
+| --------- | -------------------------------------------------------------------------------------------------- |
+| `S3`      | Requests through the S3-compatible API.                                                            |
+| `API`     | Object operations from the Cloudflare dashboard or API.                                            |
+| `Workers` | Object operations through an R2 binding. These events include the Worker script name.              |
+| `Public`  | Requests to public buckets through `r2.dev` or custom domains. These requests are unauthenticated. |
+
+## Logged operations
+
+Data Access Logs record the following operations:
+
+| Category         | Operations                                                                                                                                      |
+| ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| Read             | `GetObject`, `HeadObject`                                                                                                                       |
+| Write and copy   | `PutObject`, `CopyObject`                                                                                                                       |
+| List             | `ListObjectsV1`, `ListObjectsV2`                                                                                                                |
+| Multipart upload | `CreateMultipartUpload`, `UploadPart`, `UploadPartCopy`, `CompleteMultipartUpload`, `AbortMultipartUpload`, `ListMultipartUploads`, `ListParts` |
+| Delete           | `DeleteObject`, `DeleteObjects`, `DeleteObjectsByPrefix`                                                                                        |
+
+Bucket and configuration operations are not included. Failed requests with an HTTP status code of `400` or greater are also not included.
+
+## Turn on Data Access Logs
+
+<Steps>
+1. In the Cloudflare dashboard, go to the bucket you wish to enable.
+
+   <DashButton url="/?to=/:account/r2/:bucket/settings" />
+
+2. Under **Data Access Logs**, select _Enabled_.
+</Steps>
+
+R2 records new supported operations after you turn on Data Access Logs. Earlier operations are not added retroactively.
+
+## View Data Access Logs
+
+In the **Data Access Logs** section of the bucket settings, select **View logs in Workers Observability**. The **Events** view opens with the `r2` dataset and current bucket selected for the previous hour.
+
+Use the [Query Builder](/workers/observability/query-builder/) to change the time range, add filters, or aggregate events.
+
+## Turn off Data Access Logs
+
+<Steps>
+1. In the Cloudflare dashboard, go to the bucket you wish to disable.
+
+   <DashButton url="/?to=/:account/r2/:bucket/settings" />
+
+2. In **Data Access Logs**, select _Disabled_.
+</Steps>
+
+## Log fields
+
+Every event can include these fields:
+
+| Field                   | Description                                                                                            |
+| ----------------------- | ------------------------------------------------------------------------------------------------------ |
+| `$metadata.timestamp`   | Event timestamp in Unix milliseconds.                                                                  |
+| `$metadata.service`     | Bucket name used as the service name.                                                                  |
+| `$metadata.namespace`   | Event namespace. The value is `r2`.                                                                    |
+| `action`                | R2 operation name.                                                                                     |
+| `actor.type`            | Actor type: `user` or `service`. Public bucket requests use `service`.                                 |
+| `actor.id`              | Identifier for the authenticated actor. Public bucket requests use `public`.                           |
+| `actor.email`           | Email address for a user actor.                                                                        |
+| `actor.accessKeyId`     | Access key ID for a request authenticated with AWS Signature Version 4.                                |
+| `bucket`                | Target bucket name.                                                                                    |
+| `interface`             | Request interface: `S3`, `API`, `Workers`, or `Public`.                                                |
+| `request.bytes`         | Request `Content-Length` value in bytes.                                                               |
+| `response.bytes`        | Response `Content-Length` value in bytes.                                                              |
+| `response.errorCode`    | Response error code. This value is `NotModified` for a `304` response and `null` for a `2xx` response. |
+| `response.errorMessage` | Response error message. This value describes a `304` response and is `null` for a `2xx` response.      |
+| `requestMetadata.colo`  | Cloudflare data center code, or `XXX` when the data center is unavailable.                             |
+
+S3-compatible API, Cloudflare API, and public bucket events can also include these fields:
+
+| Field                       | Description                |
+| --------------------------- | -------------------------- |
+| `request.method`            | HTTP request method.       |
+| `request.uri`               | Request path.              |
+| `response.status`           | HTTP response status code. |
+| `requestMetadata.ip`        | Client IP address.         |
+| `requestMetadata.userAgent` | Client user agent.         |
+
+Workers binding events include this additional field:
+
+| Field        | Description                                             |
+| ------------ | ------------------------------------------------------- |
+| `scriptName` | Name of the Worker script that triggered the operation. |
+
+Workers binding events do not include the HTTP method, URI, response status, client IP address, or user agent.
+
+An event can include these operation-specific fields:
+
+| Field               | Description                                                     |
+| ------------------- | --------------------------------------------------------------- |
+| `resource.key`      | Object key.                                                     |
+| `resource.type`     | Resource type: `object` or `multipart_upload`.                  |
+| `resource.size`     | Object size in bytes when available.                            |
+| `resource.uploadId` | Upload ID for a multipart upload.                               |
+| `sourceResource`    | Source bucket, key, and resource type for a copy operation.     |
+| `prefix`            | Prefix used by a list or prefix-delete operation.               |
+| `delimiter`         | Delimiter used by a list operation.                             |
+| `maxKeys`           | Maximum keys requested by an object list operation.             |
+| `maxUploads`        | Maximum uploads requested by a multipart upload list operation. |
+| `objects`           | Object keys included in a bulk delete operation.                |
+
+The `request.bytes` and `response.bytes` fields reflect `Content-Length` values, not exact transferred-byte measurements. A byte count or resource size of `0` can mean either zero bytes or that the value was unavailable when R2 created the event.

--- a/src/content/docs/r2/platform/audit-logs.mdx
+++ b/src/content/docs/r2/platform/audit-logs.mdx
@@ -22,21 +22,23 @@ For more information on how to access and use audit logs, refer to [Review audit
 
 The following configuration actions are logged:
 
-| Operation | Description |
-|-----------|-------------|
-| CreateBucket | Creation of a new bucket. |
-| DeleteBucket | Deletion of an existing bucket. |
-| AddCustomDomain | Addition of a custom domain to a bucket. |
-| RemoveCustomDomain | Removal of a custom domain from a bucket. |
-| ChangeBucketVisibility | Change to the managed public access (`r2.dev`) settings of a bucket. |
-| PutBucketStorageClass | Change to the default storage class of a bucket. |
-| PutBucketLifecycleConfiguration | Change to the object lifecycle configuration of a bucket. |
-| DeleteBucketLifecycleConfiguration | Deletion of the object lifecycle configuration for a bucket. |
-| PutBucketCors | Change to the CORS configuration for a bucket. |
-| DeleteBucketCors | Deletion of the CORS configuration for a bucket. |
+| Operation                          | Description                                                          |
+| ---------------------------------- | -------------------------------------------------------------------- |
+| CreateBucket                       | Creation of a new bucket.                                            |
+| DeleteBucket                       | Deletion of an existing bucket.                                      |
+| AddCustomDomain                    | Addition of a custom domain to a bucket.                             |
+| RemoveCustomDomain                 | Removal of a custom domain from a bucket.                            |
+| ChangeBucketVisibility             | Change to the managed public access (`r2.dev`) settings of a bucket. |
+| PutBucketStorageClass              | Change to the default storage class of a bucket.                     |
+| PutBucketLifecycleConfiguration    | Change to the object lifecycle configuration of a bucket.            |
+| DeleteBucketLifecycleConfiguration | Deletion of the object lifecycle configuration for a bucket.         |
+| PutBucketCors                      | Change to the CORS configuration for a bucket.                       |
+| DeleteBucketCors                   | Deletion of the CORS configuration for a bucket.                     |
 
 :::note
-Logs for data access operations, such as `GetObject` and `PutObject`, are not included in audit logs. To log HTTP requests made to public R2 buckets, use the [HTTP requests](/logs/logpush/logpush-job/datasets/zone/http_requests/) Logpush dataset.
+Audit Logs do not include data access operations, such as `GetObject` and `PutObject`. To record supported object operations with response status codes below `400`, use [R2 Data Access Logs](/r2/buckets/data-access-logs/).
+
+Data Access Logs also include supported requests to public R2 buckets through `r2.dev` or custom domains.
 :::
 
 ## Example log entry
@@ -45,23 +47,22 @@ Below is an example of an audit log entry showing the creation of a new bucket:
 
 ```json
 {
-  "action": { "info": "CreateBucket", "result": true, "type": "create" },
-  "actor": {
-    "email": "<ACTOR_EMAIL>",
-    "id": "3f7b730e625b975bc1231234cfbec091",
-    "ip": "fe32:43ed:12b5:526::1d2:13",
-    "type": "user"
-  },
-  "id": "5eaeb6be-1234-406a-87ab-1971adc1234c",
-  "interface": "API",
-  "metadata": { "zone_name": "r2.cloudflarestorage.com" },
-  "newValue": "",
-  "newValueJson": {},
-  "oldValue": "",
-  "oldValueJson": {},
-  "owner": { "id": "1234d848c0b9e484dfc37ec392b5fa8a" },
-  "resource": { "id": "my-bucket", "type": "r2.bucket" },
-  "when": "2024-07-15T16:32:52.412Z"
+	"action": { "info": "CreateBucket", "result": true, "type": "create" },
+	"actor": {
+		"email": "<ACTOR_EMAIL>",
+		"id": "3f7b730e625b975bc1231234cfbec091",
+		"ip": "fe32:43ed:12b5:526::1d2:13",
+		"type": "user"
+	},
+	"id": "5eaeb6be-1234-406a-87ab-1971adc1234c",
+	"interface": "API",
+	"metadata": { "zone_name": "r2.cloudflarestorage.com" },
+	"newValue": "",
+	"newValueJson": {},
+	"oldValue": "",
+	"oldValueJson": {},
+	"owner": { "id": "1234d848c0b9e484dfc37ec392b5fa8a" },
+	"resource": { "id": "my-bucket", "type": "r2.bucket" },
+	"when": "2024-07-15T16:32:52.412Z"
 }
-
 ```


### PR DESCRIPTION
### Summary

Documenting the new Data Access Logs feature for R2.

### Documentation checklist

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
