### PR TITLE
[WAF] Add Application Profiles changelog

### DIFF
--- a/src/content/changelog/waf/2026-09-07-application-profiles.mdx
+++ b/src/content/changelog/waf/2026-09-07-application-profiles.mdx
@@ -1,0 +1,15 @@
+---
+title: Enforce positive security with Application Profiles
+description: Learn expected request structures, analyze deviations, and selectively block non-conforming traffic.
+date: 2026-09-07
+---
+
+Application Profiles add a positive-security layer to Cloudflare WAF. Instead of looking only for requests that resemble known attacks, Application Profiles learn what valid requests to your application look like and identify traffic that deviates from the expected structure.
+
+The first available profile type, Schema Profiles, can learn path variables, query parameters, headers, cookies, JSON bodies, and form-encoded bodies. Profiles model field types and constraints such as numeric ranges, string lengths, and character classes. After a profile becomes available, an always-on detection classifies requests as conforming or non-conforming without blocking traffic.
+
+Use **Profile Analysis** in [Security Analytics](/waf/analytics/security-analytics/) to review conformance trends and sampled violation details before enforcing a profile. When you are ready to mitigate traffic, use a [Custom Rule](/waf/custom-rules/) to scope enforcement by hostname, path, operation, or other security signals such as Attack Score.
+
+Customers with API Security already have access to Schema Profiles through Schema Learning and Schema Validation. Cloudflare is also opening a closed beta to invited Enterprise customers without API Security. Contact your Cloudflare account team to express interest.
+
+For more information, refer to [Application Profiles](/waf/detections/application-profiles/).


### PR DESCRIPTION
### Summary

Adds a WAF changelog entry introducing Application Profiles as a positive-security layer. It summarizes learned request structures, always-on detection, analysis before enforcement, scoped Custom Rules, availability, and links to the Application Profiles documentation.

### Documentation checklist

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) - how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
