### PR TITLE
[WAF] Document Attack Signature Detection

### DIFF
--- a/src/content/docs/security/rules.mdx
+++ b/src/content/docs/security/rules.mdx
@@ -12,6 +12,8 @@ import { DashButton, Render } from "~/components";
 
 Security rules perform security-related actions on incoming requests that match specified filters. Rules are evaluated and executed in order, from first to last.
 
+You can create Security Rules from reviewed [Attack Signature Detection](/waf/detections/attack-signature-detection/use-attack-signatures-in-security-rules/) confidence, category, and Ref metadata.
+
 To access security rules in the new security dashboard, go to the **Security rules** page.
 
 <DashButton url="/?to=/:account/:zone/security/security-rules" />

--- a/src/content/docs/waf/analytics/security-analytics.mdx
+++ b/src/content/docs/waf/analytics/security-analytics.mdx
@@ -28,6 +28,7 @@ Use the Security Analytics dashboard to:
 - Understand which traffic is being <GlossaryTooltip term="mitigated request">mitigated</GlossaryTooltip> by Cloudflare security products, and where non-mitigated traffic is being served from (Cloudflare global network or [origin server](https://www.cloudflare.com/learning/cdn/glossary/origin-server/)).
 - Analyze suspicious traffic and create tailored WAF custom rules based on applied filters.
 - Review Cloudflare's security scores (<GlossaryTooltip term="attack score" link="/waf/detections/attack-score/">attack score</GlossaryTooltip>, [bot score](/bots/concepts/bot-score/), [malicious uploads](/waf/detections/malicious-uploads/), and [leaked credentials](/waf/detections/leaked-credentials/) results) with real data from your traffic.
+- [Analyze attack signature matches](/waf/detections/attack-signature-detection/analyze-attack-signatures/) by Ref, category, and WAF Attack Score.
 - [Find an appropriate rate limit](/waf/rate-limiting-rules/find-rate-limit/) for incoming traffic.
 - Analyze suspicious traffic ([new security dashboard](/security/) only).
 
@@ -125,7 +126,7 @@ The main chart displays the following data for the selected time frame, accordin
   - **Served by Cloudflare**: Requests served by the Cloudflare global network such as cached content and redirects.
   - **Served by origin**: Requests served by your origin server.
 
-- **Attack analysis**: [WAF attack score](/waf/detections/attack-score/) analysis of incoming requests, classifying them as _Clean_, _Likely clean_, _Likely attack_, or _Attack_.
+- **Attack analysis**: [WAF attack score](/waf/detections/attack-score/) and [attack signature](/waf/detections/attack-signature-detection/analyze-attack-signatures/) analysis of incoming requests.
 
 - **Bot analysis**: [Bot score](/bots/concepts/bot-score/) analysis of incoming requests, classifying them as _Automated_, _Likely automated_, _Likely human_, or _Verified bot_.
 

--- a/src/content/docs/waf/detections/ai-security-for-apps/index.mdx
+++ b/src/content/docs/waf/detections/ai-security-for-apps/index.mdx
@@ -7,7 +7,7 @@ title: AI Security for Apps
 tags:
   - AI
 sidebar:
-  order: 7
+  order: 8
   group:
     label: AI Security for Apps
 ---

--- a/src/content/docs/waf/detections/ai-security-for-apps/index.mdx
+++ b/src/content/docs/waf/detections/ai-security-for-apps/index.mdx
@@ -7,7 +7,7 @@ title: AI Security for Apps
 tags:
   - AI
 sidebar:
-  order: 5
+  order: 7
   group:
     label: AI Security for Apps
 ---

--- a/src/content/docs/waf/detections/application-profiles/index.mdx
+++ b/src/content/docs/waf/detections/application-profiles/index.mdx
@@ -5,7 +5,7 @@ description: Compare requests with application-specific expected structures.
 products:
   - waf
 sidebar:
-  order: 4
+  order: 5
   group:
     label: Application Profiles
 ---

--- a/src/content/docs/waf/detections/application-profiles/index.mdx
+++ b/src/content/docs/waf/detections/application-profiles/index.mdx
@@ -5,7 +5,7 @@ description: Compare requests with application-specific expected structures.
 products:
   - waf
 sidebar:
-  order: 7
+  order: 4
   group:
     label: Application Profiles
 ---

--- a/src/content/docs/waf/detections/attack-signature-detection/analyze-attack-signatures.mdx
+++ b/src/content/docs/waf/detections/attack-signature-detection/analyze-attack-signatures.mdx
@@ -42,10 +42,10 @@ The request outcome shows whether existing protections mitigated matching traffi
 
 Confidence describes the expected false-positive characteristics of a signature. It does not prove that a request is malicious.
 
-| Confidence | Meaning                                                                      | Recommended analysis                                                            |
-| ---------- | ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
-| `high`     | The signature targets a high true-positive and low false-positive rate.      | Confirm affected traffic and current mitigation before applying a broad action. |
-| `low`      | The signature has a greater risk of matching legitimate application traffic. | Review requests and scope mitigation to the affected application surface.       |
+| Confidence | Meaning                                                                      | Comparison with Managed Rules                                                   | Recommended analysis                                                            |
+| ---------- | ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| `high`     | The signature targets a high true-positive and low false-positive rate.      | Includes the same signatures that the default Managed Rules deployment enables. | Confirm affected traffic and current mitigation before applying a broad action. |
+| `low`      | The signature has a greater risk of matching legitimate application traffic. | Includes the Managed Rules signatures that are disabled by default.             | Review requests and scope mitigation to the affected application surface.       |
 
 ## Investigate possible false positives
 

--- a/src/content/docs/waf/detections/attack-signature-detection/analyze-attack-signatures.mdx
+++ b/src/content/docs/waf/detections/attack-signature-detection/analyze-attack-signatures.mdx
@@ -1,0 +1,66 @@
+---
+title: Analyze attack signatures
+pcx_content_type: how-to
+description: Investigate attack signature matches, affected applications, request outcomes, and possible false positives in Security Analytics.
+products:
+  - waf
+sidebar:
+  order: 2
+---
+
+import { DashButton, Steps } from "~/components";
+
+Use **Security Analytics** > **Attack Analysis** to investigate attack signature matches before applying mitigation.
+
+:::note
+Attack Signature Detection is available in Early Access. Contact your Cloudflare account team to request access.
+:::
+
+## Review signature matches
+
+<Steps>
+
+1. In the Cloudflare dashboard, go to **Security** > **Analytics**.
+
+   <DashButton url="/?to=/:account/:zone/security/analytics" />
+
+2. Select **Attack Analysis**.
+3. Choose the time range and application scope to investigate.
+4. Plot request volume over time by signature Ref, category, or WAF Attack Score.
+5. Compare high- and low-confidence matches.
+6. Filter by request outcome to identify mitigated and unmitigated traffic.
+7. Narrow the analysis by hostname, path, method, category, CVE, or signature Ref.
+8. Review representative requests before creating or changing a Security Rule.
+
+</Steps>
+
+Use this analysis to identify common signatures and attack categories. You can also investigate a specific Common Vulnerabilities and Exposures (CVE) identifier or attack technique. Correlate the matches with [WAF Attack Score](/waf/detections/attack-score/) to add another signal.
+
+The request outcome shows whether existing protections mitigated matching traffic. It also helps identify requests served by Cloudflare or your origin. A detection does not apply an action by itself.
+
+## Interpret confidence
+
+Confidence describes the expected false-positive characteristics of a signature. It does not prove that a request is malicious.
+
+| Confidence | Meaning                                                                      | Recommended analysis                                                            |
+| ---------- | ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| `high`     | The signature targets a high true-positive and low false-positive rate.      | Confirm affected traffic and current mitigation before applying a broad action. |
+| `low`      | The signature has a greater risk of matching legitimate application traffic. | Review requests and scope mitigation to the affected application surface.       |
+
+## Investigate possible false positives
+
+Legitimate rich-text input can match a generic cross-site scripting signature. For example, a content management or support application may accept HTML.
+
+Filter the analysis to that hostname, path, and method. Review representative requests to distinguish expected content from attacks. Then create a scoped rule or exception instead of changing protection for the entire application.
+
+## Compare results with Managed Rules
+
+Each signature Ref matches the corresponding Managed Rule public Rule ID. Use this identifier to find the Managed Rule and compare the detection with your deployment.
+
+Check the request outcome and [Security Events](/waf/analytics/security-events/) before assuming Managed Rules blocked a match. Managed Rules actions and overrides determine their behavior.
+
+## Sampling
+
+Attack Analysis uses [Security Analytics adaptive sampling](/waf/analytics/security-analytics/#sampling). Use [Log Explorer](/log-explorer/) when you need 100% retention rather than sampled data.
+
+After reviewing historical traffic, refer to [Use attack signatures in Security Rules](/waf/detections/attack-signature-detection/use-attack-signatures-in-security-rules/).

--- a/src/content/docs/waf/detections/attack-signature-detection/fields.mdx
+++ b/src/content/docs/waf/detections/attack-signature-detection/fields.mdx
@@ -1,0 +1,65 @@
+---
+title: Fields
+pcx_content_type: reference
+description: Reference Attack Signature Detection fields, example values, Security Rules usage, and Logpush mappings.
+products:
+  - waf
+sidebar:
+  order: 4
+  label: Fields
+---
+
+import { Type } from "~/components";
+
+Attack Signature Detection populates these request fields when signatures match:
+
+| Field                                 | Type                          | Meaning                                                                                                             |
+| ------------------------------------- | ----------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `cf.waf.signature.request.categories` | <Type text="Array<String>" /> | Categories associated with all matching signatures. A signature can have more than one category.                    |
+| `cf.waf.signature.request.confidence` | <Type text="Array<String>" /> | Confidence values associated with matching signatures. Supported values are `high` and `low`.                       |
+| `cf.waf.signature.request.refs`       | <Type text="Array<String>" /> | Refs for matching signatures, up to 10 per request. Each Ref matches the corresponding Managed Rule public Rule ID. |
+
+:::note
+Attack Signature Detection is available in Early Access. Contact your Cloudflare account team to request access.
+:::
+
+All three fields are available in Security Analytics and Security Rules. You can reference them in rules created in the dashboard or through the API.
+
+## Example values
+
+The fields can contain values like these:
+
+| Field                                 | Example value                          |
+| ------------------------------------- | -------------------------------------- |
+| `cf.waf.signature.request.categories` | `["sqli", "cve-2025-55182"]`           |
+| `cf.waf.signature.request.confidence` | `["high"]`                             |
+| `cf.waf.signature.request.refs`       | `["d68f8101f6e14e25aefcaea69c530a29"]` |
+
+## Rules language examples
+
+Use `any()` to test array elements:
+
+```txt
+any(cf.waf.signature.request.categories[*] eq "sqli")
+```
+
+```txt
+any(cf.waf.signature.request.confidence[*] eq "high")
+```
+
+```txt
+any(cf.waf.signature.request.refs[*] eq "d68f8101f6e14e25aefcaea69c530a29")
+```
+
+For rollout guidance, refer to [Use attack signatures in Security Rules](/waf/detections/attack-signature-detection/use-attack-signatures-in-security-rules/).
+
+## Logpush fields
+
+Signature Refs and categories are available in Logpush:
+
+| Rules field                           | Logpush field                                                                                                           |
+| ------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `cf.waf.signature.request.refs`       | [`wafRequestSignatureRefs`](/logs/logpush/logpush-job/datasets/zone/http_requests/#wafrequestsignaturerefs)             |
+| `cf.waf.signature.request.categories` | [`wafRequestSignatureCategories`](/logs/logpush/logpush-job/datasets/zone/http_requests/#wafrequestsignaturecategories) |
+
+Only signature Ref and category mappings are available in Logpush.

--- a/src/content/docs/waf/detections/attack-signature-detection/index.mdx
+++ b/src/content/docs/waf/detections/attack-signature-detection/index.mdx
@@ -1,0 +1,63 @@
+---
+title: Attack Signature Detection
+pcx_content_type: overview
+description: Detect attack signature matches independently from mitigation and use the results to create scoped Security Rules.
+products:
+  - waf
+sidebar:
+  order: 8
+  group:
+    label: Attack Signature Detection
+---
+
+import { DirectoryListing } from "~/components";
+
+Attack Signature Detection evaluates requests against Cloudflare attack signatures. It records match metadata without applying an action by itself.
+
+:::note
+Attack Signature Detection is available in Early Access. Contact your Cloudflare account team to request access.
+:::
+
+Traditional WAF deployments combine detection and mitigation through managed rules. You may need to review matches before blocking traffic to reduce false positives.
+
+Attack Signature Detection separates these steps. It records confidence, category, and signature Ref metadata for matching requests. Review this data in **Security Analytics** > **Attack Analysis** before creating a [Security Rule](/security/rules/).
+
+After Cloudflare grants Early Access, Attack Signature Detection evaluates requests against signatures for attack techniques. These include SQL injection, cross-site scripting, remote code execution, and specific Common Vulnerabilities and Exposures (CVEs).
+
+Security Rules provide the mitigation layer. You can match confidence, category, or signature Ref values. You can also combine these values with properties such as hostname, path, and HTTP method.
+
+A signature match does not mean Cloudflare blocked the request. Inspect the request outcome and your deployed rules to determine the applied action.
+
+## How request evaluation works
+
+Attack Signature Detection uses the following request lifecycle:
+
+1. Cloudflare evaluates a request against attack signatures.
+2. Matching signatures populate confidence, category, and Ref fields.
+3. The match data becomes available in Security Analytics.
+4. A Security Rule can evaluate these fields and apply its action.
+
+Attack Signature Detection uses the same signature definitions as [Cloudflare Managed Rules](/waf/managed-rules/). It does not inherit your Managed Rules deployment configuration. Managed Rules actions and overrides do not create Security Rules based on detection fields.
+
+When no rule references an Attack Signature Detection field, detection does not add request latency. When a rule references a detection field, detection runs inline. Inline detection should have latency similar to Cloudflare Managed Rules evaluation.
+
+## Compare Attack Signature Detection and Managed Rules
+
+Attack Signature Detection and Managed Rules use one signature catalog. Cloudflare releases each new signature to both products at the same time.
+
+| Area           | Attack Signature Detection                                                                       | Cloudflare Managed Rules                                                              |
+| -------------- | ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------- |
+| Signatures     | Uses the same signatures as Cloudflare Managed Rules.                                            | Uses the same signatures as Attack Signature Detection.                               |
+| Primary result | Populates confidence, category, and Ref metadata.                                                | Applies the configured managed ruleset actions.                                       |
+| Mitigation     | Requires a Security Rule that references a detection field.                                      | Uses Managed Rules actions, overrides, and deployment configuration.                  |
+| Analysis       | Shows signature-oriented data in **Security Analytics** > **Attack Analysis**.                   | Shows events produced by the deployed managed ruleset configuration.                  |
+| Identifier     | A signature Ref matches the corresponding Managed Rule public Rule ID.                           | A public Rule ID matches the corresponding signature Ref.                             |
+| Rule ordering  | A Custom Rule follows normal Custom Rules ordering. A terminating action stops later evaluation. | Managed Rules evaluate unless an earlier terminating action stops request processing. |
+
+The shared Ref and Rule ID help you compare detection results with your Managed Rules deployment. Equivalent signatures do not produce equivalent behavior. Attack Signature Detection produces metadata, while Managed Rules apply configured actions.
+
+Attack Signature Detection and Managed Rules have no special interaction. Normal phase and terminating-action behavior applies. Attack Signature Detection does not replace Managed Rules during Early Access.
+
+## Explore Attack Signature Detection
+
+<DirectoryListing />

--- a/src/content/docs/waf/detections/attack-signature-detection/index.mdx
+++ b/src/content/docs/waf/detections/attack-signature-detection/index.mdx
@@ -5,9 +5,9 @@ description: Detect attack signature matches independently from mitigation and u
 products:
   - waf
 sidebar:
-  order: 8
+  order: 3
   group:
-    label: Attack Signature Detection
+    label: Attack Signature
 ---
 
 import { DirectoryListing } from "~/components";
@@ -20,13 +20,11 @@ Attack Signature Detection is available in Early Access. Contact your Cloudflare
 
 Traditional WAF deployments combine detection and mitigation through managed rules. You may need to review matches before blocking traffic to reduce false positives.
 
-Attack Signature Detection separates these steps. It records confidence, category, and signature Ref metadata for matching requests. Review this data in **Security Analytics** > **Attack Analysis** before creating a [Security Rule](/security/rules/).
-
-After Cloudflare grants Early Access, Attack Signature Detection evaluates requests against signatures for attack techniques. These include SQL injection, cross-site scripting, remote code execution, and specific Common Vulnerabilities and Exposures (CVEs).
-
-Security Rules provide the mitigation layer. You can match confidence, category, or signature Ref values. You can also combine these values with properties such as hostname, path, and HTTP method.
+Attack Signature Detection separates these steps. It records confidence, category, and signature Ref metadata for matching requests. Review this data in **Security Analytics** > **Attack Analysis** before creating a [Security Rule](/security/rules/). Security Rules provide the mitigation layer. You can match confidence, category, or signature Ref values. You can also combine these values with properties such as hostname, path, and HTTP method.
 
 A signature match does not mean Cloudflare blocked the request. Inspect the request outcome and your deployed rules to determine the applied action.
+
+Attack Signature Detection uses the same signature definitions as [Cloudflare Managed Rules](/waf/managed-rules/).
 
 ## How request evaluation works
 
@@ -37,7 +35,7 @@ Attack Signature Detection uses the following request lifecycle:
 3. The match data becomes available in Security Analytics.
 4. A Security Rule can evaluate these fields and apply its action.
 
-Attack Signature Detection uses the same signature definitions as [Cloudflare Managed Rules](/waf/managed-rules/). It does not inherit your Managed Rules deployment configuration. Managed Rules actions and overrides do not create Security Rules based on detection fields.
+Attack Signature Detection does not inherit your Managed Rules deployment configuration. Managed Rules actions and overrides do not create Security Rules based on detection fields.
 
 When no rule references an Attack Signature Detection field, detection does not add request latency. When a rule references a detection field, detection runs inline. Inline detection should have latency similar to Cloudflare Managed Rules evaluation.
 

--- a/src/content/docs/waf/detections/attack-signature-detection/use-attack-signatures-in-security-rules.mdx
+++ b/src/content/docs/waf/detections/attack-signature-detection/use-attack-signatures-in-security-rules.mdx
@@ -1,0 +1,92 @@
+---
+title: Use attack signatures in Security Rules
+pcx_content_type: configuration
+description: Create scoped Security Rules from reviewed attack signature confidence, category, and Ref metadata.
+products:
+  - waf
+sidebar:
+  order: 3
+---
+
+import { Steps } from "~/components";
+
+Attack Signature Detection fields let Security Rules act on matching traffic. The detection fields do not apply actions by themselves.
+
+:::note
+Attack Signature Detection is available in Early Access. Contact your Cloudflare account team to request access.
+:::
+
+## Create a mitigation policy
+
+<Steps>
+
+1. Review historical matches in **Security Analytics** > **Attack Analysis**.
+2. Choose whether to match a confidence, category, or signature Ref value.
+3. Scope the rule to the intended hostname, path, method, or endpoint.
+4. Select an action appropriate for the reviewed traffic.
+5. Monitor the result and adjust the expression if legitimate traffic is affected.
+
+</Steps>
+
+Start with the narrowest application scope that meets your security objective. Treat low-confidence signatures as candidates for application-specific review instead of broad blocking.
+
+You can use these fields in Security Rules created in the dashboard or through the API. For rule creation steps, refer to [Create a custom rule in the dashboard](/waf/custom-rules/create-dashboard/) or [Create a custom rule via API](/waf/custom-rules/create-api/).
+
+## Match a category
+
+This expression matches the SQL injection category:
+
+```txt
+any(cf.waf.signature.request.categories[*] eq "sqli")
+```
+
+Use the same array expression for another category, including a specific CVE category. Review historical matches before selecting an action.
+
+## Match confidence
+
+This expression matches high-confidence signatures:
+
+```txt
+any(cf.waf.signature.request.confidence[*] eq "high")
+```
+
+Replace `high` with `low` to match low-confidence signatures. You can create separate rules to apply different actions to each confidence level.
+
+## Match a signature Ref
+
+This expression matches a specific signature Ref:
+
+```txt
+any(cf.waf.signature.request.refs[*] eq "d68f8101f6e14e25aefcaea69c530a29")
+```
+
+The Ref is the same value as the corresponding Managed Rule public Rule ID. Use this mapping to reconcile the rule with your Managed Rules configuration.
+
+## Scope rules and exceptions
+
+Combine a signature condition with request properties in the rule builder. Use properties such as hostname, path, and method to limit mitigation to the affected application surface.
+
+For a known false positive, exclude the legitimate endpoint from mitigation. Keep protection for the rest of the application. Validate combined expressions in the rule builder before deployment.
+
+## Understand rule ordering
+
+Attack Signature Detection and Managed Rules have no special interaction. A Custom Rule using a detection field follows normal Custom Rules ordering.
+
+A terminating action stops request processing at that rule. Managed Rules do not evaluate the same request. A non-terminating _Log_ action lets processing continue to Managed Rules.
+
+## Compare with Managed Rules
+
+To compare the two products without changing traffic:
+
+<Steps>
+
+1. Create a Custom Rule that references the relevant detection fields.
+2. Select the _Log_ action for the Custom Rule.
+3. Keep the corresponding Managed Rules protection in _Block_ mode.
+4. In [Security Events](/waf/analytics/security-events/), compare logged detection matches with Managed Rules blocks.
+
+</Steps>
+
+Verify whether Managed Rules already mitigate the traffic before adding duplicate handling. Recheck your Security Rules after application releases or major traffic changes.
+
+For field types and Logpush mappings, refer to [Attack Signature Detection fields](/waf/detections/attack-signature-detection/fields/).

--- a/src/content/docs/waf/detections/index.mdx
+++ b/src/content/docs/waf/detections/index.mdx
@@ -19,6 +19,10 @@ Detections are always on once enabled, even if you have not configured any secur
 
 [Application Profiles](/waf/detections/application-profiles/) compare requests with application-specific expected structures. Profile detections do not mitigate traffic without a security rule.
 
+[Attack Signature Detection](/waf/detections/attack-signature-detection/) evaluates requests against Cloudflare attack signatures. It exposes match metadata independently from mitigation.
+
+Attack Signature Detection is available in Early Access. Contact your Cloudflare account team to request access.
+
 :::note[Application Profiles availability]
 Customers with API Security already have access to Schema Profiles through Schema Learning and Schema Validation. Cloudflare is opening a closed beta to invited Enterprise customers without API Security. Interested customers can contact their account team to express interest. Closed-beta access does not imply future plan availability or pricing.
 :::

--- a/src/content/docs/waf/detections/leaked-credentials/index.mdx
+++ b/src/content/docs/waf/detections/leaked-credentials/index.mdx
@@ -5,7 +5,7 @@ description: Scan incoming requests for usernames and passwords exposed in known
 products:
   - leaked-credentials
 sidebar:
-  order: 5
+  order: 6
   group:
     label: Leaked credentials
 tags:

--- a/src/content/docs/waf/detections/leaked-credentials/index.mdx
+++ b/src/content/docs/waf/detections/leaked-credentials/index.mdx
@@ -5,7 +5,7 @@ description: Scan incoming requests for usernames and passwords exposed in known
 products:
   - leaked-credentials
 sidebar:
-  order: 3
+  order: 5
   group:
     label: Leaked credentials
 tags:

--- a/src/content/docs/waf/detections/link-bots.mdx
+++ b/src/content/docs/waf/detections/link-bots.mdx
@@ -6,5 +6,5 @@ products:
 title: Bot score
 external_link: /bots/concepts/bot-score/
 sidebar:
-  order: 6
+  order: 10
 ---

--- a/src/content/docs/waf/detections/malicious-uploads/index.mdx
+++ b/src/content/docs/waf/detections/malicious-uploads/index.mdx
@@ -5,7 +5,7 @@ description: Scan uploaded files for malware and malicious content.
 products:
   - waf
 sidebar:
-  order: 4
+  order: 6
   group:
     label: Malicious uploads
 ---

--- a/src/content/docs/waf/detections/malicious-uploads/index.mdx
+++ b/src/content/docs/waf/detections/malicious-uploads/index.mdx
@@ -5,7 +5,7 @@ description: Scan uploaded files for malware and malicious content.
 products:
   - waf
 sidebar:
-  order: 6
+  order: 7
   group:
     label: Malicious uploads
 ---

--- a/src/content/docs/waf/detections/threat-intelligence/index.mdx
+++ b/src/content/docs/waf/detections/threat-intelligence/index.mdx
@@ -7,7 +7,7 @@ title: Threat intelligence
 tags:
   - Threat Intelligence
 sidebar:
-  order: 8
+  order: 9
   group:
     label: Threat intelligence
 ---

--- a/src/content/docs/waf/detections/threat-intelligence/index.mdx
+++ b/src/content/docs/waf/detections/threat-intelligence/index.mdx
@@ -7,7 +7,7 @@ title: Threat intelligence
 tags:
   - Threat Intelligence
 sidebar:
-  order: 6
+  order: 8
   group:
     label: Threat intelligence
 ---

--- a/src/content/docs/waf/managed-rules/index.mdx
+++ b/src/content/docs/waf/managed-rules/index.mdx
@@ -17,6 +17,8 @@ import { Render, RuleID } from "~/components";
 
 <Render file="waf-managed-rules-intro" product="waf" />
 
+[Attack Signature Detection](/waf/detections/attack-signature-detection/#compare-attack-signature-detection-and-managed-rules) uses the same signatures as Cloudflare Managed Rules. It records match metadata without applying an action by itself.
+
 ## Available managed rulesets
 
 - [**Cloudflare Managed Ruleset**](/waf/managed-rules/reference/cloudflare-managed-ruleset/): Created by the Cloudflare security team, this ruleset provides fast and effective protection for all of your applications. It covers known attack techniques and zero-day vulnerabilities (newly discovered flaws with no available patch). The ruleset is updated frequently to address new threats and reduce false positives (legitimate requests incorrectly flagged).<br/>Ruleset ID: <RuleID id="efb7b8c949ac4650a09736fc376e9aee" />
@@ -88,4 +90,3 @@ This means a rule with a terminal action (such as Block or Managed Challenge) in
 ### WAF exceptions
 
 WAF exceptions (skip rules) are rules with a `skip` action deployed to the `http_request_firewall_managed` phase entry-point ruleset. They are evaluated in list order within the entry-point ruleset — a skip rule only bypasses `execute` rules listed after it. Place exceptions before the managed ruleset execute rules they are intended to skip. For more information, refer to [WAF exceptions](/waf/managed-rules/waf-exceptions/).
-

--- a/src/content/fields/index.yaml
+++ b/src/content/fields/index.yaml
@@ -1257,6 +1257,51 @@ entries:
       # Check if requests to a specific endpoint contain any suspicious or infected content objects
       any(cf.waf.content_scan.obj_results[*] in {"suspicious" "infected"}) and http.request.uri.path eq "/upload"
 
+  - name: cf.waf.signature.request.categories
+    data_type: Array<String>
+    categories: [Request]
+    keywords: [request, cloudflare, waf, attack signature, category]
+    plan_info_label: Early Access
+    summary: An array of categories associated with attack signatures that matched the request.
+    description: |-
+      Available to customers with [Attack Signature Detection](/waf/detections/attack-signature-detection/) in Security Analytics and Custom Rules.
+
+      Contact your Cloudflare account team to request Early Access.
+    example_value: |-
+      ["sqli", "cve-2025-55182"]
+    example_block: |-
+      any(cf.waf.signature.request.categories[*] eq "sqli")
+
+  - name: cf.waf.signature.request.confidence
+    data_type: Array<String>
+    categories: [Request]
+    keywords: [request, cloudflare, waf, attack signature, confidence]
+    plan_info_label: Early Access
+    summary: An array of confidence values associated with attack signatures that matched the request.
+    description: |-
+      Supported values are `high` and `low`.
+
+      Available to customers with [Attack Signature Detection](/waf/detections/attack-signature-detection/) in Security Analytics and Custom Rules. Contact your Cloudflare account team to request Early Access.
+    example_value: |-
+      ["high"]
+    example_block: |-
+      any(cf.waf.signature.request.confidence[*] eq "high")
+
+  - name: cf.waf.signature.request.refs
+    data_type: Array<String>
+    categories: [Request]
+    keywords: [request, cloudflare, waf, attack signature, ref, rule id]
+    plan_info_label: Early Access
+    summary: An array containing up to 10 Refs for attack signatures that matched the request.
+    description: |-
+      Each Ref is the same value as the corresponding Cloudflare Managed Rules public Rule ID.
+
+      Available to customers with [Attack Signature Detection](/waf/detections/attack-signature-detection/) in Security Analytics and Custom Rules. Contact your Cloudflare account team to request Early Access.
+    example_value: |-
+      ["d68f8101f6e14e25aefcaea69c530a29"]
+    example_block: |-
+      any(cf.waf.signature.request.refs[*] eq "d68f8101f6e14e25aefcaea69c530a29")
+
   - name: cf.waf.score
     data_type: Number
     categories: [Request]


### PR DESCRIPTION
### Summary

Adds documentation for Attack Signature Detection, now available in Early Access. The new pages explain how to analyze signature matches, use detection fields in Security Rules, and compare confidence levels with Cloudflare Managed Rules. Related WAF and Security pages now link to the feature, and the Detections navigation places Attack Signature Detection after Attack score.

### Documentation checklist

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [x] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
