### PR TITLE
chore: add a CI check for typos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,23 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  typos:
+    name: Typos
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 1
+
+      - name: Check for typos
+        uses: crate-ci/typos@d43b6c087ac471e2ea7b8af622ff15f05c0c365b # v1.50.1
+        with:
+          files: src/content/docs src/content/partials src/content/changelog
+          config: ./_typos.toml
+
   pre-build:
     name: Pre Build
     runs-on: ubuntu-latest

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,77 @@
+[files]
+extend-exclude = [
+	# Third-party OSS license notices: names and text we must not "fix".
+	"**/legal/3rdparty.*",
+	# Filenames have typos (terrform, stablization) but renaming them changes
+	# the published changelog URL. Needs a redirect, tracked separately.
+	"src/content/changelog/terraform/2025-08-29-terrform-v5.9-provider.mdx",
+	"src/content/changelog/workers/2025-03-22-smart-placement-stablization.mdx",
+]
+
+[default]
+extend-ignore-identifiers-re = [
+	# Base64 / JWT example tokens and hex hashes get tokenized into short
+	# nonsense "words" (e.g. a JWT split into `Iy`, `OT`, `ba`). Skip long
+	# opaque alphanumeric runs instead of trying to spell-check them.
+	"[A-Za-z0-9+/_-]{20,}={0,2}",
+	"\\b[0-9a-f]{8,40}\\b",
+]
+
+[default.extend-words]
+# Real acronyms, proper nouns, package names, foreign-language example
+# strings, and intentional misspellings (used to illustrate a typo) that
+# read as typos in isolation. Add new entries above this list only after
+# confirming the flagged string isn't a real typo.
+acn = "acn"                  # Australian Company Number
+als = "als"                  # AsyncLocalStorage variable name
+aso = "aso"                  # ASN field name (Autonomous System Organization)
+ba = "ba"                    # hex hash / language code fragment
+brittish = "brittish"        # period spelling, quoted Declaration of Independence
+canva = "canva"              # Canva, the product
+certifi = "certifi"          # Python package name
+christin = "christin"        # example person name
+cloudfare = "cloudfare"      # intentional example of a common misspelling
+compleat = "compleat"        # period spelling, quoted Declaration of Independence
+ect = "ect"                  # ECT (Effective Connection Type) HTTP client hint
+ede = "ede"                  # Extended DNS Error (RFC 8914)
+eit = "eit"                  # Encryption-in-Transit (EIT)
+equest = "equest"            # truncated real-world URL example fragment
+erro = "erro"                # localized (Portuguese) UI string
+fo = "fo"                    # Faroese language code
+fpt = "fpt"                  # abbreviation in Access MFA docs
+gam = "gam"                  # Google Apps Manager
+gropus = "gropus"            # intentional typo example (SCIM attribute mismatch)
+harrass = "harrass"          # period spelling, quoted Declaration of Independence
+helo = "helo"                # SMTP HELO command
+hom = "hom"                  # column value example (pipelines SQL reference)
+hpe = "hpe"                  # Hewlett Packard Enterprise
+iin = "iin"                  # Issuer Identification Number
+ist = "ist"                  # German UI string example
+iz = "iz"                    # base64 fragment
+jus = "jus"                  # dialect quote example
+metrix = "metrix"            # GT Metrix, the product
+mis = "mis"                  # hyphenated prefix (mis-issued, mis-read)
+momento = "momento"          # Spanish UI string example
+mor = "mor"                  # Merge-on-Read (Iceberg)
+muc = "muc"                  # Munich airport code
+nd = "nd"                    # abbreviation in vendor config examples
+nin = "nin"                  # $nin query operator
+noo = "noo"                  # base64 token fragment
+participantes = "participantes" # localized (Spanish/Portuguese) UI string
+pn = "pn"                    # base64 fragment / Yarn PnP
+referers = "referers"        # HTTP header name (historic spelling)
+regon = "regon"              # Polish business registry ID
+ser = "ser"                  # base64 fragment
+seeked = "seeked"            # valid past tense of "seek" in this context
+sie = "sie"                  # German UI string example
+sur = "sur"                  # macOS "Big Sur", surName attribute
+tme = "tme"                  # example domain fragment
+toi = "toi"                  # French UI string example
+tru = "tru"                  # base64 fragment
+ue = "ue"                    # base64/JWT fragment
+unparseable = "unparseable"  # valid alternate spelling of "unparsable"
+wich = "wich"                # dialect quote example
+wya = "wya"                  # base64 fragment
+
+[default.extend-identifiers]
+implicits = "implicits"      # Scala `import spark.implicits._`


### PR DESCRIPTION
### Summary

This PR adds a new job to CI to check for typos.

### Tooling

https://github.com/crate-ci/typos is a Rust CLI built for source trees that mix prose and code.

- **Curated dictionary.** It checks "is this string a known misspelling" (`teh` → `the`, `recieve` → `receive`) rather than "is this a real English word." It doesn't need a huge custom dictionary of product names and jargon to be useable.
- **Identifier-aware.** It splits `camelCase`, `snake_case`, and `kebab-case` into sub-words before checking, so code identifiers like `getAttr` don't get flagged as a whole.
- **Fast.** Runs in about 2 seconds on my machine, so it won't add meaningful time to CI.
- **Actively maintained.** Hecka GitHub stars, regular releases, and it's used across a lot of big repos.

### Configuration

I ran this locally against the whole content tree first: 505 raw hits. Most were noise — 43% came from one directory of third-party OSS license text alone (`legal/3rdparty.*`), plus base64/JWT example tokens, hex hashes, foreign-language UI string examples, and real acronyms (`HELO`, `EDE`, `HPE`). `_typos.toml` excludes the license directory, ignores long base64/hex runs by regex, and allowlists about 45 specific words/identifiers I confirmed by hand aren't typos. After that tuning, it's now down to zero findings on the production branch.

Here's a companion PR with the actual typos it found: #33375 -- once that's merged, this PR should turn green. 🍏 

✋🏼 This PR conforms to the contribution guidelines.