### PR TITLE
chore: expand PR labeler coverage to partials, images, release notes, and missing products

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,392 +1,761 @@
-product:changelog:
-  - changed-files:
-      - any-glob-to-any-file:
-          - src/content/changelog/**
+# Generated product label rules for actions/labeler.
+#
+# Maps changed paths to product: labels. Coverage:
+#   src/content/docs/{slug}/**            product docs pages
+#   src/content/partials/{slug}/**        shared content snippets
+#   src/assets/images/{slug}/**           product screenshots/diagrams
+#   src/content/release-notes/{slug}.yaml release notes
+#   src/content/{changelog,workers-ai-models,compatibility-flags,fields,catalog-models}
+#   public/{__redirects,_headers}
+#
+# Rules referencing paths that do not exist are intentionally omitted.
+
 product:1.1.1.1:
   - changed-files:
       - any-glob-to-any-file:
           - src/content/docs/1.1.1.1/**
+          - src/content/partials/1.1.1.1/**
+          - src/assets/images/1.1.1.1/**
+
+product:_headers:
+  - changed-files:
+      - any-glob-to-any-file:
+          - public/_headers
+
+product:_redirects:
+  - changed-files:
+      - any-glob-to-any-file:
+          - public/__redirects
+
+product:agent-lee:
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/content/docs/agent-lee/**
+
+product:agent-memory:
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/content/docs/agent-memory/**
+
+product:agent-setup:
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/content/docs/agent-setup/**
+          - src/assets/images/agent-setup/**
+
 product:agents:
   - changed-files:
       - any-glob-to-any-file:
           - src/content/docs/agents/**
-product:cloudflare-agent:
+          - src/content/partials/agents/**
+          - src/assets/images/agents/**
+
+product:ai:
   - changed-files:
       - any-glob-to-any-file:
-          - src/content/docs/cloudflare-agent/**
+          - src/content/docs/ai/**
+
 product:ai-crawl-control:
   - changed-files:
       - any-glob-to-any-file:
           - src/content/docs/ai-crawl-control/**
+          - src/content/partials/ai-crawl-control/**
+          - src/assets/images/ai-crawl-control/**
+
 product:ai-gateway:
   - changed-files:
       - any-glob-to-any-file:
           - src/content/docs/ai-gateway/**
+          - src/content/partials/ai-gateway/**
+          - src/assets/images/ai-gateway/**
+          - src/content/catalog-models/**
+
 product:ai-search:
   - changed-files:
       - any-glob-to-any-file:
           - src/content/docs/ai-search/**
+          - src/content/partials/ai-search/**
+          - src/assets/images/ai-search/**
+          - src/content/release-notes/ai-search.yaml
+
 product:analytics:
   - changed-files:
       - any-glob-to-any-file:
           - src/content/docs/analytics/**
+          - src/content/partials/analytics/**
+          - src/assets/images/analytics/**
+
 product:api-shield:
   - changed-files:
       - any-glob-to-any-file:
           - src/content/docs/api-shield/**
+          - src/content/partials/api-shield/**
+          - src/assets/images/api-shield/**
+
 product:argo-smart-routing:
   - changed-files:
       - any-glob-to-any-file:
           - src/content/docs/argo-smart-routing/**
+
+product:artifacts:
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/content/docs/artifacts/**
+          - src/assets/images/artifacts/**
+
 product:automatic-platform-optimization:
   - changed-files:
       - any-glob-to-any-file:
           - src/content/docs/automatic-platform-optimization/**
+
 product:billing:
   - changed-files:
       - any-glob-to-any-file:
           - src/content/docs/billing/**
+          - src/content/partials/billing/**
+          - src/assets/images/billing/**
+
 product:bots:
   - changed-files:
       - any-glob-to-any-file:
           - src/content/docs/bots/**
+          - src/content/partials/bots/**
+          - src/assets/images/bots/**
+          - src/content/release-notes/bots.yaml
+
 product:browser-run:
   - changed-files:
       - any-glob-to-any-file:
           - src/content/docs/browser-run/**
+          - src/content/partials/browser-run/**
+          - src/assets/images/browser-run/**
+          - src/content/release-notes/browser-run.yaml
+
 product:byoip:
   - changed-files:
       - any-glob-to-any-file:
           - src/content/docs/byoip/**
+          - src/content/partials/byoip/**
+          - src/content/release-notes/byoip.yaml
+
 product:cache:
   - changed-files:
       - any-glob-to-any-file:
           - src/content/docs/cache/**
+          - src/content/partials/cache/**
+          - src/assets/images/cache/**
+
+product:changelog:
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/assets/images/changelog/**
+          - src/content/changelog/**
+
 product:china-network:
   - changed-files:
       - any-glob-to-any-file:
           - src/content/docs/china-network/**
+          - src/assets/images/china-network/**
+
 product:client-ip-geolocation:
   - changed-files:
       - any-glob-to-any-file:
           - src/content/docs/client-ip-geolocation/**
-product:cloudflare-challenges:
-  - changed-files:
-      - any-glob-to-any-file:
-          - src/content/docs/cloudflare-challenges/**
-product:cloudflare-for-platforms:
-  - changed-files:
-      - any-glob-to-any-file:
-          - src/content/docs/cloudflare-for-platforms/**
-product:cloudflare-one:
-  - changed-files:
-      - any-glob-to-any-file:
-          - src/content/docs/cloudflare-one/**
-product:tunnel:
-  - changed-files:
-      - any-glob-to-any-file:
-          - src/content/docs/tunnel/**
-product:constellation:
-  - changed-files:
-      - any-glob-to-any-file:
-          - src/content/docs/constellation/**
-product:containers:
-  - changed-files:
-      - any-glob-to-any-file:
-          - src/content/docs/containers/**
-product:d1:
-  - changed-files:
-      - any-glob-to-any-file:
-          - src/content/docs/d1/**
-product:data-localization:
-  - changed-files:
-      - any-glob-to-any-file:
-          - src/content/docs/data-localization/**
-product:ddos-protection:
-  - changed-files:
-      - any-glob-to-any-file:
-          - src/content/docs/ddos-protection/**
-product:dmarc-management:
-  - changed-files:
-      - any-glob-to-any-file:
-          - src/content/docs/dmarc-management/**
-product:dns:
-  - changed-files:
-      - any-glob-to-any-file:
-          - src/content/docs/dns/**
-product:durable-objects:
-  - changed-files:
-      - any-glob-to-any-file:
-          - src/content/docs/durable-objects/**
-product:email-routing:
-  - changed-files:
-      - any-glob-to-any-file:
-          - src/content/docs/email-routing/**
-product:email-security:
-  - changed-files:
-      - any-glob-to-any-file:
-          - src/content/docs/email-security/**
-product:firewall:
-  - changed-files:
-      - any-glob-to-any-file:
-          - src/content/docs/firewall/**
-product:fundamentals:
-  - changed-files:
-      - any-glob-to-any-file:
-          - src/content/docs/fundamentals/**
-product:google-tag-gateway:
-  - changed-files:
-      - any-glob-to-any-file:
-          - src/content/docs/google-tag-gateway/**
-product:health-checks:
-  - changed-files:
-      - any-glob-to-any-file:
-          - src/content/docs/health-checks/**
-product:hyperdrive:
-  - changed-files:
-      - any-glob-to-any-file:
-          - src/content/docs/hyperdrive/**
-product:images:
-  - changed-files:
-      - any-glob-to-any-file:
-          - src/content/docs/images/**
-product:key-transparency:
-  - changed-files:
-      - any-glob-to-any-file:
-          - src/content/docs/key-transparency/**
-product:kv:
-  - changed-files:
-      - any-glob-to-any-file:
-          - src/content/docs/kv/**
-product:learning-paths:
-  - changed-files:
-      - any-glob-to-any-file:
-          - src/content/docs/learning-paths/**
-product:load-balancing:
-  - changed-files:
-      - any-glob-to-any-file:
-          - src/content/docs/load-balancing/**
-product:log-explorer:
-  - changed-files:
-      - any-glob-to-any-file:
-          - src/content/docs/log-explorer/**
-product:logs:
-  - changed-files:
-      - any-glob-to-any-file:
-          - src/content/docs/logs/**
-product:multi-cloud-networking:
-  - changed-files:
-      - any-glob-to-any-file:
-          - src/content/docs/multi-cloud-networking/**
-product:cloudflare-network-firewall:
-  - changed-files:
-      - any-glob-to-any-file:
-          - src/content/docs/cloudflare-network-firewall/**
-product:network-flow:
-  - changed-files:
-      - any-glob-to-any-file:
-          - src/content/docs/network-flow/**
-product:magic-transit:
-  - changed-files:
-      - any-glob-to-any-file:
-          - src/content/docs/magic-transit/**
-product:cloudflare-wan:
-  - changed-files:
-      - any-glob-to-any-file:
-          - src/content/docs/cloudflare-wan/**
-product:migration-guides:
-  - changed-files:
-      - any-glob-to-any-file:
-          - src/content/docs/migration-guides/**
-product:moq:
-  - changed-files:
-      - any-glob-to-any-file:
-          - src/content/docs/moq/**
-product:network:
-  - changed-files:
-      - any-glob-to-any-file:
-          - src/content/docs/network/**
-product:network-error-logging:
-  - changed-files:
-      - any-glob-to-any-file:
-          - src/content/docs/network-error-logging/**
-product:network-interconnect:
-  - changed-files:
-      - any-glob-to-any-file:
-          - src/content/docs/network-interconnect/**
-product:notifications:
-  - changed-files:
-      - any-glob-to-any-file:
-          - src/content/docs/notifications/**
+          - src/assets/images/client-ip-geolocation/**
+
 product:client-side-security:
   - changed-files:
       - any-glob-to-any-file:
           - src/content/docs/client-side-security/**
+          - src/content/partials/client-side-security/**
+          - src/assets/images/client-side-security/**
+          - src/content/release-notes/client-side-security.yaml
+
+product:cloudflare-challenges:
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/content/docs/cloudflare-challenges/**
+          - src/content/partials/cloudflare-challenges/**
+          - src/assets/images/cloudflare-challenges/**
+
+product:cloudflare-for-platforms:
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/content/docs/cloudflare-for-platforms/**
+          - src/content/partials/cloudflare-for-platforms/**
+          - src/assets/images/cloudflare-for-platforms/**
+          - src/content/release-notes/workers-for-platforms.yaml
+
+product:cloudflare-network-firewall:
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/content/docs/cloudflare-network-firewall/**
+
+product:cloudflare-one:
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/content/docs/cloudflare-one/**
+          - src/content/partials/cloudflare-one/**
+          - src/assets/images/cloudflare-one/**
+
+product:cloudflare-wan:
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/content/docs/cloudflare-wan/**
+          - src/assets/images/cloudflare-wan/**
+
+product:constellation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/content/docs/constellation/**
+
+product:containers:
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/content/docs/containers/**
+          - src/content/partials/containers/**
+          - src/assets/images/containers/**
+
+product:d1:
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/content/docs/d1/**
+          - src/content/partials/d1/**
+          - src/content/release-notes/d1.yaml
+
+product:data-localization:
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/content/docs/data-localization/**
+          - src/content/partials/data-localization/**
+          - src/assets/images/data-localization/**
+          - src/content/release-notes/data-localization.yaml
+
+product:ddos-protection:
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/content/docs/ddos-protection/**
+          - src/content/partials/ddos-protection/**
+          - src/assets/images/ddos-protection/**
+          - src/content/release-notes/ddos-http.yaml
+          - src/content/release-notes/ddos-network.yaml
+          - src/content/release-notes/ddos.yaml
+
+product:dmarc-management:
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/content/docs/dmarc-management/**
+          - src/content/partials/dmarc-management/**
+
+product:dns:
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/content/docs/dns/**
+          - src/content/partials/dns/**
+          - src/assets/images/dns/**
+
+product:docs-for-agents:
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/content/docs/docs-for-agents/**
+
+product:durable-objects:
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/content/docs/durable-objects/**
+          - src/content/partials/durable-objects/**
+          - src/assets/images/durable-objects/**
+          - src/content/release-notes/durable-objects.yaml
+
+product:dynamic-workers:
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/content/docs/dynamic-workers/**
+          - src/assets/images/dynamic-workers/**
+
+product:email-routing:
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/content/partials/email-routing/**
+
+product:email-security:
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/content/docs/email-security/**
+          - src/content/partials/email-security/**
+          - src/assets/images/email-security/**
+
+product:email-service:
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/content/docs/email-service/**
+          - src/content/partials/email-service/**
+          - src/assets/images/email-service/**
+
+product:firewall:
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/content/docs/firewall/**
+          - src/content/partials/firewall/**
+          - src/assets/images/firewall/**
+
+product:flagship:
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/content/docs/flagship/**
+
+product:fundamentals:
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/content/docs/fundamentals/**
+          - src/content/partials/fundamentals/**
+          - src/assets/images/fundamentals/**
+          - src/content/release-notes/api-deprecations.yaml
+
+product:google-tag-gateway:
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/content/docs/google-tag-gateway/**
+          - src/assets/images/google-tag-gateway/**
+
+product:health-checks:
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/content/docs/health-checks/**
+
+product:hyperdrive:
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/content/docs/hyperdrive/**
+          - src/content/partials/hyperdrive/**
+          - src/assets/images/hyperdrive/**
+          - src/content/release-notes/hyperdrive.yaml
+
+product:images:
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/content/docs/images/**
+          - src/content/partials/images/**
+          - src/assets/images/images/**
+          - src/content/release-notes/images.yaml
+
+product:key-transparency:
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/content/docs/key-transparency/**
+
+product:kv:
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/content/docs/kv/**
+          - src/assets/images/kv/**
+          - src/content/release-notes/kv.yaml
+
+product:learning-paths:
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/content/docs/learning-paths/**
+          - src/content/partials/learning-paths/**
+          - src/assets/images/learning-paths/**
+
+product:load-balancing:
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/content/docs/load-balancing/**
+          - src/content/partials/load-balancing/**
+          - src/assets/images/load-balancing/**
+
+product:log-explorer:
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/content/docs/log-explorer/**
+          - src/assets/images/log-explorer/**
+
+product:logs:
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/content/docs/logs/**
+          - src/content/partials/logs/**
+          - src/assets/images/logs/**
+
+product:magic-transit:
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/content/docs/magic-transit/**
+          - src/assets/images/magic-transit/**
+
+product:migration-guides:
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/content/docs/migration-guides/**
+
+product:moq:
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/content/docs/moq/**
+
+product:multi-cloud-networking:
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/content/docs/multi-cloud-networking/**
+          - src/assets/images/multi-cloud-networking/**
+
+product:network:
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/content/docs/network/**
+          - src/content/partials/network/**
+
+product:network-error-logging:
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/content/docs/network-error-logging/**
+          - src/assets/images/network-error-logging/**
+
+product:network-flow:
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/content/docs/network-flow/**
+          - src/assets/images/network-flow/**
+
+product:network-interconnect:
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/content/docs/network-interconnect/**
+
+product:notifications:
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/content/docs/notifications/**
+          - src/content/partials/notifications/**
+
 product:pages:
   - changed-files:
       - any-glob-to-any-file:
           - src/content/docs/pages/**
+          - src/content/partials/pages/**
+          - src/assets/images/pages/**
+          - src/content/release-notes/pages.yaml
+
 product:pipelines:
   - changed-files:
       - any-glob-to-any-file:
           - src/content/docs/pipelines/**
+          - src/assets/images/pipelines/**
+
 product:privacy-gateway:
   - changed-files:
       - any-glob-to-any-file:
           - src/content/docs/privacy-gateway/**
+
+product:privacy-pass:
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/content/docs/privacy-pass/**
+
+product:privacy-proxy:
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/content/docs/privacy-proxy/**
+
 product:pulumi:
   - changed-files:
       - any-glob-to-any-file:
           - src/content/docs/pulumi/**
+
 product:queues:
   - changed-files:
       - any-glob-to-any-file:
           - src/content/docs/queues/**
+          - src/content/partials/queues/**
+          - src/assets/images/queues/**
+          - src/content/release-notes/queues.yaml
+
 product:r2:
   - changed-files:
       - any-glob-to-any-file:
           - src/content/docs/r2/**
+          - src/content/partials/r2/**
+          - src/assets/images/r2/**
+          - src/content/release-notes/r2.yaml
+
+product:r2-data-catalog:
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/content/docs/r2-data-catalog/**
+          - src/assets/images/r2-data-catalog/**
+
 product:r2-sql:
   - changed-files:
       - any-glob-to-any-file:
           - src/content/docs/r2-sql/**
+          - src/assets/images/r2-sql/**
+
 product:radar:
   - changed-files:
       - any-glob-to-any-file:
           - src/content/docs/radar/**
+          - src/assets/images/radar/**
+          - src/content/release-notes/radar.yaml
+
 product:randomness-beacon:
   - changed-files:
       - any-glob-to-any-file:
           - src/content/docs/randomness-beacon/**
+
 product:realtime:
   - changed-files:
       - any-glob-to-any-file:
           - src/content/docs/realtime/**
+          - src/content/partials/realtime/**
+          - src/assets/images/realtime/**
+          - src/content/release-notes/realtime.yaml
+          - src/content/release-notes/realtimekit-android-core.yaml
+          - src/content/release-notes/realtimekit-android-ui-kit.yaml
+          - src/content/release-notes/realtimekit-flutter-core.yaml
+          - src/content/release-notes/realtimekit-flutter-ui-kit.yaml
+          - src/content/release-notes/realtimekit-ios-core.yaml
+          - src/content/release-notes/realtimekit-ios-ui-kit.yaml
+          - src/content/release-notes/realtimekit-react-native-core.yaml
+          - src/content/release-notes/realtimekit-react-native-ui-kit.yaml
+          - src/content/release-notes/realtimekit-recording-sdk.yaml
+          - src/content/release-notes/realtimekit-web-core.yaml
+          - src/content/release-notes/realtimekit-web-ui-kit.yaml
+          - src/content/release-notes/realtimekit.yaml
+
 product:reference-architecture:
   - changed-files:
       - any-glob-to-any-file:
           - src/content/docs/reference-architecture/**
+          - src/content/partials/reference-architecture/**
+          - src/assets/images/reference-architecture/**
+
 product:registrar:
   - changed-files:
       - any-glob-to-any-file:
           - src/content/docs/registrar/**
+          - src/content/partials/registrar/**
+          - src/assets/images/registrar/**
+
+product:resource-tagging:
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/content/docs/resource-tagging/**
+
 product:rules:
   - changed-files:
       - any-glob-to-any-file:
           - src/content/docs/rules/**
+          - src/content/partials/rules/**
+          - src/assets/images/rules/**
+          - src/content/release-notes/trace.yaml
+
 product:ruleset-engine:
   - changed-files:
       - any-glob-to-any-file:
           - src/content/docs/ruleset-engine/**
+          - src/content/partials/ruleset-engine/**
+          - src/assets/images/ruleset-engine/**
+          - src/content/fields/**
+
 product:sandbox:
   - changed-files:
       - any-glob-to-any-file:
           - src/content/docs/sandbox/**
+
 product:secrets-store:
   - changed-files:
       - any-glob-to-any-file:
           - src/content/docs/secrets-store/**
+
 product:security:
   - changed-files:
       - any-glob-to-any-file:
           - src/content/docs/security/**
+
 product:security-center:
   - changed-files:
       - any-glob-to-any-file:
           - src/content/docs/security-center/**
+          - src/content/partials/security-center/**
+
 product:smart-shield:
   - changed-files:
       - any-glob-to-any-file:
           - src/content/docs/smart-shield/**
+          - src/content/partials/smart-shield/**
+          - src/assets/images/smart-shield/**
+
 product:spectrum:
   - changed-files:
       - any-glob-to-any-file:
           - src/content/docs/spectrum/**
+          - src/content/partials/spectrum/**
+          - src/assets/images/spectrum/**
+
 product:speed:
   - changed-files:
       - any-glob-to-any-file:
           - src/content/docs/speed/**
+          - src/content/partials/speed/**
+          - src/assets/images/speed/**
+
 product:ssl:
   - changed-files:
       - any-glob-to-any-file:
           - src/content/docs/ssl/**
+          - src/content/partials/ssl/**
+          - src/assets/images/ssl/**
+
 product:stream:
   - changed-files:
       - any-glob-to-any-file:
           - src/content/docs/stream/**
+          - src/content/partials/stream/**
+          - src/assets/images/stream/**
+          - src/content/release-notes/stream.yaml
+
 product:style-guide:
   - changed-files:
       - any-glob-to-any-file:
           - src/content/docs/style-guide/**
+          - src/content/partials/style-guide/**
+          - src/assets/images/style-guide/**
+
 product:support:
   - changed-files:
       - any-glob-to-any-file:
           - src/content/docs/support/**
+          - src/content/partials/support/**
+          - src/assets/images/support/**
+
 product:tenant:
   - changed-files:
       - any-glob-to-any-file:
           - src/content/docs/tenant/**
+          - src/content/partials/tenant/**
+          - src/assets/images/tenant/**
+
 product:terraform:
   - changed-files:
       - any-glob-to-any-file:
           - src/content/docs/terraform/**
+          - src/content/partials/terraform/**
+
 product:time-services:
   - changed-files:
       - any-glob-to-any-file:
           - src/content/docs/time-services/**
+          - src/content/partials/time-services/**
+          - src/assets/images/time-services/**
+
+product:tunnel:
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/content/docs/tunnel/**
+
 product:turnstile:
   - changed-files:
       - any-glob-to-any-file:
           - src/content/docs/turnstile/**
+          - src/content/partials/turnstile/**
+          - src/assets/images/turnstile/**
+          - src/content/release-notes/turnstile.yaml
+
 product:use-cases:
   - changed-files:
       - any-glob-to-any-file:
           - src/content/docs/use-cases/**
+          - src/content/partials/use-cases/**
+
 product:vectorize:
   - changed-files:
       - any-glob-to-any-file:
           - src/content/docs/vectorize/**
+          - src/content/partials/vectorize/**
+          - src/assets/images/vectorize/**
+          - src/content/release-notes/vectorize.yaml
+
 product:version-management:
   - changed-files:
       - any-glob-to-any-file:
           - src/content/docs/version-management/**
+          - src/content/partials/version-management/**
+          - src/assets/images/version-management/**
+          - src/content/release-notes/version-management.yaml
+
 product:waf:
   - changed-files:
       - any-glob-to-any-file:
           - src/content/docs/waf/**
+          - src/content/partials/waf/**
+          - src/assets/images/waf/**
+
 product:waiting-room:
   - changed-files:
       - any-glob-to-any-file:
           - src/content/docs/waiting-room/**
+          - src/content/partials/waiting-room/**
+          - src/assets/images/waiting-room/**
+
+product:wallets:
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/content/docs/wallets/**
+
 product:warp-client:
   - changed-files:
       - any-glob-to-any-file:
           - src/content/docs/warp-client/**
+          - src/content/partials/warp-client/**
+
 product:web-analytics:
   - changed-files:
       - any-glob-to-any-file:
           - src/content/docs/web-analytics/**
+          - src/content/partials/web-analytics/**
+          - src/assets/images/web-analytics/**
+          - src/content/release-notes/beacon-min-js.yaml
+
 product:web3:
   - changed-files:
       - any-glob-to-any-file:
           - src/content/docs/web3/**
+          - src/content/partials/web3/**
+          - src/assets/images/web3/**
+
 product:workers:
   - changed-files:
       - any-glob-to-any-file:
           - src/content/docs/workers/**
+          - src/content/partials/workers/**
+          - src/assets/images/workers/**
+          - src/content/compatibility-flags/**
+
 product:workers-ai:
   - changed-files:
       - any-glob-to-any-file:
           - src/content/docs/workers-ai/**
+          - src/content/partials/workers-ai/**
+          - src/assets/images/workers-ai/**
+          - src/content/release-notes/workers-ai.yaml
+          - src/content/workers-ai-models/**
+
 product:workers-vpc:
   - changed-files:
       - any-glob-to-any-file:
           - src/content/docs/workers-vpc/**
+          - src/content/partials/workers-vpc/**
+
 product:workflows:
   - changed-files:
       - any-glob-to-any-file:
           - src/content/docs/workflows/**
+          - src/content/partials/workflows/**
+
 product:zaraz:
   - changed-files:
       - any-glob-to-any-file:
           - src/content/docs/zaraz/**
+          - src/content/partials/zaraz/**
+          - src/assets/images/zaraz/**

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -416,7 +416,7 @@ product:network-flow:
   - changed-files:
       - any-glob-to-any-file:
           - src/content/docs/network-flow/**
-          - src/content/partials/networking-services/**
+          - src/content/partials/networking-services/mnm/**
           - src/assets/images/network-flow/**
 
 product:network-interconnect:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -416,6 +416,7 @@ product:network-flow:
   - changed-files:
       - any-glob-to-any-file:
           - src/content/docs/network-flow/**
+          - src/content/partials/networking-services/**
           - src/assets/images/network-flow/**
 
 product:network-interconnect:


### PR DESCRIPTION
### Summary

Expands the PR product-labeler (`.github/labeler.yml`) so pull requests touching product content actually receive `product:*` labels. The old config only mapped `src/content/docs/{slug}/**`, which left several real gaps:

- **Partials had no rules at all** — PRs changing only `src/content/partials/{product}/` got no label (e.g. #32601, #32716, #33205, #33214)
- **14 product docs directories were uncovered**: `agent-lee`, `agent-memory`, `agent-setup`, `ai`, `artifacts`, `docs-for-agents`, `dynamic-workers`, `email-service`, `flagship`, `privacy-pass`, `privacy-proxy`, `r2-data-catalog`, `resource-tagging`, `wallets`
- **Other content collections were uncovered**: `src/content/release-notes/` (#32233), `src/content/workers-ai-models/` (#33055), `src/assets/images/{product}/` (#33253), `src/content/compatibility-flags/` (#32987, #32777), `src/content/fields/` (#32787, #32733), `src/content/catalog-models/` (#32778, #32677), `public/__redirects` (#32847), `public/_headers`

The file is regenerated from the current content tree. Each product rule now maps every location that product's content can live:

```yaml
product:workers:
  - changed-files:
      - any-glob-to-any-file:
          - src/content/docs/workers/**
          - src/content/partials/workers/**
          - src/assets/images/workers/**
          - src/content/compatibility-flags/**
```

Release-notes files are mapped through each file's `productLink` (e.g. `ddos*.yaml` → `product:ddos-protection`, `realtimekit*.yaml` → `product:realtime`, `workers-for-platforms.yaml` → `product:cloudflare-for-platforms`).

Also removed:

- The dead `product:cloudflare-agent` rule — `src/content/docs/cloudflare-agent/` no longer exists, so it could never match.
- The dead `src/content/docs/email-routing/**` glob — those docs no longer live there; the rule now maps `src/content/partials/email-routing/**` instead.

Note for reviewers: eight referenced labels do not exist yet (`product:agent-lee`, `product:agent-memory`, `product:docs-for-agents`, `product:flagship`, `product:privacy-pass`, `product:r2-data-catalog`, `product:resource-tagging`, `product:wallets`) and are being created before merge — `actions/labeler` skips labels that don't exist in the repo.
