### PR TITLE
docs(agents): correct two imports that the agents package does not export

### DIFF
--- a/src/content/docs/agents/examples/browser-agent.mdx
+++ b/src/content/docs/agents/examples/browser-agent.mdx
@@ -266,12 +266,7 @@ For custom integrations, import the building blocks directly:
 <TypeScriptExample>
 
 ```ts
-import {
-	CdpSession,
-	connectBrowser,
-	connectUrl,
-	createBrowserToolHandlers,
-} from "agents/browser";
+import { CdpSession, connectBrowser, connectUrl } from "agents/browser";
 
 // Connect to a custom CDP endpoint
 const session = await connectUrl("http://localhost:9222");

--- a/src/content/docs/agents/runtime/execution/schedule-tasks.mdx
+++ b/src/content/docs/agents/runtime/execution/schedule-tasks.mdx
@@ -576,7 +576,7 @@ Returns a system prompt for parsing natural language into scheduling parameters:
 <TypeScriptExample>
 
 ```ts
-import { getSchedulePrompt, scheduleSchema } from "agents";
+import { getSchedulePrompt, scheduleSchema } from "agents/schedules/parser";
 import { generateObject } from "ai";
 import { openai } from "@ai-sdk/openai";
 
@@ -634,7 +634,7 @@ A Zod schema for validating parsed scheduling data. Uses a discriminated union o
 <TypeScriptExample>
 
 ```ts
-import { scheduleSchema } from "agents";
+import { scheduleSchema } from "agents/schedules/parser";
 
 // The schema is a discriminated union:
 // {


### PR DESCRIPTION
Two Agents examples import names the `agents` package does not export, so neither compiles
as written. Verified against the published `agents@0.22.0` typings.

### `runtime/execution/schedule-tasks` — wrong entry point

```diff
-import { getSchedulePrompt, scheduleSchema } from "agents";
+import { getSchedulePrompt, scheduleSchema } from "agents/schedules/parser";
```

Both helpers are real, but the root entry does not re-export them. They are exported from
`./schedules/parser` (and, with deprecated `unstable_*` aliases alongside, from
`./schedule`). `agents/schedules/parser` is also the path the SDK's own JSDoc `@example`
on `scheduleSchema` uses, so I matched that. Two occurrences on the page.

### `examples/browser-agent` — name does not exist

```diff
-import {
-	CdpSession,
-	connectBrowser,
-	connectUrl,
-	createBrowserToolHandlers,
-} from "agents/browser";
+import { CdpSession, connectBrowser, connectUrl } from "agents/browser";
```

`createBrowserToolHandlers` appears in no `.d.ts` and no shipped `.js` in the package,
under any subpath. The snippet never used it either — it only calls `connectUrl` — so
dropping it leaves the example intact. The other three names are genuine exports of
`agents/browser`.

### Not fixed here

The same pass found `agents/model-context-protocol/apis/client-api` importing
`isUnauthorized` and `isTransportNotImplemented` from `"agents"`. Those exist only as
internal helpers in a bundled chunk and are not exported from any public subpath, and
there is no obvious public equivalent to point the example at, so that one needs someone
who knows the intent. Filed as #33265 rather than guessed at.

### How this was checked

Extracted every `import { … } from "…"` in the docs' TypeScript blocks and diffed each
named import against the `exports` map and typings of the published package. After this
PR the only remaining mismatches for `agents` are the two in #33265.
