### PR TITLE
docs: drop Wrangler v1 keys from two configuration examples

### DIFF
--- a/src/content/docs/kv/reference/environments.mdx
+++ b/src/content/docs/kv/reference/environments.mdx
@@ -75,7 +75,6 @@ For example, you could use separate staging and production KV namespaces for KV 
 ```jsonc
 {
 	"$schema": "./node_modules/wrangler/config-schema.json",
-	"type": "webpack",
 	"name": "my-worker",
 	"account_id": "<account id here>",
 	"route": "staging.example.com/*",

--- a/src/content/docs/pages/how-to/add-custom-http-headers.mdx
+++ b/src/content/docs/pages/how-to/add-custom-http-headers.mdx
@@ -81,8 +81,10 @@ To operate your Workers function alongside your Pages application, deploy it to 
 	"name": "custom-headers-example",
 	"account_id": "FILL-IN-YOUR-ACCOUNT-ID",
 	"workers_dev": false,
-	"route": "FILL-IN-YOUR-WEBSITE.com/*",
-	"zone_id": "FILL-IN-YOUR-ZONE-ID"
+	"route": {
+		"pattern": "FILL-IN-YOUR-WEBSITE.com/*",
+		"zone_id": "FILL-IN-YOUR-ZONE-ID"
+	}
 }
 ```
 


### PR DESCRIPTION
Two configuration examples still carry Wrangler v1 fields. Both blocks declare `"$schema": "./node_modules/wrangler/config-schema.json"`, so an editor validates them against the current schema and flags the keys, and copying either produces a configuration Wrangler does not accept.

Found by parsing every `jsonc` block in the docs that looks like a Wrangler configuration and checking its top-level keys against `definitions/RawConfig.properties` in the schema shipped with `wrangler@4.129.0`. 253 blocks parsed; after excluding the `wrangler-legacy/*` migration pages, which document the v1 format deliberately, these two are what remain.

### `kv/reference/environments.mdx`

```diff
 {
 	"$schema": "./node_modules/wrangler/config-schema.json",
-	"type": "webpack",
 	"name": "my-worker",
```

`type` was a Wrangler v1 field and was removed in v2. Everything else in that example is current, so the line is simply dropped.

### `pages/how-to/add-custom-http-headers.mdx`

```diff
-	"route": "FILL-IN-YOUR-WEBSITE.com/*",
-	"zone_id": "FILL-IN-YOUR-ZONE-ID"
+	"route": {
+		"pattern": "FILL-IN-YOUR-WEBSITE.com/*",
+		"zone_id": "FILL-IN-YOUR-ZONE-ID"
+	}
```

Top-level `zone_id` is not in the current schema. `zone_id` is still supported, but inside a route object — `ZoneIdRoute` requires `pattern` and `zone_id` together, with `additionalProperties: false`. The rewrite keeps exactly the same meaning, and the surrounding prose ("update the Wrangler file in your project with your account and zone details", plus the link to finding your Zone ID) still reads correctly.

Both files re-validate clean against the schema after the change.
