### PR TITLE
[Containers] Document per-container observability in Wrangler

### DIFF
--- a/src/content/changelog/containers/2026-09-08-per-container-observability.mdx
+++ b/src/content/changelog/containers/2026-09-08-per-container-observability.mdx
@@ -1,0 +1,39 @@
+---
+title: Configure observability per container application
+description: Set observability for individual container applications in Wrangler.
+products:
+  - containers
+date: 2026-09-08
+---
+
+import { WranglerConfig } from "~/components";
+
+You can now configure observability for each container application when you deploy [Containers](/containers/) with [Wrangler](/workers/wrangler/). This lets you change logging for one container without changing the rest of your Worker.
+
+If you omit `containers[].observability`, Wrangler uses the top-level `observability` setting for that container. If you set it, the container setting overrides the top-level setting.
+
+Use `target_instance_percentage` or `target_instance_count` to apply an observability change to a subset of running instances.
+
+<WranglerConfig>
+
+```jsonc
+{
+	"observability": {
+		"enabled": false,
+	},
+	"containers": [
+		{
+			"class_name": "MyContainer",
+			"image": "./Dockerfile",
+			"observability": {
+				"enabled": true,
+				"target_instance_percentage": 25,
+			},
+		},
+	],
+}
+```
+
+</WranglerConfig>
+
+For more information about Workers Logs, refer to [Workers Logs](/workers/observability/logs/workers-logs/).

--- a/src/content/docs/containers/faq.mdx
+++ b/src/content/docs/containers/faq.mdx
@@ -12,12 +12,14 @@ import { Render, WranglerConfig } from "~/components";
 
 ## How do Container logs work?
 
-To get logs in the Dashboard, including live tailing of logs, toggle `observability` to true
-in your Worker's wrangler config:
+To get logs in the Dashboard, including live tailing of logs, turn on observability in
+your Wrangler config.
+
+You can turn it on at the Worker level, which applies to containers by default:
 
 <WranglerConfig>
 
-```json
+```jsonc
 {
 	"observability": {
 		"enabled": true
@@ -26,6 +28,29 @@ in your Worker's wrangler config:
 ```
 
 </WranglerConfig>
+
+You can also configure observability per container:
+
+<WranglerConfig>
+
+```jsonc
+{
+	"containers": [
+		{
+			"class_name": "MyContainer",
+			"image": "./Dockerfile",
+			"observability": {
+				"enabled": true
+			}
+		}
+	]
+}
+```
+
+</WranglerConfig>
+
+If a container sets `observability` in its container entry, it overrides the top-level
+`observability` setting for that container.
 
 Logs are subject to the same [limits as Worker logs](/workers/observability/logs/workers-logs/#limits), which means that they are
 retained for 3 days on Free plans and 7 days on Paid plans.

--- a/src/content/docs/containers/platform/pricing.mdx
+++ b/src/content/docs/containers/platform/pricing.mdx
@@ -53,4 +53,4 @@ When you use Containers, incoming requests to your containers are handled by you
 
 Containers are integrated with the [Workers Logs](/workers/observability/logs/workers-logs/) platform, and billed at the same rate. Refer to [Workers Logs pricing](/workers/observability/logs/workers-logs/#pricing) for details.
 
-When you [enable observability for your Worker](/workers/observability/logs/workers-logs/#enable-workers-logs) with a binding to a container, logs from your container will show in both the Containers and Observability sections of the Cloudflare dashboard.
+When you [turn on observability for your Worker](/workers/observability/logs/workers-logs/#enable-workers-logs), or configure `observability` on a specific container, logs from that container will show in both the Containers and Observability sections of the Cloudflare dashboard.

--- a/src/content/docs/workers/wrangler/configuration.mdx
+++ b/src/content/docs/workers/wrangler/configuration.mdx
@@ -400,8 +400,10 @@ Example:
 
 The [Observability](/workers/observability/logs/workers-logs) setting allows you to automatically ingest, store, filter, and analyze logging data emitted from Cloudflare Workers directly from your Cloudflare Worker's dashboard.
 
-- `enabled` <Type text="boolean" /> <MetaInfo text="required" />
-  - When set to `true` on a Worker, logs for the Worker are persisted. Defaults to `true` for all new Workers.
+- `enabled` <Type text="boolean" /> <MetaInfo text="optional" />
+  - Shorthand for `logs.enabled`. When set to `true` on a Worker, logs for the Worker are persisted. Defaults to `true` for all new Workers.
+- `logs.enabled` <Type text="boolean" /> <MetaInfo text="optional" />
+  - Whether logs for the Worker are persisted.
 - `head_sampling_rate` <Type text="number" /> <MetaInfo text="optional" />
   - A number between 0 and 1, where 0 indicates zero out of one hundred requests are logged, and 1 indicates every request is logged. If `head_sampling_rate` is unspecified, it is configured to a default value of 1 (100%). Read more about [head-based sampling](/workers/observability/logs/workers-logs/#head-based-sampling).
 
@@ -1305,6 +1307,29 @@ The following options are available:
 - `constraints.jurisdiction` <Type text="string" /> <MetaInfo text="optional" />
   - Restrict containers to compliance boundaries. Valid values: `"eu"`, `"fedramp"`.
 
+- `observability` <Type text="object" /> <MetaInfo text="optional" />
+  - Configures observability for this container application when deploying with `wrangler deploy`.
+  - If omitted, Wrangler uses the top-level [`observability`](#observability) setting as a fallback for that container.
+  - If set, it overrides the top-level `observability` setting for that container.
+
+- `observability.enabled` <Type text="boolean" /> <MetaInfo text="optional" />
+  - Shorthand for `observability.logs.enabled`.
+
+- `observability.logs.enabled` <Type text="boolean" /> <MetaInfo text="optional" />
+  - Whether logs for this container are persisted to Cloudflare's observability platform.
+
+- `observability.target_instance_percentage` <Type text="number" /> <MetaInfo text="optional" />
+  - Apply application-level observability changes to this percentage of running instances.
+  - Must be an integer from `1` to `99`.
+  - Cannot be used with `observability.target_instance_count`.
+  - Requires observability to be enabled for the container.
+
+- `observability.target_instance_count` <Type text="number" /> <MetaInfo text="optional" />
+  - Apply application-level observability changes to this many running instances.
+  - Must be a positive integer.
+  - Cannot be used with `observability.target_instance_percentage`.
+  - Requires observability to be enabled for the container.
+
 <WranglerConfig>
 
 ```jsonc
@@ -1315,6 +1340,10 @@ The following options are available:
 			"image": "./Dockerfile",
 			"max_instances": 10,
 			"instance_type": "basic", // Optional, defaults to "lite"
+			"observability": {
+				"enabled": true,
+				"target_instance_percentage": 25,
+			},
 			"image_vars": {
 				"FOO": "BAR",
 			},


### PR DESCRIPTION
### Summary

Document `containers[].observability` for Wrangler Containers.

Add the new container-level observability fields to the Wrangler configuration reference, including root `observability` fallback, per-container override behavior, and the targeting fields.

Also update the Containers FAQ and pricing docs to clarify that logs can be enabled either at the Worker level or per container.

### Documentation checklist

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).