### PR TITLE
[Analytics, Log Explorer] Clarify Custom Dashboards workflow

### DIFF
--- a/src/content/changelog/log-explorer/2026-04-22-custom-dashboards-ga.mdx
+++ b/src/content/changelog/log-explorer/2026-04-22-custom-dashboards-ga.mdx
@@ -13,7 +13,7 @@ This update significantly expands the data available for visualization. Build ch
 
 ## Log Explorer integration
 
-For Log Explorer customers, you can now turn raw log queries directly into dashboard charts. When you identify a specific pattern or spike while investigating logs, save that query as a visualization to monitor those signals in real-time without leaving the dashboard.
+Log Explorer customers can select Log Explorer datasets to create charts from raw, unsampled log data.
 
 ## Key benefits
 

--- a/src/content/docs/analytics/custom-dashboards.mdx
+++ b/src/content/docs/analytics/custom-dashboards.mdx
@@ -22,7 +22,7 @@ Analyze application performance by visualizing origin response times, cache hit 
 
 Track business metrics by monitoring API usage, bandwidth consumption, and traffic patterns. Build executive dashboards that surface the KPIs that matter to your organization.
 
-Investigate incidents so that when something goes wrong, you can create focused dashboards that combine the specific signals relevant to your investigation. Log Explorer customers can turn log queries directly into dashboard charts for ongoing monitoring.
+Investigate incidents so that when something goes wrong, you can create focused dashboards that combine the specific signals relevant to your investigation. Log Explorer customers can select Log Explorer datasets to create charts from raw, unsampled log data.
 
 ## Availability
 

--- a/src/content/docs/log-explorer/faq.mdx
+++ b/src/content/docs/log-explorer/faq.mdx
@@ -67,7 +67,13 @@ Log Explorer uses Cloudflare Logpush and R2 behind the scenes to stream and stor
 
 ## Are Custom Dashboards based on R2 Log Explorer data, or on GraphQL?
 
-Custom Dashboards currently run on [GraphQL](/analytics/graphql-api/sampling/). Over time, this will evolve to include deeper integration between the two features, such as building charts directly from logs.
+Custom Dashboards use [GraphQL](/analytics/graphql-api/sampling/) for standard analytics datasets.
+
+Customers with Log Explorer can also select Log Explorer datasets to create charts from raw, unsampled log data. This is supported on all plans and account types, with no additional enablement required.
+
+You cannot turn a saved or active Log Explorer query directly into a Custom Dashboard chart.
+
+For more information, refer to [Custom dashboards](/analytics/custom-dashboards/).
 
 ## How can I track my Log Explorer usage?
 

--- a/src/content/docs/log-explorer/index.mdx
+++ b/src/content/docs/log-explorer/index.mdx
@@ -46,7 +46,7 @@ Authentication with the API can be done via an API token or API key with an emai
 Explore your Cloudflare logs directly within the Cloudflare dashboard or [API](/log-explorer/api/).
 </Feature>
 
-<Feature header="Custom dashboards" href="/log-explorer/custom-dashboards/">
+<Feature header="Custom dashboards" href="/analytics/custom-dashboards/">
 Design customized views for tracking application security, performance, and usage metrics.
 </Feature>
 


### PR DESCRIPTION
### Summary

Corrects conflicting Custom Dashboards documentation: Log Explorer customers can create charts by selecting datasets, but cannot convert saved or active Log Explorer queries directly into charts.

- Clarifies raw, unsampled Log Explorer data support and availability across plans and account types, with no extra enablement for Log Explorer customers.
- Aligns the FAQ, Custom Dashboards overview, and existing GA changelog with the supported workflow.
- Links the Log Explorer overview directly to the canonical Custom Dashboards page.

Validated with repository formatting, type checks, a full build, and rendered-page and link checks.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
