### PR TITLE
docs: fix three Wrangler config examples the shipped schema rejects

### DIFF
--- a/src/content/docs/d1/configuration/environments.mdx
+++ b/src/content/docs/d1/configuration/environments.mdx
@@ -55,14 +55,16 @@ If you need to specify different D1 databases for different environments, your [
 
 ```jsonc
 {
-	"production": {
-		"d1_databases": [
-			{
-				"binding": "DB",
-				"database_name": "DATABASE_NAME",
-				"database_id": "DATABASE_ID"
-			}
-		]
+	"env": {
+		"production": {
+			"d1_databases": [
+				{
+					"binding": "DB",
+					"database_name": "DATABASE_NAME",
+					"database_id": "DATABASE_ID"
+				}
+			]
+		}
 	}
 }
 ```
@@ -71,21 +73,23 @@ If you need to specify different D1 databases for different environments, your [
 
 In the above configuration:
 
-- `[[production.d1_databases]]` creates an object `production` with a property `d1_databases`, where `d1_databases` is an array of objects, since you can create multiple D1 bindings in case you have more than one database.
+- `[[env.production.d1_databases]]` creates an object `production` under `env` with a property `d1_databases`, where `d1_databases` is an array of objects, since you can create multiple D1 bindings in case you have more than one database.
 - Any property below the line in the form `<key> = <value>` is a property of an object within the `d1_databases` array.
 
 Therefore, the above binding is equivalent to:
 
 ```json
 {
-  "production": {
-    "d1_databases": [
-      {
-        "binding": "DB",
-        "database_name": "DATABASE_NAME",
-        "database_id": "DATABASE_ID"
-      }
-    ]
+  "env": {
+    "production": {
+      "d1_databases": [
+        {
+          "binding": "DB",
+          "database_name": "DATABASE_NAME",
+          "database_id": "DATABASE_ID"
+        }
+      ]
+    }
   }
 }
 ```

--- a/src/content/docs/radar/investigate/bgp-anomalies.mdx
+++ b/src/content/docs/radar/investigate/bgp-anomalies.mdx
@@ -388,7 +388,6 @@ For this alert to work, you will need to configure the proper email bindings in 
 {
 	"send_email": [
 		{
-			"type": "send_email",
 			"name": "SEND_EMAIL_BINDING",
 			"destination_address": "<YOUR_EMAIL>@example.com"
 		}

--- a/src/content/docs/workers/wrangler/configuration.mdx
+++ b/src/content/docs/workers/wrangler/configuration.mdx
@@ -1470,14 +1470,14 @@ The files in this directory represent your vendored packages and is where the py
 may find that the files in this folder are too large and if your worker doesn't require them then they just grow your bundle size for
 no reason.
 
-To fix this, you can exclude certain files from being included. To do this use the `python_modules.excludes` option, for example:
+To fix this, you can exclude certain files from being included. To do this use the `python_modules.exclude` option, for example:
 
 <WranglerConfig>
 
 ```jsonc
 {
 	"python_modules": {
-		"excludes": ["**/*.pyc", "**/__pycache__"],
+		"exclude": ["**/*.pyc", "**/__pycache__"],
 	},
 }
 ```
@@ -1486,7 +1486,7 @@ To fix this, you can exclude certain files from being included. To do this use t
 
 This will exclude any .pyc files and `__pycache__` directories inside any subdirectory in `python_modules`.
 
-By default, `python_modules.excludes` is set to `["**/*.pyc"]`, so be sure to include this when setting it to a different value.
+By default, `python_modules.exclude` is set to `["**/*.pyc"]`, so be sure to include this when setting it to a different value.
 
 ## Local development settings
 


### PR DESCRIPTION
Three Wrangler configuration examples that the shipped `config-schema.json` rejects, so a
reader copying them gets an editor error and, for the first one, a config key Wrangler
ignores.

Found by validating every ` ```jsonc ` block wrapped in `<WranglerConfig>` against
`wrangler@4.129.0`'s `config-schema.json`.

### 1. `workers/wrangler/configuration` — `python_modules.excludes` → `exclude`

The Python Workers section names the option `excludes` in the example and in the two
sentences around it. The real key is `exclude`:

- schema: `python_modules` has one property, `exclude`, with `additionalProperties: false`
- `packages/workers-utils/src/config/config.ts` defaults it to
  `python_modules: { exclude: ["**/*.pyc"] }`
- wrangler's own e2e test writes `[python_modules]` / `exclude = [...]`

The documented default value (`["**/*.pyc"]`) was already right — only the key name was
wrong.

### 2. `radar/investigate/bgp-anomalies` — `send_email` had a `type` key

```diff
 "send_email": [
   {
-    "type": "send_email",
     "name": "SEND_EMAIL_BINDING",
     "destination_address": "<YOUR_EMAIL>@example.com"
   }
 ]
```

The schema defines `name`, `destination_address`, `allowed_destination_addresses`,
`allowed_sender_addresses` and `remote`, with `additionalProperties: false`. Every other
`send_email` example in the docs — across `email-service` and `workflows` — already omits
`type`; this page was the only one carrying it.

### 3. `d1/configuration/environments` — "Anatomy" example missing the `env` wrapper

The example under **Anatomy of Wrangler file** put `production` at the top level. Wrangler
environments live under `env`, which is exactly what the correct example higher up the
same page shows. Updated the `<WranglerConfig>` block, the plain JSON block below it that
restates the same shape, and the accompanying `[[production.d1_databases]]` prose.

---

Verified: with these three changes the scan drops from 10 failing blocks to 7. The seven
that remain are deliberate and left alone — the Artifacts examples (closed beta, the docs
reference fields the schema does not have), `containers/guides/ssh` (an explicit
`// other options here...` fragment), `workers/configuration/placement` (shows mutually
exclusive options together, as its own comment says), and two blocks already covered by
#33261.
