### PR TITLE
Document automatic cleanup for inactive service tokens

### DIFF
--- a/src/content/changelog/access/2026-09-14-service-token-inactivity-cleanup.mdx
+++ b/src/content/changelog/access/2026-09-14-service-token-inactivity-cleanup.mdx
@@ -1,0 +1,13 @@
+---
+title: Automatically manage inactive Access service tokens
+description: Disable or delete service tokens that have not authenticated for a specified period.
+date: 2026-09-14
+products:
+  - access
+---
+
+Cloudflare Access administrators can now automatically disable or delete inactive service tokens. Administrators can set an inactivity period from 30 to 365 days and choose what Access does when a token reaches that limit.
+
+Access checks service tokens daily. A token must be older than the configured period and must not have successfully authenticated during that period. Service tokens referenced by an Access policy rule are excluded from automatic cleanup.
+
+For configuration instructions, refer to [Manage inactive service tokens](/cloudflare-one/access-controls/service-credentials/service-tokens/#manage-inactive-service-tokens).

--- a/src/content/docs/cloudflare-one/access-controls/service-credentials/service-tokens.mdx
+++ b/src/content/docs/cloudflare-one/access-controls/service-credentials/service-tokens.mdx
@@ -23,7 +23,7 @@ import {
 
 You can provide automated systems with service tokens to authenticate against your Cloudflare One policies. Cloudflare Access will generate service tokens that consist of a Client ID and a Client Secret. Automated systems or applications can then use these values to reach an application protected by Access.
 
-This section covers how to create, rotate, renew, disable, and revoke a service token.
+This section covers how to create, rotate, renew, disable, and revoke a service token. You can also configure Access to manage inactive service tokens automatically.
 
 ## Create a service token
 
@@ -169,6 +169,25 @@ resource "cloudflare_zero_trust_access_service_token" "example_service_token" {
 ```
 
 </TabItem> </Tabs>
+
+## Manage inactive service tokens
+
+You can configure Access to automatically disable or delete service tokens that are no longer in use. The setting applies to all service tokens in your Zero Trust account.
+
+To configure automatic service token cleanup:
+
+1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Access controls** > **Service credentials** > **Service Tokens**.
+2. Open the service token inactivity settings.
+3. Choose how long a service token can remain inactive. You can select a period from 30 to 365 days.
+4. Choose whether Access should disable or delete inactive tokens.
+5. Save your changes.
+
+Access checks service tokens once a day. A token is eligible for automatic cleanup when both of these conditions are true:
+
+- The token is older than the configured inactivity period.
+- The token has not successfully authenticated with an Access application during that period.
+
+Access does not automatically disable or delete a service token that is referenced by an Access policy rule. Disabled tokens remain in your account and can be turned on again. Deleted tokens cannot be recovered.
 
 ## Turn a service token on or off
 


### PR DESCRIPTION
## Summary

- Document automatic disable or deletion of inactive Access service tokens.
- Add dashboard and API configuration instructions for the organization-level control.
- Explain the 30–365 day threshold, eligibility conditions, and gradual background cleanup.
- Add the September 14 Access changelog entry.

## Tests

- pnpm run check
- pnpm exec prettier --check src/content/docs/cloudflare-one/access-controls/service-credentials/service-tokens.mdx src/content/changelog/access/2026-09-14-service-token-inactivity-cleanup.mdx
- git diff --check