### PR TITLE
docs: remove stale Always Online guidance

### DIFF
--- a/src/content/docs/support/troubleshooting/http-status-codes/cloudflare-1xxx-errors/error-1001.mdx
+++ b/src/content/docs/support/troubleshooting/http-status-codes/cloudflare-1xxx-errors/error-1001.mdx
@@ -17,12 +17,9 @@ This error indicates a DNS resolution failure preventing access to the requested
 - An external domain that is not on using Cloudflare has a CNAME record to a domain active on Cloudflare
 - The target of the DNS CNAME record does not resolve.
 - A CNAME record in your Cloudflare DNS app requires resolution via a DNS provider that is currently offline.
-- [Always Online](/cache/how-to/always-online/) is enabled for a [Custom Hostname (Cloudflare for SaaS)](/cloudflare-for-platforms/cloudflare-for-saas/) domain.
 
 ### Resolution
 
 A non-Cloudflare domain cannot CNAME to a Cloudflare domain, unless the non-Cloudflare domain is added to a Cloudflare account.
 
 Attempting to directly access DNS records used for [Cloudflare CNAME setups](/dns/zone-setups/partial-setup) also causes error 1001. For example, `www.example.com.cdn.cloudflare.net`.
-
-Disable [Always Online](/cache/how-to/always-online/#enable-always-online), if using [Custom Hostname (Cloudflare for SaaS)](/cloudflare-for-platforms/cloudflare-for-saas/) domain.


### PR DESCRIPTION
Removes the Custom Hostname-specific Always Online statements from Error 1001 guidance.

The behavior was validated with a Custom Hostname: Always Online served a stale cached response during an origin outage, and an uncached request returned 522 rather than Error 1001.