### PR TITLE
Document 90-day Cloudflare One Client session limit

### DIFF
--- a/src/content/docs/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/client-sessions.mdx
+++ b/src/content/docs/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/client-sessions.mdx
@@ -37,7 +37,7 @@ To configure device client sessions for Access applications:
 
 1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Access controls** > **Access settings**.
 2. Enable **Authenticate with Cloudflare One Client**.
-3. Under **Session duration**, choose a session timeout value. This timeout will apply to all Access applications that have **Authenticate with Cloudflare One Client** enabled.
+3. Under **Session duration**, choose a session timeout value of up to 90 days. This timeout will apply to all Access applications that have **Authenticate with Cloudflare One Client** enabled.
 
 :::note
 


### PR DESCRIPTION
## Summary

Document the new 90-day maximum for the organization-level session duration used by Authenticate with Cloudflare One Client.

## Testing

- checked the value against AUTH-8922
- git diff --check origin/production...HEAD