### PR TITLE
Document V8 coverage in Vitest integration

### DIFF
--- a/src/content/docs/workers/testing/vitest-integration/configuration.mdx
+++ b/src/content/docs/workers/testing/vitest-integration/configuration.mdx
@@ -9,7 +9,7 @@ products:
   - workers
 ---
 
-import { Details } from "~/components";
+import { Details, PackageManagers } from "~/components";
 
 The Workers Vitest integration provides additional configuration on top of Vitest's usual options using the `cloudflareTest()` Vite plugin.
 
@@ -35,6 +35,20 @@ export default defineConfig({
 Custom Vitest `environment`s or `runner`s are not supported when using the Workers Vitest integration.
 
 :::
+
+## Code coverage
+
+The Workers Vitest integration supports Vitest's V8 and Istanbul coverage providers for tests that run locally. Vitest uses V8 by default.
+
+To collect V8 coverage, install the provider that matches your Vitest version:
+
+<PackageManagers pkg="@vitest/coverage-v8@^4.1.0" dev />
+
+Then, run Vitest with coverage enabled:
+
+<PackageManagers type="exec" pkg="vitest" args="run --coverage" />
+
+The Workers Vitest integration automatically applies the compatibility settings required for local V8 coverage. For coverage options, refer to the [Vitest coverage documentation](https://v4.vitest.dev/guide/coverage).
 
 ## APIs
 

--- a/src/content/docs/workers/testing/vitest-integration/known-issues.mdx
+++ b/src/content/docs/workers/testing/vitest-integration/known-issues.mdx
@@ -11,10 +11,6 @@ products:
 
 The Workers Vitest plugin has the following known issues:
 
-### Coverage
-
-Native code coverage via [V8](https://v8.dev/blog/javascript-code-coverage) is not supported. You must use instrumented code coverage via [Istanbul](https://istanbul.js.org/) instead. Refer to the [Vitest Coverage documentation](https://vitest.dev/guide/coverage) for setup instructions.
-
 ### Fake timers
 
 Vitest's [fake timers](https://vitest.dev/guide/mocking.html#timers) do not apply to KV, R2 and cache simulators. For example, you cannot expire a KV key by advancing fake time.


### PR DESCRIPTION
This PR updates the workers documentation in regards to the V8 code coverage support being introduced in the vitest plugin in https://github.com/cloudflare/workers-sdk/pull/15591