### PR TITLE
[Cloudflare One] Clarify Access mTLS plan availability

### DIFF
--- a/src/content/docs/cloudflare-one/access-controls/service-credentials/mutual-tls-authentication.mdx
+++ b/src/content/docs/cloudflare-one/access-controls/service-credentials/mutual-tls-authentication.mdx
@@ -12,6 +12,12 @@ sidebar:
 
 import { AvailableNotifications, Render, Example } from "~/components";
 
+:::note[Availability]
+Access mTLS is available with Zero Trust contract plans. It is not included in Free, Pro, Business, or pay-as-you-go Zero Trust plans. Customers on these plans can use [service tokens](/cloudflare-one/access-controls/service-credentials/service-tokens/) to authenticate automated systems.
+
+This page covers Access mTLS for Service Auth policies. [Zone-level mTLS](/api-shield/security/mtls/) is a separate feature with different plan availability.
+:::
+
 [Mutual TLS (mTLS) authentication](https://www.cloudflare.com/learning/access-management/what-is-mutual-tls/) requires both the client and the server to present certificates during the TLS handshake. In the Cloudflare Access implementation, the CA you upload is used to verify the client certificate (server certificate verification is handled by standard TLS). Access mTLS serves two purposes:
 
 - **Authenticate devices that do not use an identity provider** — Automated systems and IoT devices can prove their identity by presenting a client certificate instead of logging in through an IdP.

--- a/src/content/docs/cloudflare-one/access-controls/service-credentials/mutual-tls-authentication.mdx
+++ b/src/content/docs/cloudflare-one/access-controls/service-credentials/mutual-tls-authentication.mdx
@@ -13,7 +13,7 @@ sidebar:
 import { AvailableNotifications, Render, Example } from "~/components";
 
 :::note[Availability]
-Access mTLS is available with Zero Trust contract plans. It is not included in Free, Pro, Business, or pay-as-you-go Zero Trust plans. Customers on these plans can use [service tokens](/cloudflare-one/access-controls/service-credentials/service-tokens/) to authenticate automated systems.
+Access mTLS is available with Enterprise and pay-as-you-go Zero Trust plans. It is not included in the Free plan. Free customers can use [service tokens](/cloudflare-one/access-controls/service-credentials/service-tokens/) to authenticate automated systems.
 
 This page covers Access mTLS for Service Auth policies. [Zone-level mTLS](/api-shield/security/mtls/) is a separate feature with different plan availability.
 :::


### PR DESCRIPTION
## Summary

- document that Access mTLS requires a Zero Trust contract plan
- direct non-contract customers to service tokens for automated authentication
- distinguish Access Service Auth mTLS from zone-level mTLS, which has different plan availability

## Validation

- git diff --check
- verified both internal link targets exist
- full Astro validation was not run because the installed Node.js 22 runtime does not meet the repository's Node.js 24 requirement