### PR TITLE
[SSL] document client certificate quota behavior and BYOCA guidance

### DIFF
--- a/src/content/docs/ssl/client-certificates/byo-ca.mdx
+++ b/src/content/docs/ssl/client-certificates/byo-ca.mdx
@@ -31,6 +31,20 @@ Bring your own CA (BYOCA) is especially useful if you already have mTLS implemen
 If you exceed the CA certificate quota, the API returns error `1489` with the message "Hit maximum CA cert allocation." Contact your account team to request a quota increase.
 :::
 
+:::note[Cloudflare Access uses a separate quota]
+CAs uploaded through [Cloudflare Access](/cloudflare-one/access-controls/service-credentials/mutual-tls-authentication/) use a separate quota that is not counted against the five-CA limit. If you see error `12130` ("maximum number of certificates has been reached") in Access, this relates to the Access certificate quota, not the BYOCA CA quota.
+:::
+
+## When to use BYOCA
+
+BYOCA works well if:
+
+- You already have an internal CA and client certificates are installed on your devices.
+- You issue certificates at high volume or high churn — for example, one certificate per ephemeral virtual machine, container, or device. With BYOCA, Cloudflare stores only your CA certificate, not individual issued certificates, so there is no per-certificate quota.
+- You want full control over certificate validity periods, key types, and revocation through your own CA tooling.
+
+If you only have a small, stable set of devices or services to authenticate, the [Cloudflare-managed CA](/ssl/client-certificates/create-a-client-certificate/) is simpler to set up.
+
 ## CA certificate requirements
 
 When you upload your CA, Cloudflare validates the certificate according to certain requirements.

--- a/src/content/docs/ssl/client-certificates/create-a-client-certificate.mdx
+++ b/src/content/docs/ssl/client-certificates/create-a-client-certificate.mdx
@@ -34,8 +34,7 @@ If you reach the limit, the API returns error `1445` with the message `Hit maxim
 
 If your use case involves short-lived or frequently rotated certificates — for example, one certificate per ephemeral device or session — the 100-certificate default can fill up quickly.
 
-- **Revoke certificates immediately** when a device or session ends. Revoking frees the quota slot right away.
-- **Use [BYOCA](/ssl/client-certificates/byo-ca/)** if you need to issue a large volume of certificates. With BYOCA, Cloudflare stores only your CA certificate, not individual issued certificates, so there is no per-certificate inventory limit.
+Revoke certificates immediately when a device or session ends — revoking frees the quota slot right away. If you need to issue a large volume of certificates, use [BYOCA](/ssl/client-certificates/byo-ca/) instead. With BYOCA, Cloudflare stores only your CA certificate, not individual issued certificates, so there is no per-certificate inventory limit.
 
 :::
 

--- a/src/content/docs/ssl/client-certificates/create-a-client-certificate.mdx
+++ b/src/content/docs/ssl/client-certificates/create-a-client-certificate.mdx
@@ -19,6 +19,27 @@ Use Cloudflare's public key infrastructure (PKI) to create client certificates i
 The following process only refers to certificates issued from the Cloudflare-managed CA. To bring your own CA, refer to [BYOCA](/ssl/client-certificates/byo-ca/) instead. Only available to Enterprise accounts.
 :::
 
+## Quota and limits
+
+By default, each zone allows up to **100 active client certificates** issued by the Cloudflare-managed CA. Only active certificates count toward this limit — revoking a certificate frees its slot immediately.
+
+| Plan | Default limit | Increase available |
+|------|--------------|-------------------|
+| Free, Pro, Business | 100 per zone | No |
+| Enterprise (with API Shield) | 100,000 per zone | Yes, via account team |
+
+If you reach the limit, the API returns error `1445` with the message `Hit maximum certificate allocation: 100 certificates per zone are allowed`. To request an increase, contact your account team. Increases require an Enterprise plan with API Shield.
+
+:::note[High-churn workloads]
+
+If your use case involves short-lived or frequently rotated certificates — for example, one certificate per ephemeral device or session — the 100-certificate default can fill up quickly.
+
+- **Revoke certificates immediately** when a device or session ends. Revoking frees the quota slot right away.
+- **Use [BYOCA](/ssl/client-certificates/byo-ca/)** if you need to issue a large volume of certificates. With BYOCA, Cloudflare stores only your CA certificate, not individual issued certificates, so there is no per-certificate inventory limit.
+
+:::
+
+
 To create a client certificate on the Cloudflare dashboard:
 
 1. Go to the **Client Certificates** page.

--- a/src/content/docs/ssl/client-certificates/index.mdx
+++ b/src/content/docs/ssl/client-certificates/index.mdx
@@ -41,6 +41,32 @@ Cloudflare then stores the validation result in a field called [`cf.tls_client_a
 - **Success**: `cf.tls_client_auth.cert_verified` is `true`, and you can find client certificate details in [specific mTLS fields](/ruleset-engine/rules-language/fields/reference/?search-term=cf.tls_client_auth).
 - **Failure**: `cf.tls_client_auth.cert_verified` is `false`.
 
+
+---
+
+## Limits
+
+### Cloudflare-managed CA
+
+Each zone allows up to **100 active client certificates** by default. Only active certificates count toward this quota. Revoking a certificate frees its slot immediately.
+
+Increasing the quota requires an Enterprise account with [API Shield](/api-shield/). After the entitlement is applied, the default increases to 100,000 per zone. Contact your account team to request an increase.
+
+### BYOCA
+
+Each Enterprise account can upload up to **five CA certificates**. This quota is shared across [API Shield](/api-shield/security/mtls/configure/), [Workers mTLS](/workers/runtime-apis/bindings/mtls/), and [Cloudflare Gateway](/cloudflare-one/traffic-policies/). It does not apply to CAs uploaded through [Cloudflare Access](/cloudflare-one/access-controls/service-credentials/mutual-tls-authentication/), which uses a separate quota.
+
+Contact your account team to request an increase to the BYOCA CA quota.
+
+:::note[Choosing between managed CA and BYOCA]
+
+Use the Cloudflare-managed CA if you have a small, stable set of clients that authenticate infrequently.
+
+Use [BYOCA](/ssl/client-certificates/byo-ca/) if you issue certificates at high volume or high churn, already operate an internal CA, or want to issue certificates without calling the Cloudflare API for each one.
+
+:::
+
+
 ---
 
 ## Use cases

--- a/src/content/docs/ssl/client-certificates/revoke-client-certificate.mdx
+++ b/src/content/docs/ssl/client-certificates/revoke-client-certificate.mdx
@@ -24,6 +24,14 @@ It is not possible to permanently delete client certificates generated with the 
 2. Select the certificate you want to revoke.
 3. Select **Revoke** and confirm the operation.
 
+:::note[Effect on quota]
+
+Revoking a certificate immediately removes it from your active certificate count. Only active certificates count toward the per-zone limit. Revoked certificates remain listed but do not consume quota.
+
+If you manage short-lived or device-bound certificates, revoke them as soon as they are no longer needed. Revoking promptly frees the quota slot without waiting for the certificate to expire.
+
+:::
+
 :::caution[Important]
 
 


### PR DESCRIPTION
### Summary

Add previously missing documentation about the per-zone client certificate quota and lifecycle behavior across the `ssl/client-certificates` section.

- `revoke-client-certificate.mdx`: note that revoking a certificate immediately frees its quota slot; guidance to revoke short-lived certs promptly
- `create-a-client-certificate.mdx`: add Quota and limits section with per-plan defaults, error `1445`, and high-churn guidance pointing to BYOCA
- `index.mdx`: add Limits section covering both managed-CA and BYOCA quotas, plan requirements, and when to choose each
- `byo-ca.mdx`: separate the Cloudflare Access CA quota from the BYOCA five-CA quota (disambiguates error `12130`); add When to use BYOCA section

### Screenshots (optional)

N/A

### Documentation checklist

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? Omitted — this documents existing undocumented behavior, not a new feature release.
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [x] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file). N/A — no file moves.
