### PR TITLE
ci: run preview deploys concurrently

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -285,8 +285,16 @@ jobs:
           echo "branch_slug=${BRANCH_SLUG}" >> "$GITHUB_OUTPUT"
           echo "short_sha=${SHORT_SHA}" >> "$GITHUB_OUTPUT"
 
-          pnpm exec wrangler deploy --config wrangler.preview.json --dispatch-namespace preview-deployments --name "${SHORT_SHA}"
-          pnpm exec wrangler deploy --config wrangler.preview.json --dispatch-namespace preview-deployments --name "${BRANCH_SLUG}"
+          # These two deploys are independent (different Worker names in the
+          # same dispatch namespace), so run them concurrently instead of
+          # back-to-back.
+          pnpm exec wrangler deploy --config wrangler.preview.json --dispatch-namespace preview-deployments --name "${SHORT_SHA}" &
+          short_sha_pid=$!
+          pnpm exec wrangler deploy --config wrangler.preview.json --dispatch-namespace preview-deployments --name "${BRANCH_SLUG}" &
+          branch_slug_pid=$!
+
+          wait "$short_sha_pid"
+          wait "$branch_slug_pid"
 
       - name: Post preview URL on PR
         env:


### PR DESCRIPTION
This PR makes the two `wrangler deploy` calls in the `Deploy Preview` job's "Deploy to Cloudflare Workers" step run concurrently instead of sequentially.

Each PR preview is deployed twice, once under the short commit SHA and once under the branch-slug name, to the same dispatch namespace. These deploys are independent of each other, but currently run back-to-back in a single shell step, roughly doubling the time of that step (observed ~5m18s across two deploys on a recent run).

This backgrounds both `wrangler deploy` invocations and waits on each, so the step fails the same way as before if either deploy fails, but the wall-clock time should be close to that of a single deploy.