### PR TITLE
[SECONDARY DNS] Secondary DNS Override entitlement

### DIFF
--- a/src/content/docs/dns/zone-setups/zone-transfers/cloudflare-as-secondary/proxy-traffic.mdx
+++ b/src/content/docs/dns/zone-setups/zone-transfers/cloudflare-as-secondary/proxy-traffic.mdx
@@ -23,6 +23,12 @@ Only A, AAAA, and CNAME records can be proxied.
 
 :::
 
+:::note
+
+Secondary DNS Override is an add-on feature. Contact your account team to confirm it is enabled on your account before toggling this setting.
+
+:::
+
 ## Prerequisites
 
 Before you set up Secondary DNS override, make sure that you have:


### PR DESCRIPTION
Secondary DNS Override requires a provisioned entitlement, therefore Secondary DNS Override is an add-on feature, please contact your account team to confirm it is enabled on your account before toggling this setting.