### PR TITLE
Add changelog for Python Workers Python 3.14 update

### DIFF
--- a/src/content/changelog/workers/2026-09-08-python-workers-314.mdx
+++ b/src/content/changelog/workers/2026-09-08-python-workers-314.mdx
@@ -1,0 +1,13 @@
+---
+title: Python 3.14 for Python Workers
+description: Python 3.14 for Python Workers
+products:
+  - workers
+date: 2026-09-08
+---
+
+Python workers now use Python 3.14 by default.
+
+This change applies to all new Python workers using compatibility date `2026-09-08` or later.
+
+Internally, this change updates the Pyodide runtime to 314.0.6.

--- a/src/content/compatibility-flags/python-workers-314.md
+++ b/src/content/compatibility-flags/python-workers-314.md
@@ -1,0 +1,16 @@
+---
+_build:
+  publishResources: false
+  render: never
+  list: never
+
+name: "Python 314 for Python Workers"
+sort_date: "2026-09-08"
+enable_date: "2026-09-08"
+enable_flag: "python_workers_314"
+---
+
+When this flag is set, Python 3.14 is used for Python Workers.
+Normally, you don't need to enable this flag manually,
+and the Python version is selected based on the compatibility date or your worker.
+


### PR DESCRIPTION
### Summary

Adds a changelog for announcing Python 3.14 upgrade in Python workers.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).