### PR TITLE
docs: correct the service bindings environment example

### DIFF
--- a/src/content/docs/workers/wrangler/environments.mdx
+++ b/src/content/docs/workers/wrangler/environments.mdx
@@ -134,17 +134,21 @@ In the example below, we have two Workers, both with a `staging` environment. `w
 {
 	"$schema": "./node_modules/wrangler/config-schema.json",
 	"name": "worker-b",
-	"services": {
-		"binding": "<BINDING_NAME>",
-		"service": "worker-a",
-	},
+	"services": [
+		{
+			"binding": "<BINDING_NAME>",
+			"service": "worker-a",
+		},
+	],
 	// Note how `service = "worker-a-staging"`
 	"env": {
 		"staging": {
-			"service": {
-				"binding": "<BINDING_NAME>",
-				"service": "worker-a-staging",
-			},
+			"services": [
+				{
+					"binding": "<BINDING_NAME>",
+					"service": "worker-a-staging",
+				},
+			],
 		},
 	},
 }


### PR DESCRIPTION
The example under [Service bindings](/workers/wrangler/environments/#service-bindings) does not validate against the Wrangler configuration schema. Validated with `ajv` against `definitions/RawConfig` from the schema shipped with `wrangler@4.129.0`:

```
/services      type                  must be array
/env/staging   additionalProperties  must NOT have additional properties  {"additionalProperty":"service"}
```

Two separate problems in one block:

- `services` was written as a single object. The schema defines it as an array of `{ binding, service }` entries.
- The `staging` environment used a `service` key. That key does not exist in the schema — an environment takes `services`, the same array shape as the top level.

### Change

```diff
-	"services": {
-		"binding": "<BINDING_NAME>",
-		"service": "worker-a",
-	},
+	"services": [
+		{
+			"binding": "<BINDING_NAME>",
+			"service": "worker-a",
+		},
+	],
 	// Note how `service = "worker-a-staging"`
 	"env": {
 		"staging": {
-			"service": {
-				"binding": "<BINDING_NAME>",
-				"service": "worker-a-staging",
-			},
+			"services": [
+				{
+					"binding": "<BINDING_NAME>",
+					"service": "worker-a-staging",
+				},
+			],
 		},
 	},
```

The meaning is unchanged. The prose immediately above already states the intent — "the `service` field in the `staging` environment points to `worker-a-staging`, whereas the top-level service binding points to `worker-a`" — and that still reads correctly against the corrected example. The block re-validates clean.

Since the block declares `"$schema": "./node_modules/wrangler/config-schema.json"`, an editor flags both of these today, and copying the example produces a configuration Wrangler rejects.
