### PR TITLE
Document approval for infrastructure applications

### DIFF
--- a/src/content/docs/cloudflare-one/access-controls/applications/non-http/infrastructure-apps.mdx
+++ b/src/content/docs/cloudflare-one/access-controls/applications/non-http/infrastructure-apps.mdx
@@ -52,6 +52,10 @@ Access for Infrastructure currently supports [SSH](/cloudflare-one/networks/conn
 
 <Render file="access/add-infrastructure-app" product="cloudflare-one" />
 
+### Require purpose justification or approval
+
+Infrastructure application policies support [purpose justification](/cloudflare-one/access-controls/policies/require-purpose-justification/) and [temporary authentication](/cloudflare-one/access-controls/policies/temporary-auth/). Enable these settings on an Allow policy to ask users why they need access or require approval before they connect to an infrastructure target.
+
 ## 3. (Recommended) Modify order of precedence in Gateway
 
 <Render

--- a/src/content/docs/cloudflare-one/access-controls/policies/temporary-auth.mdx
+++ b/src/content/docs/cloudflare-one/access-controls/policies/temporary-auth.mdx
@@ -10,12 +10,12 @@ tags:
 - Authentication
 ---
 
-With Cloudflare Access, you can require that users obtain approval before they can access a specific self-hosted application or SaaS application. The administrator will receive an email notification to approve or deny the request. Unlike a typical Allow policy, the user will have to request access at the end of each session. This allows you to define the users who should have persistent access and those who must request temporary access.
+With Cloudflare Access, you can require that users obtain approval before they can access a specific self-hosted, SaaS, or infrastructure application. The administrator will receive an email notification to approve or deny the request. Unlike a typical Allow policy, the user will have to request access at the end of each session. This allows you to define the users who should have persistent access and those who must request temporary access.
 
 ## Set up temporary authentication
 
 1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Access controls** > **Applications**.
-2. Choose a **Self-hosted** or **SaaS** application and select **Configure**.
+2. Choose a **Self-hosted**, **SaaS**, or **Infrastructure** application and select **Configure**.
 3. Choose an **Allow** policy and select **Configure**.
 4. Under **Additional settings**, turn on [**Purpose justification**](/cloudflare-one/access-controls/policies/require-purpose-justification/).
 5. Turn on **Temporary authentication**.


### PR DESCRIPTION
## Summary

- add infrastructure applications to the temporary authentication guide
- link purpose justification and approval setup from the infrastructure application workflow
- clarify that both controls are configured on an Allow policy

## Testing

- verified both internal policy links
- git diff --check origin/production...HEAD