### PR TITLE
[Workers AI] Make rate limits rule-based instead of a maintained list

### DIFF
--- a/src/content/docs/ai-gateway/features/unified-billing.mdx
+++ b/src/content/docs/ai-gateway/features/unified-billing.mdx
@@ -74,7 +74,7 @@ The `cf-aig-byok-alias` header selects a non-default alias only on [direct provi
 
 Unified Billing works in two ways: through the AI binding or through the HTTP API. Both deduct credits from your account automatically without requiring provider API keys.
 
-To use credits for Workers AI, [configure the gateway's Workers AI billing setting](/ai-gateway/configuration/manage-gateway/#configure-workers-ai-billing) as **Unified billing**. Workers AI requests routed through that gateway deduct from your prepaid credit balance in real time. In the AI binding, include the gateway ID in the third argument to `env.AI.run()`. For REST API requests, include the `cf-aig-gateway-id` header. Prepaid credits provide access to Workers AI models that otherwise require the Workers Paid plan and provide [higher rate limits for frontier models](/workers-ai/platform/limits/#frontier-models).
+To use credits for Workers AI, [configure the gateway's Workers AI billing setting](/ai-gateway/configuration/manage-gateway/#configure-workers-ai-billing) as **Unified billing**. Workers AI requests routed through that gateway deduct from your prepaid credit balance in real time. In the AI binding, include the gateway ID in the third argument to `env.AI.run()`. For REST API requests, include the `cf-aig-gateway-id` header. Prepaid credits provide access to Workers AI models that otherwise require the Workers Paid plan and provide [higher rate limits for frontier models](/workers-ai/platform/limits/#paid-models).
 
 ### AI binding
 

--- a/src/content/docs/ai-gateway/usage/providers/workersai.mdx
+++ b/src/content/docs/ai-gateway/usage/providers/workersai.mdx
@@ -12,7 +12,7 @@ products:
 
 import { TypeScriptExample } from "~/components";
 
-Use AI Gateway as a unified control layer for [Workers AI](/workers-ai/) requests, with analytics, logging, caching, security, and prepaid billing. To use prepaid [AI Gateway credits](/ai-gateway/features/unified-billing/), set the gateway's [Workers AI billing setting](/ai-gateway/configuration/manage-gateway/#configure-workers-ai-billing) to **Unified billing**. Requests to frontier models billed with prepaid credits receive [higher rate limits](/workers-ai/platform/limits/#frontier-models).
+Use AI Gateway as a unified control layer for [Workers AI](/workers-ai/) requests, with analytics, logging, caching, security, and prepaid billing. To use prepaid [AI Gateway credits](/ai-gateway/features/unified-billing/), set the gateway's [Workers AI billing setting](/ai-gateway/configuration/manage-gateway/#configure-workers-ai-billing) to **Unified billing**. Requests to frontier models billed with prepaid credits receive [higher rate limits](/workers-ai/platform/limits/#paid-models).
 
 ## REST API
 

--- a/src/content/docs/ai-gateway/usage/rest-api.mdx
+++ b/src/content/docs/ai-gateway/usage/rest-api.mdx
@@ -121,7 +121,7 @@ curl -X POST "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_
   }'
 ```
 
-To use prepaid AI Gateway credits for Workers AI, use the model-in-path endpoint shown above, set the gateway's [Workers AI billing setting](/ai-gateway/configuration/manage-gateway/#configure-workers-ai-billing) to **Unified billing**, and include its ID in the `cf-aig-gateway-id` header. Requests to frontier models billed with prepaid credits receive [higher rate limits](/workers-ai/platform/limits/#frontier-models).
+To use prepaid AI Gateway credits for Workers AI, use the model-in-path endpoint shown above, set the gateway's [Workers AI billing setting](/ai-gateway/configuration/manage-gateway/#configure-workers-ai-billing) to **Unified billing**, and include its ID in the `cf-aig-gateway-id` header. Requests to frontier models billed with prepaid credits receive [higher rate limits](/workers-ai/platform/limits/#paid-models).
 
 ### Background requests and webhooks
 

--- a/src/content/docs/ai-gateway/usage/worker-binding-methods.mdx
+++ b/src/content/docs/ai-gateway/usage/worker-binding-methods.mdx
@@ -64,7 +64,7 @@ const resp = await env.AI.run(
 
 </TypeScriptExample>
 
-To use prepaid [AI Gateway credits](/ai-gateway/features/unified-billing/), set the gateway's [Workers AI billing setting](/ai-gateway/configuration/manage-gateway/#configure-workers-ai-billing) to **Unified billing** and specify that gateway in the binding request. Prepaid credits provide access to Workers AI models that otherwise require the Workers Paid plan and provide [higher rate limits for frontier models](/workers-ai/platform/limits/#frontier-models).
+To use prepaid [AI Gateway credits](/ai-gateway/features/unified-billing/), set the gateway's [Workers AI billing setting](/ai-gateway/configuration/manage-gateway/#configure-workers-ai-billing) to **Unified billing** and specify that gateway in the binding request. Prepaid credits provide access to Workers AI models that otherwise require the Workers Paid plan and provide [higher rate limits for frontier models](/workers-ai/platform/limits/#paid-models).
 
 **Third-party model:**
 

--- a/src/content/docs/workers-ai/platform/limits.mdx
+++ b/src/content/docs/workers-ai/platform/limits.mdx
@@ -51,23 +51,16 @@ Rate limits are default per task type, with some per-model limits defined as fol
 
 ### [Text Generation](/workers-ai/models/)
 
-- 300 requests per minute
-- [@hf/thebloke/mistral-7b-instruct-v0.1-awq](/workers-ai/models/mistral-7b-instruct-v0.1-awq/) is 400 requests per minute
-- [@cf/microsoft/phi-2](/workers-ai/models/phi-2/) is 720 requests per minute
-- [@cf/qwen/qwen1.5-0.5b-chat](/workers-ai/models/qwen1.5-0.5b-chat/) is 1500 requests per minute
-- [@cf/qwen/qwen1.5-1.8b-chat](/workers-ai/models/qwen1.5-1.8b-chat/) is 720 requests per minute
-- [@cf/qwen/qwen1.5-14b-chat-awq](/workers-ai/models/qwen1.5-14b-chat-awq/) is 150 requests per minute
-- [@cf/tinyllama/tinyllama-1.1b-chat-v1.0](/workers-ai/models/tinyllama-1.1b-chat-v1.0/) is 720 requests per minute
+- 300 requests per minute, unless the model requires the Workers Paid plan
 
-#### Frontier models
+#### Paid models
 
-The following limits apply per account, per model:
+The following limits apply per account, per model to any model that requires the [Workers Paid plan](/workers/platform/pricing/#workers) — each model page states whether it does. These models are the only models that do not receive the default limit:
 
-| Model                                                               | Standard Workers AI billing | Prepaid AI Gateway credits |
-| ------------------------------------------------------------------- | --------------------------- | -------------------------- |
-| [@cf/moonshotai/kimi-k2.6](/workers-ai/models/kimi-k2.6/)           | 20 requests per minute      | 50 requests per minute     |
-| [@cf/moonshotai/kimi-k2.7-code](/workers-ai/models/kimi-k2.7-code/) | 20 requests per minute      | 50 requests per minute     |
-| [@cf/zai-org/glm-5.2](/workers-ai/models/glm-5.2/)                  | 20 requests per minute      | 50 requests per minute     |
+| Billing                     | Rate limit             |
+| --------------------------- | ---------------------- |
+| Standard Workers AI billing | 20 requests per minute |
+| Prepaid AI Gateway credits  | 50 requests per minute |
 
 To receive the elevated limit, load [prepaid AI Gateway credits](/ai-gateway/features/unified-billing/) and set the gateway's [Workers AI billing setting](/ai-gateway/configuration/manage-gateway/#configure-workers-ai-billing) to **Unified billing**. These limits are designed for typical agentic and coding workloads, where requests to frontier models can take longer to complete.
 

--- a/src/content/docs/workers-ai/platform/pricing.mdx
+++ b/src/content/docs/workers-ai/platform/pricing.mdx
@@ -33,7 +33,7 @@ Some models require a paid billing method. This applies to `@cf/moonshotai/kimi-
 
 You can use prepaid [AI Gateway credits](/ai-gateway/features/unified-billing/) to pay for Workers AI inference. Set the gateway's [Workers AI billing setting](/ai-gateway/configuration/manage-gateway/#configure-workers-ai-billing) to **Unified billing**, then specify that gateway in the [AI binding](/ai-gateway/usage/worker-binding-methods/) or REST API request.
 
-Requests to frontier models that use prepaid credits receive [higher rate limits](/workers-ai/platform/limits/#frontier-models).
+Requests to frontier models that use prepaid credits receive [higher rate limits](/workers-ai/platform/limits/#paid-models).
 
 ## What are Neurons?
 


### PR DESCRIPTION
Updates the Workers AI limits page to use a rule instead of a hardcoded model list, reflecting the unified billing announcement. Removes the Frontier models section title and its inbound anchor links.