### PR TITLE
fix(fundamentals): point the Global API key step at the user profile

### DIFF
--- a/src/content/docs/fundamentals/api/get-started/keys.mdx
+++ b/src/content/docs/fundamentals/api/get-started/keys.mdx
@@ -39,9 +39,9 @@ For these reasons, Global API key is not recommended for new customers. Current 
 
 To retrieve your Global API key:
 
-1. In the Cloudflare dashboard and select **User Profile** > **API Tokens**.
+1. In the Cloudflare dashboard, go to **My Profile** > **API Tokens**.
 
-   <DashButton url="/?to=/:account/api-tokens" />
+   <DashButton url="/profile/api-tokens" />
 
 2. In the **API Keys** section, click `View` button of **Global API Key**.
 


### PR DESCRIPTION
Fixes #31646.

The **View your Global API key** step deep-links to `/?to=/:account/api-tokens`. The
repo's own route table says that is the wrong page:

```jsonc
// src/content/dash-routes/core.json
{ "name": "Account API tokens", "deeplink": "/?to=/:account/api-tokens", "parent": ["Manage account"] },
...
{ "name": "API Tokens",         "deeplink": "/profile/api-tokens" }
```

The Global API key is a user-level credential, so it lives on the user profile page, not
the account one. The step's own prose already said "User Profile", and the
`api-change-api-key` partial rendered a few lines further down the same page says
**My Profile** — only the button disagreed, sending readers somewhere the key is not.

Two changes on that one step:

- `DashButton url` → `/profile/api-tokens`.
- Step text → `In the Cloudflare dashboard, go to **My Profile** > **API Tokens**.`
  The old sentence read "In the Cloudflare dashboard and select ...", which is the only
  occurrence of that phrasing in the docs (against 863 uses of "In the Cloudflare
  dashboard, go to"), and **My Profile** is the label used everywhere else, including on
  this page.

Credit to @poetryofcode, who found the same link bug in #31791 — that PR was closed by the
stale bot rather than on merit, and its closing message invited a fresh one.

<!-- Not changed here, but noticed while checking: `fundamentals/api/get-started/ca-keys.mdx`
and `fundamentals/user-profiles/2fa.mdx` are the only other places that say "User Profile"
rather than "My Profile". Their links are fine, so I left them alone — happy to fold that
label sweep in if you want it. -->
