### PR TITLE
[Cloudflare One] Add SSH client routing troubleshooting

### DIFF
--- a/src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/use-cases/ssh/ssh-infrastructure-access.mdx
+++ b/src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/use-cases/ssh/ssh-infrastructure-access.mdx
@@ -219,9 +219,10 @@ SSH sessions have a maximum expected duration of 10 hours. For more information,
 Failure to connect to your SSH endpoint could be the result of multiple variables. Use the following steps to investigate and resolve the source of your connection failure.
 
 1. [Verify that your Access policies](#1-review-access-policies) allow the user to access the target.
-2. [Check Cloudflare Tunnel](#2-check-target-machine-connection) health.
-3. [Confirm user existence](#3-confirm-user-existence-on-the-target-server) on the server.
-4. [Check your `sshd_config` file](#4-debug-sshd_config-file-misconfiguration) for misconfiguration.
+2. [Check the user's device profile](#2-check-client-routing) routes the target through the Cloudflare One Client.
+3. [Check Cloudflare Tunnel](#3-check-target-connection) health.
+4. [Confirm user existence](#4-confirm-user-existence-on-the-server) on the server.
+5. [Check your `sshd_config` file](#5-debug-sshd_config-file-misconfiguration) for misconfiguration.
 
 ### 1. Review Access policies
 
@@ -243,7 +244,7 @@ As an end user, run [`warp-cli target list`](/cloudflare-one/access-controls/app
 
 <Render file="tunnel/warp-cli-target-list" product="cloudflare-one" />
 
-- If the target appears in the list, confirm that the username you are attempting to connect with is shown in the output. If the username is not shown, an administrator must find the Access policy associated with the target and add that username to the Access policy. An administrator should have created an Access policy in [substep 9 of step 5: Add an infrastructure application](/cloudflare-one/networks/connectors/cloudflare-tunnel/use-cases/ssh/ssh-infrastructure-access/#5-add-an-infrastructure-application). If the username is shown, that means the Access policy should be granting access and you should ensure that the tunnel is healthy in [step 2](/cloudflare-one/networks/connectors/cloudflare-tunnel/use-cases/ssh/ssh-infrastructure-access/#2-check-target-machine-connection).
+- If the target appears in the list, confirm that the username you are attempting to connect with is shown in the output. If the username is not shown, an administrator must find the Access policy associated with the target and add that username to the Access policy. An administrator should have created an Access policy in [substep 9 of step 5: Add an infrastructure application](/cloudflare-one/networks/connectors/cloudflare-tunnel/use-cases/ssh/ssh-infrastructure-access/#5-add-an-infrastructure-application). If the username is shown, that means the Access policy should be granting access. Continue to [check client routing](#2-check-client-routing).
 
 - If the target does not appear in the list, an administrator must audit the Access policies for the target in Cloudflare One for potential misconfiguration that may be blocking connection.
 
@@ -265,7 +266,7 @@ You will need Cloudflare dashboard access and log view [permissions](/cloudflare
 
 4. Review the **Decision**. If the **Decision** is `Access denied`, select the application and copy the name under App.
 
-   If the decision is `Access granted`, Access policies are not interfering with your connection attempts and your connection issue is due to the Cloudflare Tunnel ([step 2](/cloudflare-one/networks/connectors/cloudflare-tunnel/use-cases/ssh/ssh-infrastructure-access/#2-check-target-machine-connection)), the SSH server ([step 3](/cloudflare-one/networks/connectors/cloudflare-tunnel/use-cases/ssh/ssh-infrastructure-access/#3-confirm-user-existence-on-the-target-server)), or the `sshd_config` file ([step 4](/cloudflare-one/networks/connectors/cloudflare-tunnel/use-cases/ssh/ssh-infrastructure-access/#4-debug-sshd_config-file-misconfiguration)).
+   If the decision is `Access granted`, continue to [check client routing](#2-check-client-routing).
 
 5. Go to **Access controls** > **Applications**.
 
@@ -277,9 +278,24 @@ You will need Cloudflare dashboard access and log view [permissions](/cloudflare
 
 By adding an Access [policy](/cloudflare-one/access-controls/policies/) to allow the user, the connection issue should be resolved. After saving your policy changes, attempt to connect to the server.
 
-If you are still having connection issues after auditing your Access policies, review tunnel health in the following step.
+If you are still having connection issues after auditing your Access policies, check the client routing configuration in the following step.
 
-### 2. Check target connection
+### 2. Check client routing
+
+The target's IP address must route through the Cloudflare One Client. A device can receive a different Split Tunnel configuration than expected if it matches another device profile.
+
+To check the active profile and its Split Tunnel configuration:
+
+1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Team & Resources** > **Devices**.
+2. Find the user's device and note its **Last active device profile**.
+3. Go to **Team & Resources** > **Devices** > **Device profiles** > **General profiles**.
+4. Edit the active profile and open **Split Tunnels**.
+5. Confirm that the target's IP address or CIDR routes through the Cloudflare One Client. Refer to [Split Tunnels](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/route-traffic/split-tunnels/#change-split-tunnels-mode) for configuration instructions.
+6. If the profile uses an `identity.email` selector, confirm that its email matches the identity allowed by the infrastructure application policy.
+
+If the connection attempt does not appear in Access authentication logs, correct the client routing configuration before reviewing the tunnel or SSH server.
+
+### 3. Check target connection
 
 If the end user cannot connect to the target, the tunnel you set up in [step 1: Connect the server to Cloudflare](#1-connect-the-server-to-cloudflare) may be down or inactive.
 
@@ -303,13 +319,13 @@ For detailed steps on troubleshooting, refer to the [Troubleshooting Tunnel docu
 
 After you have verified that there are no issues with your tunnel's health, confirm the user's existence on the server in the following step.
 
-### 3. Confirm user existence on the server
+### 4. Confirm user existence on the server
 
 To verify the existence of a user on a UNIX server, run the `id <USERNAME>` command on the server to verify that the username exists. If the username does not exist, you must add the user to the server.
 
 If the user exists on the server, debug your `sshd_config` file in the following step.
 
-### 4. Debug `sshd_config` file misconfiguration
+### 5. Debug `sshd_config` file misconfiguration
 
 One reason a user is failing to connect to your SSH endpoint might be the result of a misconfigured `sshd_config` file. Follow the steps below to audit your `sshd_config` file for misconfigurations.
 
@@ -514,9 +530,9 @@ These troubleshooting steps could result in you being locked out of your SSH ser
 
    <Render file="ssh/restart-server" product="cloudflare-one" />
 
-By completing all four troubleshooting steps, you should have resolved any connection issues caused by misconfiguration of the SSH server. If issues persist, [recheck `sshd` logs](/cloudflare-one/networks/connectors/cloudflare-tunnel/use-cases/ssh/ssh-infrastructure-access/#review-your-sshd-logs). The example [`sshd_config` shared above](/cloudflare-one/networks/connectors/cloudflare-tunnel/use-cases/ssh/ssh-infrastructure-access/#review-your-sshd_config-file-for-misconfigurations) enables debug logging and may expose more specific issues.
+After completing these troubleshooting steps, retry the connection. If issues persist, [recheck `sshd` logs](/cloudflare-one/networks/connectors/cloudflare-tunnel/use-cases/ssh/ssh-infrastructure-access/#review-your-sshd-logs). The example [`sshd_config` shared above](/cloudflare-one/networks/connectors/cloudflare-tunnel/use-cases/ssh/ssh-infrastructure-access/#review-your-sshd_config-file-for-misconfigurations) enables debug logging and may expose more specific issues.
 
-### 5. Get help
+### 6. Get help
 
 For the fastest possible troubleshooting, ensure your support ticket includes comprehensive details. The more context you provide, the faster your issue can be identified and resolved.
 


### PR DESCRIPTION
## Summary

- add a client routing check to the Access for Infrastructure SSH troubleshooting flow
- show administrators how to verify the active device profile and Split Tunnel configuration
- call out identity selector mismatches and missing Access authentication logs as routing signals

## Validation

- git diff --check
- verified the Split Tunnels link target exists
- full Astro validation was not run because the installed Node.js 22 runtime does not meet the repository's Node.js 24 requirement