### PR TITLE
[Cache] Add missing purge edge-case documentation

### DIFF
--- a/src/content/docs/cache/how-to/purge-cache/index.mdx
+++ b/src/content/docs/cache/how-to/purge-cache/index.mdx
@@ -17,6 +17,10 @@ Cloudflare's Instant Purge ensures that updates to your content are reflected im
 To purge cached content using the Cloudflare API, refer to [Purge Cached Content](/api/resources/cache/methods/purge/).
 
 :::note
+A successful purge request returns HTTP 200. This indicates the request was received — it does not confirm that the targeted content was cached or that any content was evicted. To verify a purge, request the asset after purging and confirm that `CF-Cache-Status` is no longer `HIT`.
+:::
+
+:::note
 If versioning is active on your zone and multiple environments are configured, you can select the specific environment you want to purge. For more details, refer to the [Version Management](/version-management/) documentation.
 :::
 

--- a/src/content/docs/cache/how-to/purge-cache/purge-by-single-file.mdx
+++ b/src/content/docs/cache/how-to/purge-cache/purge-by-single-file.mdx
@@ -52,6 +52,18 @@ Update your Cache Rule expression to also match on the `PURGE` method, for examp
 
 For rules that match on fields which cannot be evaluated during purge (such as `cf.bot_management.score`), use [purge by prefix](/cache/how-to/purge-cache/purge_by_prefix/), [purge by tag](/cache/how-to/purge-cache/purge-by-tags/), or [purge everything](/cache/how-to/purge-cache/purge-everything/).
 
+### Redirect responses
+
+If the URL you want to purge returns a redirect (301 or 302), single-file purge removes the cached redirect response — not the content at the redirect destination. The resource at the destination URL remains cached.
+
+To clear the destination content, purge the final destination URL directly. You can find it by checking the `Location` header in the response:
+
+```bash
+curl -I https://example.com/redirecting-path
+```
+
+Use the URL in the `Location` header for your purge request instead.
+
 ### Resources with special headers
 
 A single-file purge performed through your Cloudflare dashboard does not clear objects that contain any of the following:
@@ -85,4 +97,4 @@ For information on how to purge assets cached by [Cache API](/workers/runtime-ap
 
 ## Resulting cache status
 
-Purging by single-file deletes the resource, resulting in the `CF-Cache-Status` header being set to [`MISS`](/cache/concepts/cache-responses/#miss) for subsequent requests.
+Purging by single-file deletes the resource, resulting in the `CF-Cache-Status` header showing [MISS](/cache/concepts/cache-responses/#miss) for the subsequent request.

--- a/src/content/docs/cache/how-to/purge-cache/purge-everything.mdx
+++ b/src/content/docs/cache/how-to/purge-cache/purge-everything.mdx
@@ -1,5 +1,5 @@
 ---
-title: ​Purge everything
+title: \Purge everything
 pcx_content_type: how-to
 description: Purge all cached content for your entire zone.
 products:
@@ -13,7 +13,13 @@ import { DashButton } from "~/components"
 
 To maintain optimal site performance, Cloudflare strongly recommends using single-file (by URL) purging instead of a complete cache purge.
 
-Purging everything instantly clears all resources from your CDN cache in all Cloudflare data centers. Each new request for a purged resource returns to your origin server to validate the resource. If Cloudflare cannot validate the resource, Cloudflare fetches the latest version from the origin server and replaces the cached version. When a site with heavy traffic contains a lot of assets, requests to your origin server can increase substantially and result in slow site performance.
+Purging everything instantly clears all resources from your CDN cache in all Cloudflare data centers. Each new request for a purged resource returns to your origin server to validate the resource. If Cloudflare cannot validate the resource, Cloudflare fetches the latest version from the origin server and replaces the cached version.
+
+::caution
+When you purge everything, all cached content for your zone is removed at once. Every subsequent request must be served from your origin until the cache is repopulated. On high-traffic sites with many assets, this can cause a large spike in origin requests and may significantly slow down your site or overload your origin server.
+
+Before using purge everything, consider whether a more targeted method — such as [purge by URL](/cache/how-to/purge-cache/purge-by-single-file/), [purge by prefix](/cache/how-to/purge-cache/purge_by_prefix/), or [purge by tag](/cache/how-to/purge-cache/purge-by-tags/) -- can achieve the same result with less impact on your origin.
+:::
 
 1. In the Cloudflare dashboard, go to the **Configuration** page.
 


### PR DESCRIPTION
Three small additions to the cache purge documentation covering edge cases that frequently cause customer confusion in support.

**`index.mdx`** — Add a note clarifying that a successful purge request returns HTTP 200, but 200 does not confirm that the targeted content was cached or that any content was evicted. Customers often interpret a 200 response as confirmation that the purge worked, then report that Cloudflare is broken when content does not update. The note recommends verifying by checking that `CF-Cache-Status` is no longer `HIT`.

**`purge-by-single-file.mdx`** — Add a "Redirect responses" subsection explaining that purging a URL which returns a 301 or 302 removes the cached redirect response, not the content at the redirect destination. The destination resource remains cached. Customers need to purge the final destination URL directly.

**`purge-everything.mdx`** — Promote the existing inline performance warning to a dedicated `:::caution` callout and add a recommendation to consider targeted purge methods (by URL, prefix, or tag) first to avoid overloading the origin with a cache-fill spike.