### PR TITLE
[Workers] Clarify local development sandbox protections

### DIFF
--- a/src/content/docs/agents/examples/browser-agent.mdx
+++ b/src/content/docs/agents/examples/browser-agent.mdx
@@ -11,6 +11,7 @@ import {
 	TypeScriptExample,
 	WranglerConfig,
 	PackageManagers,
+	Render,
 } from "~/components";
 
 Build an agent that can browse the web, inspect pages, capture screenshots, and debug frontend issues with [Browser Run](/browser-run/) tools. <InlineBadge preset="beta" />
@@ -287,7 +288,11 @@ Recent Wrangler releases support Browser Run in local development. `npx wrangler
 
 Use `cdpUrl` only when you intentionally want to connect to some other CDP-compatible browser endpoint, such as a tunnel or a manually managed Chrome instance.
 
+<Render file="local-development-security" product="workers" />
+
 ## Security considerations
+
+The following protections apply when this agent is deployed to Cloudflare:
 
 - LLM-generated code runs in **isolated Worker sandboxes** — each execution gets its own Worker instance
 - External network access (`fetch`, `connect`) is **blocked** in the sandbox at the runtime level

--- a/src/content/docs/agents/examples/browser-agent.mdx
+++ b/src/content/docs/agents/examples/browser-agent.mdx
@@ -292,7 +292,7 @@ Use `cdpUrl` only when you intentionally want to connect to some other CDP-compa
 
 ## Security considerations
 
-The following protections apply when this agent is deployed to Cloudflare:
+The following protections apply when you deploy this agent to Cloudflare:
 
 - LLM-generated code runs in **isolated Worker sandboxes** — each execution gets its own Worker instance
 - External network access (`fetch`, `connect`) is **blocked** in the sandbox at the runtime level

--- a/src/content/docs/dynamic-workers/examples/dynamic-workers-playground.mdx
+++ b/src/content/docs/dynamic-workers/examples/dynamic-workers-playground.mdx
@@ -12,7 +12,7 @@ tags:
   - Logging
 ---
 
-import { TypeScriptExample } from "~/components";
+import { Render, TypeScriptExample } from "~/components";
 
 Try the Dynamic Workers [playground](https://github.com/cloudflare/agents/tree/main/examples/dynamic-workers-playground) to write or import code from GitHub, bundle it at runtime, execute it in a Dynamic Worker, and view real-time logs.
 
@@ -108,6 +108,8 @@ For more information on how to capture and stream logs from Dynamic Workers, ref
 ## Running locally
 
 Clone the repo and start the dev server:
+
+<Render file="local-development-security" product="workers" />
 
 ```sh
 npm install

--- a/src/content/docs/dynamic-workers/examples/dynamic-workers-starter.mdx
+++ b/src/content/docs/dynamic-workers/examples/dynamic-workers-starter.mdx
@@ -11,7 +11,7 @@ tags:
   - TypeScript
 ---
 
-import { TypeScriptExample, WranglerConfig } from "~/components";
+import { Render, TypeScriptExample, WranglerConfig } from "~/components";
 
 A [starter template](https://github.com/cloudflare/agents/tree/main/examples/dynamic-workers) for deploying a Worker that loads and runs [Dynamic Workers](/dynamic-workers/).
 
@@ -74,6 +74,8 @@ export default {
 </TypeScriptExample>
 
 ## Running locally
+
+<Render file="local-development-security" product="workers" />
 
 ```sh
 npm install

--- a/src/content/docs/workers/local-development/index.mdx
+++ b/src/content/docs/workers/local-development/index.mdx
@@ -23,9 +23,13 @@ import {
 	TypeScriptExample,
 } from "~/components";
 
-You can build, run, and test your Worker code on your own local machine before deploying it to Cloudflare's network. This is made possible through [Miniflare](/workers/testing/miniflare/), a simulator that executes your Worker code using the same runtime used in production, [`workerd`](https://github.com/cloudflare/workerd).
+You can build, run, and test your Worker code on your own local machine before deploying it to Cloudflare's network. This is made possible through [Miniflare](/workers/testing/miniflare/), a simulator that executes your Worker code in a local [`workerd`](https://github.com/cloudflare/workerd) process. `workerd` also powers the hosted Workers platform.
 
 [By default](/workers/local-development/#defaults), your Worker's bindings [connect to locally simulated resources](/workers/local-development/#bindings-during-local-development), but can be configured to interact with the real, production resource with [remote bindings](/workers/local-development/#remote-bindings).
+
+## Security considerations
+
+<Render file="local-development-security" product="workers" />
 
 ## Core concepts
 

--- a/src/content/docs/workers/local-development/local-dev-tunnels.mdx
+++ b/src/content/docs/workers/local-development/local-dev-tunnels.mdx
@@ -84,14 +84,17 @@ export default defineConfig({
 
 ## Security considerations
 
-Anyone with the tunnel URL can reach your dev server, so review what your app exposes before enabling a tunnel.
+The [local development security considerations](/workers/local-development/#security-considerations) apply with or without a tunnel. A tunnel increases exposure by making your dev server remotely reachable. It does not add security isolation around the local `workerd` process.
+
+Unless the tunnel is protected by access controls, anyone with its URL can reach your dev server. Review what your app exposes before starting a tunnel.
 
 - Pay special attention to ungated preview or admin endpoints.
+- Do not expose endpoints that accept and execute code supplied by users.
 - Review any [remote bindings](/workers/local-development/#remote-bindings) connected to real resources.
 - Review any code that proxies requests to private or internal services.
-- If you are using the Cloudflare Vite plugin with `vite dev`, HMR and module serving may expose source files, file paths, or project structure over the tunnel. If you only need to share a built preview, prefer `vite preview` for public sharing.
+- If you are using the Cloudflare Vite plugin with `vite dev`, HMR and module serving may expose source files, file paths, or project structure over the tunnel. If you only need to share a built preview, prefer `vite preview` for public sharing. This reduces source exposure but does not add runtime isolation.
 - Local dev-related routes, such as `/cdn-cgi/*`, remain restricted and are not exposed over the tunnel.
-- If you need a stable hostname or stricter access control, use a named tunnel protected by Cloudflare Access.
+- If you need a stable hostname or stricter access control, use a named tunnel protected by Cloudflare Access. Access restricts who can reach the server but does not harden the local runtime.
 
 ## Related docs
 

--- a/src/content/docs/workers/reference/security-model.mdx
+++ b/src/content/docs/workers/reference/security-model.mdx
@@ -9,6 +9,12 @@ products:
 
 import { WorkersArchitectureDiagram } from "~/components"
 
+:::note[Hosted Workers security model]
+
+This page describes Workers deployed on Cloudflare. Local `workerd` processes do not include every defense-in-depth protection described here. For local execution guidance, refer to [Local development security considerations](/workers/local-development/#security-considerations).
+
+:::
+
 This article includes an overview of Cloudflare security architecture, and then addresses two frequently asked about issues: V8 bugs and Spectre.
 
 Since the very start of the Workers project, security has been a high priority — there was a concern early on that when hosting a large number of tenants on shared infrastructure, side channels of various kinds would pose a threat. The Cloudflare Workers runtime is carefully designed to defend against side channel attacks.

--- a/src/content/docs/workers/runtime-apis/bindings/worker-loader.mdx
+++ b/src/content/docs/workers/runtime-apis/bindings/worker-loader.mdx
@@ -7,13 +7,15 @@ products:
   - workers
 ---
 
-import { Type, MetaInfo, WranglerConfig } from "~/components";
+import { MetaInfo, Render, Type, WranglerConfig } from "~/components";
 
 :::note[Dynamic Worker Loading is in closed beta]
 
 The Worker Loader API is available in local development with Wrangler and workerd. But to run dynamic Workers on Cloudflare, you must [sign up for the closed beta](https://forms.gle/MoeDxE9wNiqdf8ri9).
 
 :::
+
+<Render file="local-development-security" product="workers" />
 
 A Worker Loader binding allows you to load additional Workers containing arbitrary code at runtime.
 
@@ -26,7 +28,7 @@ Worker Loaders also enable **sandboxing** of code, meaning that you can strictly
 - You can arrange to intercept or simply block all network requests made by the Worker within.
 - You can supply the sandboxed Worker with custom bindings to represent specific resources which it should be allowed to access.
 
-With proper sandboxing configured, you can safely run code you do not trust in a dynamic isolate.
+When deployed to Cloudflare, properly configured Dynamic Workers can run code you do not trust in a dynamic isolate.
 
 ## Code Mode
 

--- a/src/content/docs/workers/testing/index.mdx
+++ b/src/content/docs/workers/testing/index.mdx
@@ -8,7 +8,11 @@ products:
   - workers
 ---
 
+import { Render } from "~/components";
+
 The Workers platform provides complementary tools for testing different parts of your application. For most projects, use the [Workers Vitest integration](/workers/testing/vitest-integration/) for unit tests and the [`createTestHarness()`](/workers/testing/test-harness/) API for integration tests.
+
+<Render file="local-development-security" product="workers" />
 
 ## Unit tests
 

--- a/src/content/docs/workers/testing/miniflare/index.mdx
+++ b/src/content/docs/workers/testing/miniflare/index.mdx
@@ -11,15 +11,17 @@ products:
   - workers
 ---
 
-import { DirectoryListing, LinkButton } from "~/components";
+import { DirectoryListing, LinkButton, Render } from "~/components";
 
-:::caution
-This documentation describes the Miniflare API, which is only relevant for advanced use cases. Instead, most users should use [Wrangler](/workers/wrangler) to build, run & deploy their Workers locally
+:::note[Use Wrangler for most projects]
+This documentation describes the Miniflare API, which is only relevant for advanced use cases. Most users should use [Wrangler](/workers/wrangler/) to build, run, and deploy their Workers.
 :::
 
 **Miniflare** is a simulator for developing and testing
-[**Cloudflare Workers**](https://workers.cloudflare.com/). It's written in
-TypeScript, and runs your code in a sandbox implementing Workers' runtime APIs.
+[**Cloudflare Workers**](https://workers.cloudflare.com/). It is written in
+TypeScript and uses a local `workerd` process to implement Workers runtime APIs.
+
+<Render file="local-development-security" product="workers" />
 
 - 🎉 **Fun:** develop Workers easily with detailed logging, file watching and
   pretty error pages supporting source maps.

--- a/src/content/docs/workers/vite-plugin/index.mdx
+++ b/src/content/docs/workers/vite-plugin/index.mdx
@@ -8,8 +8,12 @@ products:
   - workers
 ---
 
+import { Render } from "~/components";
+
 The Cloudflare Vite plugin enables a full-featured integration between [Vite](https://vite.dev/) and the [Workers runtime](/workers/runtime-apis/).
-Your Worker code runs inside [workerd](https://github.com/cloudflare/workerd), matching the production behavior as closely as possible and providing confidence as you develop and deploy your applications.
+Your Worker code runs inside a local [`workerd`](https://github.com/cloudflare/workerd) process, which closely matches the runtime APIs and behavior of deployed Workers.
+
+<Render file="local-development-security" product="workers" />
 
 ## Features
 

--- a/src/content/docs/workers/wrangler/commands/workers.mdx
+++ b/src/content/docs/workers/wrangler/commands/workers.mdx
@@ -50,6 +50,8 @@ Start a local server for developing your Worker.
 wrangler dev [<SCRIPT>] [OPTIONS]
 ```
 
+By default, `wrangler dev` executes your Worker in a local `workerd` process, which is not a hardened sandbox. Only run code you trust. For more information, refer to [Local development security considerations](/workers/local-development/#security-considerations).
+
 :::note
 
 None of the options for this command are required. Many of these options can be set in your Wrangler file. Refer to the [Wrangler configuration](/workers/wrangler/configuration) documentation for more information.
@@ -122,7 +124,7 @@ None of the options for this command are required. Many of these options can be 
 - `--persist-to` <Type text="string" /> <MetaInfo text="optional" />
   - Specify directory to use for local persistence.
 - `--remote` <Type text="boolean" /> <MetaInfo text="(default: false) optional" />
-  - Develop against remote resources and data stored on Cloudflare's network.
+  - Execute your Worker in a preview environment on Cloudflare. All bindings connect to remote resources.
 - `--tunnel` <Type text="boolean" /> <MetaInfo text="(default: false) optional" />
   - Expose your local dev server over a Cloudflare Tunnel. For more information, refer to [Share a local dev server](/workers/local-development/local-dev-tunnels/).
 - `--tunnel-name` <Type text="string" /> <MetaInfo text="optional" />

--- a/src/content/partials/workers/local-development-security.mdx
+++ b/src/content/partials/workers/local-development-security.mdx
@@ -1,0 +1,13 @@
+---
+{}
+---
+
+:::caution[Local development is not a hardened sandbox]
+
+Miniflare starts a local [`workerd`](https://github.com/cloudflare/workerd#warning-workerd-is-not-a-hardened-sandbox) process. This applies to default local execution with `wrangler dev`, `vite dev`, `vite preview`, direct Miniflare use, and Miniflare-based testing tools. Setting `remote: true` on a binding changes which resource your code accesses, but your Worker code still executes locally. By contrast, legacy `wrangler dev --remote` executes your Worker code on Cloudflare.
+
+`workerd` attempts to restrict Worker code to configured resources. However, it does not provide suitable defense-in-depth protection against implementation bugs. The hosted Workers platform applies [additional layers of defense in depth](/workers/reference/security-model/).
+
+Only run code you trust during local development. To run untrusted or potentially malicious code locally, place the entire development process inside an appropriate secure sandbox, such as a virtual machine.
+
+:::


### PR DESCRIPTION
### Summary

Clarifies that Miniflare-powered local execution in Wrangler, Vite, and testing does not include the hosted Workers platform's additional defense-in-depth protections. It also distinguishes remote bindings from `wrangler dev --remote` and explains that tunnels increase exposure without adding runtime isolation.

This aligns the documentation with [`workerd`'s hardened sandbox warning](https://github.com/cloudflare/workerd#warning-workerd-is-not-a-hardened-sandbox).

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
