### PR TITLE
[Cache] Add missing purge edge-case documentation

### DIFF
--- a/src/content/docs/cache/how-to/purge-cache/index.mdx
+++ b/src/content/docs/cache/how-to/purge-cache/index.mdx
@@ -17,7 +17,7 @@ Cloudflare's Instant Purge ensures that updates to your content are reflected im
 To purge cached content using the Cloudflare API, refer to [Purge Cached Content](/api/resources/cache/methods/purge/).
 
 :::note
-A successful purge request returns `HTTP 200`. This indicates that Cloudflare received the request — it does not confirm that Cloudflare cached the targeted content or evicted any content. To verify a purge, request the asset after purging and confirm that `CF-Cache-Status` is no longer `HIT`.
+A successful purge request returns `HTTP 200`. This indicates that Cloudflare received the request — it does not confirm that Cloudflare cached the targeted content or evicted any content. To verify a purge, request the asset after purging and confirm that [`CF-Cache-Status`](/cache/concepts/cache-responses/) is no longer `HIT`.
 :::
 
 :::note

--- a/src/content/docs/cache/how-to/purge-cache/index.mdx
+++ b/src/content/docs/cache/how-to/purge-cache/index.mdx
@@ -17,7 +17,7 @@ Cloudflare's Instant Purge ensures that updates to your content are reflected im
 To purge cached content using the Cloudflare API, refer to [Purge Cached Content](/api/resources/cache/methods/purge/).
 
 :::note
-A successful purge request returns `HTTP 200`. This indicates the request was received — it does not confirm that the targeted content was cached or that any content was evicted. To verify a purge, request the asset after purging and confirm that `CF-Cache-Status` is no longer `HIT`.
+A successful purge request returns `HTTP 200`. This indicates that Cloudflare received the request — it does not confirm that Cloudflare cached the targeted content or evicted any content. To verify a purge, request the asset after purging and confirm that `CF-Cache-Status` is no longer `HIT`.
 :::
 
 :::note

--- a/src/content/docs/cache/how-to/purge-cache/index.mdx
+++ b/src/content/docs/cache/how-to/purge-cache/index.mdx
@@ -17,7 +17,7 @@ Cloudflare's Instant Purge ensures that updates to your content are reflected im
 To purge cached content using the Cloudflare API, refer to [Purge Cached Content](/api/resources/cache/methods/purge/).
 
 :::note
-A successful purge request returns HTTP 200. This indicates the request was received — it does not confirm that the targeted content was cached or that any content was evicted. To verify a purge, request the asset after purging and confirm that `CF-Cache-Status` is no longer `HIT`.
+A successful purge request returns `HTTP 200`. This indicates the request was received — it does not confirm that the targeted content was cached or that any content was evicted. To verify a purge, request the asset after purging and confirm that `CF-Cache-Status` is no longer `HIT`.
 :::
 
 :::note

--- a/src/content/docs/cache/how-to/purge-cache/index.mdx
+++ b/src/content/docs/cache/how-to/purge-cache/index.mdx
@@ -17,6 +17,10 @@ Cloudflare's Instant Purge ensures that updates to your content are reflected im
 To purge cached content using the Cloudflare API, refer to [Purge Cached Content](/api/resources/cache/methods/purge/).
 
 :::note
+A successful purge request returns HTTP 200. This indicates the request was received — it does not confirm that the targeted content was cached or that any content was evicted. To verify a purge, request the asset after purging and confirm that `CF-Cache-Status` is no longer `HIT`.
+:::
+
+:::note
 If versioning is active on your zone and multiple environments are configured, you can select the specific environment you want to purge. For more details, refer to the [Version Management](/version-management/) documentation.
 :::
 

--- a/src/content/docs/cache/how-to/purge-cache/purge-by-single-file.mdx
+++ b/src/content/docs/cache/how-to/purge-cache/purge-by-single-file.mdx
@@ -52,6 +52,18 @@ Update your Cache Rule expression to also match on the `PURGE` method, for examp
 
 For rules that match on fields which cannot be evaluated during purge (such as `cf.bot_management.score`), use [purge by prefix](/cache/how-to/purge-cache/purge_by_prefix/), [purge by tag](/cache/how-to/purge-cache/purge-by-tags/), or [purge everything](/cache/how-to/purge-cache/purge-everything/).
 
+### Redirect responses
+
+If the URL you want to purge returns a redirect (301 or 302), single-file purge removes the cached redirect response — not the content at the redirect destination. The resource at the destination URL remains cached.
+
+To clear the destination content, purge the final destination URL directly. You can find it by checking the `Location` header in the response:
+
+```bash
+curl -v https://example.com/redirecting-path 2>&1 | grep -i location
+```
+
+Use the URL in the `Location` header for your purge request instead.
+
 ### Resources with special headers
 
 A single-file purge performed through your Cloudflare dashboard does not clear objects that contain any of the following:

--- a/src/content/docs/cache/how-to/purge-cache/purge-by-single-file.mdx
+++ b/src/content/docs/cache/how-to/purge-cache/purge-by-single-file.mdx
@@ -54,12 +54,13 @@ For rules that match on fields which cannot be evaluated during purge (such as `
 
 ### Redirect responses
 
-If the URL you want to purge returns a redirect (301 or 302), single-file purge removes the cached redirect response — not the content at the redirect destination. The resource at the destination URL remains cached.
+If the URL you want to purge returns a redirect (`301` or `302`), single-file purge removes the cached redirect response — not the content at the redirect destination. The resource at the destination URL remains cached.
 
 To clear the destination content, purge the final destination URL directly. You can find it by checking the `Location` header in the response:
 
 ```bash
-curl -v https://example.com/redirecting-path 2>&1 | grep -i location
+curl -Ls -o /dev/null -w "%{url_effective}
+" https://example.com/redirecting-path
 ```
 
 Use the URL in the `Location` header for your purge request instead.

--- a/src/content/docs/cache/how-to/purge-cache/purge-by-single-file.mdx
+++ b/src/content/docs/cache/how-to/purge-cache/purge-by-single-file.mdx
@@ -56,14 +56,14 @@ For rules that match on fields which cannot be evaluated during purge (such as `
 
 If the URL you want to purge returns a redirect (`301` or `302`), single-file purge removes the cached redirect response — not the content at the redirect destination. The resource at the destination URL remains cached.
 
-To clear the destination content, purge the final destination URL directly. You can find it by checking the `Location` header in the response:
+To clear the destination content, purge the final destination URL directly. You can find it by following the redirect chain to its end:
 
 ```bash
 curl -Ls -o /dev/null -w "%{url_effective}
 " https://example.com/redirecting-path
 ```
 
-Use the URL in the `Location` header for your purge request instead.
+This outputs the final URL after following all redirects. Use that URL for your purge request.
 
 ### Resources with special headers
 

--- a/src/content/docs/cache/how-to/purge-cache/purge-everything.mdx
+++ b/src/content/docs/cache/how-to/purge-cache/purge-everything.mdx
@@ -13,7 +13,13 @@ import { DashButton } from "~/components"
 
 To maintain optimal site performance, Cloudflare strongly recommends using single-file (by URL) purging instead of a complete cache purge.
 
-Purging everything instantly clears all resources from your CDN cache in all Cloudflare data centers. Each new request for a purged resource returns to your origin server to validate the resource. If Cloudflare cannot validate the resource, Cloudflare fetches the latest version from the origin server and replaces the cached version. When a site with heavy traffic contains a lot of assets, requests to your origin server can increase substantially and result in slow site performance.
+Purging everything instantly clears all resources from your CDN cache in all Cloudflare data centers. Each new request for a purged resource returns to your origin server to validate the resource. If Cloudflare cannot validate the resource, Cloudflare fetches the latest version from the origin server and replaces the cached version.
+
+:::caution
+When you purge everything, all cached content for your zone is removed at once. Every subsequent request must be served from your origin until the cache is repopulated. On high-traffic sites with many assets, this can cause a large spike in origin requests and may significantly slow down your site or overload your origin server.
+
+Before using purge everything, consider whether a more targeted method — such as [purge by URL](/cache/how-to/purge-cache/purge-by-single-file/), [purge by prefix](/cache/how-to/purge-cache/purge_by_prefix/), or [purge by tag](/cache/how-to/purge-cache/purge-by-tags/) — can achieve the same result with less impact on your origin.
+:::
 
 1. In the Cloudflare dashboard, go to the **Configuration** page.
 

--- a/src/content/docs/cache/how-to/purge-cache/purge-everything.mdx
+++ b/src/content/docs/cache/how-to/purge-cache/purge-everything.mdx
@@ -13,12 +13,12 @@ import { DashButton } from "~/components"
 
 To maintain optimal site performance, Cloudflare strongly recommends using single-file (by URL) purging instead of a complete cache purge.
 
-Purging everything instantly clears all resources from your CDN cache in all Cloudflare data centers. Each new request for a purged resource returns to your origin server to validate the resource. If Cloudflare cannot validate the resource, Cloudflare fetches the latest version from the origin server and replaces the cached version.
+Purging everything instantly clears all resources from your CDN cache in all Cloudflare data centers. Each new request for a purged resource returns to your origin server to validate the resource. If the cached version is no longer valid, Cloudflare fetches the latest version from your origin server and caches it.
 
 :::caution
 When you purge everything, all cached content for your zone is removed at once. Every subsequent request must be served from your origin until the cache is repopulated. On high-traffic sites with many assets, this can cause a large spike in origin requests and may significantly slow down your site or overload your origin server.
 
-Before using purge everything, consider whether a more targeted method — such as [purge by URL](/cache/how-to/purge-cache/purge-by-single-file/), [purge by prefix](/cache/how-to/purge-cache/purge_by_prefix/), or [purge by tag](/cache/how-to/purge-cache/purge-by-tags/) — can achieve the same result with less impact on your origin.
+Before using purge everything, consider whether a more targeted method — such as [purge by URL](/cache/how-to/purge-cache/purge-by-single-file/), [purge by prefix](/cache/how-to/purge-cache/purge_by_prefix/), or [purge by tag](/cache/how-to/purge-cache/purge-by-tags/) — can achieve the same result with less impact on your origin. If your zone uses [Tiered Cache](/cache/how-to/tiered-cache/), cache repopulation also propagates across cache tiers, which can further increase origin load during this period.
 :::
 
 1. In the Cloudflare dashboard, go to the **Configuration** page.


### PR DESCRIPTION
Add three missing edge cases to the cache purge documentation.

DEE-1922

**index.mdx** — note that a 200 response from the purge API does not confirm eviction. The API returns 200 even when the targeted URL was not in cache, which is a frequent source of confusion in support cases.

**purge-by-single-file.mdx** — new "Redirect responses" subsection explaining that purging a URL that returns a 301/302 removes the cached redirect response, not the destination resource. Customers need to purge the final destination URL.

**purge-everything.mdx** — promote the existing performance warning to a `:::caution` callout and recommend targeted purge methods first to reduce origin load.