### PR TITLE
[WAF] Add Attack Signature Detection changelog

### DIFF
--- a/src/content/changelog/waf/2026-09-07-attack-signature-detection.mdx
+++ b/src/content/changelog/waf/2026-09-07-attack-signature-detection.mdx
@@ -1,0 +1,13 @@
+---
+title: Attack Signature Detection is now available in Early Access
+description: Attack Signature Detection separates attack detection from mitigation and exposes signature match metadata for investigation and Security Rules.
+date: 2026-09-07
+---
+
+Attack Signature Detection is now available in Early Access. It evaluates requests against Cloudflare attack signatures and records matches without applying a mitigation action, allowing you to investigate detected traffic before deciding how to respond.
+
+In **Security Analytics** > **Attack Analysis**, you can review matching signature references, categories, confidence levels, and request outcomes. You can then use these fields in [Security Rules](/security/rules/) and combine them with request properties such as hostname, path, and HTTP method to apply scoped mitigation.
+
+Attack Signature Detection uses the same signature definitions as [Cloudflare Managed Rules](/waf/managed-rules/), but it does not inherit your Managed Rules actions, overrides, or deployment configuration. Managed Rules remain the recommended baseline protection during Early Access.
+
+Contact your Cloudflare account team to request access. For more information, refer to [Attack Signature Detection](/waf/detections/attack-signature-detection/).


### PR DESCRIPTION
### Summary

Adds a WAF changelog entry announcing the Early Access release of Attack Signature Detection. It summarizes how detection is separated from mitigation, where customers can investigate signature metadata, how Security Rules apply scoped mitigation, and how the feature relates to Cloudflare Managed Rules.

Depends on #33277 for the linked product documentation.

### Documentation checklist

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) - how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
