### PR TITLE
fix: register DeepSeek V4 Flash for Bonk

### DIFF
--- a/opencode.jsonc
+++ b/opencode.jsonc
@@ -26,6 +26,26 @@
 						"parallel_tool_calls": true,
 					},
 				},
+				"workers-ai/@cf/zai-org/glm-4.7-flash": {
+					"name": "GLM-4.7-Flash",
+					"reasoning": true,
+					"tool_call": true,
+					"temperature": true,
+					"interleaved": {
+						"field": "reasoning_content",
+					},
+					"modalities": {
+						"input": ["text"],
+						"output": ["text"],
+					},
+					"limit": {
+						"context": 131072,
+						"output": 131072,
+					},
+					"options": {
+						"parallel_tool_calls": true,
+					},
+				},
 				"workers-ai/@cf/moonshotai/kimi-k2.5": {
 					"name": "Kimi K2.5",
 					"attachment": true,

--- a/opencode.jsonc
+++ b/opencode.jsonc
@@ -6,6 +6,26 @@
 	"provider": {
 		"cloudflare-ai-gateway": {
 			"models": {
+				"workers-ai/@cf/deepseek-ai/deepseek-v4-flash-0731": {
+					"name": "DeepSeek V4 Flash",
+					"reasoning": true,
+					"tool_call": true,
+					"temperature": true,
+					"interleaved": {
+						"field": "reasoning_content",
+					},
+					"modalities": {
+						"input": ["text"],
+						"output": ["text"],
+					},
+					"limit": {
+						"context": 1048576,
+						"output": 64000,
+					},
+					"options": {
+						"parallel_tool_calls": true,
+					},
+				},
 				"workers-ai/@cf/moonshotai/kimi-k2.5": {
 					"name": "Kimi K2.5",
 					"attachment": true,


### PR DESCRIPTION
### Summary

Registers DeepSeek V4 Flash in the OpenCode configuration so Bonk can resolve the model already selected by its workflow.

[PR #33193](https://github.com/cloudflare/cloudflare-docs/pull/33193), merged in [commit `660c3cfa95`](https://github.com/cloudflare/cloudflare-docs/commit/660c3cfa95cf16db83f3dea042b0fabbbfe667d7), switched Bonk from Kimi K2.6 to DeepSeek V4 Flash. Although DeepSeek V4 Flash is available through Workers AI and AI Gateway, it was not registered in OpenCode 1.17.7's Cloudflare AI Gateway model catalog or the repository's `opencode.jsonc`.

As a result, OpenCode could not resolve the configured model when Bonk sent its first prompt. The run failed before inference and surfaced the model lookup failure as `share subscriber failed` followed by exit code 1.

This change explicitly defines the model's capabilities and limits in `opencode.jsonc`, allowing Bonk to continue using DeepSeek V4 Flash.

- Failed run: https://github.com/cloudflare/cloudflare-docs/actions/runs/33918336245/job/101170688280
- Workers AI release: https://developers.cloudflare.com/changelog/post/2026-08-14-deepseek-v4-workers-ai/
