### PR TITLE
[Workers] Correct pnpm build cache path

### DIFF
--- a/src/content/docs/workers/ci-cd/builds/build-caching.mdx
+++ b/src/content/docs/workers/ci-cd/builds/build-caching.mdx
@@ -22,12 +22,14 @@ The following shows which package managers and frameworks are supported for depe
 
 Workers build cache will cache the global cache directories of the following package managers:
 
-| Package Manager               | Directories cached         |
-| ----------------------------- | -------------------------- |
-| [npm](https://www.npmjs.com/) | `.npm`                     |
-| [yarn](https://yarnpkg.com/)  | `.cache/yarn`              |
-| [pnpm](https://pnpm.io/)      | `.local/share/pnpm/store`  |
-| [bun](https://bun.sh/)        | `.bun/install/cache`       |
+| Package Manager               | Directories cached                        |
+| ----------------------------- | ----------------------------------------- |
+| [npm](https://www.npmjs.com/) | `.npm`                                    |
+| [yarn](https://yarnpkg.com/)  | `.cache/yarn`                             |
+| [pnpm](https://pnpm.io/)      | `.pnpm-store`, `.local/share/pnpm/store` |
+| [bun](https://bun.sh/)        | `.bun/install/cache`                      |
+
+If you configure pnpm to use a different store directory, Workers Builds does not cache it.
 
 ### Frameworks
 

--- a/src/content/docs/workers/ci-cd/builds/build-caching.mdx
+++ b/src/content/docs/workers/ci-cd/builds/build-caching.mdx
@@ -22,12 +22,12 @@ The following shows which package managers and frameworks are supported for depe
 
 Workers build cache will cache the global cache directories of the following package managers:
 
-| Package Manager               | Directories cached   |
-| ----------------------------- | -------------------- |
-| [npm](https://www.npmjs.com/) | `.npm`               |
-| [yarn](https://yarnpkg.com/)  | `.cache/yarn`        |
-| [pnpm](https://pnpm.io/)      | `.pnpm-store`        |
-| [bun](https://bun.sh/)        | `.bun/install/cache` |
+| Package Manager               | Directories cached         |
+| ----------------------------- | -------------------------- |
+| [npm](https://www.npmjs.com/) | `.npm`                     |
+| [yarn](https://yarnpkg.com/)  | `.cache/yarn`              |
+| [pnpm](https://pnpm.io/)      | `.local/share/pnpm/store`  |
+| [bun](https://bun.sh/)        | `.bun/install/cache`       |
 
 ### Frameworks
 


### PR DESCRIPTION
### Summary

Documents both pnpm directories cached by Workers Builds: `.pnpm-store` and pnpm's Linux default, `.local/share/pnpm/store`. Clarifies that configured store locations outside these directories are not cached.

Reference: https://pnpm.io/settings/store#storedir

### Screenshots (optional)

Not applicable.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).

### Validation

- `pnpm run build` completed successfully.
- `pnpm run check` is blocked by existing unresolved `ExportedHandler` and `Fetcher` types in generated `skills/turnstile-spin` files.