### PR TITLE
[Realtime] RT-690: remove port 53

### DIFF
--- a/src/content/docs/realtime/turn/custom-domains.mdx
+++ b/src/content/docs/realtime/turn/custom-domains.mdx
@@ -12,8 +12,8 @@ Cloudflare Realtime TURN service supports using custom domains for UDP, and TCP 
 
 | Protocol      | Custom domains | Primary port | Alternate port |
 | ------------- | -------------- | ------------ | -------------- |
-| STUN over UDP | ✅              | 3478/udp     | 53/udp         |
-| TURN over UDP | ✅              | 3478/udp     | 53 udp         |
+| STUN over UDP | ✅              | 3478/udp     |                |
+| TURN over UDP | ✅              | 3478/udp     |                |
 | TURN over TCP | ✅              | 3478/tcp     | 80/tcp         |
 | TURN over TLS | No             | 5349/tcp     | 443/tcp        |
 

--- a/src/content/docs/realtime/turn/generate-credentials.mdx
+++ b/src/content/docs/realtime/turn/generate-credentials.mdx
@@ -39,14 +39,12 @@ The **201 (Created)** response below can then be passed on to your front-end app
   "iceServers": [
 		{
 			"urls": [
-				"stun:stun.cloudflare.com:3478",
-				"stun:stun.cloudflare.com:53"
+				"stun:stun.cloudflare.com:3478"
 			]
 		},
 		{
 			"urls": [
 				"turn:turn.cloudflare.com:3478?transport=udp",
-				"turn:turn.cloudflare.com:53?transport=udp",
 				"turn:turn.cloudflare.com:3478?transport=tcp",
 				"turn:turn.cloudflare.com:80?transport=tcp",
 				"turns:turn.cloudflare.com:5349?transport=tcp",
@@ -70,14 +68,12 @@ const myPeerConnection = new RTCPeerConnection({
   iceServers: [
     {
       urls: [
-				"stun:stun.cloudflare.com:3478",
-				"stun:stun.cloudflare.com:53"
+				"stun:stun.cloudflare.com:3478"
 			]
 		},
 		{
 			urls: [
 				"turn:turn.cloudflare.com:3478?transport=udp",
-				"turn:turn.cloudflare.com:53?transport=udp",
 				"turn:turn.cloudflare.com:3478?transport=tcp",
 				"turn:turn.cloudflare.com:80?transport=tcp",
 				"turns:turn.cloudflare.com:5349?transport=tcp",

--- a/src/content/docs/realtime/turn/index.mdx
+++ b/src/content/docs/realtime/turn/index.mdx
@@ -16,14 +16,10 @@ Using Cloudflare Realtime TURN service is available free of charge when used tog
 
 | Protocol      | Primary address     | Primary port | Alternate port |
 | ------------- | ------------------- | ------------ | -------------- |
-| STUN over UDP | stun.cloudflare.com | 3478/udp     | 53/udp         |
-| TURN over UDP | turn.cloudflare.com | 3478/udp     | 53/udp         |
+| STUN over UDP | stun.cloudflare.com | 3478/udp     |                |
+| TURN over UDP | turn.cloudflare.com | 3478/udp     |                |
 | TURN over TCP | turn.cloudflare.com | 3478/tcp     | 80/tcp         |
 | TURN over TLS | turn.cloudflare.com | 5349/tcp     | 443/tcp        |
-
-:::note[Note]
-Use of alternate port 53 only by itself is not recommended. Port 53 is blocked by many ISPs, and by popular browsers such as [Chrome](https://chromium.googlesource.com/chromium/src.git/+/refs/heads/master/net/base/port_util.cc#44) and [Firefox](https://github.com/mozilla/gecko-dev/blob/master/netwerk/base/nsIOService.cpp#L132). It is useful only in certain specific scenarios.
-:::
 
 ## Regions
 


### PR DESCRIPTION
### Summary

Our alternate port 53 is breaking Google Chrome, so this PR removes all mention of port 53.
We are going to update the documentation once the new alternate port is usable by customers.

### Screenshots (optional)

### Documentation checklist

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [X] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
