### PR TITLE
fix: stop applying API badge to /api-shield/ sidebar links

### DIFF
--- a/src/util/sidebar.astro.test.ts
+++ b/src/util/sidebar.astro.test.ts
@@ -1,7 +1,22 @@
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 
 import { docsSidebarTransform, externalAppLinksTransform } from "./sidebar";
 import type { SidebarItem } from "@cloudflare/nimbus-docs/types";
+
+// The `product-availability` collection is a remote middlecache loader that
+// downloads over the network at test time. Stub it to keep the badge tests
+// hermetic and data-independent; everything else still reads real content.
+vi.mock("astro:content", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("astro:content")>();
+	return {
+		...actual,
+		getCollection: vi.fn(async (id: string, ...args: any[]) =>
+			id === "product-availability"
+				? []
+				: actual.getCollection(id as any, ...args),
+		),
+	};
+});
 
 const ARROW = " \u2197";
 
@@ -88,6 +103,7 @@ describe("docsSidebarTransform badges", () => {
 		const [item] = await runDocs([
 			link({ label: "API Gateway", href: "/api-gateway/" }),
 		]);
+		expect(item.type).toBe("link");
 		expect(item.badge).toBeUndefined();
 	});
 

--- a/src/util/sidebar.astro.test.ts
+++ b/src/util/sidebar.astro.test.ts
@@ -1,12 +1,19 @@
 import { describe, expect, test } from "vitest";
 
-import { externalAppLinksTransform } from "./sidebar";
+import { docsSidebarTransform, externalAppLinksTransform } from "./sidebar";
 import type { SidebarItem } from "@cloudflare/nimbus-docs/types";
 
 const ARROW = " \u2197";
 
 const run = (tree: SidebarItem[]) =>
 	externalAppLinksTransform({
+		tree,
+		sectionSlug: "test",
+		currentSlug: "test/page",
+	});
+
+const runDocs = (tree: SidebarItem[]) =>
+	docsSidebarTransform({
 		tree,
 		sectionSlug: "test",
 		currentSlug: "test/page",
@@ -65,5 +72,30 @@ describe("externalAppLinksTransform", () => {
 		];
 		const [item] = await run(await run(input));
 		expect(item.label).toBe(`Redirect${ARROW}`);
+	});
+});
+
+describe("docsSidebarTransform badges", () => {
+	test("does not badge /api-shield/ links as API", async () => {
+		const [item] = await runDocs([
+			link({ label: "API Shield", href: "/api-shield/" }),
+		]);
+		expect(item.type).toBe("link");
+		expect(item.badge).toBeUndefined();
+	});
+
+	test("does not badge /api-gateway/ links as API", async () => {
+		const [item] = await runDocs([
+			link({ label: "API Gateway", href: "/api-gateway/" }),
+		]);
+		expect(item.badge).toBeUndefined();
+	});
+
+	test("badges the /api/ OpenAPI reference as API", async () => {
+		const [item] = await runDocs([link({ label: "API", href: "/api/" })]);
+		expect(item).toMatchObject({
+			type: "external",
+			badge: { text: "API", variant: "note" },
+		});
 	});
 });

--- a/src/util/sidebar.ts
+++ b/src/util/sidebar.ts
@@ -261,7 +261,7 @@ function inferBadgeVariant(badge: SidebarBadge): SidebarBadge {
 // Fixed badge for external-app links by URL shape (`/api` → "API", MCP server
 // repo → "MCP"). Takes precedence over authored/auto-Beta badges.
 function getExternalBadge(href: string): SidebarBadge | undefined {
-	if (href.startsWith("/api")) return { text: "API", variant: "note" };
+	if (isExternalAppHref(href)) return { text: "API", variant: "note" };
 	if (href.includes("/mcp-server-cloudflare"))
 		return { text: "MCP", variant: "note" };
 	return undefined;


### PR DESCRIPTION
### Summary

Fixes the sidebar badge logic that applied the "API" badge to every link under `/api-shield/` and `/api-gateway/`. The badge is meant only for the external `/api/` OpenAPI reference app.

Root cause: `getExternalBadge` matched `href.startsWith("/api")`, which is too broad and caught `/api-shield/`, `/api-gateway/`, etc. It now reuses the existing `isExternalAppHref` helper, which matches only the `/api/` app prefix.

Adds regression tests covering `/api-shield/`, `/api-gateway/`, and the real `/api/` case.

### Screenshots (optional)

<!-- TODO: add before/after screenshot of the API Shield sidebar before requesting review -->