### PR TITLE
[AI Search] Document extensionless R2 object support

### DIFF
--- a/src/content/changelog/ai-search/2026-09-11-extensionless-r2-content-type.mdx
+++ b/src/content/changelog/ai-search/2026-09-11-extensionless-r2-content-type.mdx
@@ -1,0 +1,12 @@
+---
+title: AI Search supports extensionless R2 objects with Content-Type metadata
+description: Index extensionless R2 objects by setting supported Content-Type metadata.
+products:
+  - ai-search
+date: 2026-09-11
+publish_future_dated_entry: true
+---
+
+AI Search can index R2 objects without filename extensions when they include supported `Content-Type` metadata. This supports object keys that do not include file extensions while preserving file-type validation during indexing.
+
+For supported file types and Content-Type requirements, refer to [R2 data sources](/ai-search/configuration/data-source/r2/).

--- a/src/content/docs/ai-search/configuration/data-source/r2.mdx
+++ b/src/content/docs/ai-search/configuration/data-source/r2.mdx
@@ -20,6 +20,12 @@ If you have never created an R2-backed instance before, we recommend using the d
 
 To get started, [configure an R2 bucket](/r2/get-started/) containing your data. Files that are unsupported or exceed the size limit will be skipped during indexing and logged as errors.
 
+## Set Content-Type metadata
+
+AI Search uses recognized filename extensions as its preferred, faster file-type detection path. For R2 objects without a filename extension, set explicit `Content-Type` metadata to a supported MIME type.
+
+Objects with a missing, unsupported, malformed, or `application/octet-stream` `Content-Type` are not supported. For supported file types and MIME types, refer to [Data source](/ai-search/configuration/data-source/#supported-file-types).
+
 ## Path filtering
 
 You can control which files get indexed by defining include and exclude rules for object paths. Use this to limit indexing to specific folders or to exclude files you do not want searchable.


### PR DESCRIPTION
### Summary

Documents how AI Search uses `Content-Type` metadata to index R2 objects without filename extensions. Adds a changelog entry and explains which `Content-Type` values are unsupported.

### Documentation checklist

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) - how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
