### PR TITLE
Add bandwidth limits and overages section to MT bandwidth measurement

### DIFF
--- a/src/content/docs/magic-transit/reference/bandwidth-measurement.mdx
+++ b/src/content/docs/magic-transit/reference/bandwidth-measurement.mdx
@@ -12,6 +12,12 @@ Cloudflare measures Magic Transit usage based on the 95th percentile of clean ba
 
 To measure 95th percentile bandwidth, Cloudflare records clean bandwidth leaving our global network at five-minute intervals, sorts these measurements in descending order, and discards the top 5% of measurements it recorded. The highest remaining value constitutes the 95th percentile bandwidth measurement for that time period.
 
+## Bandwidth limits and overages
+
+Magic Transit contracts may include a subscribed bandwidth amount, but this is a billing metric, not a technical limitation. Cloudflare does not restrict, throttle, or drop traffic when your usage exceeds your contracted bandwidth. Instead, overage charges apply according to your contract terms.
+
+If you want to discuss adjusting your subscribed bandwidth or contract terms, contact your Cloudflare account team.
+
 ## Cloudflare-originated traffic
 
 Clean bandwidth includes all egress traffic Cloudflare routes to your network through Magic Transit tunnels and interconnects. This includes traffic that originated from the public Internet, as well as response traffic from services within the Cloudflare network (such as Cloudflare CDN) destined to your servers.


### PR DESCRIPTION
### Summary

Adds a "Bandwidth limits and overages" section to the [Magic Transit bandwidth measurement](/magic-transit/reference/bandwidth-measurement/) reference page. Clarifies that any subscribed bandwidth amount in a Magic Transit contract is a **billing metric, not a technical limitation** — Cloudflare does not restrict, throttle, or drop traffic when usage exceeds the contracted amount.

### Screenshots (optional)

N/A — text-only change.

### Documentation checklist

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [x] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [x] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).