### PR TITLE
[Agents] Add FLUJO remote MCP testing instructions

### DIFF
--- a/src/content/docs/agents/model-context-protocol/guides/test-remote-mcp-server.mdx
+++ b/src/content/docs/agents/model-context-protocol/guides/test-remote-mcp-server.mdx
@@ -10,7 +10,7 @@ products:
   - agents
 ---
 
-import { Render } from "~/components";
+import { Steps } from "~/components";
 
 Remote, authorized connections are an evolving part of the [Model Context Protocol (MCP) specification](https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization). Not all MCP clients support remote connections yet.
 
@@ -49,6 +49,28 @@ You should see the **List tools** button, which will list the tools that your MC
 ## Connect your remote MCP server to Cloudflare Workers AI Playground
 
 Visit the [Workers AI Playground](https://playground.ai.cloudflare.com/), enter your MCP server URL, and click "Connect". Once authenticated (if required), you should see your tools listed and they will be available to the AI model in the chat.
+
+## Connect your remote MCP server to FLUJO
+
+[FLUJO](https://github.com/mario-andreschak/FLUJO) connects directly to remote MCP servers using Streamable HTTP. This example uses Cloudflare's public [Documentation MCP server](https://github.com/cloudflare/mcp-server-cloudflare/tree/main/apps/docs-ai-search), which does not require authentication.
+
+<Steps>
+
+1. [Install and open FLUJO](https://github.com/mario-andreschak/FLUJO#run-via-npx-npm-package).
+
+2. In **Connected Apps**, select **Connect App** > **I have connection details** > **At a remote URL**.
+
+3. In **Server URL**, enter `https://docs.mcp.cloudflare.com/mcp` and select **Connect**. FLUJO creates the server configuration and tests the connection.
+
+4. When the connection test passes, select **Update server**.
+
+5. In **Connected Apps**, select the new **docs-mcp-cloudflare-com** server card. In the **Tools** tab, select `search_cloudflare_documentation` from **Select tool**.
+
+6. In **query**, enter a documentation question, such as `How do I create a Cloudflare Worker with Wrangler?`, and select **Test tool**. FLUJO displays the returned documentation in **Result**.
+
+</Steps>
+
+To test your own public Streamable HTTP server, replace the example URL with your server's endpoint and select one of its tools.
 
 ## Connect your remote MCP server to Claude Desktop via a local proxy
 


### PR DESCRIPTION
### Summary

Adds FLUJO to the existing [remote MCP testing guide](https://developers.cloudflare.com/agents/model-context-protocol/guides/test-remote-mcp-server/) with the current connection flow and a documentation search example using Cloudflare's [public Documentation MCP server](https://github.com/cloudflare/mcp-server-cloudflare/tree/main/apps/docs-ai-search).

Verified in a fresh FLUJO 3.45.2 npm installation on Linux: anonymous Streamable HTTP handshake, two discovered tools, and a successful `search_cloudflare_documentation` call through FLUJO's Tool Tester. The instructions cover the public documentation endpoint; they do not claim OAuth compatibility with other Cloudflare servers. Prepared with Codex assistance and actual browser verification.

Validation: `pnpm run check` passed (453 files, zero errors/warnings/hints; worker typecheck passed), `pnpm run build` passed (8,965 pages), `pnpm run format` passed, and `git diff --check` passed. Formatting left only the intended guide change.

### Screenshots (optional)

![Successful FLUJO connection test](https://raw.githubusercontent.com/flujo-app/flujo-mcp-client-validation/main/cloudflare/connection.png)

![Successful documentation search in FLUJO](https://raw.githubusercontent.com/flujo-app/flujo-mcp-client-validation/main/cloudflare/search.png)

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).




Preview review completed: served the completed production build on the isolated cloud machine and visually checked all six FLUJO steps, links/code spans, the table of contents and neighboring sections. This was a locally served production build, not an upstream deployment preview. All required local checks and current upstream CI checks pass.
