### PR TITLE
docs: fix typos across docs

### DIFF
--- a/src/content/docs/cloudflare-one/team-and-resources/devices/cloudflare-one-client/troubleshooting/common-issues.mdx
+++ b/src/content/docs/cloudflare-one/team-and-resources/devices/cloudflare-one-client/troubleshooting/common-issues.mdx
@@ -79,7 +79,7 @@ This usually indicates a missing dependency, such as .NET Framework `4.7.2` or l
 If WSL2 loses connectivity, check your [split tunnel configuration](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/route-traffic/split-tunnels/). The IP range used by WSL to communicate with the host may be accidentally included in the tunnel. Exclude the WSL network range to restore connectivity.
 
 ### SMTP port 25 blocked
-The client blocks outgoing traffic on port `25` to prevent spam and reputational harm to IP adresses used by customers. Use port `587` or `465` for encrypted email.
+The client blocks outgoing traffic on port `25` to prevent spam and reputational harm to IP addresses used by customers. Use port `587` or `465` for encrypted email.
 
 ### Admin override codes expired
 [Admin override codes](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/settings/#allow-admin-override-codes) are time-sensitive and adhere to fixed-hour blocks. A code generated at 9:30 AM with a 1-hour timeout will expire at 10:00 AM because its validity is counted within the 9:00 AM-10:00 AM window.

--- a/src/content/docs/dynamic-workers/api-reference.mdx
+++ b/src/content/docs/dynamic-workers/api-reference.mdx
@@ -129,7 +129,7 @@ Using this, you can provide custom bindings to the Worker.
 
 `env` is serialized and transferred into the dynamic Worker, where it is used directly as the value of `env` there. It may contain:
 
-- [Structured clonable types](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm).
+- [Structured cloneable types](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm).
 - [Service Bindings](/workers/runtime-apis/bindings/service-bindings), including [loopback bindings from `ctx.exports`](/workers/runtime-apis/context/#exports).
 
 The second point is the key to creating custom bindings: you can define a binding with any arbitrary API, by defining a [`WorkerEntrypoint` class](/workers/runtime-apis/bindings/service-bindings/rpc) implementing an RPC API, and then giving it to the dynamic Worker as a Service Binding.

--- a/src/content/docs/reference-architecture/how-to-use.mdx
+++ b/src/content/docs/reference-architecture/how-to-use.mdx
@@ -28,7 +28,7 @@ Below are the different types of architecture content and information is organiz
 
 ## Reference architecture diagrams
 
-A [reference architecture diagram](/reference-architecture/diagrams/) focusses on a specific solution or use case where Cloudflare can be used. One or more diagrams are the primary content with supporting introduction and summary. These can focus on sections from a reference architecture that are not fully developed. The goal of this type of document is:
+A [reference architecture diagram](/reference-architecture/diagrams/) focuses on a specific solution or use case where Cloudflare can be used. One or more diagrams are the primary content with supporting introduction and summary. These can focus on sections from a reference architecture that are not fully developed. The goal of this type of document is:
 
 - Visualize the components of a specific solution's architecture
 - Provide a quick answer to a specific question around a use case

--- a/src/content/docs/workers/examples/openai-sdk-streaming.mdx
+++ b/src/content/docs/workers/examples/openai-sdk-streaming.mdx
@@ -56,7 +56,7 @@ export default {
 					stream: true,
 				});
 
-				// loop over the data as it is streamed and write to the writeable
+				// loop over the data as it is streamed and write to the writable
 				for await (const part of stream) {
 					writer.write(
 						textEncoder.encode(part.choices[0]?.delta?.content || ""),

--- a/src/content/docs/workers/runtime-apis/bindings/worker-loader.mdx
+++ b/src/content/docs/workers/runtime-apis/bindings/worker-loader.mdx
@@ -211,7 +211,7 @@ Using this, you can provide custom bindings to the Worker.
 
 `env` is serialized and transferred into the dynamic Worker, where it is used directly as the value of `env` there. It may contain:
 
-- [Structured clonable types](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm).
+- [Structured cloneable types](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm).
 - [Service Bindings](/workers/runtime-apis/bindings/service-bindings), including [loopback bindings from `ctx.exports`](/workers/runtime-apis/context/#exports).
 
 The second point is the key to creating custom bindings: you can define a binding with any arbitrary API, by defining a [`WorkerEntrypoint` class](/workers/runtime-apis/bindings/service-bindings/rpc) implementing an RPC API, and then giving it to the dynamic Worker as a Service Binding.

--- a/src/content/docs/workers/runtime-apis/context.mdx
+++ b/src/content/docs/workers/runtime-apis/context.mdx
@@ -176,7 +176,7 @@ export default {
 
 Specifying props dynamically is permitted in this case because the caller is the same Worker, and thus can be presumed to be trusted to specify any props. The ability to customize props is particularly useful when the resulting binding is to be passed to another Worker over RPC or used in the `env` of a [dynamically-loaded worker](/workers/runtime-apis/bindings/worker-loader/).
 
-Note that `props` values specified in this way are allowed to contain any "persistently" serializable type. This includes all basic [structured clonable data types](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm). It also includes Service Bindings themselves: you can place a Service Binding into the `props` of another Service Binding.
+Note that `props` values specified in this way are allowed to contain any "persistently" serializable type. This includes all basic [structured cloneable data types](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm). It also includes Service Bindings themselves: you can place a Service Binding into the `props` of another Service Binding.
 
 ### TypeScript types for `ctx.exports` and `ctx.props`
 

--- a/src/content/docs/workers/runtime-apis/rpc/index.mdx
+++ b/src/content/docs/workers/runtime-apis/rpc/index.mdx
@@ -45,7 +45,7 @@ Note that RPC calls do not actually return `Promise`s, but they return a type th
 
 (We'll see why the type is not actually a Promise a bit later.)
 
-## Structured clonable types, and more
+## Structured cloneable types, and more
 
 Nearly all types that are [Structured Cloneable](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm#supported_types) can be used as a parameter or return value of an RPC method. This includes, most basic "value" types in JavaScript, including objects, arrays, strings and numbers.
 
@@ -55,7 +55,7 @@ The RPC system also supports a number of types that are not Structured Cloneable
 
 - Functions, which are replaced by stubs that call back to the sender.
 - Application-defined classes that extend `RpcTarget`, which are similarly replaced by stubs.
-- [ReadableStream](/workers/runtime-apis/streams/readablestream/) and [WriteableStream](/workers/runtime-apis/streams/writablestream/), with automatic streaming flow control.
+- [ReadableStream](/workers/runtime-apis/streams/readablestream/) and [WritableStream](/workers/runtime-apis/streams/writablestream/), with automatic streaming flow control.
 - [Request](/workers/runtime-apis/request/) and [Response](/workers/runtime-apis/response/), for conveniently representing HTTP messages.
 - RPC stubs themselves, even if the stub was received from a third Worker.
 
@@ -209,7 +209,7 @@ While it's possible to define a similar interface to the caller using an object 
 
 :::note
 
-Classes which do not inherit `RpcTarget` cannot be sent over RPC at all. This differs from Structured Clone, which defines application-defined classes as clonable. Why the difference? By default, the Structured Clone algorithm simply ignores an object's class entirely. So, the recipient receives a plain object, containing the original object's instance properties but entirely missing its original type. This behavior is rarely useful in practice, and could be confusing if the developer had intended the class to be treated as an `RpcTarget`. So, Workers RPC has chosen to disallow classes that are not `RpcTarget`s, to avoid any confusion.
+Classes which do not inherit `RpcTarget` cannot be sent over RPC at all. This differs from Structured Clone, which defines application-defined classes as cloneable. Why the difference? By default, the Structured Clone algorithm simply ignores an object's class entirely. So, the recipient receives a plain object, containing the original object's instance properties but entirely missing its original type. This behavior is rarely useful in practice, and could be confusing if the developer had intended the class to be treated as an `RpcTarget`. So, Workers RPC has chosen to disallow classes that are not `RpcTarget`s, to avoid any confusion.
 :::
 
 ### Promise pipelining
@@ -348,9 +348,9 @@ class Default(WorkerEntrypoint):
 
 If the initial RPC ends up throwing an exception, then any pipelined calls will also fail with the same exception
 
-## ReadableStream, WriteableStream, Request and Response
+## ReadableStream, WritableStream, Request and Response
 
-You can send and receive [`ReadableStream`](/workers/runtime-apis/streams/readablestream/), [`WriteableStream`](/workers/runtime-apis/streams/writablestream/), [`Request`](/workers/runtime-apis/request/), and [`Response`](/workers/runtime-apis/response/) using RPC methods. When doing so, bytes in the body are automatically streamed with appropriate flow control. This allows you to send messages over RPC which are larger than [the typical 32 MiB limit](#limitations).
+You can send and receive [`ReadableStream`](/workers/runtime-apis/streams/readablestream/), [`WritableStream`](/workers/runtime-apis/streams/writablestream/), [`Request`](/workers/runtime-apis/request/), and [`Response`](/workers/runtime-apis/response/) using RPC methods. When doing so, bytes in the body are automatically streamed with appropriate flow control. This allows you to send messages over RPC which are larger than [the typical 32 MiB limit](#limitations).
 
 Only [byte-oriented streams](https://developer.mozilla.org/en-US/docs/Web/API/Streams_API/Using_readable_byte_streams) (streams with an underlying byte source of `type: "bytes"`) are supported.
 

--- a/src/content/docs/workflows/build/rules-of-workflows.mdx
+++ b/src/content/docs/workflows/build/rules-of-workflows.mdx
@@ -383,7 +383,7 @@ const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
 export class MyWorkflow extends WorkflowEntrypoint {
 	async run(event: WorkflowEvent<Params>, step: WorkflowStep) {
-		// 🔴 Bad: The `Promise.race` is not surrounded by a `step.do`, which may cause undeterministic caching behavior.
+		// 🔴 Bad: The `Promise.race` is not surrounded by a `step.do`, which may cause non-deterministic caching behavior.
 		const race_return = await Promise.race([
 			step.do("Promise first race", async () => {
 				await sleep(1000);


### PR DESCRIPTION
### Summary

This PR fixes a bunch of typos.

I also opened a companion PR to add this as a CI check: #33377

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).

