### PR TITLE
Replace httpx with httpx2

### DIFF
--- a/src/content/docs/workers/languages/python/packages/index.mdx
+++ b/src/content/docs/workers/languages/python/packages/index.mdx
@@ -64,4 +64,4 @@ on the Cloudflare Workers Runtime GitHub repository — we would be happy to hel
 
 ## HTTP Client Libraries
 
-Only HTTP libraries that are able to make requests asynchronously are supported. Currently, these include [`aiohttp`](https://docs.aiohttp.org/en/stable/index.html) and [`httpx`](https://www.python-httpx.org/). You can also use the [`fetch()` API](/workers/runtime-apis/fetch/) from JavaScript, using Python Workers' [foreign function interface](/workers/languages/python/ffi) to make HTTP requests.
+Only HTTP libraries that are able to make requests asynchronously are supported. Currently, these include [`aiohttp`](https://docs.aiohttp.org/en/stable/index.html) and [`httpx2`](https://pydantic.dev/docs/httpx2/). You can also use the [`fetch()` API](/workers/runtime-apis/fetch/) from JavaScript, using Python Workers' [foreign function interface](/workers/languages/python/ffi) to make HTTP requests.


### PR DESCRIPTION
### Summary

`httpx` is not maintained anymore so document `httpx2` (fork of httpx) instead.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
