### PR TITLE
docs(artifacts): state the Workers Paid plan requirement

### DIFF
--- a/src/content/docs/artifacts/get-started/rest-api.mdx
+++ b/src/content/docs/artifacts/get-started/rest-api.mdx
@@ -24,6 +24,7 @@ Start by reading [Namespaces](/artifacts/concepts/namespaces/), then choose the 
 You need:
 
 - Access to Artifacts.
+- The Workers Paid plan. Artifacts is unavailable on the Workers Free plan — refer to [Pricing](/artifacts/platform/pricing/).
 - A namespace name, for example `default`.
 - A [Cloudflare API token](/fundamentals/api/get-started/create-token/) with **Artifacts** > **Read** and **Artifacts** > **Edit**.
 - A local `git` client.

--- a/src/content/docs/artifacts/get-started/workers.mdx
+++ b/src/content/docs/artifacts/get-started/workers.mdx
@@ -36,6 +36,7 @@ You also need:
 
 - Wrangler installed. If you use local Wrangler commands in this guide, authenticate Wrangler first. For local OAuth authentication or CI setup, refer to [`wrangler login`](/workers/wrangler/commands/general/#login) and [Running Wrangler in CI/CD](/workers/ci-cd/).
 - Access to Artifacts in your Cloudflare account.
+- The Workers Paid plan. Artifacts is unavailable on the Workers Free plan — refer to [Pricing](/artifacts/platform/pricing/).
 - A namespace name, for example `default`.
 - A local `git` client.
 - `jq`, if you want to extract response fields automatically.

--- a/src/content/docs/artifacts/index.mdx
+++ b/src/content/docs/artifacts/index.mdx
@@ -25,6 +25,8 @@ Versioned storage that speaks Git.
 
 Artifacts is currently in closed beta. To request access, fill out [this form](https://forms.gle/DwBoPRa3CWQ8ajFp7).
 
+Artifacts requires the Workers Paid plan. Operations and storage are both unavailable on the Workers Free plan — review [Pricing](/artifacts/platform/pricing/) before requesting access.
+
 :::
 
 Artifacts stores versioned file trees behind a Git-compatible interface. Create repositories programmatically, import existing repositories, and hand off a URL to any standard Git client.


### PR DESCRIPTION
Closes #32812.

The Artifacts overview asks readers to fill in the closed-beta access form, but never mentions that the product requires a paid plan. As the reporter notes, the form itself asks about a paid Workers subscription — so people complete the application before finding out.

The requirement is already documented one page away. `artifacts/platform/pricing.mdx` lists both billing dimensions as unavailable without a paid plan:

| Unit | Workers Free | Workers Paid |
| --- | --- | --- |
| Operations (1,000 operations) | Unavailable | First 10,000 per month + $0.15 per additional 1,000 operations |
| Storage (GB-mo) | Unavailable | First 1 GB per month + $0.50 per additional GB-mo |

So this only surfaces an existing, documented constraint at the points where someone would act on it.

### Changes

- `artifacts/index.mdx` — adds the requirement to the existing beta-access note, so it is read before the form is opened.
- `artifacts/get-started/rest-api.mdx` and `artifacts/get-started/workers.mdx` — adds it as a prerequisite bullet alongside "Access to Artifacts".

All three link to [Pricing](/artifacts/platform/pricing/), and the wording follows the phrasing already used elsewhere in the docs (for example Workers AI and Email Service both say "requires the Workers Paid plan").

The change is purely additive: three files, four inserted lines, nothing removed or reworded.
