### PR TITLE
[Sandbox] Move OpenAI Agents API guide to tutorials

### DIFF
--- a/public/__redirects
+++ b/public/__redirects
@@ -662,6 +662,7 @@
 # Sandbox
 /sandbox/platform/beta-info/ /sandbox/platform/ 301
 /sandbox/guides/openai-agents-sdk/ /sandbox/tutorials/openai-agents/ 301
+/sandbox/guides/openai-agents-api/ /sandbox/tutorials/openai-agents-api/ 301
 /sandbox/guides/production-deployment/ /sandbox/guides/preview-urls-custom-domain/ 301
 # D1
 /d1/client-api/ /d1/worker-api/ 301

--- a/src/content/changelog/containers/2026-09-10-using-openai-agents-api-with-cloudflare-containers.mdx
+++ b/src/content/changelog/containers/2026-09-10-using-openai-agents-api-with-cloudflare-containers.mdx
@@ -14,4 +14,4 @@ Cloudflare Containers can now provide self-hosted execution environments for the
 
 You can configure the reference implementation to meet your needs by extending the Container to provide controlled access to data and the network or by integrating it with other Cloudflare products.
 
-To get started, refer to [Run Codex on Cloudflare using the OpenAI Agents API](/sandbox/guides/openai-agents-api/).
+To get started, refer to [Run Codex on Cloudflare using the OpenAI Agents API](/sandbox/tutorials/openai-agents-api/).

--- a/src/content/docs/sandbox/tutorials/openai-agents-api.mdx
+++ b/src/content/docs/sandbox/tutorials/openai-agents-api.mdx
@@ -1,8 +1,9 @@
 ---
 title: Run Codex with Cloudflare Containers using the OpenAI Agents API
-pcx_content_type: how-to
+pcx_content_type: tutorial
+difficulty: Beginner
 sidebar:
-  order: 19
+  order: 6
 description: Deploy a Cloudflare execution environment that can be used by Codex via the OpenAI Agents API.
 products:
   - sandbox


### PR DESCRIPTION
## Summary

- move the OpenAI Agents API setup guide from `/sandbox/guides/` to `/sandbox/tutorials/` alongside the other managed-agent tutorials
- classify it as a beginner tutorial and update the changelog to use the canonical URL
- add a permanent redirect from the already published guide URL

## Validation

- `npm run check`
- targeted Prettier check
- `npx tsm bin/validate-redirects.ts`