### PR TITLE
[SSL] Update Client TLS Key Exchange Group field name and description in changelog

### DIFF
--- a/src/content/changelog/logs/2026-08-20-pqc-key-exchange-visibility.mdx
+++ b/src/content/changelog/logs/2026-08-20-pqc-key-exchange-visibility.mdx
@@ -9,7 +9,7 @@ date: 2026-08-20
 
 [Cloudflare Radar](https://radar.cloudflare.com/post-quantum) publishes global statistics on post-quantum key agreement adoption across all Cloudflare traffic, but until now customers had no way to see the same measurement scoped to their own zones. This is now possible because the [`http_requests`](/logs/logpush/logpush-job/datasets/zone/http_requests/) Logpush dataset — also queryable in [Log Explorer](/log-explorer/) — includes a new `ClientTLSKeyExchangeGroup` field.
 
-The field reports the TLS key exchange group negotiated on the client-to-Cloudflare connection, by group name. Post-quantum connections appear as `X25519MLKEM768`, and classical connections appear as `X25519`, `P-256`, or another named group. A value of `UNK` means the group could not be determined, and `NONE` means TLS was not used.
+The field reports the TLS key exchange group negotiated on the client-to-Cloudflare connection, by group name. Post-quantum connections appear as `X25519MLKEM768`, and classical connections appear as `X25519`, `P-256`, or another named group. A value of `UNK` means the group could not be determined, and `NONE` means either RSA key exchange was used OR TLS was not used.
 
 With this field, you can build per-zone reports showing what percentage of your inbound HTTPS traffic is protected by post-quantum key agreement, break the number down by hostname, path, user agent, or country, and push the data into your SIEM via any [Logpush destination](/logs/logpush/logpush-job/enable-destinations/).
 

--- a/src/content/docs/logs/logpush/logpush-job/datasets/zone/http_requests.md
+++ b/src/content/docs/logs/logpush/logpush-job/datasets/zone/http_requests.md
@@ -259,7 +259,7 @@ The smoothed average of TCP round-trip time (SRTT). For the initial request on a
 
 Type: `string`
 
-TLS key exchange group between the client and Cloudflare (for example, 'X25519MLKEM768'). 'UNK' means it could not be determined. 'NONE' means TLS was not used.
+TLS key exchange group between the client and Cloudflare (for example, 'X25519MLKEM768'). 'UNK' means it could not be determined. 'NONE' means either RSA key exchange was used OR TLS was not used.
 
 ## ClientXRequestedWith
 


### PR DESCRIPTION
### Summary

This MR updates the Client TLS Key Exchange Group naming and description to match the version in Cloudflare dash. It removes 'TLS 1.3' prefix to clarify the field includes all traffic.

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
