### PR TITLE
[AI] Improve model catalog metadata and comparison

### DIFF
--- a/bin/catalog-import-utils.node.test.ts
+++ b/bin/catalog-import-utils.node.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import {
+	hasMoreCatalogModels,
+	mapConcurrentOrdered,
+} from "./catalog-import-utils";
+
+describe("catalog import utilities", () => {
+	it("stops pagination after all API rows are consumed", () => {
+		expect(hasMoreCatalogModels(100, 101, 100)).toBe(true);
+		expect(hasMoreCatalogModels(101, 101, 1)).toBe(false);
+		expect(hasMoreCatalogModels(100, 101, 0)).toBe(false);
+	});
+
+	it("keeps workers busy and returns results in input order", async () => {
+		let active = 0;
+		let maxActive = 0;
+		const completed: number[] = [];
+		const results = await mapConcurrentOrdered(
+			[30, 5, 10, 1],
+			2,
+			async (delay, index) => {
+				active++;
+				maxActive = Math.max(maxActive, active);
+				await new Promise((resolve) => setTimeout(resolve, delay));
+				active--;
+				return index;
+			},
+			(count) => completed.push(count),
+		);
+
+		expect(results).toEqual([0, 1, 2, 3]);
+		expect(maxActive).toBe(2);
+		expect(completed).toEqual([1, 2, 3, 4]);
+	});
+});

--- a/bin/catalog-import-utils.node.test.ts
+++ b/bin/catalog-import-utils.node.test.ts
@@ -35,6 +35,7 @@ describe("catalog import utilities", () => {
 
 	it("stops dispatching and drains active work after a failure", async () => {
 		const started: number[] = [];
+		const finished: number[] = [];
 		let releaseActive!: () => void;
 		const active = new Promise<void>((resolve) => {
 			releaseActive = resolve;
@@ -43,13 +44,21 @@ describe("catalog import utilities", () => {
 			started.push(index);
 			if (index === 0) throw new Error("failed");
 			await active;
+			finished.push(index);
 			return index;
 		});
+		let settled = false;
+		void operation.then(
+			() => (settled = true),
+			() => (settled = true),
+		);
 
 		await new Promise((resolve) => setTimeout(resolve, 0));
 		expect(started).toEqual([0, 1]);
+		expect(settled).toBe(false);
 		releaseActive();
 		await expect(operation).rejects.toThrow("failed");
 		expect(started).toEqual([0, 1]);
+		expect(finished).toEqual([1]);
 	});
 });

--- a/bin/catalog-import-utils.node.test.ts
+++ b/bin/catalog-import-utils.node.test.ts
@@ -32,4 +32,24 @@ describe("catalog import utilities", () => {
 		expect(maxActive).toBe(2);
 		expect(completed).toEqual([1, 2, 3, 4]);
 	});
+
+	it("stops dispatching and drains active work after a failure", async () => {
+		const started: number[] = [];
+		let releaseActive!: () => void;
+		const active = new Promise<void>((resolve) => {
+			releaseActive = resolve;
+		});
+		const operation = mapConcurrentOrdered([0, 1, 2], 2, async (_, index) => {
+			started.push(index);
+			if (index === 0) throw new Error("failed");
+			await active;
+			return index;
+		});
+
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		expect(started).toEqual([0, 1]);
+		releaseActive();
+		await expect(operation).rejects.toThrow("failed");
+		expect(started).toEqual([0, 1]);
+	});
 });

--- a/bin/catalog-import-utils.ts
+++ b/bin/catalog-import-utils.ts
@@ -17,17 +17,25 @@ export async function mapConcurrentOrdered<T, R>(
 	const results = new Array<R>(values.length);
 	let nextIndex = 0;
 	let completed = 0;
+	let failed = false;
+	let firstError: unknown;
 
 	async function run(): Promise<void> {
-		while (nextIndex < values.length) {
+		while (!failed && nextIndex < values.length) {
 			const index = nextIndex++;
-			results[index] = await mapper(values[index], index);
-			onComplete?.(++completed);
+			try {
+				results[index] = await mapper(values[index], index);
+				onComplete?.(++completed);
+			} catch (error) {
+				if (!failed) firstError = error;
+				failed = true;
+			}
 		}
 	}
 
 	await Promise.all(
 		Array.from({ length: Math.min(concurrency, values.length) }, run),
 	);
+	if (failed) throw firstError;
 	return results;
 }

--- a/bin/catalog-import-utils.ts
+++ b/bin/catalog-import-utils.ts
@@ -1,0 +1,33 @@
+export function hasMoreCatalogModels(
+	modelsSeen: number,
+	totalCount: number,
+	pageSize: number,
+): boolean {
+	return pageSize > 0 && modelsSeen < totalCount;
+}
+
+export async function mapConcurrentOrdered<T, R>(
+	values: readonly T[],
+	concurrency: number,
+	mapper: (value: T, index: number) => Promise<R>,
+	onComplete?: (completed: number) => void,
+): Promise<R[]> {
+	if (!Number.isInteger(concurrency) || concurrency < 1)
+		throw new RangeError("concurrency must be a positive integer");
+	const results = new Array<R>(values.length);
+	let nextIndex = 0;
+	let completed = 0;
+
+	async function run(): Promise<void> {
+		while (nextIndex < values.length) {
+			const index = nextIndex++;
+			results[index] = await mapper(values[index], index);
+			onComplete?.(++completed);
+		}
+	}
+
+	await Promise.all(
+		Array.from({ length: Math.min(concurrency, values.length) }, run),
+	);
+	return results;
+}

--- a/bin/fetch-catalog-models.ts
+++ b/bin/fetch-catalog-models.ts
@@ -25,6 +25,10 @@
 
 import fs from "node:fs";
 import path from "node:path";
+import {
+	hasMoreCatalogModels,
+	mapConcurrentOrdered,
+} from "./catalog-import-utils";
 
 interface CatalogModel {
 	model_id: string;
@@ -80,8 +84,6 @@ interface CatalogModel {
 	private?: boolean;
 	created_at?: string;
 	updated_at?: string;
-	// Returned by the catalog API but not consumed by the docs site.
-	// Stripped before writing to disk.
 	pricing?: Record<string, unknown>;
 }
 
@@ -188,6 +190,7 @@ async function fetchModelList(
 	const modelIds: string[] = [];
 	let page = 1;
 	let hasMore = true;
+	let modelsSeen = 0;
 
 	console.log("Fetching model list from Unified Catalog API...");
 	console.log(`  Base URL: ${API_BASE_URL}`);
@@ -225,13 +228,14 @@ async function fetchModelList(
 		}
 
 		const { count, total_count } = data.result_info!;
+		modelsSeen += data.result.length;
 		const privateNote =
 			skippedPrivate > 0 ? ` (${skippedPrivate} private skipped)` : "";
 		console.log(
-			`  Page ${page}: ${count} models (${modelIds.length}/${total_count})${privateNote}`,
+			`  Page ${page}: ${count} models (${modelsSeen}/${total_count})${privateNote}`,
 		);
 
-		hasMore = modelIds.length < total_count;
+		hasMore = hasMoreCatalogModels(modelsSeen, total_count, data.result.length);
 		page++;
 	}
 
@@ -289,26 +293,20 @@ async function fetchFromApi(): Promise<CatalogModel[]> {
 	);
 
 	// Pass 2: fetch full details for each model
+	const results = await mapConcurrentOrdered(
+		modelIds,
+		CONCURRENCY,
+		(modelId) => fetchModelDetail(ACCOUNT_ID, API_TOKEN, modelId),
+		(fetched) =>
+			process.stdout.write(`\r  ${fetched}/${modelIds.length} models fetched`),
+	);
+
 	const models: CatalogModel[] = [];
 	const failed: string[] = [];
-
-	for (let i = 0; i < modelIds.length; i += CONCURRENCY) {
-		const batch = modelIds.slice(i, i + CONCURRENCY);
-		const results = await Promise.all(
-			batch.map((id) => fetchModelDetail(ACCOUNT_ID, API_TOKEN, id)),
-		);
-
-		for (let j = 0; j < results.length; j++) {
-			const result = results[j];
-			if (result) {
-				models.push(result);
-			} else {
-				failed.push(batch[j]);
-			}
-		}
-
-		const fetched = Math.min(i + CONCURRENCY, modelIds.length);
-		process.stdout.write(`\r  ${fetched}/${modelIds.length} models fetched`);
+	for (let index = 0; index < results.length; index++) {
+		const result = results[index];
+		if (result) models.push(result);
+		else failed.push(modelIds[index]);
 	}
 
 	console.log();
@@ -432,10 +430,6 @@ function writeModels(models: CatalogModel[]): void {
 		// Trim string fields that may have leading/trailing whitespace
 		model.name = model.name.trim();
 		model.description = model.description.trim();
-
-		// Drop the `pricing` field — it's returned by the catalog API but is
-		// not consumed by the docs site and isn't declared in the schema.
-		delete model.pricing;
 
 		// Strip credentials from any pre-signed URLs in the response.
 		const redacted = redactCredentialUrls(model);

--- a/bin/fetch-catalog-models.ts
+++ b/bin/fetch-catalog-models.ts
@@ -296,7 +296,14 @@ async function fetchFromApi(): Promise<CatalogModel[]> {
 	const results = await mapConcurrentOrdered(
 		modelIds,
 		CONCURRENCY,
-		(modelId) => fetchModelDetail(ACCOUNT_ID, API_TOKEN, modelId),
+		async (modelId) => {
+			try {
+				return await fetchModelDetail(ACCOUNT_ID, API_TOKEN, modelId);
+			} catch (error) {
+				console.error(`  Failed to fetch ${modelId}:`, error);
+				return null;
+			}
+		},
 		(fetched) =>
 			process.stdout.write(`\r  ${fetched}/${modelIds.length} models fetched`),
 	);

--- a/src/components/models/ModelBadges.astro
+++ b/src/components/models/ModelBadges.astro
@@ -55,7 +55,7 @@ for (const { property_id, value } of model.propertiesList) {
 const badges: BadgeDef[] = [providerBadge, ...propertyBadges];
 ---
 
-<ul class="m-0 flex list-none flex-wrap items-center gap-1.5 p-0">
+<ul class="m-0 flex list-none flex-wrap items-center gap-x-1.5 p-0">
 	{
 		badges.map((badge) => (
 			<li class="m-0">

--- a/src/components/models/ModelCard.astro
+++ b/src/components/models/ModelCard.astro
@@ -91,7 +91,9 @@ const decisionFacts = [
 
 	<a
 		href={href}
-		class="group/card hover:bg-muted/30 focus-visible:outline-ring relative flex h-full min-w-0 flex-col p-5 pb-14 text-inherit! no-underline transition-colors duration-150 focus-visible:outline-2 focus-visible:-outline-offset-2"
+		class:list={[
+			"group/card hover:bg-muted/30 focus-visible:outline-ring relative flex h-full min-w-0 flex-col p-5 pb-16 text-inherit! no-underline transition-colors duration-150 focus-visible:outline-2 focus-visible:-outline-offset-2",
+		]}
 	>
 		{
 			isPinned && (
@@ -160,14 +162,12 @@ const decisionFacts = [
 		</div>
 
 		<p
-			class="text-muted-foreground mb-4 line-clamp-3 h-[4.5rem] min-w-0 shrink-0 text-sm leading-relaxed [overflow-wrap:anywhere]"
+			class="text-muted-foreground line-clamp-3 h-[4.5rem] min-w-0 shrink-0 text-sm leading-relaxed [overflow-wrap:anywhere]"
 		>
 			{model.description}
 		</p>
 
-		<div class="mt-auto">
-			<ModelBadges model={model} />
-		</div>
+		<ModelBadges model={model} />
 	</a>
 	<div
 		class="pointer-events-none absolute right-3 bottom-3 left-5 z-20 flex items-center justify-between gap-3"

--- a/src/components/models/ModelCard.astro
+++ b/src/components/models/ModelCard.astro
@@ -15,6 +15,8 @@ import ModelBadges from "./ModelBadges.astro";
 import { authorData } from "~/components/models/data";
 import {
 	facetValues,
+	formatCompactTokens,
+	formatModelPricing,
 	pinnedModelNames,
 	type ModelCardData,
 } from "~/util/models";
@@ -43,12 +45,20 @@ const pinnedIndex = pinnedModelNames.indexOf(model.name);
 const isPinned = pinnedIndex >= 0;
 // Author logo; initial-letter tile when the author id is unmapped.
 const authorLogo = authorData[model.author]?.logo;
+const contextWindow = formatCompactTokens(model.properties.context_window);
+const maxOutputTokens = formatCompactTokens(model.properties.max_output_tokens);
+const pricing = formatModelPricing(model.pricing);
+const decisionFacts = [
+	contextWindow ? `${contextWindow} context` : null,
+	maxOutputTokens ? `${maxOutputTokens} output` : null,
+	pricing.length > 0 ? "Pricing listed" : null,
+].filter((value): value is string => value !== null);
 ---
 
 <div
 	data-models-cell
 	data-name={model.name.toLowerCase()}
-	data-search={[model.name, model.shortName, model.description]
+	data-search={[model.name, model.shortName, model.description, ...model.tags]
 		.filter(Boolean)
 		.join(" ")
 		.toLowerCase()}
@@ -58,6 +68,18 @@ const authorLogo = authorData[model.author]?.logo;
 	data-facet-authors={facetValues(model, "authors").join("|")}
 	data-date={dateValue}
 	data-pinned-index={pinnedIndex}
+	data-model-id={model.modelId ?? model.name}
+	data-model-label={model.displayName}
+	data-model-href={href}
+	data-model-provider={model.authorName}
+	data-model-task={model.task}
+	data-model-hosting={model.hosting}
+	data-model-context={model.properties.context_window ?? ""}
+	data-model-output={model.properties.max_output_tokens ?? ""}
+	data-model-pricing={pricing.join("\n")}
+	data-model-capabilities={model.capabilities.join(", ")}
+	data-model-tags={model.tags.join(", ")}
+	data-model-zdr={model.properties.zdr === "true" ? "Yes" : "No"}
 	class={cellClass}
 >
 	<div
@@ -69,7 +91,7 @@ const authorLogo = authorData[model.author]?.logo;
 
 	<a
 		href={href}
-		class="group/card hover:bg-muted/30 focus-visible:outline-ring relative flex h-full flex-col p-5 text-inherit! no-underline transition-colors duration-150 focus-visible:outline-2 focus-visible:-outline-offset-2"
+		class="group/card hover:bg-muted/30 focus-visible:outline-ring relative flex h-full min-w-0 flex-col p-5 pb-14 text-inherit! no-underline transition-colors duration-150 focus-visible:outline-2 focus-visible:-outline-offset-2"
 	>
 		{
 			isPinned && (
@@ -103,9 +125,9 @@ const authorLogo = authorData[model.author]?.logo;
 					</span>
 				)
 			}
-			<div class="flex min-w-0 flex-1 items-center gap-2">
+			<div class="flex min-w-0 flex-1 items-center gap-2 overflow-hidden">
 				<h3
-					class="text-foreground group-hover/card:text-primary line-clamp-2 text-sm leading-snug font-semibold break-words"
+					class="text-foreground group-hover/card:text-primary line-clamp-2 min-w-0 text-sm leading-snug font-semibold [overflow-wrap:anywhere]"
 				>
 					{model.shortName}
 				</h3>
@@ -123,20 +145,46 @@ const authorLogo = authorData[model.author]?.logo;
 		</div>
 
 		<div
-			class="border-border mt-3 mb-3 flex items-center justify-between gap-2 border-t pt-3 text-xs"
+			class="border-border mt-3 mb-3 flex min-h-10 items-start justify-between gap-3 border-t pt-3 text-xs"
 		>
-			<span class="text-foreground truncate">{model.authorName}</span>
-			<span class="text-foreground shrink-0 font-mono tracking-wider uppercase">
+			<span
+				class="text-foreground line-clamp-2 min-w-0 flex-1 [overflow-wrap:anywhere]"
+			>
+				{model.authorName}
+			</span>
+			<span
+				class="text-foreground line-clamp-2 max-w-[58%] text-right font-mono leading-snug tracking-wider [overflow-wrap:anywhere] uppercase"
+			>
 				{model.task}
 			</span>
 		</div>
 
 		<p
-			class="text-muted-foreground mb-4 line-clamp-2 min-h-10 flex-1 text-sm leading-relaxed"
+			class="text-muted-foreground mb-4 line-clamp-3 h-[4.5rem] min-w-0 shrink-0 text-sm leading-relaxed [overflow-wrap:anywhere]"
 		>
 			{model.description}
 		</p>
 
-		<ModelBadges model={model} />
+		<div class="mt-auto">
+			<ModelBadges model={model} />
+			{
+				decisionFacts.length > 0 && (
+					<ul class="text-muted-foreground mt-3 flex list-none flex-wrap gap-x-3 gap-y-1 p-0 text-xs">
+						{decisionFacts.map((fact) => (
+							<li class="m-0">{fact}</li>
+						))}
+					</ul>
+				)
+			}
+		</div>
 	</a>
+	<button
+		type="button"
+		data-model-compare
+		aria-label={`Add ${model.displayName} to comparison`}
+		aria-pressed="false"
+		class="border-border bg-background text-muted-foreground hover:border-primary hover:text-primary focus-visible:outline-ring absolute right-3 bottom-3 z-20 cursor-pointer rounded-md border px-2 py-1 text-xs font-medium focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-40"
+	>
+		Compare
+	</button>
 </div>

--- a/src/components/models/ModelCard.astro
+++ b/src/components/models/ModelCard.astro
@@ -71,9 +71,9 @@ const decisionFacts = [
 	data-model-id={model.modelId ?? model.name}
 	data-model-label={model.displayName}
 	data-model-href={href}
-	data-model-provider={model.authorName}
+	data-model-provider={model.hosting === "hosted" ? "Workers AI" : "AI Gateway"}
+	data-model-author={model.authorName}
 	data-model-task={model.task}
-	data-model-hosting={model.hosting}
 	data-model-context={model.properties.context_window ?? ""}
 	data-model-output={model.properties.max_output_tokens ?? ""}
 	data-model-pricing={pricing.join("\n")}
@@ -167,24 +167,28 @@ const decisionFacts = [
 
 		<div class="mt-auto">
 			<ModelBadges model={model} />
-			{
-				decisionFacts.length > 0 && (
-					<ul class="text-muted-foreground mt-3 flex list-none flex-wrap gap-x-3 gap-y-1 p-0 text-xs">
-						{decisionFacts.map((fact) => (
-							<li class="m-0">{fact}</li>
-						))}
-					</ul>
-				)
-			}
 		</div>
 	</a>
-	<button
-		type="button"
-		data-model-compare
-		aria-label={`Add ${model.displayName} to comparison`}
-		aria-pressed="false"
-		class="border-border bg-background text-muted-foreground hover:border-primary hover:text-primary focus-visible:outline-ring absolute right-3 bottom-3 z-20 cursor-pointer rounded-md border px-2 py-1 text-xs font-medium focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-40"
+	<div
+		class="pointer-events-none absolute right-3 bottom-3 left-5 z-20 flex items-center justify-between gap-3"
 	>
-		Compare
-	</button>
+		{
+			decisionFacts.length > 0 && (
+				<ul class="text-muted-foreground flex min-w-0 list-none flex-wrap gap-x-3 gap-y-1 p-0 text-xs">
+					{decisionFacts.map((fact) => (
+						<li class="m-0">{fact}</li>
+					))}
+				</ul>
+			)
+		}
+		<button
+			type="button"
+			data-model-compare
+			aria-label={`Add ${model.displayName} to comparison`}
+			aria-pressed="false"
+			class="border-border bg-background text-muted-foreground hover:border-primary hover:text-primary focus-visible:outline-ring aria-pressed:border-primary aria-pressed:bg-primary aria-pressed:text-primary-foreground aria-pressed:hover:text-primary-foreground pointer-events-auto ml-auto shrink-0 cursor-pointer rounded-md border px-2 py-1 text-xs font-medium focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-40"
+		>
+			Compare
+		</button>
+	</div>
 </div>

--- a/src/components/models/ModelCard.astro
+++ b/src/components/models/ModelCard.astro
@@ -49,8 +49,8 @@ const contextWindow = formatCompactTokens(model.properties.context_window);
 const maxOutputTokens = formatCompactTokens(model.properties.max_output_tokens);
 const pricing = formatModelPricing(model.pricing);
 const decisionFacts = [
-	contextWindow ? `${contextWindow} context` : null,
-	maxOutputTokens ? `${maxOutputTokens} output` : null,
+	contextWindow ? `Context: ${contextWindow}` : null,
+	maxOutputTokens ? `Maximum output: ${maxOutputTokens}` : null,
 	pricing.length > 0 ? "Pricing listed" : null,
 ].filter((value): value is string => value !== null);
 ---

--- a/src/components/models/ModelCatalog.astro
+++ b/src/components/models/ModelCatalog.astro
@@ -355,6 +355,7 @@ const facetMatchMaps = Object.fromEntries(
 	}
 	comparisonClear.addEventListener("click", () => {
 		const selected = [...selectedModels];
+		const focusTarget = compareButtonByCell.get(selected[0]);
 		selectedModels.length = 0;
 		renderComparison();
 		for (const cell of selected) {
@@ -364,7 +365,7 @@ const facetMatchMaps = Object.fromEntries(
 		for (const entry of compareButtonEntries) {
 			if (entry.button.disabled) updateCompareButton(entry.button, entry.cell);
 		}
-		searchInput.focus();
+		focusTarget?.focus();
 	});
 
 	function compareModels(
@@ -396,6 +397,10 @@ const facetMatchMaps = Object.fromEntries(
 	}
 
 	function relayout(): number {
+		if (relayoutFrame !== 0) {
+			cancelAnimationFrame(relayoutFrame);
+			relayoutFrame = 0;
+		}
 		// Split the query into whitespace-separated tokens; each must appear
 		// somewhere in the card's searchable text (name + shortName +
 		// description). This lets "happy horse" match a "HappyHorse" model
@@ -501,7 +506,8 @@ const facetMatchMaps = Object.fromEntries(
 	// Event listeners.
 	searchInput.addEventListener("input", () => {
 		state.search = searchInput.value;
-		scheduleRelayout();
+		if (document.visibilityState === "hidden") relayout();
+		else scheduleRelayout();
 		syncUrl();
 	});
 

--- a/src/components/models/ModelCatalog.astro
+++ b/src/components/models/ModelCatalog.astro
@@ -3,6 +3,7 @@
 import ModelCard from "./ModelCard.astro";
 import { FilterDropdownWrapper } from "./FilterDropdownWrapper";
 import { SortSelectWrapper } from "./SortSelectWrapper";
+import { Dialog, DialogClose, DialogContent } from "~/components/ui/dialog";
 import { getFacets, type ModelCardData } from "~/util/models";
 import { resolveCols, LG_GRID_CLASS } from "~/components/directory/grid";
 
@@ -87,41 +88,49 @@ const facetMatchMaps = Object.fromEntries(
 		</button>
 	</div>
 
-	<section
+	<Dialog
+		id="model-comparison-dialog"
 		data-model-comparison
-		hidden
-		class="border-border bg-muted/20 mb-5 overflow-hidden rounded-lg border"
 		aria-labelledby="model-comparison-heading"
 	>
-		<div
-			class="border-border flex flex-wrap items-center justify-between gap-3 border-b px-4 py-3"
-		>
-			<div>
-				<h2
-					id="model-comparison-heading"
-					class="text-foreground m-0 text-base font-semibold"
-				>
-					Compare models
-				</h2>
-				<p class="text-muted-foreground m-0 text-xs">
-					Compare up to three models.
-				</p>
-			</div>
-			<button
-				type="button"
-				data-model-comparison-clear
-				class="text-primary cursor-pointer text-sm underline-offset-2 hover:underline"
+		<DialogContent class="bg-background max-h-[85vh] max-w-6xl">
+			<div
+				class="border-border flex flex-wrap items-center justify-between gap-3 border-b px-4 py-3"
 			>
-				Clear comparison
-			</button>
-		</div>
-		<div class="overflow-x-auto">
-			<table class="m-0 w-full min-w-[640px] border-collapse text-sm">
-				<thead data-model-comparison-head></thead>
-				<tbody data-model-comparison-body></tbody>
-			</table>
-		</div>
-	</section>
+				<div>
+					<h2
+						id="model-comparison-heading"
+						class="text-foreground m-0 text-base font-semibold"
+					>
+						Compare models
+					</h2>
+					<p class="text-muted-foreground m-0 text-xs">
+						Compare up to three models.
+					</p>
+				</div>
+				<DialogClose
+					class="border-border bg-background text-foreground hover:bg-muted focus-visible:outline-ring cursor-pointer rounded-md border px-3 py-1.5 text-sm font-medium focus-visible:outline-2 focus-visible:outline-offset-2"
+				>
+					Close
+				</DialogClose>
+			</div>
+			<div class="min-h-0 flex-1 overflow-auto">
+				<table class="m-0 w-full min-w-[640px] border-collapse text-sm">
+					<thead data-model-comparison-head></thead>
+					<tbody data-model-comparison-body></tbody>
+				</table>
+			</div>
+			<div class="border-border flex justify-end border-t px-4 py-3">
+				<button
+					type="button"
+					data-model-comparison-clear
+					class="text-primary cursor-pointer text-sm underline-offset-2 hover:underline"
+				>
+					Clear comparison
+				</button>
+			</div>
+		</DialogContent>
+	</Dialog>
 
 	<div
 		data-models-empty
@@ -143,6 +152,17 @@ const facetMatchMaps = Object.fromEntries(
 			}
 		</div>
 	</div>
+
+	<button
+		type="button"
+		data-model-comparison-trigger
+		hidden
+		aria-controls="model-comparison-dialog"
+		aria-haspopup="dialog"
+		class="bg-primary text-primary-foreground focus-visible:outline-ring fixed bottom-[max(1.25rem,env(safe-area-inset-bottom))] left-1/2 z-40 -translate-x-1/2 cursor-pointer rounded-lg px-5 py-3 text-sm font-semibold shadow-lg transition-opacity hover:opacity-90 focus-visible:outline-2 focus-visible:outline-offset-2"
+	>
+		Compare models
+	</button>
 </div>
 
 <div id="model-facet-data" data-facets={JSON.stringify(facetMatchMaps)}></div>
@@ -175,8 +195,11 @@ const facetMatchMaps = Object.fromEntries(
 	const countEl = document.getElementById("model-count")!;
 	const countLabelEl = document.getElementById("model-count-label")!;
 	const clearBtn = document.getElementById("clear-filters")!;
-	const comparison = root.querySelector<HTMLElement>(
+	const comparison = root.querySelector<HTMLDialogElement>(
 		"[data-model-comparison]",
+	)!;
+	const comparisonTrigger = root.querySelector<HTMLButtonElement>(
+		"[data-model-comparison-trigger]",
 	)!;
 	const comparisonHead = comparison.querySelector<HTMLTableSectionElement>(
 		"[data-model-comparison-head]",
@@ -256,7 +279,13 @@ const facetMatchMaps = Object.fromEntries(
 	}
 
 	function renderComparison(): void {
-		comparison.hidden = selectedModels.length === 0;
+		comparisonTrigger.hidden = selectedModels.length === 0;
+		root.style.paddingBottom =
+			selectedModels.length === 0
+				? ""
+				: "calc(5rem + env(safe-area-inset-bottom))";
+		comparisonTrigger.textContent = `Compare ${selectedModels.length} ${selectedModels.length === 1 ? "model" : "models"}`;
+		if (selectedModels.length === 0 && comparison.open) comparison.close();
 		comparisonHead.replaceChildren();
 		comparisonBody.replaceChildren();
 
@@ -280,6 +309,7 @@ const facetMatchMaps = Object.fromEntries(
 
 		const rows: Array<[string, (model: HTMLElement) => string]> = [
 			["Provider", (model) => model.dataset.modelProvider ?? "Not listed"],
+			["Author", (model) => model.dataset.modelAuthor ?? "Not listed"],
 			["Task", (model) => model.dataset.modelTask ?? "Not listed"],
 			[
 				"Context window",
@@ -295,13 +325,6 @@ const facetMatchMaps = Object.fromEntries(
 				"Capabilities",
 				(model) => model.dataset.modelCapabilities || "Not listed",
 			],
-			[
-				"Delivery",
-				(model) =>
-					model.dataset.modelHosting === "hosted"
-						? "Cloudflare-hosted"
-						: "Third-party",
-			],
 			["Zero Data Retention", (model) => model.dataset.modelZdr ?? "No"],
 		];
 		for (const [label, value] of rows) {
@@ -316,6 +339,10 @@ const facetMatchMaps = Object.fromEntries(
 			comparisonBody.append(row);
 		}
 	}
+
+	comparisonTrigger.addEventListener("click", () => {
+		if (selectedModels.length > 0) comparison.showModal();
+	});
 
 	for (const button of compareButtons) {
 		button.addEventListener("click", () => {

--- a/src/components/models/ModelCatalog.astro
+++ b/src/components/models/ModelCatalog.astro
@@ -251,7 +251,7 @@ const facetMatchMaps = Object.fromEntries(
 	function formatTokenCount(value: string | undefined): string {
 		const count = Number(value);
 		return Number.isFinite(count) && count > 0
-			? `${count.toLocaleString()} tokens`
+			? `${count.toLocaleString("en-US")} tokens`
 			: "Not listed";
 	}
 

--- a/src/components/models/ModelCatalog.astro
+++ b/src/components/models/ModelCatalog.astro
@@ -248,6 +248,13 @@ const facetMatchMaps = Object.fromEntries(
 		);
 	}
 
+	function formatTokenCount(value: string | undefined): string {
+		const count = Number(value);
+		return Number.isFinite(count) && count > 0
+			? `${count.toLocaleString()} tokens`
+			: "Not listed";
+	}
+
 	function renderComparison(): void {
 		comparison.hidden = selectedModels.length === 0;
 		comparisonHead.replaceChildren();
@@ -276,17 +283,11 @@ const facetMatchMaps = Object.fromEntries(
 			["Task", (model) => model.dataset.modelTask ?? "Not listed"],
 			[
 				"Context window",
-				(model) =>
-					model.dataset.modelContext
-						? `${Number(model.dataset.modelContext).toLocaleString()} tokens`
-						: "Not listed",
+				(model) => formatTokenCount(model.dataset.modelContext),
 			],
 			[
 				"Maximum output",
-				(model) =>
-					model.dataset.modelOutput
-						? `${Number(model.dataset.modelOutput).toLocaleString()} tokens`
-						: "Not listed",
+				(model) => formatTokenCount(model.dataset.modelOutput),
 			],
 			["Pricing", (model) => model.dataset.modelPricing || "Not listed"],
 			["Best for", (model) => model.dataset.modelTags || "Not listed"],

--- a/src/components/models/ModelCatalog.astro
+++ b/src/components/models/ModelCatalog.astro
@@ -334,7 +334,10 @@ const facetMatchMaps = Object.fromEntries(
 	}
 	comparisonClear.addEventListener("click", () => {
 		const selected = [...selectedModels];
-		const focusTarget = compareButtonByCell.get(selected[0]);
+		const visibleCell = selected.find((cell) => cell.style.display !== "none");
+		const focusTarget = visibleCell
+			? compareButtonByCell.get(visibleCell)
+			: searchInput;
 		selectedModels.length = 0;
 		renderComparison();
 		for (const cell of selected) {

--- a/src/components/models/ModelCatalog.astro
+++ b/src/components/models/ModelCatalog.astro
@@ -107,6 +107,42 @@ const facetMatchMaps = Object.fromEntries(
 		</button>
 	</div>
 
+	<section
+		data-model-comparison
+		hidden
+		class="border-border bg-muted/20 mb-5 overflow-hidden rounded-lg border"
+		aria-labelledby="model-comparison-heading"
+	>
+		<div
+			class="border-border flex flex-wrap items-center justify-between gap-3 border-b px-4 py-3"
+		>
+			<div>
+				<h2
+					id="model-comparison-heading"
+					class="text-foreground m-0 text-base font-semibold"
+				>
+					Compare models
+				</h2>
+				<p class="text-muted-foreground m-0 text-xs">
+					Compare up to three models.
+				</p>
+			</div>
+			<button
+				type="button"
+				data-model-comparison-clear
+				class="text-primary cursor-pointer text-sm underline-offset-2 hover:underline"
+			>
+				Clear comparison
+			</button>
+		</div>
+		<div class="overflow-x-auto">
+			<table class="m-0 w-full min-w-[640px] border-collapse text-sm">
+				<thead data-model-comparison-head></thead>
+				<tbody data-model-comparison-body></tbody>
+			</table>
+		</div>
+	</section>
+
 	{/* Empty state — toggled by the script. */}
 	<div
 		data-models-empty
@@ -138,7 +174,6 @@ const facetMatchMaps = Object.fromEntries(
 		LG_GRID_CLASS,
 		resolveCols,
 		cornersFor,
-		cellClass,
 		cornerSpansHTML,
 	} from "~/components/directory/grid";
 
@@ -162,6 +197,46 @@ const facetMatchMaps = Object.fromEntries(
 	const countEl = document.getElementById("model-count")!;
 	const countLabelEl = document.getElementById("model-count-label")!;
 	const clearBtn = document.getElementById("clear-filters")!;
+	const comparison = root.querySelector<HTMLElement>(
+		"[data-model-comparison]",
+	)!;
+	const comparisonHead = comparison.querySelector<HTMLTableSectionElement>(
+		"[data-model-comparison-head]",
+	)!;
+	const comparisonBody = comparison.querySelector<HTMLTableSectionElement>(
+		"[data-model-comparison-body]",
+	)!;
+	const comparisonClear = comparison.querySelector<HTMLButtonElement>(
+		"[data-model-comparison-clear]",
+	)!;
+	const compareButtons = Array.from(
+		root.querySelectorAll<HTMLButtonElement>("[data-model-compare]"),
+	);
+	const compareButtonEntries = compareButtons.flatMap((button) => {
+		const cell = button.closest<HTMLElement>("[data-models-cell]");
+		return cell === null ? [] : [{ button, cell }];
+	});
+	const compareButtonByCell = new Map(
+		compareButtonEntries.map(({ button, cell }) => [cell, button]),
+	);
+	const selectedModels: HTMLElement[] = [];
+	const indexedModels = Array.from(
+		grid.querySelectorAll<HTMLElement>("[data-models-cell]"),
+	).map((cell) => ({
+		cell,
+		marks: cell.querySelector<HTMLElement>("[data-corner-marks]"),
+		search: cell.dataset.search ?? cell.dataset.name ?? "",
+		facets: Object.fromEntries(
+			facetKeys.map((key) => [
+				key,
+				new Set(
+					(cell.dataset[datasetKey(key)] ?? "").split("|").filter(Boolean),
+				),
+			]),
+		) as Record<string, Set<string>>,
+		pinnedIndex: Number(cell.dataset.pinnedIndex ?? -1),
+		date: Number(cell.dataset.date ?? 0),
+	}));
 
 	const state = {
 		search: "",
@@ -169,10 +244,158 @@ const facetMatchMaps = Object.fromEntries(
 		sort: "newest" as SortOrder,
 	};
 
-	function relayout(): number {
-		const cells = Array.from(
-			grid.querySelectorAll<HTMLElement>("[data-models-cell]"),
+	function tableCell(tag: "th" | "td", text: string): HTMLTableCellElement {
+		const cell = document.createElement(tag);
+		cell.className =
+			"border-border whitespace-pre-line border-b border-r px-4 py-3 text-left align-top last:border-r-0";
+		cell.textContent = text;
+		return cell;
+	}
+
+	function updateCompareButton(
+		button: HTMLButtonElement,
+		cell: HTMLElement,
+	): void {
+		const selected = selectedModels.includes(cell);
+		const disabled = !selected && selectedModels.length >= 3;
+		if (button.ariaPressed !== String(selected))
+			button.ariaPressed = String(selected);
+		const text = selected ? "Selected" : "Compare";
+		if (button.textContent !== text) button.textContent = text;
+		if (button.disabled !== disabled) button.disabled = disabled;
+		button.setAttribute(
+			"aria-label",
+			`${selected ? "Remove" : "Add"} ${cell.dataset.modelLabel ?? "model"} ${selected ? "from" : "to"} comparison`,
 		);
+	}
+
+	function renderComparison(): void {
+		comparison.hidden = selectedModels.length === 0;
+		comparisonHead.replaceChildren();
+		comparisonBody.replaceChildren();
+
+		const header = document.createElement("tr");
+		const corner = tableCell("td", "");
+		corner.ariaHidden = "true";
+		header.append(corner);
+		for (const model of selectedModels) {
+			const cell = tableCell("th", "");
+			cell.scope = "col";
+			const link = document.createElement("a");
+			link.href = model.dataset.modelHref ?? "#";
+			link.className =
+				"text-primary font-semibold no-underline hover:underline";
+			link.textContent =
+				model.dataset.modelLabel ?? model.dataset.modelId ?? "Model";
+			cell.append(link);
+			header.append(cell);
+		}
+		comparisonHead.append(header);
+
+		const rows: Array<[string, (model: HTMLElement) => string]> = [
+			["Provider", (model) => model.dataset.modelProvider ?? "Not listed"],
+			["Task", (model) => model.dataset.modelTask ?? "Not listed"],
+			[
+				"Context window",
+				(model) =>
+					model.dataset.modelContext
+						? `${Number(model.dataset.modelContext).toLocaleString()} tokens`
+						: "Not listed",
+			],
+			[
+				"Maximum output",
+				(model) =>
+					model.dataset.modelOutput
+						? `${Number(model.dataset.modelOutput).toLocaleString()} tokens`
+						: "Not listed",
+			],
+			["Pricing", (model) => model.dataset.modelPricing || "Not listed"],
+			["Best for", (model) => model.dataset.modelTags || "Not listed"],
+			[
+				"Capabilities",
+				(model) => model.dataset.modelCapabilities || "Not listed",
+			],
+			[
+				"Delivery",
+				(model) =>
+					model.dataset.modelHosting === "hosted"
+						? "Cloudflare-hosted"
+						: "Third-party",
+			],
+			["Zero Data Retention", (model) => model.dataset.modelZdr ?? "No"],
+		];
+		for (const [label, value] of rows) {
+			const values = selectedModels.map(value);
+			if (values.every((entry) => entry === "Not listed")) continue;
+			const row = document.createElement("tr");
+			const heading = tableCell("th", label);
+			heading.scope = "row";
+			heading.classList.add("text-muted-foreground", "font-medium");
+			row.append(heading);
+			for (const entry of values) row.append(tableCell("td", entry));
+			comparisonBody.append(row);
+		}
+	}
+
+	for (const button of compareButtons) {
+		button.addEventListener("click", () => {
+			const cell = button.closest<HTMLElement>("[data-models-cell]");
+			if (cell === null) return;
+			const wasAtLimit = selectedModels.length >= 3;
+			const index = selectedModels.indexOf(cell);
+			if (index >= 0) selectedModels.splice(index, 1);
+			else if (selectedModels.length < 3) selectedModels.push(cell);
+			renderComparison();
+			updateCompareButton(button, cell);
+			if (wasAtLimit !== selectedModels.length >= 3) {
+				for (const entry of compareButtonEntries)
+					updateCompareButton(entry.button, entry.cell);
+			}
+		});
+	}
+	comparisonClear.addEventListener("click", () => {
+		const selected = [...selectedModels];
+		selectedModels.length = 0;
+		renderComparison();
+		for (const cell of selected) {
+			const button = compareButtonByCell.get(cell);
+			if (button) updateCompareButton(button, cell);
+		}
+		for (const entry of compareButtonEntries) {
+			if (entry.button.disabled) updateCompareButton(entry.button, entry.cell);
+		}
+		searchInput.focus();
+	});
+
+	function compareModels(
+		a: (typeof indexedModels)[number],
+		b: (typeof indexedModels)[number],
+		dir: number,
+	): number {
+		const aPinned = a.pinnedIndex >= 0;
+		const bPinned = b.pinnedIndex >= 0;
+		if (aPinned && !bPinned) return -1;
+		if (!aPinned && bPinned) return 1;
+		if (aPinned && bPinned) return a.pinnedIndex - b.pinnedIndex;
+		return a.date === b.date ? 0 : (a.date < b.date ? -1 : 1) * dir;
+	}
+
+	const sortedModels: Record<SortOrder, typeof indexedModels> = {
+		newest: [...indexedModels].sort((a, b) => compareModels(a, b, -1)),
+		oldest: [...indexedModels].sort((a, b) => compareModels(a, b, 1)),
+	};
+	let renderedSort: SortOrder | null = null;
+	let relayoutFrame = 0;
+
+	function scheduleRelayout(): void {
+		if (relayoutFrame !== 0) return;
+		relayoutFrame = requestAnimationFrame(() => {
+			relayoutFrame = 0;
+			relayout();
+		});
+	}
+
+	function relayout(): number {
 		// Split the query into whitespace-separated tokens; each must appear
 		// somewhere in the card's searchable text (name + shortName +
 		// description). This lets "happy horse" match a "HappyHorse" model
@@ -191,52 +414,43 @@ const facetMatchMaps = Object.fromEntries(
 			);
 		}
 
-		const matches = cells.filter((cell) => {
-			const haystack = cell.dataset.search ?? cell.dataset.name ?? "";
+		const orderedModels = sortedModels[state.sort];
+		const matches = orderedModels.filter((model) => {
 			const searchOk =
 				queryTokens.length === 0 ||
-				queryTokens.every((token) => haystack.includes(token));
+				queryTokens.every((token) => model.search.includes(token));
 			if (!searchOk) return false;
 			return facetKeys.every((key) => {
 				const chosen = selMatch[key];
 				if (chosen.length === 0) return true;
-				const vals = (cell.dataset[datasetKey(key)] ?? "")
-					.split("|")
-					.filter(Boolean);
-				return chosen.some((c) => vals.includes(c));
+				const values = model.facets[key];
+				return chosen.some((value) => values.has(value));
 			});
 		});
 
-		// Pinned-first sort; rest by date.
-		const dir = state.sort === "oldest" ? 1 : -1;
-		matches.sort((a, b) => {
-			const pa = Number(a.dataset.pinnedIndex ?? -1);
-			const pb = Number(b.dataset.pinnedIndex ?? -1);
-			const aPinned = pa >= 0;
-			const bPinned = pb >= 0;
-			if (aPinned && !bPinned) return -1;
-			if (!aPinned && bPinned) return 1;
-			if (aPinned && bPinned) return pa - pb;
-			const da = Number(a.dataset.date ?? 0);
-			const db = Number(b.dataset.date ?? 0);
-			return da === db ? 0 : (da < db ? -1 : 1) * dir;
-		});
-
 		const lgCols = resolveCols(matches.length);
-		grid.className = LG_GRID_CLASS[lgCols] ?? LG_GRID_CLASS[1];
+		const gridClass = LG_GRID_CLASS[lgCols] ?? LG_GRID_CLASS[1];
+		if (grid.className !== gridClass) grid.className = gridClass;
 		const cols =
 			typeof window !== "undefined" &&
 			window.matchMedia("(min-width: 1024px)").matches
 				? lgCols
 				: 1;
 
-		for (const cell of cells) cell.style.display = "none";
-		matches.forEach((cell, i) => {
-			cell.style.display = "";
-			cell.className = cellClass;
-			grid.appendChild(cell);
-			const marks = cell.querySelector<HTMLElement>("[data-corner-marks]");
-			if (marks) marks.innerHTML = cornerSpansHTML(cornersFor(i, cols));
+		if (renderedSort !== state.sort) {
+			for (const model of orderedModels) grid.appendChild(model.cell);
+			renderedSort = state.sort;
+		}
+		const visibleCells = new Set(matches.map((model) => model.cell));
+		for (const model of indexedModels) {
+			const display = visibleCells.has(model.cell) ? "" : "none";
+			if (model.cell.style.display !== display)
+				model.cell.style.display = display;
+		}
+		matches.forEach((model, i) => {
+			const markup = cornerSpansHTML(cornersFor(i, cols));
+			if (model.marks && model.marks.innerHTML !== markup)
+				model.marks.innerHTML = markup;
 		});
 
 		if (empty) empty.hidden = matches.length > 0;
@@ -287,7 +501,7 @@ const facetMatchMaps = Object.fromEntries(
 	// Event listeners.
 	searchInput.addEventListener("input", () => {
 		state.search = searchInput.value;
-		relayout();
+		scheduleRelayout();
 		syncUrl();
 	});
 

--- a/src/components/models/ModelCatalog.astro
+++ b/src/components/models/ModelCatalog.astro
@@ -1,20 +1,5 @@
 ---
-/**
- * ModelCatalog — filterable AI model catalog, rendered inside the docs layout.
- *
- * The toolbar (search + Task Types / Capabilities / Providers? / Authors
- * multi-selects + sort) and the "We found N models" count/clear live in small
- * React islands (FilterDropdownWrapper / SortSelectWrapper) built on base-ui,
- * styled with Nimbus design tokens. The islands fire CustomEvents; a vanilla
- * JS `<script>` owns filter/sort/URL state and re-flows the grid below.
- *
- * The card grid itself stays server-rendered here (better for SEO than a
- * fully-client catalog, and preserves the Directory corner-mark grid). The
- * host page resolves the model slice (`getLegacyModels` / `getResolvedModels`
- * → `toModelCardData`) and passes it in; `basePath` selects the per-model URL
- * prefix + card href slug form. The Providers facet is computed internally and
- * appears only when the slice spans more than one `hosting` value.
- */
+/** Renders the filterable model catalog and comparison table. */
 import ModelCard from "./ModelCard.astro";
 import { FilterDropdownWrapper } from "./FilterDropdownWrapper";
 import { SortSelectWrapper } from "./SortSelectWrapper";
@@ -30,8 +15,7 @@ const { models, basePath = "/ai/models" } = Astro.props;
 const facets = getFacets(models);
 const cols = resolveCols(models.length);
 
-// Embed facet match maps so the vanilla script can convert selected option
-// values (e.g. author ids) to the strings stamped on card data-facet-* attrs.
+// Maps filter values to card facet values.
 const facetMatchMaps = Object.fromEntries(
 	facets.map((f) => [
 		f.key,
@@ -41,11 +25,9 @@ const facetMatchMaps = Object.fromEntries(
 ---
 
 <div data-models class="not-prose">
-	{/* Toolbar */}
 	<div
 		class="mb-4 flex flex-col gap-3 md:flex-row md:flex-wrap md:items-center"
 	>
-		{/* Search */}
 		<div class="relative flex-1 md:min-w-[300px]">
 			<svg
 				class="text-muted-foreground pointer-events-none absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2"
@@ -68,7 +50,6 @@ const facetMatchMaps = Object.fromEntries(
 			/>
 		</div>
 
-		{/* Filter dropdowns (React islands) + sort */}
 		<div class="flex flex-wrap items-center gap-2">
 			{
 				facets.map((facet) => (
@@ -87,7 +68,6 @@ const facetMatchMaps = Object.fromEntries(
 		</div>
 	</div>
 
-	{/* Count + clear */}
 	<div class="text-muted-foreground mb-4 flex items-center gap-3 text-sm">
 		<span aria-live="polite">
 			We found{" "}
@@ -143,7 +123,6 @@ const facetMatchMaps = Object.fromEntries(
 		</div>
 	</section>
 
-	{/* Empty state — toggled by the script. */}
 	<div
 		data-models-empty
 		hidden
@@ -155,7 +134,6 @@ const facetMatchMaps = Object.fromEntries(
 		</p>
 	</div>
 
-	{/* Grid (server-rendered; script reflows it). */}
 	<div class="border-border relative w-full border-t border-l">
 		<div data-models-grid class={LG_GRID_CLASS[cols]}>
 			{
@@ -179,7 +157,7 @@ const facetMatchMaps = Object.fromEntries(
 
 	type SortOrder = "newest" | "oldest";
 
-	// Facet match maps + keys injected from build-time facet data.
+	// Reads facet match data embedded at build time.
 	const facetMatchMaps = JSON.parse(
 		document.getElementById("model-facet-data")!.dataset.facets!,
 	) as Record<string, Record<string, string>>;
@@ -225,6 +203,7 @@ const facetMatchMaps = Object.fromEntries(
 	).map((cell) => ({
 		cell,
 		marks: cell.querySelector<HTMLElement>("[data-corner-marks]"),
+		layoutSignature: "",
 		search: cell.dataset.search ?? cell.dataset.name ?? "",
 		facets: Object.fromEntries(
 			facetKeys.map((key) => [
@@ -401,17 +380,14 @@ const facetMatchMaps = Object.fromEntries(
 			cancelAnimationFrame(relayoutFrame);
 			relayoutFrame = 0;
 		}
-		// Split the query into whitespace-separated tokens; each must appear
-		// somewhere in the card's searchable text (name + shortName +
-		// description). This lets "happy horse" match a "HappyHorse" model
-		// whose term only lives in the description.
+		// Every search token must appear in the card text.
 		const queryTokens = state.search
 			.trim()
 			.toLowerCase()
 			.split(/\s+/)
 			.filter(Boolean);
 
-		// Convert selected values to match strings using the match maps.
+		// Converts selected filters to card facet values.
 		const selMatch: Record<string, string[]> = {};
 		for (const key of facetKeys) {
 			selMatch[key] = (state.selected[key] ?? []).map(
@@ -453,18 +429,17 @@ const facetMatchMaps = Object.fromEntries(
 				model.cell.style.display = display;
 		}
 		matches.forEach((model, i) => {
-			const markup = cornerSpansHTML(cornersFor(i, cols));
-			if (model.marks && model.marks.innerHTML !== markup)
-				model.marks.innerHTML = markup;
+			const layoutSignature = `${i}:${cols}`;
+			if (!model.marks || model.layoutSignature === layoutSignature) return;
+			model.marks.innerHTML = cornerSpansHTML(cornersFor(i, cols));
+			model.layoutSignature = layoutSignature;
 		});
 
 		if (empty) empty.hidden = matches.length > 0;
 
-		// Update count + label.
 		countEl.textContent = String(matches.length);
 		countLabelEl.textContent = matches.length === 1 ? "model" : "models";
 
-		// Clear button: show when any dropdown filter is active.
 		const hasActive = facetKeys.some(
 			(k) => (state.selected[k] ?? []).length > 0,
 		);
@@ -490,7 +465,6 @@ const facetMatchMaps = Object.fromEntries(
 		}
 	}
 
-	// Hydrate from URL once.
 	const initParams = new URLSearchParams(window.location.search);
 	const initSearch = initParams.get("search") ?? "";
 	if (initSearch) {
@@ -501,9 +475,8 @@ const facetMatchMaps = Object.fromEntries(
 	if (initSort === "oldest" || initSort === "newest") {
 		state.sort = initSort;
 	}
-	// Dropdowns self-initialise from URL via their useEffect and fire events.
+	// Dropdowns initialize from the URL and dispatch filter events.
 
-	// Event listeners.
 	searchInput.addEventListener("input", () => {
 		state.search = searchInput.value;
 		if (document.visibilityState === "hidden") relayout();
@@ -533,11 +506,10 @@ const facetMatchMaps = Object.fromEntries(
 		syncUrl();
 	});
 
-	// Reflow on breakpoint changes (corner marks depend on column count).
+	// Reflows corner marks when the desktop breakpoint changes.
 	window
 		.matchMedia("(min-width: 1024px)")
 		.addEventListener("change", () => relayout());
 
-	// Initial layout pass (handles URL-initialised search and sort).
 	relayout();
 </script>

--- a/src/components/models/ModelFeatures.astro
+++ b/src/components/models/ModelFeatures.astro
@@ -6,7 +6,7 @@
  * beta → Batch → request formats → partner → realtime → unit price →
  * dashboard pricing link.
  */
-import type { ModelView } from "~/util/models";
+import { modelCurrencyFormatter, type ModelView } from "~/util/models";
 
 interface Props {
 	model: ModelView;
@@ -15,11 +15,6 @@ interface Props {
 const { model } = Astro.props;
 
 const nf = new Intl.NumberFormat("en-US");
-const currencyFormatter = new Intl.NumberFormat("en-US", {
-	style: "currency",
-	currency: "USD",
-	maximumFractionDigits: 10,
-});
 
 // Flatten the property list into a lookup (values are strings).
 const properties: Record<string, any> = {};
@@ -194,7 +189,9 @@ const price = Array.isArray(properties.price)
 						<td>Unit Pricing</td>
 						<td>
 							{price
-								.map((p) => `${currencyFormatter.format(p.price)} ${p.unit}`)
+								.map(
+									(p) => `${modelCurrencyFormatter.format(p.price)} ${p.unit}`,
+								)
 								.join(", ")}
 						</td>
 					</tr>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -417,6 +417,7 @@ export const collections = {
 			// Capabilities
 			context_length: z.number().nullable(),
 			max_output_tokens: z.number().nullable(),
+			pricing: z.record(z.string(), z.unknown()).optional().default({}),
 			supports_async: z.boolean(),
 
 			// Zero Data Retention (optional — older API rows omit it).

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -417,7 +417,7 @@ export const collections = {
 			// Capabilities
 			context_length: z.number().nullable(),
 			max_output_tokens: z.number().nullable(),
-			pricing: z.record(z.string(), z.unknown()).optional().default({}),
+			pricing: z.record(z.string(), z.unknown()).default({}),
 			supports_async: z.boolean(),
 
 			// Zero Data Retention (optional — older API rows omit it).

--- a/src/util/models/index.ts
+++ b/src/util/models/index.ts
@@ -3,6 +3,7 @@
  */
 export * from "./model-types";
 export * from "./model-helpers";
+export * from "./model-format";
 export * from "./model-properties";
 export * from "./model-schema";
 export * from "./model-resolver";

--- a/src/util/models/model-format.node.test.ts
+++ b/src/util/models/model-format.node.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { formatCompactTokens, formatModelPricing } from "./model-format";
+
+describe("model display formatting", () => {
+	it("formats token counts compactly", () => {
+		expect(formatCompactTokens(200_000)).toBe("200K tokens");
+		expect(formatCompactTokens(null)).toBeNull();
+	});
+
+	it("formats supported pricing values and omits nested metadata", () => {
+		expect(
+			formatModelPricing({
+				"Input tokens (per 1M)": 1.25,
+				"per M output tokens": 2.5,
+				"per M cached input tokens": 0.25,
+				plan: "included",
+				metadata: { currency: "USD" },
+			}),
+		).toEqual([
+			"Input (per 1M tokens): $1.25",
+			"Output (per 1M tokens): $2.50",
+			"Cached input (per 1M tokens): $0.25",
+			"plan: included",
+		]);
+	});
+
+	it("preserves non-token billing units", () => {
+		expect(
+			formatModelPricing({
+				"per input 512x512 tile": 0.000059,
+				"per step": 0.01,
+				"per image MP": 0.02,
+				"per audio minute": 0.03,
+				"per request": 0.04,
+			}),
+		).toEqual([
+			"per input 512x512 tile: $0.000059",
+			"per step: $0.01",
+			"per image MP: $0.02",
+			"per audio minute: $0.03",
+			"per request: $0.04",
+		]);
+	});
+});

--- a/src/util/models/model-format.node.test.ts
+++ b/src/util/models/model-format.node.test.ts
@@ -13,6 +13,7 @@ describe("model display formatting", () => {
 				"Input tokens (per 1M)": 1.25,
 				"per M output tokens": 2.5,
 				"per M cached input tokens": 0.25,
+				"cached output tokens (per 1m)": 0.5,
 				plan: "included",
 				metadata: { currency: "USD" },
 			}),
@@ -20,6 +21,7 @@ describe("model display formatting", () => {
 			"Input (per 1M tokens): $1.25",
 			"Output (per 1M tokens): $2.50",
 			"Cached input (per 1M tokens): $0.25",
+			"Cached output (per 1M tokens): $0.50",
 			"plan: included",
 		]);
 	});

--- a/src/util/models/model-format.ts
+++ b/src/util/models/model-format.ts
@@ -1,0 +1,45 @@
+const compactNumber = new Intl.NumberFormat("en-US", {
+	notation: "compact",
+	maximumFractionDigits: 1,
+});
+
+const currency = new Intl.NumberFormat("en-US", {
+	style: "currency",
+	currency: "USD",
+	maximumFractionDigits: 10,
+});
+
+export function formatCompactTokens(value: unknown): string | null {
+	const count = Number(value);
+	return Number.isFinite(count) && count > 0
+		? `${compactNumber.format(count)} tokens`
+		: null;
+}
+
+export function formatModelPricing(
+	pricing: Record<string, unknown> | undefined,
+): string[] {
+	return Object.entries(pricing ?? {}).flatMap(([label, value]) => {
+		const displayLabel = formatPricingLabel(label);
+		if (typeof value === "number" && Number.isFinite(value) && value >= 0) {
+			return [`${displayLabel}: ${currency.format(value)}`];
+		}
+		if (typeof value === "string" && value.trim()) {
+			return [`${displayLabel}: ${value.trim()}`];
+		}
+		return [];
+	});
+}
+
+function formatPricingLabel(label: string): string {
+	const normalized = label.replaceAll("_", " ").replace(/\s+/g, " ").trim();
+	const lower = normalized.toLowerCase();
+	const tokenPrice =
+		/^per (?:1)?m (cached )?(input|output) tokens$/.exec(lower) ??
+		/^(cached )?(input|output) tokens \(per (?:1)?m\)$/.exec(lower);
+	if (tokenPrice) {
+		const direction = tokenPrice[2] === "input" ? "Input" : "Output";
+		return `${tokenPrice[1] ? "Cached input" : direction} (per 1M tokens)`;
+	}
+	return normalized;
+}

--- a/src/util/models/model-format.ts
+++ b/src/util/models/model-format.ts
@@ -3,7 +3,7 @@ const compactNumber = new Intl.NumberFormat("en-US", {
 	maximumFractionDigits: 1,
 });
 
-const currency = new Intl.NumberFormat("en-US", {
+export const modelCurrencyFormatter = new Intl.NumberFormat("en-US", {
 	style: "currency",
 	currency: "USD",
 	maximumFractionDigits: 10,
@@ -22,7 +22,7 @@ export function formatModelPricing(
 	return Object.entries(pricing ?? {}).flatMap(([label, value]) => {
 		const displayLabel = formatPricingLabel(label);
 		if (typeof value === "number" && Number.isFinite(value) && value >= 0) {
-			return [`${displayLabel}: ${currency.format(value)}`];
+			return [`${displayLabel}: ${modelCurrencyFormatter.format(value)}`];
 		}
 		if (typeof value === "string" && value.trim()) {
 			return [`${displayLabel}: ${value.trim()}`];

--- a/src/util/models/model-format.ts
+++ b/src/util/models/model-format.ts
@@ -39,7 +39,10 @@ function formatPricingLabel(label: string): string {
 		/^(cached )?(input|output) tokens \(per (?:1)?m\)$/.exec(lower);
 	if (tokenPrice) {
 		const direction = tokenPrice[2] === "input" ? "Input" : "Output";
-		return `${tokenPrice[1] ? "Cached input" : direction} (per 1M tokens)`;
+		const displayDirection = tokenPrice[1]
+			? `Cached ${direction.toLowerCase()}`
+			: direction;
+		return `${displayDirection} (per 1M tokens)`;
 	}
 	return normalized;
 }

--- a/src/util/models/model-resolver.ts
+++ b/src/util/models/model-resolver.ts
@@ -38,7 +38,10 @@ function legacyPricing(value: unknown): Record<string, unknown> {
 				entry === null ||
 				!("unit" in entry) ||
 				!("price" in entry) ||
-				typeof entry.unit !== "string"
+				typeof entry.unit !== "string" ||
+				typeof entry.price !== "number" ||
+				!Number.isFinite(entry.price) ||
+				entry.price < 0
 			) {
 				return [];
 			}
@@ -162,7 +165,7 @@ export function catalogToResolved(entry: CatalogEntry): ModelView {
 		zdrComment: model.zdr_comment ?? null,
 		modelId: model.model_id,
 		requestFormats: (model.request_formats as string[] | undefined) ?? null,
-		pricing: (model.pricing as Record<string, unknown> | undefined) ?? {},
+		pricing: model.pricing,
 		examples: (model.examples as ModelExample[] | undefined) ?? [],
 		banner: (model.banner as ModelBanner | null | undefined) ?? null,
 		digest: entry.digest,

--- a/src/util/models/model-resolver.ts
+++ b/src/util/models/model-resolver.ts
@@ -29,6 +29,24 @@ const isTrue = (v: unknown): boolean => v === true || v === "true";
 const authorDisplayName = (author: string): string =>
 	authorData[author]?.name ?? author;
 
+function legacyPricing(value: unknown): Record<string, unknown> {
+	if (!Array.isArray(value)) return {};
+	return Object.fromEntries(
+		value.flatMap((entry) => {
+			if (
+				typeof entry !== "object" ||
+				entry === null ||
+				!("unit" in entry) ||
+				!("price" in entry) ||
+				typeof entry.unit !== "string"
+			) {
+				return [];
+			}
+			return [[entry.unit, entry.price]];
+		}),
+	);
+}
+
 function buildView(args: {
 	id: string;
 	name: string;
@@ -39,6 +57,7 @@ function buildView(args: {
 	hosting: "hosted" | "proxied";
 	task: string;
 	description: string;
+	tags: string[];
 	properties: Record<string, unknown>;
 	propertiesList: { property_id: string; value: unknown }[];
 	schema: { input: Record<string, unknown>; output: Record<string, unknown> };
@@ -46,6 +65,7 @@ function buildView(args: {
 	zdrComment?: string | null;
 	modelId?: string;
 	requestFormats?: string[] | null;
+	pricing?: Record<string, unknown>;
 	examples?: ModelExample[];
 	banner?: ModelBanner | null;
 	digest?: number | string;
@@ -68,6 +88,7 @@ function buildView(args: {
 		source: args.source,
 		task: args.task,
 		description: args.description,
+		tags: args.tags,
 		capabilities,
 		beta: isTrue(args.properties.beta),
 		createdAt: args.createdAt,
@@ -75,6 +96,7 @@ function buildView(args: {
 		propertiesList: args.propertiesList,
 		modelId: args.modelId,
 		requestFormats: args.requestFormats ?? null,
+		pricing: args.pricing,
 		examples: args.examples,
 		banner: args.banner ?? null,
 		schema: args.schema,
@@ -131,6 +153,7 @@ export function catalogToResolved(entry: CatalogEntry): ModelView {
 		hosting: "proxied",
 		task: model.task,
 		description: model.description,
+		tags: Array.isArray(model.tags) ? model.tags : [],
 		properties,
 		propertiesList,
 		schema,
@@ -139,6 +162,7 @@ export function catalogToResolved(entry: CatalogEntry): ModelView {
 		zdrComment: model.zdr_comment ?? null,
 		modelId: model.model_id,
 		requestFormats: (model.request_formats as string[] | undefined) ?? null,
+		pricing: (model.pricing as Record<string, unknown> | undefined) ?? {},
 		examples: (model.examples as ModelExample[] | undefined) ?? [],
 		banner: (model.banner as ModelBanner | null | undefined) ?? null,
 		digest: entry.digest,
@@ -168,6 +192,8 @@ export function legacyToResolved(entry: LegacyEntry): ModelView {
 		hosting: "hosted",
 		task: d.task.name,
 		description: d.description,
+		tags: Array.isArray(d.tags) ? d.tags : [],
+		pricing: legacyPricing(properties.price),
 		properties,
 		propertiesList,
 		schema: {

--- a/src/util/models/model-types.ts
+++ b/src/util/models/model-types.ts
@@ -59,6 +59,7 @@ export interface ModelView {
 	source: number;
 	task: string;
 	description: string;
+	tags: string[];
 	/** Derived capability labels (filter facet + badges). */
 	capabilities: string[];
 	beta: boolean;
@@ -71,6 +72,7 @@ export interface ModelView {
 	modelId?: string;
 	/** Accepted request formats (e.g. `["responses","chat-completions"]`). Catalog-only. */
 	requestFormats?: string[] | null;
+	pricing?: Record<string, unknown>;
 	/** Usage (first) + Examples list (rest). Catalog-only. */
 	examples?: ModelExample[];
 	/** In-page notice. Catalog-only. */


### PR DESCRIPTION
### Summary

- Preserve catalog tags and pricing during model imports.
- Add aligned model facts and accessible three-model comparison.
- Format token and non-token pricing with explicit billing units.
- Improve catalog filtering, sorting, and importer concurrency.
- Add pagination, ordering, failure, and pricing tests.

Related roadmap epic: [RM-27401](https://jira.cfdata.org/browse/RM-27401)

### Validation

- `pnpm run check`
- `pnpm run lint`
- `pnpm run format:core:check`
- `pnpm run format:content:check`
- `pnpm run test -- --run` (165 tests)
- `pnpm run build` (8,983 pages)
- `git diff --check`

### Documentation checklist

- Changelog: not applicable; this updates the existing model catalog UI and metadata.
- [x] The change adheres to the documentation style guide.
- [x] Related tracking exists in RM-27401.
- Redirects: not applicable.