### PR TITLE
[SECONDARY DNS] Secondary DNS Override - Live Signing only

### DIFF
--- a/src/content/docs/dns/zone-setups/zone-transfers/cloudflare-as-secondary/dnssec-for-secondary.mdx
+++ b/src/content/docs/dns/zone-setups/zone-transfers/cloudflare-as-secondary/dnssec-for-secondary.mdx
@@ -24,7 +24,13 @@ import {
 
 - **[Multi-signer DNSSEC](/dns/dnssec/multi-signer-dnssec/setup/)**: Both Cloudflare and your primary DNS provider know the signing keys of each other and perform their own live-signing of DNS records, in accordance with [RFC 8901](https://www.rfc-editor.org/rfc/rfc8901.html).
 - **[Live signing](#set-up-live-signing-dnssec)**: If your domain is not delegated to your primary provider's nameservers and Cloudflare secondary nameservers are the only nameservers authoritatively responding to DNS queries (hidden primary setup), you can choose this option to allow Cloudflare to perform live-signing of your DNS records.
-- **[Pre-signed](#set-up-pre-signed-dnssec)**: Your primary DNS provider signs records and transfers out the signatures. Cloudflare then serves these records and signatures as is, without doing any signing. By default, Cloudflare uses [NSEC records](https://www.cloudflare.com/dns/dnssec/how-dnssec-works/) and not NSEC3 - refer to [NSEC3 support](/dns/dnssec/enable-nsec3/) if needed. Also, Pre-signed DNSSEC does not support [Secondary DNS Overrides](/dns/zone-setups/zone-transfers/cloudflare-as-secondary/proxy-traffic/) nor [Load Balancing](/load-balancing/).
+- **[Pre-signed](#set-up-pre-signed-dnssec)**: Your primary DNS provider signs records and transfers out the signatures. Cloudflare then serves these records and signatures as is, without doing any signing. By default, Cloudflare uses [NSEC records](https://www.cloudflare.com/dns/dnssec/how-dnssec-works/) and not NSEC3 - refer to [NSEC3 support](/dns/dnssec/enable-nsec3/) if needed. Also, Pre-signed DNSSEC does not support [Secondary DNS Overrides](/dns/zone-setups/zone-transfers/cloudflare-as-secondary/proxy-traffic/) nor [Load Balancing](/load-balancing/). 
+
+:::note
+
+If Secondary DNS Override is enabled, you must use Live Signing. Pre-signed zones cannot serve proxied, Spectrum, or Load Balancer records.
+
+:::
 
 ---
 


### PR DESCRIPTION
Regarding DNSSEC: Live Signing only — pre-signed zones don't support Secondary Override, if Secondary DNS Override is enabled, you must use Live Signing. Pre-signed zones cannot serve proxied, Spectrum, or Load Balancer records.