### PR TITLE
[Custom Errors] Add bandwidth warning for large custom error assets

### DIFF
--- a/src/content/docs/rules/custom-errors/index.mdx
+++ b/src/content/docs/rules/custom-errors/index.mdx
@@ -100,3 +100,9 @@ You can use a custom error asset in one or more [custom error rules](#custom-err
 When you provide a URL for a custom error asset, Cloudflare fetches the page and inlines all referenced resources into the HTML. Images and other binary resources (including those referenced from CSS via `url(...)`) are inlined as base64-encoded data URLs. CSS and JavaScript files are inlined as plain text inside `<style>` and `<script>` tags. The processed page must not exceed approximately 1.5 MB.
 
 If your custom error asset exceeds this size, reduce the number or size of referenced resources. You can also host large resources externally, as long as they remain accessible from Cloudflare's network when the asset is fetched.
+
+:::caution[Large assets increase bandwidth]
+
+Because a custom error asset is served to every visitor that triggers the associated rule, a large asset can generate significant egress traffic. To reduce bandwidth and improve load times, keep the asset small by reducing the size or number of referenced images, fonts, and other binary resources. Cloudflare inlines referenced resources when fetching the asset, so external URLs are fetched and inlined as well.
+
+:::


### PR DESCRIPTION
Adds a caution note to the Custom Error Assets size limits section warning that large assets are served on every matching error and can generate significant egress traffic. Recommends keeping assets small and avoiding inlined large resources.