### PR TITLE
[Agents] Document Lifecycle and Durable Object capabilities

### DIFF
--- a/src/content/changelog/agents/2026-09-11-agents-lifecycle-capabilities.mdx
+++ b/src/content/changelog/agents/2026-09-11-agents-lifecycle-capabilities.mdx
@@ -1,0 +1,105 @@
+---
+title: Agents SDK v0.23.0 adds composable Durable Object capabilities
+description: Agents SDK v0.23.0 lets developers compose durable agent features on the platform Durable Object class through Lifecycle capabilities.
+products:
+  - agents
+  - workers
+date: 2026-09-11
+---
+
+import { PackageManagers, TypeScriptExample } from "~/components";
+
+[Agents SDK v0.23.0](https://github.com/cloudflare/agents/releases/tag/agents%400.23.0) expands the set of durable features that you can compose without extending the `Agent` class. The `agents/lifecycle` entry point connects contained capabilities to any Cloudflare Durable Object.
+
+A capability owns its storage and control flow. Lifecycle coordinates startup, request dispatch, WebSocket events, durable jobs, alarms, and cleanup across every installed capability.
+
+Lifecycle and these capabilities are replatforming the `Agent` class and [Think harness](/agents/harnesses/think/). The same durable implementations can now power framework internals and plain Durable Objects. Developers can combine these building blocks into rich agent experiences without adopting a complete framework.
+
+The Lifecycle entry point and directly installed capability APIs are experimental. Established APIs on `Agent` remain available.
+
+The following example attaches all public Lifecycle capabilities available in `agents@0.23.0` to a plain Durable Object:
+
+<TypeScriptExample>
+
+```ts
+import { DurableObject } from "cloudflare:workers";
+import { Lifecycle } from "agents/lifecycle";
+import { MCPClientManager } from "agents/mcp/client";
+import { RoutedAgents } from "agents/routing";
+import { Scheduler } from "agents/schedules";
+import { Sessions } from "agents/sessions";
+import { Streams } from "agents/streams";
+import { Tasks, type TaskStep } from "agents/tasks";
+import { WebSockets } from "agents/websockets";
+import type { ChatAgent } from "./chat-agent";
+
+export class AgentHost extends DurableObject<Env> {
+	readonly mcp = new MCPClientManager("agent-host", "1.0.0", {
+		env: this.env,
+	});
+
+	readonly chats = new RoutedAgents<ChatAgent, { title: string }>({
+		namespace: this.env.ChatAgent,
+		route: "chats",
+	});
+
+	readonly scheduler = new Scheduler({
+		callbacks: {
+			remind: (payload: { message: string }) => console.log(payload.message),
+		},
+	});
+
+	readonly sessions = new Sessions({
+		reservedMetadataKeys: ["internal"],
+	});
+
+	readonly streams = new Streams({ maxChunkBytes: 64 * 1024 });
+
+	readonly tasks = new Tasks({
+		definitions: {
+			"research@v1": async (input: { topic: string }, step: TaskStep) =>
+				step.do("search", () => ({
+					topic: input.topic,
+					results: [],
+				})),
+		},
+	});
+
+	readonly webSockets = new WebSockets({
+		handlers: {
+			onMessage: (connection, message) => connection.send(message),
+		},
+	});
+
+	readonly lifecycle = Lifecycle.install(this)
+		.use(this.mcp)
+		.use(this.chats)
+		.use(this.scheduler)
+		.use(this.sessions)
+		.use(this.streams)
+		.use(this.tasks)
+		.use(this.webSockets, { fallback: true });
+}
+```
+
+</TypeScriptExample>
+
+Most applications install only the capabilities they need. The fallback option keeps the WebSocket catch-all after other request and upgrade middleware.
+
+Each capability has a focused role:
+
+- `MCPClientManager` restores persisted Model Context Protocol (MCP) server registrations and reconnects clients.
+- `RoutedAgents` manages and routes to independent top-level Agents.
+- `Scheduler` runs delayed, dated, cron, and interval callbacks.
+- `Sessions` stores branching conversation history and attachments.
+- `Streams` persists replayable incremental output.
+- `Tasks` runs journaled work that survives process loss.
+- `WebSockets` owns hibernating connections and remote callables.
+
+Lifecycle also provides a shared durable job queue. Capabilities schedule future work without competing for the Durable Object's single alarm.
+
+Install this release with your package manager:
+
+<PackageManagers pkg="agents@0.23.0" />
+
+For the runtime model and custom hooks, refer to [Durable Object lifecycle](/agents/runtime/lifecycle/). For capability imports and options, refer to [Capabilities](/agents/runtime/capabilities/).

--- a/src/content/docs/agents/index.mdx
+++ b/src/content/docs/agents/index.mdx
@@ -11,10 +11,7 @@ head:
     content: Agents
 ---
 
-import {
-	AgentsPlatformDiagram,
-	RelatedProduct,
-} from "~/components";
+import { AgentsPlatformDiagram, RelatedProduct } from "~/components";
 
 Build and host Agents on Cloudflare, connect chat, voice, email, Slack, and webhooks to a durable agent runtime with Browser, Sandbox, AI Search, MCP, Payments, and other MCP tools.
 
@@ -28,7 +25,7 @@ Agents on Cloudflare are composed from four parts:
 
 - **Communication channels** define how users and systems reach your agent, such as [chat](/agents/communication-channels/chat/), [voice](/agents/communication-channels/voice/), [email](/agents/communication-channels/email/), [Slack](/agents/communication-channels/slack/), [webhooks](/agents/communication-channels/webhooks/), and other event sources.
 - **The agent harness** defines the loop: how the agent calls models, selects tools, handles tool results, streams responses, and decides whether to continue. Use [Project Think](/agents/harnesses/think/) for an opinionated harness, or build your own loop directly on the [Agents SDK runtime](/agents/runtime/agents-api/).
-- **The Agents SDK runtime** provides durable infrastructure: the [`Agent` class](/agents/runtime/lifecycle/agent-class/), [state](/agents/runtime/lifecycle/state/), [sessions](/agents/runtime/lifecycle/sessions/), [routing](/agents/runtime/communication/routing/), [WebSockets](/agents/runtime/communication/websockets/), [scheduling](/agents/runtime/execution/schedule-tasks/), [fibers](/agents/runtime/execution/durable-execution/), and [observability](/agents/runtime/operations/observability/).
+- **The Agents SDK runtime** provides a [Durable Object lifecycle](/agents/runtime/lifecycle/), composable [capabilities](/agents/runtime/capabilities/), and the [`Agent` class](/agents/runtime/lifecycle/agent-class/). Runtime features include [state](/agents/runtime/lifecycle/state/), [routing](/agents/runtime/communication/routing/), [WebSockets](/agents/runtime/communication/websockets/), [scheduling](/agents/runtime/execution/schedule-tasks/), [durable execution](/agents/runtime/execution/durable-execution/), and [observability](/agents/runtime/operations/observability/).
 - **Tools** give the agent capabilities: [browser automation](/agents/tools/browser/), [sandboxed code execution](/agents/tools/sandbox/), [AI Search](/agents/tools/ai-search/), [MCP tools](/agents/tools/mcp/), and [payments](/agents/tools/payments/). [Code Mode](/agents/tools/codemode/) lets models discover and orchestrate multiple tools by writing code.
 
 ### Get started

--- a/src/content/docs/agents/runtime/capabilities/index.mdx
+++ b/src/content/docs/agents/runtime/capabilities/index.mdx
@@ -1,0 +1,297 @@
+---
+title: Capabilities
+description: Add contained storage and control-flow features to a Durable Object with composable Agents SDK capabilities.
+pcx_content_type: concept
+sidebar:
+  order: 1.5
+products:
+  - agents
+---
+
+import { TypeScriptExample } from "~/components";
+
+A capability is a contained piece of logic that controls its own storage and control flow. It exposes a focused API and implements only the lifecycle hooks it needs.
+
+Capabilities use composition instead of another base class. You can attach them to a plain Durable Object or the [`Agent` class](/agents/runtime/lifecycle/agent-class/) through the same [Lifecycle](/agents/runtime/lifecycle/).
+
+:::caution[Experimental]
+
+Lifecycle capabilities may change between releases while the composition model stabilizes. Established APIs on the `Agent` class remain available.
+
+:::
+
+## Compose capabilities
+
+Construct one instance of each capability as a Durable Object field. Then register each instance with `Lifecycle.use()`:
+
+<TypeScriptExample>
+
+```ts
+import { DurableObject } from "cloudflare:workers";
+import { Lifecycle } from "agents/lifecycle";
+import { Sessions } from "agents/sessions";
+import { Streams } from "agents/streams";
+
+export class ConversationObject extends DurableObject<Env> {
+	readonly sessions = new Sessions();
+	readonly streams = new Streams();
+
+	readonly lifecycle = Lifecycle.install(this)
+		.use(this.sessions)
+		.use(this.streams);
+}
+```
+
+</TypeScriptExample>
+
+Each new in-memory Durable Object instance recreates these capability objects. Lifecycle then runs each capability's startup hook. Capabilities use that hook to initialize or restore durable state.
+
+A capability controls any tables, keys, migrations, or platform state it needs. All capabilities share the host Durable Object storage, so each one namespaces its own data. Lifecycle owns shared coordination, including startup order and the physical Durable Object alarm. Host-specific bindings remain explicit constructor options.
+
+## MCP client
+
+Import `MCPClientManager` from `agents/mcp/client`:
+
+<TypeScriptExample>
+
+```ts
+import { DurableObject } from "cloudflare:workers";
+import { Lifecycle } from "agents/lifecycle";
+import { MCPClientManager } from "agents/mcp/client";
+
+export class ToolObject extends DurableObject<Env> {
+	readonly mcp = new MCPClientManager("tool-object", "1.0.0", {
+		env: this.env,
+	});
+	readonly lifecycle = Lifecycle.install(this).use(this.mcp);
+}
+```
+
+</TypeScriptExample>
+
+`MCPClientManager` stores a catalog of Model Context Protocol (MCP) servers. It restores connections during startup and handles registered OAuth callbacks before the host request handler.
+
+Pass `env` when the catalog can contain Durable Object RPC servers. HTTP-only MCP connections do not require it. Use `listTools()` for raw tools or `getAITools()` for AI SDK tools.
+
+For server registration and authentication, refer to the [MCP client API](/agents/model-context-protocol/apis/client-api/).
+
+## Routed Agents
+
+Import `RoutedAgents` from `agents/routing`:
+
+<TypeScriptExample>
+
+```ts
+import { DurableObject } from "cloudflare:workers";
+import { Lifecycle } from "agents/lifecycle";
+import { RoutedAgents } from "agents/routing";
+import type { ChatAgent } from "./chat-agent";
+
+export class UserHub extends DurableObject<Env> {
+	readonly chats = new RoutedAgents<ChatAgent, { title: string }>({
+		namespace: this.env.ChatAgent,
+		route: "chats",
+	});
+	readonly lifecycle = Lifecycle.install(this).use(this.chats);
+}
+```
+
+</TypeScriptExample>
+
+`RoutedAgents` lets a hub Durable Object manage independent top-level Agents. It stores public IDs and metadata without waking target Agents. Requests under `/{route}/{id}` forward to the selected target.
+
+The hub can extend `DurableObject` directly. Each target must extend `Agent`. Use `create()`, `list()`, `get()`, `setMetadata()`, and `delete()` to manage the catalog.
+
+## Scheduler
+
+Import `Scheduler` from `agents/schedules`:
+
+<TypeScriptExample>
+
+```ts
+import { DurableObject } from "cloudflare:workers";
+import { Lifecycle } from "agents/lifecycle";
+import { Scheduler } from "agents/schedules";
+
+export class ReminderObject extends DurableObject<Env> {
+	readonly scheduler = new Scheduler({
+		callbacks: {
+			sendReminder: (payload: { message: string }) => {
+				console.log(payload.message);
+			},
+		},
+		retry: { maxAttempts: 3 },
+	});
+	readonly lifecycle = Lifecycle.install(this).use(this.scheduler);
+}
+```
+
+</TypeScriptExample>
+
+`Scheduler` runs typed callbacks after a delay, on a date, from a cron expression, or at a fixed interval. Register callbacks in the constructor so each Durable Object wake rebuilds the same dispatch map.
+
+Lifecycle stores each schedule as a job and manages the shared alarm. Create schedules with `set()` or `every()`. Use `list()` and `cancel()` to manage pending schedules.
+
+For timing modes and callback behavior, refer to [Schedule tasks](/agents/runtime/execution/schedule-tasks/).
+
+## Sessions
+
+Import `Sessions` from `agents/sessions`:
+
+<TypeScriptExample>
+
+```ts
+import { DurableObject } from "cloudflare:workers";
+import { Lifecycle } from "agents/lifecycle";
+import { Sessions } from "agents/sessions";
+
+export class SessionObject extends DurableObject<Env> {
+	readonly sessions = new Sessions({
+		reservedMetadataKeys: ["internal"],
+	});
+	readonly lifecycle = Lifecycle.install(this).use(this.sessions);
+	readonly session = this.sessions.session();
+}
+```
+
+</TypeScriptExample>
+
+`Sessions` stores durable conversation messages. Each session supports branches, compaction overlays, streamed reads, byte-budgeted history, attachments, and full-text search.
+
+One capability can hold several sessions by identifier. A Durable Object that represents one conversation can use the default empty identifier. `Sessions` stores messages only. Build model context separately with `agents/context`.
+
+## Streams
+
+Import `Streams` from `agents/streams`:
+
+<TypeScriptExample>
+
+```ts
+import { DurableObject } from "cloudflare:workers";
+import { Lifecycle } from "agents/lifecycle";
+import { Streams } from "agents/streams";
+
+export class StreamObject extends DurableObject<Env> {
+	readonly streams = new Streams({
+		maxChunkBytes: 64 * 1024,
+	});
+	readonly lifecycle = Lifecycle.install(this).use(this.streams);
+}
+```
+
+</TypeScriptExample>
+
+`Streams` stores durable incremental output with a monotonic cursor. Producers call `open()`, append JSON chunks, and finish with `close()` or `error()`.
+
+Consumers can replay stored chunks and then follow live output. Tags support operation lookups, while `sseResponse()` serves resumable Server-Sent Events (SSE). Streams require no alarm.
+
+## Tasks
+
+Import `Tasks` and `TaskStep` from `agents/tasks`:
+
+<TypeScriptExample>
+
+```ts
+import { DurableObject } from "cloudflare:workers";
+import { Lifecycle } from "agents/lifecycle";
+import { Tasks, type TaskStep } from "agents/tasks";
+
+export class ReportObject extends DurableObject<Env> {
+	readonly tasks = new Tasks({
+		definitions: {
+			"prepare-report@v1": async (input: { topic: string }, step: TaskStep) => {
+				const draft = await step.do("draft", () => ({
+					topic: input.topic,
+					status: "draft",
+				}));
+				await step.sleep("review-window", "10 minutes");
+				return { ...draft, status: "published" };
+			},
+		},
+		retries: { limit: 3, delay: "1 second" },
+	});
+	readonly lifecycle = Lifecycle.install(this).use(this.tasks);
+}
+```
+
+</TypeScriptExample>
+
+`Tasks` runs replayable background work. Completed `step.do()` calls return their journaled results after interruption. A durable sleep parks the run without holding the object open.
+
+Declare definitions in the constructor so recovery can find them after every wake. `run()` returns a durable receipt. Runs support idempotency keys, status inspection, cancellation, and retention.
+
+## WebSockets
+
+Import `WebSockets` from `agents/websockets`:
+
+<TypeScriptExample>
+
+```ts
+import { DurableObject } from "cloudflare:workers";
+import { Lifecycle } from "agents/lifecycle";
+import { WebSockets } from "agents/websockets";
+
+export class RoomObject extends DurableObject<Env> {
+	readonly webSockets = new WebSockets({
+		handlers: {
+			onConnect: (connection) => connection.send("ready"),
+			onMessage: (connection, message) => connection.send(message),
+		},
+		getConnectionTags: () => ["chat"],
+	});
+	readonly lifecycle = Lifecycle.install(this).use(this.webSockets);
+}
+```
+
+</TypeScriptExample>
+
+`WebSockets` claims upgrade requests and owns hibernating connections. It dispatches connection callbacks, stores connection state in hibernation attachments, and exposes connection lookup methods.
+
+Pass an `RpcTarget` through the `callables` option to expose remote methods over Cap'n Web. Without handlers or callables, this capability declines WebSocket upgrades.
+
+For connection behavior, refer to [WebSockets](/agents/runtime/communication/websockets/).
+
+## Build a capability
+
+Extend `LifecycleCapability` when application logic needs reusable lifecycle integration. Give every capability a stable, non-empty identifier:
+
+<TypeScriptExample>
+
+```ts
+import { DurableObject } from "cloudflare:workers";
+import {
+	Lifecycle,
+	LifecycleCapability,
+	type CapabilityRequestContext,
+} from "agents/lifecycle";
+
+class HealthCheck extends LifecycleCapability {
+	constructor() {
+		super("health-check");
+	}
+
+	onStart(): void {
+		this.lifecycle.storage.sql.exec(`
+			CREATE TABLE IF NOT EXISTS health_checks (
+				checked_at INTEGER NOT NULL
+			)
+		`);
+	}
+
+	onRequest({ request }: CapabilityRequestContext): Response | undefined {
+		if (!new URL(request.url).pathname.endsWith("/health")) return;
+		return Response.json({ ok: true });
+	}
+}
+
+export class HealthObject extends DurableObject<Env> {
+	readonly health = new HealthCheck();
+	readonly lifecycle = Lifecycle.install(this).use(this.health);
+}
+```
+
+</TypeScriptExample>
+
+Install custom capabilities with the same `use()` method. A capability receives Durable Object storage, capability-scoped jobs, events, and routing, socket access, readiness, and host callback services through `this.lifecycle`.
+
+Capability request hooks return a `Response` to claim a request. Other lifecycle hooks cover startup, WebSocket events, durable jobs, routed messages, memory-limit policy, and explicit disposal.

--- a/src/content/docs/agents/runtime/index.mdx
+++ b/src/content/docs/agents/runtime/index.mdx
@@ -9,6 +9,6 @@ sidebar:
 
 import { DirectoryListing } from "~/components";
 
-The runtime powers your agent — state, communication, execution, and operations.
+Build directly on the [Durable Object lifecycle](/agents/runtime/lifecycle/) and [capabilities](/agents/runtime/capabilities/), or use them through the `Agent` class. The runtime also covers communication, execution, and operations.
 
 <DirectoryListing />

--- a/src/content/docs/agents/runtime/lifecycle/agent-class.mdx
+++ b/src/content/docs/agents/runtime/lifecycle/agent-class.mdx
@@ -1,6 +1,6 @@
 ---
 title: Agent class internals
-description: Explore how the Agent class extends Durable Objects to provide state, WebSockets, scheduling, and RPC.
+description: Explore how the Agent class composes a Durable Object lifecycle and capabilities for state, WebSockets, scheduling, and RPC.
 pcx_content_type: concept
 sidebar:
   order: 5
@@ -14,9 +14,16 @@ The snippets shown here are illustrative and do not necessarily represent best p
 
 ## What is the Agent?
 
-The `Agent` class is an extension of `DurableObject` — agents _are_ Durable Objects. If you are not familiar with Durable Objects, read [What are Durable Objects](/durable-objects/) first. At their core, Durable Objects are globally addressable (each instance has a unique ID), single-threaded compute instances with long-term storage (key-value and SQLite).
+`Agent` directly extends the platform `DurableObject` class. Each Agent is a globally addressable compute instance with durable key-value and SQLite storage. For more information, refer to [What are Durable Objects](/durable-objects/).
 
-`Agent` does not extend `DurableObject` directly. It extends `Server` from the [`partyserver`](https://github.com/cloudflare/partykit/tree/main/packages/partyserver) package, which extends `DurableObject`. Think of it as layers: **DurableObject** > **Server** > **Agent**.
+Each Agent also installs a [`Lifecycle`](/agents/runtime/lifecycle/) instance. The lifecycle connects the Agent to reusable [capabilities](/agents/runtime/capabilities/).
+
+```txt
+DurableObject
+└── Agent
+    └── Lifecycle
+        └── capabilities
+```
 
 ## Layer 0: Durable Object
 
@@ -81,9 +88,9 @@ export class MyDurableObject extends DurableObject {
 
 ### `alarm()`
 
-HTTP and RPC requests are not the only entrypoints for a Durable Object. Alarms allow developers to schedule an event to trigger at a later time. Whenever the next alarm is due, the runtime will call the `alarm()` method, which is left to the developer to implement.
+HTTP and RPC requests are not the only Durable Object entry points. A plain Durable Object can schedule one alarm with `ctx.storage.setAlarm()` and handle it through `alarm()`. For more information, refer to [Alarms](/durable-objects/api/alarms/).
 
-To schedule an alarm, you can use the `this.ctx.storage.setAlarm()` method. For more information, refer to [Alarms](/durable-objects/api/alarms/).
+Lifecycle owns the physical alarm for an Agent. Do not override `alarm()` or call `ctx.storage.setAlarm()` from Agent code. Use `this.schedule()` for Agent callbacks. A reusable capability can push durable jobs through its scoped Lifecycle job queue.
 
 ### `this.ctx`
 
@@ -107,90 +114,23 @@ const token = this.ctx.storage.get("someToken");
 
 Lastly, it is worth mentioning that the Durable Object also has the Worker `Env` in `this.env`. Learn more in [Bindings](/workers/runtime-apis/bindings).
 
-## Layer 1: `Server` (partyserver)
+## Layer 1: lifecycle composition
 
-Now that you have seen what Durable Objects provide out of the box, the `Server` class from [`partyserver`](https://github.com/cloudflare/partykit/tree/main/packages/partyserver) will make more sense. It is an opinionated `DurableObject` wrapper that replaces low-level primitives with developer-friendly callbacks.
+`Agent` uses `Lifecycle.install(this)` to install its platform-facing request, alarm, and hibernating WebSocket event handlers. Agent subclasses implement semantic callbacks such as `onStart()` and `onRequest()` instead of forwarding those platform events.
 
-`Server` does not add any storage operations of its own — it only wraps the Durable Object lifecycle.
+The `Agent` class installs reusable capabilities for WebSockets, schedules, tasks, MCP clients, and internal features. Capabilities start before Agent startup. They can claim requests before `onRequest()` and share one Lifecycle-managed Durable Object alarm.
 
-### Addressing
+You can install additional capabilities through `this.lifecycle.use(capability)`. The same capability can also run on a class that directly extends `DurableObject`.
 
-`partyserver` exposes helpers to address Durable Objects by name instead of going through bindings manually. This includes a URL routing scheme (`<your-worker>/servers/:durableClass/:durableName`) that the Agent layer builds on.
-
-```ts
-// Note the await here!
-const stub = await getServerByName(env.MY_DO, "foo");
-
-// We can still call RPC methods.
-await stub.bar();
-```
-
-The URL scheme also enables a request router. In the Agent layer, this is re-exported as `routeAgentRequest`:
-
-```ts
-  async fetch(request: Request, env: Env, ctx: ExecutionContext) {
-    const res = await routeAgentRequest(request, env);
-
-    if (res) return res;
-
-    return new Response("Not found", { status: 404 });
-  }
-```
-
-### `onStart`
-
-The addressing layer allows `Server` to expose an `onStart` callback that runs every time the Durable Object starts up (after eviction, hibernation, or first creation) and before any `fetch` or RPC call.
-
-```ts
-class MyServer extends Server {
-	onStart() {
-		// Some initialization logic that you wish
-		// to run every time the DO is started up.
-		const sql = this.ctx.storage.sql;
-		sql.exec(`...`);
-	}
-}
-```
-
-### `onRequest` and `onConnect`
-
-`Server` already implements `fetch` for the underlying Durable Object and exposes two different callbacks that developers can make use of, `onRequest` and `onConnect` for HTTP requests and incoming WS connections, respectively (WebSocket connections are accepted by default).
-
-```ts
-class MyServer extends Server {
-	async onRequest(request: Request) {
-		const url = new URL(request.url);
-
-		return new Response(`Hello from ${url.origin}!`);
-	}
-
-	async onConnect(conn, ctx) {
-		const { request } = ctx;
-		const url = new URL(request.url);
-
-		// Connections are a WebSocket wrapper
-		conn.send(`Hello from ${url.origin}!`);
-	}
-}
-```
-
-### WebSockets
-
-Just as `onConnect` is the callback for every new connection, `Server` also provides wrappers on top of the default callbacks from the `DurableObject` class: `onMessage`, `onClose` and `onError`.
-
-There's also `this.broadcast` that sends a WS message to all connected clients (no magic, just a loop over `this.getConnections()`!).
-
-### `this.name`
-
-It is hard to get a Durable Object's `name` from within it. `partyserver` tries to make it available in `this.name` but it is not a perfect solution. Learn more about it in [this GitHub issue](https://github.com/cloudflare/workerd/issues/2240).
+Lifecycle reads names assigned through `idFromName()` or `getByName()` from `ctx.id.name`. The Agent exposes this value as `this.name`.
 
 ## Layer 2: Agent
 
-Now finally, the `Agent` class. `Agent` extends `Server` and provides opinionated primitives for stateful, schedulable, and observable agents that can communicate via RPC, WebSockets, and (even!) email.
+The `Agent` class directly extends `DurableObject`. It adds state, scheduling, RPC, WebSockets, MCP clients, email, and other agent-focused APIs.
 
 ### `this.state` and `this.setState()`
 
-One of the core features of `Agent` is **automatic state persistence**. Developers define the shape of their state via the generic parameter and `initialState` (which is only used if no state exists in storage), and the Agent handles loading, saving, and broadcasting state changes (check `Server`'s `this.broadcast()` above).
+One of the core features of `Agent` is **automatic state persistence**. Developers define the state shape through a generic parameter and `initialState`. The Agent loads, saves, and broadcasts state changes through its lifecycle-managed WebSocket capability.
 
 `this.state` is a getter that lazily loads state from storage (SQL). State is persisted across Durable Object evictions when it is updated with `this.setState()`, which automatically serializes the state and writes it back to storage.
 
@@ -402,7 +342,7 @@ function someUtilityFunction() {
 
 ### `this.onError`
 
-`Agent` extends `Server`'s `onError` so it can be used to handle errors that are not necessarily WebSocket errors. It is called with a `Connection` or `unknown` error.
+`Agent` exposes `onError()` for WebSocket and other Agent errors. It receives either a `Connection` with an error, or an error value.
 
 ```ts
 class MyAgent extends Agent {
@@ -411,12 +351,12 @@ class MyAgent extends Agent {
 			// WebSocket connection error
 			console.error("Connection error:", error);
 		} else {
-			// Server error
-			console.error("Server error:", connectionOrError);
+			// Non-WebSocket error
+			console.error("Agent error:", connectionOrError);
 		}
 
 		// Optionally throw to propagate the error
-		throw connectionOrError;
+		throw error ?? connectionOrError;
 	}
 }
 ```
@@ -467,20 +407,22 @@ Configure agent behavior by overriding `static options` on your class. All field
 ```ts
 export class MyAgent extends Agent {
 	static options = {
-		hibernate: true,
 		sendIdentityOnConnect: false,
 		retry: { maxAttempts: 5, baseDelayMs: 200, maxDelayMs: 5000 },
+		maxAlarmMemoryLimitStrikes: 3,
 	};
 }
 ```
 
-| Option | Type | Default | Description |
-| --- | --- | --- | --- |
-| `hibernate` | `boolean` | `true` | Whether the agent hibernates when inactive. WebSocket connections stay open while the DO sleeps |
-| `sendIdentityOnConnect` | `boolean` | `true` | Send identity (agent name, instance name) to clients on WebSocket connect. Set to `false` to hide sensitive instance names |
-| `hungScheduleTimeoutSeconds` | `number` | `30` | Timeout before a running interval schedule is considered hung and force-reset. Increase for long-running callbacks |
-| `keepAliveIntervalMs` | `number` | `30000` | Interval in milliseconds for `keepAlive()` alarm heartbeats. Lower values mean faster recovery but more frequent alarms |
-| `retry` | `RetryOptions` | `{ maxAttempts: 3, baseDelayMs: 100, maxDelayMs: 3000 }` | Default retry options for `schedule()`, `queue()`, and `this.retry()`. Per-task options override these defaults |
+Agents always use the WebSocket Hibernation API. There is no hibernation option.
+
+| Option                       | Type           | Default                                                  | Description                                                                                                                |
+| ---------------------------- | -------------- | -------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `sendIdentityOnConnect`      | `boolean`      | `true`                                                   | Send identity (agent name, instance name) to clients on WebSocket connect. Set to `false` to hide sensitive instance names |
+| `hungScheduleTimeoutSeconds` | `number`       | `30`                                                     | Timeout before a running interval schedule is considered hung and force-reset. Increase for long-running callbacks         |
+| `keepAliveIntervalMs`        | `number`       | `30000`                                                  | Interval in milliseconds for `keepAlive()` alarm heartbeats. Lower values mean faster recovery but more frequent alarms    |
+| `maxAlarmMemoryLimitStrikes` | `number`       | `3`                                                      | Consecutive alarm memory-limit resets allowed before Lifecycle seals recovery-loop work                                    |
+| `retry`                      | `RetryOptions` | `{ maxAttempts: 3, baseDelayMs: 100, maxDelayMs: 3000 }` | Default retry options for `schedule()`, `queue()`, and `this.retry()`. Per-task options override these defaults            |
 
 ### `this.keepAlive()` and `this.keepAliveWhile()`
 
@@ -511,7 +453,7 @@ class MyAgent extends Agent {
 
 ### Routing
 
-The `Agent` class re-exports the [addressing helpers](#addressing) as `getAgentByName` and `routeAgentRequest`.
+The Agents SDK exports `getAgentByName` and `routeAgentRequest` for named Agent routing.
 
 ```ts
 const stub = await getAgentByName(env.MY_DO, "foo");
@@ -527,6 +469,6 @@ return new Response("Not found", { status: 404 });
 
 The [`AIChatAgent`](/agents/communication-channels/chat/chat-agents/) class from `@cloudflare/ai-chat` extends `Agent` with an opinionated layer for AI chat. It adds automatic message persistence to SQLite, resumable streaming, tool support (server-side, client-side, and human-in-the-loop), and a React hook (`useAgentChat`) for building chat UIs.
 
-The full hierarchy is: **DurableObject** > **Server** > **Agent** > **AIChatAgent**.
+The full class hierarchy is **DurableObject** > **Agent** > **AIChatAgent**. `Agent` composes Lifecycle and its capabilities instead of adding another base class.
 
 If you are building a chat agent, start with `AIChatAgent`. If you need lower-level control or are not building a chat interface, use `Agent` directly.

--- a/src/content/docs/agents/runtime/lifecycle/index.mdx
+++ b/src/content/docs/agents/runtime/lifecycle/index.mdx
@@ -1,12 +1,233 @@
 ---
-title: Lifecycle
-pcx_content_type: navigation
+title: Durable Object lifecycle
+description: Compose Agents SDK capabilities in a Durable Object and coordinate startup, requests, WebSockets, alarms, jobs, and cleanup.
+pcx_content_type: concept
 sidebar:
   order: 1
   group:
-    hideIndex: true
+    label: Lifecycle
+    hideIndex: false
+products:
+  - agents
 ---
 
-import { DirectoryListing } from "~/components";
+import { TypeScriptExample } from "~/components";
 
-<DirectoryListing />
+`Lifecycle` connects Agents SDK capabilities to a Cloudflare Durable Object. It coordinates startup, requests, WebSocket events, durable jobs, alarms, and cleanup.
+
+You can install it on a class that extends the platform `DurableObject`. The [`Agent` class](/agents/runtime/lifecycle/agent-class/) installs the same lifecycle internally.
+
+:::caution[Experimental]
+
+Everything exported from `agents/lifecycle` may change between releases. Capabilities built on this API may also change while the composition model stabilizes.
+
+:::
+
+## Install the lifecycle
+
+Construct the lifecycle as a field on your Durable Object:
+
+<TypeScriptExample>
+
+```ts
+import { DurableObject } from "cloudflare:workers";
+import { Lifecycle } from "agents/lifecycle";
+
+export class MyObject extends DurableObject<Env> {
+	readonly lifecycle = Lifecycle.install(this);
+
+	onStart(): void {
+		// Runs once for each in-memory object lifetime.
+	}
+
+	onRequest(request: Request): Response {
+		return new Response(`Hello from ${this.lifecycle.name}: ${request.url}`);
+	}
+}
+```
+
+</TypeScriptExample>
+
+`Lifecycle.install(this)` installs the platform-facing `fetch`, `alarm`, and hibernating WebSocket event handlers. Implement semantic callbacks such as `onStart()` and `onRequest()` instead of forwarding those platform handlers yourself.
+
+The expanded form separates construction from handler installation:
+
+<TypeScriptExample>
+
+```ts
+import { DurableObject } from "cloudflare:workers";
+import { Lifecycle } from "agents/lifecycle";
+
+export class MyObject extends DurableObject<Env> {
+	readonly lifecycle = new Lifecycle(this);
+
+	constructor(ctx: DurableObjectState, env: Env) {
+		super(ctx, env);
+		this.lifecycle.installHandlers();
+	}
+}
+```
+
+</TypeScriptExample>
+
+Use the expanded form only when construction and installation must happen separately. Calling `installHandlers()` more than once throws an error.
+
+## Route requests
+
+Use `routeAgentRequest()` in the outer Worker to reach named lifecycle objects:
+
+<TypeScriptExample>
+
+```ts
+import { routeAgentRequest } from "agents";
+
+export default {
+	async fetch(request: Request, env: Env): Promise<Response> {
+		return (
+			(await routeAgentRequest(request, env)) ??
+			new Response("Not found", { status: 404 })
+		);
+	},
+} satisfies ExportedHandler<Env>;
+```
+
+</TypeScriptExample>
+
+The default URL shape is `/agents/:binding/:name`. Direct calls through `env.MY_OBJECT.getByName(name).fetch(request)` also work.
+
+Lifecycle objects require named Durable Object IDs. Address them with `getByName()` or `idFromName()`. Raw IDs from `newUniqueId()` or `idFromString()` do not expose the name that Lifecycle uses for `lifecycle.name`.
+
+## Attach capabilities
+
+Construct each capability before the lifecycle starts. Register it with `use()`:
+
+<TypeScriptExample>
+
+```ts
+import { DurableObject } from "cloudflare:workers";
+import { Lifecycle } from "agents/lifecycle";
+import { Sessions } from "agents/sessions";
+import { Streams } from "agents/streams";
+
+export class ConversationObject extends DurableObject<Env> {
+	readonly sessions = new Sessions();
+	readonly streams = new Streams();
+
+	readonly lifecycle = Lifecycle.install(this)
+		.use(this.sessions)
+		.use(this.streams);
+}
+```
+
+</TypeScriptExample>
+
+Capabilities start and receive requests in registration order. `use()` throws after lifecycle startup begins.
+
+Install a catch-all capability with `{ fallback: true }`. Lifecycle always dispatches fallback capabilities after other capabilities, regardless of installation order.
+
+For available capabilities and import paths, refer to [Capabilities](/agents/runtime/capabilities/).
+
+## Startup and request dispatch
+
+Lifecycle starts during the first request, alarm, or WebSocket event. Startup follows this order:
+
+1. Each capability runs `onStart()` in registration order.
+2. The host Durable Object runs `onStart()`.
+3. Lifecycle handles the incoming event.
+
+A warm object skips startup for later events. A failed startup can run again during a later event.
+
+For an HTTP request, Lifecycle offers the request to each capability. The first capability that returns a `Response` handles it. Returning `undefined` passes the request to the next capability. Unclaimed requests reach the host `onRequest()` callback.
+
+WebSocket upgrades follow the same claim model. The capability that accepts an upgrade owns that connection and its later WebSocket events. Lifecycle returns `404` when no capability accepts the upgrade.
+
+Lifecycle does not provide a `next()` callback. A capability can handle a request or decline it, but it cannot wrap a later response.
+
+## Durable jobs and alarms
+
+A Durable Object has one physical alarm. Lifecycle owns that alarm and derives its next time from a shared durable job queue. This prevents a scheduler, task runner, and custom capability from overwriting each other's alarms.
+
+The host can add jobs through `lifecycle.jobs` and handle them with `onJob()`:
+
+<TypeScriptExample>
+
+```ts
+import { DurableObject } from "cloudflare:workers";
+import {
+	Lifecycle,
+	type LifecycleJobContext,
+	type LifecycleJobOutcome,
+} from "agents/lifecycle";
+
+export class CleanupObject extends DurableObject<Env> {
+	readonly lifecycle = Lifecycle.install(this, {
+		maxAlarmMemoryLimitStrikes: 3,
+	});
+
+	async scheduleCleanup(): Promise<void> {
+		await this.lifecycle.jobs.push({
+			id: "cleanup",
+			fn: "delete-marker",
+			time: Date.now() + 60_000,
+			retry: { maxAttempts: 3 },
+		});
+	}
+
+	async onJob({ job }: LifecycleJobContext): Promise<LifecycleJobOutcome> {
+		if (job.fn !== "delete-marker") return;
+		await this.ctx.storage.delete("cleanup:marker");
+	}
+}
+```
+
+</TypeScriptExample>
+
+Job operations are scoped to their owner. If two owners push the same identifier, Lifecycle rejects the collision instead of replacing another owner's job.
+
+The `onJob()` result controls the job:
+
+- Return nothing to complete and delete the job.
+- Return `{ rescheduleAt }` to move it to another time.
+- Return `"yield"` to leave it due and wake again.
+
+Lifecycle drives due jobs in timestamp order. It retries application failures according to each job policy. Jobs marked as recovery loops receive backoff and sealing after repeated Durable Object memory-limit resets.
+
+The host `onAlarm()` callback runs after due jobs. Do not call `ctx.storage.setAlarm()` while using Lifecycle because that alarm would compete with the shared queue.
+
+## Native Durable Object RPC
+
+Native Durable Object RPC bypasses `fetch()`. Start the lifecycle before an RPC method uses state that capability startup initializes:
+
+<TypeScriptExample>
+
+```ts
+import { DurableObject } from "cloudflare:workers";
+import { Lifecycle } from "agents/lifecycle";
+
+export class StatusObject extends DurableObject<Env> {
+	readonly lifecycle = Lifecycle.install(this);
+
+	async status(): Promise<{ pending: number }> {
+		await this.lifecycle.start();
+		return { pending: this.lifecycle.jobs.list().length };
+	}
+}
+```
+
+</TypeScriptExample>
+
+Some asynchronous capability methods start Lifecycle automatically. Native RPC methods should call `lifecycle.start()` before using synchronous capability APIs or startup-initialized state.
+
+## Host context
+
+Lifecycle makes the current host available while it invokes host callbacks. Use `getCurrentAgent()` from `agents/lifecycle` to read that context in shared code.
+
+Capability hooks run outside the host context. A capability that invokes an application callback must use its Lifecycle host boundary. Built-in capabilities, including `Scheduler` and `WebSockets`, do this automatically.
+
+For context values available to each callback, refer to [`getCurrentAgent()`](/agents/runtime/lifecycle/get-current-agent/).
+
+## Cleanup
+
+`lifecycle.dispose()` calls each installed capability's `dispose()` hook in reverse registration order. Disposal releases live resources, such as connections and listeners. It does not delete capability storage.
+
+Durable Object eviction does not call `dispose()`. Invoke it only during explicit application teardown before deleting shared storage.


### PR DESCRIPTION
### Summary

- document `agents/lifecycle` as the composition layer for plain Durable Objects and the `Agent` class
- add a capabilities overview for `MCPClientManager`, `RoutedAgents`, `Scheduler`, `Sessions`, `Streams`, `Tasks`, and `WebSockets`, with import paths, constructor options, and `Lifecycle.use()` examples
- announce Agents SDK v0.23.0 with one plain `DurableObject` that composes every public Lifecycle capability
- update the Agent internals and runtime navigation to reflect direct `DurableObject` inheritance and Lifecycle composition

### Validation

- `pnpm run check`
- `pnpm run lint`
- targeted Prettier check for all changed MDX files
- `pnpm run build`
- `pnpm run build:incremental`
- aggregate example type-checked against the `agents@0.23.0` release tag

### Documentation checklist

- [x] Added an Agents changelog entry.
- [x] The change adheres to the documentation style guide.
