### PR TITLE
[SSL] add troubleshooting for conflicting _acme-challenge records in direct Cloudflare zone

### DIFF
--- a/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/issue-and-validate/validate-certificates/troubleshooting.mdx
+++ b/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/issue-and-validate/validate-certificates/troubleshooting.mdx
@@ -16,7 +16,7 @@ head:
 
 ## High-risk domains
 
-Occasionally, a domain will be flagged as "high risk" by Cloudflare's CA partners. Typically this is done only for domains that have been flagged for phishing or malware by Google's Safe Browsing service.
+Cloudflare's CA partners occasionally flag a domain as "high risk" — typically only for domains that Google's Safe Browsing service has flagged for phishing or malware.
 
 If a domain is flagged by the CA, you need to contact Support before validation can finish. The API call will return indicating the failure, along with a link to where the ticket can be filed.
 

--- a/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/issue-and-validate/validate-certificates/troubleshooting.mdx
+++ b/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/issue-and-validate/validate-certificates/troubleshooting.mdx
@@ -75,7 +75,7 @@ Check whether the delegation CNAME is in place at the `_acme-challenge` hostname
 dig _acme-challenge.example.com CNAME +short
 ```
 
-- If this returns **nothing**, the delegation CNAME is missing. Run a TXT query to check whether a hardcoded record is also present:
+- If this returns **nothing**, the delegation CNAME is missing. Run a `TXT` query to check whether a hardcoded record is also present:
 
   ```sh
   dig _acme-challenge.example.com TXT +short

--- a/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/issue-and-validate/validate-certificates/troubleshooting.mdx
+++ b/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/issue-and-validate/validate-certificates/troubleshooting.mdx
@@ -16,7 +16,7 @@ head:
 
 ## High-risk domains
 
-Occasionally, a domain will be flagged as "high risk" by Cloudflare's CA partners. Typically this is done only for domains with an Alexa ranking of 1-1,000 and domains that have been flagged for phishing or malware by Google's Safe Browsing service.
+Occasionally, a domain will be flagged as "high risk" by Cloudflare's CA partners. Typically this is done only for domains that have been flagged for phishing or malware by Google's Safe Browsing service.
 
 If a domain is flagged by the CA, you need to contact Support before validation can finish. The API call will return indicating the failure, along with a link to where the ticket can be filed.
 
@@ -69,17 +69,14 @@ If certificate validation is stuck despite the correct CNAME or TXT records bein
 
 ### How to diagnose
 
-Run these commands to check what type of records exist at the `_acme-challenge` hostname:
+Check whether the delegation CNAME is in place at the `_acme-challenge` hostname:
 
 ```sh
 dig _acme-challenge.example.com CNAME +short
 ```
 
-```sh
-dig _acme-challenge.example.com TXT +short
-```
-
-If the CNAME query returns empty and the TXT query returns a raw token string, a hardcoded TXT record exists directly at the `_acme-challenge` hostname and is preventing the delegated DCV CNAME from taking effect.
+- If this returns **nothing**, the delegation CNAME is missing. If a TXT query also returns a raw token string, a hardcoded `_acme-challenge` TXT record is present and is blocking certificate issuance — remove it before adding the delegation CNAME.
+- If this returns a **CNAME target** but certificate validation is still stuck, the conflict is likely a hardcoded `_acme-challenge` TXT record inside your customer's direct Cloudflare zone. Because resolvers follow the CNAME chain rather than exposing records at the source name, the only way to confirm this is to inspect the customer's zone directly: go to **DNS** > **Records** in the Cloudflare dashboard for their zone and look for any `_acme-challenge` TXT entries.
 
 ### Common causes and remediation
 

--- a/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/issue-and-validate/validate-certificates/troubleshooting.mdx
+++ b/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/issue-and-validate/validate-certificates/troubleshooting.mdx
@@ -62,6 +62,31 @@ If these return an error, delete and recreate the custom hostname.
 
 ***
 
+
+## Conflicting `_acme-challenge` TXT records
+
+If certificate validation is stuck despite the correct CNAME or TXT records being in place, a conflicting `_acme-challenge` TXT record may be preventing the certificate authority from completing validation.
+
+### How to diagnose
+
+Run this command to check for unexpected values at the `_acme-challenge` hostname:
+
+```sh
+$ dig _acme-challenge.example.com TXT +short
+```
+
+If the output includes a hardcoded TXT value that does not match the current expected validation token — or appears alongside a CNAME target for delegated DCV — a conflicting record is present.
+
+### Common causes and remediation
+
+**Record from a prior Cloudflare certificate order** — Cloudflare adds `_acme-challenge` TXT records during certificate issuance. Records from a previous or abandoned order may persist and are not always visible in the Cloudflare dashboard. [Contact Cloudflare Support](/support/contacting-cloudflare-support/) to have them removed.
+
+**Record in a direct Cloudflare zone** — If your customer's domain is also present in a direct Cloudflare zone (for example, they proxy `example.com` through their own Cloudflare account), that zone may have an `_acme-challenge` TXT record from a Universal SSL or Advanced certificate order. When the certificate authority queries `_acme-challenge.example.com`, it resolves the record from the direct zone rather than following the delegated DCV CNAME.
+
+To resolve this, ask your customer to remove the `_acme-challenge` TXT record from their zone's DNS settings in the Cloudflare dashboard, then [trigger an immediate validation check](#immediate-validation-checks).
+
+***
+
 ## Immediate validation checks
 
 You can send a [PATCH request](/api/resources/custom_hostnames/methods/edit/) to request an immediate validation check on any certificate. The PATCH data should include the same `ssl` object as the original request.

--- a/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/issue-and-validate/validate-certificates/troubleshooting.mdx
+++ b/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/issue-and-validate/validate-certificates/troubleshooting.mdx
@@ -16,7 +16,7 @@ head:
 
 ## High-risk domains
 
-Occasionally, a domain will be flagged as “high risk” by Cloudflare’s CA partners. Typically this is done only for domains with an Alexa ranking of 1-1,000 and domains that have been flagged for phishing or malware by Google’s Safe Browsing service.
+Occasionally, a domain will be flagged as "high risk" by Cloudflare's CA partners. Typically this is done only for domains with an Alexa ranking of 1-1,000 and domains that have been flagged for phishing or malware by Google's Safe Browsing service.
 
 If a domain is flagged by the CA, you need to contact Support before validation can finish. The API call will return indicating the failure, along with a link to where the ticket can be filed.
 
@@ -69,13 +69,17 @@ If certificate validation is stuck despite the correct CNAME or TXT records bein
 
 ### How to diagnose
 
-Run this command to check for unexpected values at the `_acme-challenge` hostname:
+Run these commands to check what type of records exist at the `_acme-challenge` hostname:
 
 ```sh
-$ dig _acme-challenge.example.com TXT +short
+dig _acme-challenge.example.com CNAME +short
 ```
 
-If the output includes a hardcoded TXT value that does not match the current expected validation token — or appears alongside a CNAME target for delegated DCV — a conflicting record is present.
+```sh
+dig _acme-challenge.example.com TXT +short
+```
+
+If the CNAME query returns empty and the TXT query returns a raw token string, a hardcoded TXT record exists directly at the `_acme-challenge` hostname and is preventing the delegated DCV CNAME from taking effect.
 
 ### Common causes and remediation
 

--- a/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/issue-and-validate/validate-certificates/troubleshooting.mdx
+++ b/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/issue-and-validate/validate-certificates/troubleshooting.mdx
@@ -75,7 +75,13 @@ Check whether the delegation CNAME is in place at the `_acme-challenge` hostname
 dig _acme-challenge.example.com CNAME +short
 ```
 
-- If this returns **nothing**, the delegation CNAME is missing. If a TXT query also returns a raw token string, a hardcoded `_acme-challenge` TXT record is present and is blocking certificate issuance — remove it before adding the delegation CNAME.
+- If this returns **nothing**, the delegation CNAME is missing. Run a TXT query to check whether a hardcoded record is also present:
+
+  ```sh
+  dig _acme-challenge.example.com TXT +short
+  ```
+
+  If this returns a raw token string, a hardcoded `_acme-challenge` TXT record is blocking certificate issuance — remove it before adding the delegation CNAME.
 - If this returns a **CNAME target** but certificate validation is still stuck, the conflict is likely a hardcoded `_acme-challenge` TXT record inside your customer's direct Cloudflare zone. Because resolvers follow the CNAME chain rather than exposing records at the source name, the only way to confirm this is to inspect the customer's zone directly: go to **DNS** > **Records** in the Cloudflare dashboard for their zone and look for any `_acme-challenge` TXT entries.
 
 ### Common causes and remediation

--- a/src/content/partials/ssl/dcv-conflicting-records.mdx
+++ b/src/content/partials/ssl/dcv-conflicting-records.mdx
@@ -13,18 +13,14 @@ _acme-challenge.example.com TXT <CERTIFICATE_VALIDATION_VALUE>
 
 This includes records that Cloudflare may have placed automatically during a previous certificate order or Universal SSL issuance. If your customer's domain is also present in a direct Cloudflare zone (for example, they proxy `example.com` through their own Cloudflare account), check that zone's DNS records for any `_acme-challenge` entries and remove them.
 
-To verify whether a conflicting TXT record is present, first check whether a delegation CNAME record exists at the `_acme-challenge` hostname:
+To check whether the delegation CNAME is in place, run:
 
 ```sh
 dig _acme-challenge.example.com CNAME +short
 ```
 
-If this returns a CNAME target, the delegated DCV record is in place. Then check whether a hardcoded TXT record also exists at this name:
+If this returns nothing, the delegation CNAME is not present — add it before proceeding.
 
-```sh
-dig _acme-challenge.example.com TXT +short
-```
-
-If the CNAME query returned nothing and the TXT query returns a raw token string, a hardcoded TXT record exists at `_acme-challenge.example.com` and is causing a conflict. Refer to [Troubleshooting](/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/issue-and-validate/validate-certificates/troubleshooting/#conflicting-_acme-challenge-txt-records) for remediation steps.
+If the CNAME is in place but certificate validation is still stuck, a conflicting `_acme-challenge` TXT record may exist inside your customer's direct Cloudflare zone. Because resolvers follow the CNAME chain rather than exposing records at the source name, the only way to confirm this is to inspect the customer's zone directly: go to **DNS** > **Records** in the Cloudflare dashboard for their zone and look for any `_acme-challenge` TXT entries. Refer to [Troubleshooting](/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/issue-and-validate/validate-certificates/troubleshooting/#conflicting-_acme-challenge-txt-records) for remediation steps.
 
 :::

--- a/src/content/partials/ssl/dcv-conflicting-records.mdx
+++ b/src/content/partials/ssl/dcv-conflicting-records.mdx
@@ -3,12 +3,22 @@
 
 ---
 
-:::caution[Remove previous TXT records]
+:::caution[Remove conflicting `_acme-challenge` TXT records]
 
-Existing TXT records for `_acme-challenge` will conflict with the delegated DCV CNAME record. Make sure to check and remove records such as the following:
+Existing `_acme-challenge` TXT records will prevent delegated DCV from functioning. Before setting up delegated DCV, check for and remove any records in this form from your customer's authoritative DNS:
 
 ```txt
 _acme-challenge.example.com TXT <CERTIFICATE_VALIDATION_VALUE>
 ```
+
+This includes records that Cloudflare may have placed automatically during a previous certificate order or Universal SSL issuance. If your customer's domain is also present in a direct Cloudflare zone (for example, they proxy `example.com` through their own Cloudflare account), check that zone's DNS records for any `_acme-challenge` entries and remove them.
+
+To verify whether a conflicting record is present, run:
+
+```sh
+$ dig _acme-challenge.example.com TXT +short
+```
+
+If the output contains a hardcoded TXT value rather than the CNAME target for delegated DCV, a conflicting record exists. Refer to [Troubleshooting](/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/issue-and-validate/validate-certificates/troubleshooting/#conflicting-_acme-challenge-txt-records) for remediation steps.
 
 :::

--- a/src/content/partials/ssl/dcv-conflicting-records.mdx
+++ b/src/content/partials/ssl/dcv-conflicting-records.mdx
@@ -13,12 +13,18 @@ _acme-challenge.example.com TXT <CERTIFICATE_VALIDATION_VALUE>
 
 This includes records that Cloudflare may have placed automatically during a previous certificate order or Universal SSL issuance. If your customer's domain is also present in a direct Cloudflare zone (for example, they proxy `example.com` through their own Cloudflare account), check that zone's DNS records for any `_acme-challenge` entries and remove them.
 
-To verify whether a conflicting record is present, run:
+To verify whether a conflicting TXT record is present, first check whether a delegation CNAME record exists at the `_acme-challenge` hostname:
 
 ```sh
-$ dig _acme-challenge.example.com TXT +short
+dig _acme-challenge.example.com CNAME +short
 ```
 
-If the output contains a hardcoded TXT value rather than the CNAME target for delegated DCV, a conflicting record exists. Refer to [Troubleshooting](/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/issue-and-validate/validate-certificates/troubleshooting/#conflicting-_acme-challenge-txt-records) for remediation steps.
+If this returns a CNAME target, the delegated DCV record is in place. Then check whether a hardcoded TXT record also exists at this name:
+
+```sh
+dig _acme-challenge.example.com TXT +short
+```
+
+If the CNAME query returned nothing and the TXT query returns a raw token string, a hardcoded TXT record exists at `_acme-challenge.example.com` and is causing a conflict. Refer to [Troubleshooting](/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/issue-and-validate/validate-certificates/troubleshooting/#conflicting-_acme-challenge-txt-records) for remediation steps.
 
 :::


### PR DESCRIPTION
Adds documentation for Issue 2 from the certificate DCV support analysis (DEE-3645).

**What:** Expands the existing `dcv-conflicting-records` partial and adds a new "Conflicting `_acme-challenge` TXT records" section to the SaaS certificate validation troubleshooting page.

**Why:** When a customer's domain is simultaneously present in a direct Cloudflare zone and onboarded as a custom hostname via a SaaS provider (Cloudflare for SaaS), a hardcoded `_acme-challenge` TXT record in the direct zone overrides the DCV delegation CNAME. This causes certificate validation to remain stuck at `pending_validation` with no actionable error message. The issue is invisible to both the SaaS operator and the end customer — the docs previously did not document this scenario or how to resolve it.