### PR TITLE
fix(email-service): correct the inbound Email Routing configuration example

### DIFF
--- a/src/content/docs/email-service/index.mdx
+++ b/src/content/docs/email-service/index.mdx
@@ -108,11 +108,7 @@ Add the bindings to your Wrangler configuration file:
 	],
 
 	// Email routing
-	"email": [
-		{
-			"name": "EMAIL_HANDLER"
-		}
-	]
+	"addresses": ["support@yourdomain.com"]
 }
 ```
 


### PR DESCRIPTION
Closes #33252.

The Email Service overview showed this block for inbound routing:

```jsonc
// Email routing
"email": [
  {
    "name": "EMAIL_HANDLER"
  }
]
```

That key does not exist in the Wrangler configuration schema. Checking the published `wrangler@4.129.0` `config-schema.json`:

- `send_email` — present (outbound Email Sending binding)
- `addresses` — present, top-level array
- `email` — **not present at all**

So the example produced a configuration Wrangler does not recognise, and the reporter was correct that `addresses` is the field that actually exists.

`addresses` is documented in the schema as:

> The inbound email addresses handled by the Worker being deployed. Each entry is a literal recipient address (e.g. `"support@example.com"`) or a `*@domain` catch-all (e.g. `"*@example.com"`). Every entry creates an Email Routing rule whose action routes mail to this Worker. This field is top-level only and applies to every environment of the Worker; it cannot be set under `env.*`.

The example now uses `support@yourdomain.com`, which matches the `email()` handler shown directly above it in the same snippet — that handler checks `message.to.includes("support@yourdomain.com")`, so the config and the code now line up.

`send_email` is unchanged, since it is correct.
