### PR TITLE
fix: show full AI model card text

### DIFF
--- a/src/components/models/ModelCard.astro
+++ b/src/components/models/ModelCard.astro
@@ -105,7 +105,7 @@ const authorLogo = authorData[model.author]?.logo;
 			}
 			<div class="flex min-w-0 flex-1 items-center gap-2">
 				<h3
-					class="text-foreground group-hover/card:text-primary line-clamp-2 text-sm leading-snug font-semibold break-words"
+					class="text-foreground group-hover/card:text-primary min-w-0 text-sm leading-snug font-semibold break-words"
 				>
 					{model.shortName}
 				</h3>
@@ -132,7 +132,7 @@ const authorLogo = authorData[model.author]?.logo;
 		</div>
 
 		<p
-			class="text-muted-foreground mb-4 line-clamp-2 min-h-10 flex-1 text-sm leading-relaxed"
+			class="text-muted-foreground mb-4 min-h-10 flex-1 text-sm leading-relaxed"
 		>
 			{model.description}
 		</p>

--- a/src/components/models/ModelCard.astro
+++ b/src/components/models/ModelCard.astro
@@ -103,7 +103,7 @@ const authorLogo = authorData[model.author]?.logo;
 					</span>
 				)
 			}
-			<div class="flex min-w-0 flex-1 items-center gap-2">
+			<div class="line-clamp-2 flex min-w-0 flex-1 items-center gap-2">
 				<h3
 					class="text-foreground group-hover/card:text-primary min-w-0 text-sm leading-snug font-semibold break-words"
 				>
@@ -132,7 +132,7 @@ const authorLogo = authorData[model.author]?.logo;
 		</div>
 
 		<p
-			class="text-muted-foreground mb-4 min-h-10 flex-1 text-sm leading-relaxed"
+			class="text-muted-foreground mb-4 line-clamp-2 h-full max-h-12 flex-1 text-sm leading-relaxed"
 		>
 			{model.description}
 		</p>

--- a/src/components/models/ModelCard.astro
+++ b/src/components/models/ModelCard.astro
@@ -132,7 +132,7 @@ const authorLogo = authorData[model.author]?.logo;
 		</div>
 
 		<p
-			class="text-muted-foreground mb-4 min-h-10 flex-1 text-sm leading-relaxed"
+			class="text-muted-foreground mb-4 min-h-10 flex-1 text-sm leading-relaxed break-words"
 		>
 			{model.description}
 		</p>

--- a/src/components/models/ModelCard.astro
+++ b/src/components/models/ModelCard.astro
@@ -103,7 +103,7 @@ const authorLogo = authorData[model.author]?.logo;
 					</span>
 				)
 			}
-			<div class="line-clamp-2 flex min-w-0 flex-1 items-center gap-2">
+			<div class="flex min-w-0 flex-1 items-center gap-2">
 				<h3
 					class="text-foreground group-hover/card:text-primary min-w-0 text-sm leading-snug font-semibold break-words"
 				>
@@ -132,7 +132,7 @@ const authorLogo = authorData[model.author]?.logo;
 		</div>
 
 		<p
-			class="text-muted-foreground mb-4 line-clamp-2 h-full max-h-12 flex-1 text-sm leading-relaxed"
+			class="text-muted-foreground mb-4 min-h-10 flex-1 text-sm leading-relaxed"
 		>
 			{model.description}
 		</p>

--- a/src/components/models/ModelCard.astro.test.ts
+++ b/src/components/models/ModelCard.astro.test.ts
@@ -29,7 +29,7 @@ const truncationClasses = (className: string | undefined): string[] =>
 	(className ?? "")
 		.split(/\s+/)
 		.filter((token) =>
-			/^(?:line-clamp-|truncate$|overflow-(?:hidden|clip)$|max-h-|text-ellipsis$|whitespace-nowrap$)/.test(
+			/^(?:line-clamp-|truncate$|overflow-(?:[xy]-)?(?:hidden|clip|ellipsis)$|max-h-|text-ellipsis$|whitespace-nowrap$)/.test(
 				token,
 			),
 		);

--- a/src/components/models/ModelCard.astro.test.ts
+++ b/src/components/models/ModelCard.astro.test.ts
@@ -42,9 +42,11 @@ describe("ModelCard", () => {
 		});
 		const root = parse(html);
 		const title = root.querySelector("h3");
+		const titleRow = title?.parentNode;
 		const description = root.querySelector("p");
 
 		expect(title?.textContent).toBe(model.shortName);
+		expect(truncationClasses(titleRow?.getAttribute("class"))).toEqual([]);
 		expect(truncationClasses(title?.getAttribute("class"))).toEqual([]);
 		expect(title?.getAttribute("class")).toContain("min-w-0");
 		expect(title?.getAttribute("class")).toContain("break-words");

--- a/src/components/models/ModelCard.astro.test.ts
+++ b/src/components/models/ModelCard.astro.test.ts
@@ -25,6 +25,9 @@ const model: ModelCardData = {
 	propertiesList: [],
 };
 
+const truncationClass =
+	/\b(?:line-clamp-\S+|truncate|overflow-hidden|max-h-\S+)\b/;
+
 describe("ModelCard", () => {
 	test("does not emit truncation classes for titles and descriptions", async () => {
 		const container = await AstroContainer.create();
@@ -36,10 +39,10 @@ describe("ModelCard", () => {
 		const description = root.querySelector("p");
 
 		expect(title?.textContent).toBe(model.shortName);
-		expect(title?.getAttribute("class")).not.toContain("line-clamp-2");
+		expect(title?.getAttribute("class")).not.toMatch(truncationClass);
 		expect(title?.getAttribute("class")).toContain("min-w-0");
 		expect(title?.getAttribute("class")).toContain("break-words");
 		expect(description?.textContent).toBe(model.description);
-		expect(description?.getAttribute("class")).not.toContain("line-clamp-2");
+		expect(description?.getAttribute("class")).not.toMatch(truncationClass);
 	});
 });

--- a/src/components/models/ModelCard.astro.test.ts
+++ b/src/components/models/ModelCard.astro.test.ts
@@ -29,7 +29,7 @@ const truncationClasses = (className: string | undefined): string[] =>
 	(className ?? "")
 		.split(/\s+/)
 		.filter((token) =>
-			/^(?:line-clamp-(?:[1-9]\d*|\[[^\]]+\])|truncate$|overflow-(?:[xy]-)?(?:hidden|clip|ellipsis)$|text-ellipsis$|whitespace-nowrap$)/.test(
+			/^(?:line-clamp-(?:[1-9]\d*|\[[^\]]+\])$|truncate$|overflow-(?:[xy]-)?(?:hidden|clip|ellipsis)$|text-ellipsis$|whitespace-nowrap$)/.test(
 				token,
 			),
 		);
@@ -52,5 +52,6 @@ describe("ModelCard", () => {
 		expect(title?.getAttribute("class")).toContain("break-words");
 		expect(description?.textContent).toBe(model.description);
 		expect(truncationClasses(description?.getAttribute("class"))).toEqual([]);
+		expect(description?.getAttribute("class")).toContain("break-words");
 	});
 });

--- a/src/components/models/ModelCard.astro.test.ts
+++ b/src/components/models/ModelCard.astro.test.ts
@@ -25,8 +25,14 @@ const model: ModelCardData = {
 	propertiesList: [],
 };
 
-const truncationClass =
-	/\b(?:line-clamp-\S+|truncate|overflow-hidden|max-h-\S+)\b/;
+const truncationClasses = (className: string | undefined): string[] =>
+	(className ?? "")
+		.split(/\s+/)
+		.filter((token) =>
+			/^(?:line-clamp-|truncate$|overflow-(?:hidden|clip)$|max-h-|text-ellipsis$|whitespace-nowrap$)/.test(
+				token,
+			),
+		);
 
 describe("ModelCard", () => {
 	test("does not emit truncation classes for titles and descriptions", async () => {
@@ -39,10 +45,10 @@ describe("ModelCard", () => {
 		const description = root.querySelector("p");
 
 		expect(title?.textContent).toBe(model.shortName);
-		expect(title?.getAttribute("class")).not.toMatch(truncationClass);
+		expect(truncationClasses(title?.getAttribute("class"))).toEqual([]);
 		expect(title?.getAttribute("class")).toContain("min-w-0");
 		expect(title?.getAttribute("class")).toContain("break-words");
 		expect(description?.textContent).toBe(model.description);
-		expect(description?.getAttribute("class")).not.toMatch(truncationClass);
+		expect(truncationClasses(description?.getAttribute("class"))).toEqual([]);
 	});
 });

--- a/src/components/models/ModelCard.astro.test.ts
+++ b/src/components/models/ModelCard.astro.test.ts
@@ -29,7 +29,7 @@ const truncationClasses = (className: string | undefined): string[] =>
 	(className ?? "")
 		.split(/\s+/)
 		.filter((token) =>
-			/^(?:line-clamp-|truncate$|overflow-(?:[xy]-)?(?:hidden|clip|ellipsis)$|max-h-|text-ellipsis$|whitespace-nowrap$)/.test(
+			/^(?:line-clamp-(?:[1-9]\d*|\[[^\]]+\])|truncate$|overflow-(?:[xy]-)?(?:hidden|clip|ellipsis)$|text-ellipsis$|whitespace-nowrap$)/.test(
 				token,
 			),
 		);

--- a/src/components/models/ModelCard.astro.test.ts
+++ b/src/components/models/ModelCard.astro.test.ts
@@ -1,0 +1,45 @@
+import { experimental_AstroContainer as AstroContainer } from "astro/container";
+import { parse } from "node-html-parser";
+import { describe, expect, test } from "vitest";
+
+import type { ModelCardData } from "~/util/models";
+import ModelCard from "./ModelCard.astro";
+
+const model: ModelCardData = {
+	id: "model-card-fixture",
+	name: "fixture-author/verylongmodelnamethatmustwrapwithouttruncation",
+	slug: "fixture-author/verylongmodelnamethatmustwrapwithouttruncation",
+	displayName: "Very Long Model",
+	shortName: "verylongmodelnamethatmustwrapwithouttruncation",
+	author: "fixture-author",
+	authorName: "Fixture Author",
+	hosting: "proxied",
+	dataSource: "catalog",
+	source: 2,
+	task: "Text Generation",
+	description:
+		"A deliberately long model description that exceeds two lines and must remain fully visible in the model card instead of being clipped by a presentation-only line clamp.",
+	capabilities: [],
+	beta: true,
+	properties: {},
+	propertiesList: [],
+};
+
+describe("ModelCard", () => {
+	test("does not emit truncation classes for titles and descriptions", async () => {
+		const container = await AstroContainer.create();
+		const html = await container.renderToString(ModelCard, {
+			props: { model, index: 0, cols: 3 },
+		});
+		const root = parse(html);
+		const title = root.querySelector("h3");
+		const description = root.querySelector("p");
+
+		expect(title?.textContent).toBe(model.shortName);
+		expect(title?.getAttribute("class")).not.toContain("line-clamp-2");
+		expect(title?.getAttribute("class")).toContain("min-w-0");
+		expect(title?.getAttribute("class")).toContain("break-words");
+		expect(description?.textContent).toBe(model.description);
+		expect(description?.getAttribute("class")).not.toContain("line-clamp-2");
+	});
+});

--- a/src/components/models/ModelCard.astro.test.ts
+++ b/src/components/models/ModelCard.astro.test.ts
@@ -43,7 +43,7 @@ describe("ModelCard", () => {
 		const root = parse(html);
 		const title = root.querySelector("h3");
 		const titleRow = title?.parentNode;
-		const description = root.querySelector("p");
+		const description = root.querySelector("a > p");
 
 		expect(title?.textContent).toBe(model.shortName);
 		expect(truncationClasses(titleRow?.getAttribute("class"))).toEqual([]);


### PR DESCRIPTION
## Defect
AI model cards on `/ai/models` visually clipped titles and descriptions and showed ellipses after the second line.

## Fix
- Remove forced `line-clamp-2` from model-card titles and descriptions.
- Add `min-w-0` so long titles wrap beside the logo and Beta badge.
- Preserve author truncation and shared card/grid primitives.
- Add focused Astro regression coverage for the unclamped title and description contract.

## Validation
- Hosted Pre Build: passed Astro check, Worker TypeScript check, ESLint, Prettier, and 125 Node/Astro tests.
- Local rendered model-page smoke checks: no card `line-clamp-2`; author truncation retained.
- The local worker-suite run was blocked by Miniflare’s 25 MiB per-asset limit on a generated 52 MiB build asset. This local build-artifact limitation is unrelated to this change.