### PR TITLE
Cache keys - update note with link about mentioning cache by device type

### DIFF
--- a/src/content/docs/cache/how-to/cache-keys.mdx
+++ b/src/content/docs/cache/how-to/cache-keys.mdx
@@ -44,7 +44,7 @@ Custom cache keys let you precisely set the cacheability setting for any resourc
 7. To save and deploy your rule, select **Deploy**. If you are not ready to deploy your rule, select **Save as Draft**.
 
 :::note
-When [URL normalization](/rules/normalization/) is enabled, we recommend also enabling [Normalize URLs to origin](/rules/normalization/manage/), especially if you are setting custom cache keys or using cache by device type, which also modifies the cache key. This helps ensure the URL in the cache key matches the URL sent to the origin, preventing cache poisoning and ensuring consistent behavior.
+When [URL normalization](/rules/normalization/) is enabled, we recommend also enabling [Normalize URLs to origin](/rules/normalization/manage/), especially if you are setting custom cache keys or using [cache by device type](/automatic-platform-optimization/reference/cache-device-type/), which also modifies the cache key. This helps ensure the URL in the cache key matches the URL sent to the origin, preventing cache poisoning and ensuring consistent behavior.
 :::
 
 ## Cache Key Template


### PR DESCRIPTION
Update the existing note where "cache by device type" is already mentioned with a link towards APO's sub-page about device type cache