### PR TITLE
[Cloudflare One] Document private MCP servers

### DIFF
--- a/src/content/changelog/cloudflare-one/2026-09-08-private-mcp-servers.mdx
+++ b/src/content/changelog/cloudflare-one/2026-09-08-private-mcp-servers.mdx
@@ -1,0 +1,14 @@
+---
+title: Private MCP server support for MCP server portals
+description: MCP server portals can now connect to MCP servers available only on your private network.
+date: 2026-09-08
+products:
+  - cloudflare-one
+  - access
+---
+
+[MCP server portals](/cloudflare-one/access-controls/ai-controls/mcp-portals/) can now connect to MCP servers available only on your private network. The portal uses Cloudflare Gateway to reach private hostnames and IP addresses without exposing the MCP server to the public Internet.
+
+Connect the server network to Cloudflare with Cloudflare Tunnel or another Cloudflare One connector. Configure a private hostname or CIDR route, then turn on **Route traffic through Cloudflare Gateway** when you add the server. OAuth authorization and token endpoints must remain reachable on the public Internet.
+
+For setup instructions, refer to [Connect a private MCP server](/cloudflare-one/access-controls/ai-controls/mcp-portals/#connect-a-private-mcp-server).

--- a/src/content/changelog/cloudflare-one/2026-09-08-private-mcp-servers.mdx
+++ b/src/content/changelog/cloudflare-one/2026-09-08-private-mcp-servers.mdx
@@ -9,6 +9,6 @@ products:
 
 [MCP server portals](/cloudflare-one/access-controls/ai-controls/mcp-portals/) can now connect to MCP servers available only on your private network. The portal uses Cloudflare Gateway to reach private hostnames and IP addresses without exposing the MCP server to the public Internet.
 
-Connect the server network to Cloudflare with Cloudflare Tunnel or another Cloudflare One connector. Configure a private hostname or CIDR route, then turn on **Route traffic through Cloudflare Gateway** when you add the server. OAuth authorization and token endpoints must remain reachable on the public Internet.
+Connect the server network to Cloudflare with Cloudflare Tunnel or another Cloudflare One connector. Configure a private hostname or CIDR route, then turn on **Route traffic through Cloudflare Gateway** when you add the server. OAuth authorization server endpoints, such as the authorization and token endpoints, must be accessible on the public Internet. If Cloudflare automatically registers the OAuth client through Dynamic Client Registration (DCR), the registration endpoint must also be accessible on the public Internet.
 
 For setup instructions, refer to [Connect a private MCP server](/cloudflare-one/access-controls/ai-controls/mcp-portals/#connect-a-private-mcp-server).

--- a/src/content/docs/cloudflare-one/access-controls/ai-controls/mcp-portals.mdx
+++ b/src/content/docs/cloudflare-one/access-controls/ai-controls/mcp-portals.mdx
@@ -124,7 +124,7 @@ Cloudflare Access will validate the server connection and retrieve a list of pro
 
 ### Connect a private MCP server
 
-MCP server portals can connect to an MCP server available only on your private network. The MCP server URL and its [OAuth protected resource metadata](https://www.rfc-editor.org/rfc/rfc9728.html) can use a private hostname. OAuth authorization and token endpoints must be reachable on the public Internet.
+MCP server portals can connect to an MCP server available only on your private network. The MCP server URL and its [OAuth protected resource metadata](https://www.rfc-editor.org/rfc/rfc9728.html) can use a private hostname. OAuth authorization server endpoints, such as the authorization and token endpoints, must be accessible on the public Internet. If Cloudflare automatically registers the OAuth client through Dynamic Client Registration (DCR), the registration endpoint must also be accessible on the public Internet.
 
 Before you add the server, connect its network to Cloudflare. Use [Cloudflare Tunnel](/cloudflare-one/networks/connectors/cloudflare-tunnel/) or another [Cloudflare One connector](/cloudflare-one/networks/connectors/). Configure a [private hostname route](/cloudflare-one/networks/connectors/cloudflare-tunnel/private-net/cloudflared/connect-private-hostname/) or [CIDR route](/cloudflare-one/networks/connectors/cloudflare-tunnel/private-net/cloudflared/connect-cidr/) for the server. If the hostname uses an internal DNS server, also configure a [resolver policy](/cloudflare-one/traffic-policies/resolver-policies/).
 
@@ -135,7 +135,8 @@ To add the private MCP server:
 1. Follow the steps in [Add an MCP server](#add-an-mcp-server), and enter the private URL in **HTTP URL**.
 2. Turn on **Route traffic through Cloudflare Gateway**. Private server registration and capability synchronization require this setting.
 3. Select **Save and connect server**.
-4. Complete the upstream OAuth flow, if required. The authorization server must be publicly reachable even when the MCP server is private.
+4. Complete the upstream OAuth flow, if required.
+5. Wait for the server status to change to **Ready**. You can then add the server to a portal.
 
 </Steps>
 

--- a/src/content/docs/cloudflare-one/access-controls/ai-controls/mcp-portals.mdx
+++ b/src/content/docs/cloudflare-one/access-controls/ai-controls/mcp-portals.mdx
@@ -122,6 +122,24 @@ To add an MCP server:
 
 Cloudflare Access will validate the server connection and retrieve a list of prompts and tools. Once the server is successfully connected, the [server status](#server-status) will change to **Ready**. You can now add the MCP server to an [MCP server portal](#create-a-portal).
 
+### Connect a private MCP server
+
+MCP server portals can connect to an MCP server available only on your private network. The MCP server URL and its [OAuth protected resource metadata](https://www.rfc-editor.org/rfc/rfc9728.html) can use a private hostname. OAuth authorization and token endpoints must be reachable on the public Internet.
+
+Before you add the server, connect its network to Cloudflare. Use [Cloudflare Tunnel](/cloudflare-one/networks/connectors/cloudflare-tunnel/) or another [Cloudflare One connector](/cloudflare-one/networks/connectors/). Configure a [private hostname route](/cloudflare-one/networks/connectors/cloudflare-tunnel/private-net/cloudflared/connect-private-hostname/) or [CIDR route](/cloudflare-one/networks/connectors/cloudflare-tunnel/private-net/cloudflared/connect-cidr/) for the server. If the hostname uses an internal DNS server, also configure a [resolver policy](/cloudflare-one/traffic-policies/resolver-policies/).
+
+To add the private MCP server:
+
+<Steps>
+
+1. Follow the steps in [Add an MCP server](#add-an-mcp-server), and enter the private URL in **HTTP URL**.
+2. Turn on **Route traffic through Cloudflare Gateway**. Private server registration and capability synchronization require this setting.
+3. Select **Save and connect server**.
+4. Complete the upstream OAuth flow, if required. The authorization server must be publicly reachable even when the MCP server is private.
+
+</Steps>
+
+
 ### Configure manual OAuth credentials
 
 Use manual OAuth credentials when the upstream provider does not support [OAuth Dynamic Client Registration](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#dynamic-client-registration). This flow uses an OAuth application that you register with the upstream provider.


### PR DESCRIPTION
### Summary

Documents how to connect MCP server portals to servers on private networks. Covers private network routing, Gateway requirements, OAuth endpoint availability, and TLS certificate troubleshooting.

Adds a Cloudflare One changelog entry announcing private MCP server support.

### Documentation checklist

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
